### PR TITLE
Fix `integration_time` attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,8 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  # create environment and install dependencies
-  - conda install numpy scipy astropy nose pip h5py six
-  - conda install -c conda-forge healpy python-casacore pycodestyle coveralls
+  # install dependencies
+  - conda install -c conda-forge numpy scipy astropy nose pip h5py six healpy python-casacore pycodestyle coveralls
   - conda list
 script:
   - python setup.py build_ext --force --inplace

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - conda info -a
 
   # install dependencies
-  - conda install -c conda-forge numpy scipy astropy nose pip h5py six healpy python-casacore pycodestyle coveralls
+  - conda install numpy scipy astropy nose pip h5py six healpy python-casacore pycodestyle coveralls
   - conda list
 script:
   - python setup.py build_ext --force --inplace

--- a/pyuvdata/fhd.py
+++ b/pyuvdata/fhd.py
@@ -241,7 +241,12 @@ class FHD(UVData):
         # integrations. This can have limited accuracy, so it can be slightly
         # off the actual value.
         # (e.g. 1.999426... rather than 2)
-        self.integration_time = float(obs['TIME_RES'][0])
+        time_res = obs['TIME_RES']
+        if len(time_res) == 1:
+            self.integration_time = (np.ones_like(self.time_array, dtype=np.float64)
+                                     * time_res[0])
+        else:
+            self.integration_time = time_res
         self.channel_width = float(obs['FREQ_RES'][0])
 
         # # --- observation information ---

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -347,6 +347,10 @@ class Miriad(UVData):
         # UVData.time_array marks center of integration, while Miriad 'time' marks beginning
         self.time_array = t_grid + uv['inttime'] / (24 * 3600.) / 2
 
+        # assume inttime in the header is the same integration time for all records
+        self.integration_time = (uv['inttime']
+                                 * np.ones_like(self.time_array, dtype=np.float64))
+
         self.ant_1_array = ant_i_grid.astype(int)
         self.ant_2_array = ant_j_grid.astype(int)
 
@@ -583,7 +587,7 @@ class Miriad(UVData):
         uv.add_var('nspect', 'i')
         uv['nspect'] = self.Nspws
         uv.add_var('inttime', 'd')
-        uv['inttime'] = self.integration_time
+        uv['inttime'] = self.integration_time[0]
         uv.add_var('sdf', 'd')
         uv['sdf'] = self.channel_width / 1e9  # in GHz
         uv.add_var('source', 'a')
@@ -912,7 +916,6 @@ class Miriad(UVData):
 
         miriad_header_data = {'Nfreqs': 'nchan',
                               'Npols': 'npol',
-                              'integration_time': 'inttime',
                               'channel_width': 'sdf',  # in Ghz!
                               'object_name': 'source',
                               'telescope_name': 'telescop'

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -310,7 +310,7 @@ class Miriad(UVData):
                        str(k[9]).zfill(ndig_t)]
                 blt = "_".join(blt)
                 blts.append(blt)
-        unique_blts = np.unique(np.array(blts), axis=0)
+        unique_blts = np.unique(np.array(blts))
 
         reverse_inds = dict(zip(unique_blts, range(len(unique_blts))))
         self.Nants_data = len(sorted_unique_ants)

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -307,7 +307,7 @@ class Miriad(UVData):
             for k in d:
                 blt = ["{1:.{0}f}".format(prec_t, k[1]).zfill(ndig_t),
                        str(k[2]).zfill(ndig_ant), str(k[3]).zfill(ndig_ant),
-                       str(k[9]).zfill(ndig_ant)]
+                       str(k[9]).zfill(ndig_t)]
                 blt = "_".join(blt)
                 blts.append(blt)
         unique_blts = np.unique(np.array(blts), axis=0)
@@ -396,7 +396,7 @@ class Miriad(UVData):
             for ind, d in enumerate(data):
                 blt = ["{1:.{0}f}".format(prec_t, d[1]).zfill(ndig_t),
                        str(d[2]).zfill(ndig_ant), str(d[3]).zfill(ndig_ant),
-                       str(d[9]).zfill(ndig_ant)]
+                       str(d[9]).zfill(ndig_t)]
                 blt = "_".join(blt)
                 blt_index = reverse_inds[blt]
 

--- a/pyuvdata/ms.py
+++ b/pyuvdata/ms.py
@@ -191,10 +191,11 @@ class MS(UVData):
         # self.integration_time=tb.getcol('INTERVAL')[0]
         # for some reason, interval ends up larger than the difference between times...
         if len(times_unique) == 1:
-            self.integration_time = 1.0
+            self.integration_time = np.ones_like(self.time_array, dtype=np.float64)
         else:
-            self.integration_time = float(
-                times_unique[1] - times_unique[0]) * 3600. * 24.
+            # assume that all times in the file are the same size
+            dt = times_unique[1] - times_unique[0]) * 3600. * 24.
+            self.integration_time = np.ones_like(self.time_array, dtype=np.float64) * dt
         # open table with antenna location information
         tbAnt = tables.table(filepath + '/ANTENNA')
         tbObs = tables.table(filepath + '/OBSERVATION')

--- a/pyuvdata/ms.py
+++ b/pyuvdata/ms.py
@@ -194,8 +194,8 @@ class MS(UVData):
             self.integration_time = np.ones_like(self.time_array, dtype=np.float64)
         else:
             # assume that all times in the file are the same size
-            dt = (times_unique[1] - times_unique[0]) * 3600. * 24.
-            self.integration_time = np.ones_like(self.time_array, dtype=np.float64) * dt
+            int_time = self._calc_single_integration_time()
+            self.integration_time = np.ones_like(self.time_array, dtype=np.float64) * int_time
         # open table with antenna location information
         tbAnt = tables.table(filepath + '/ANTENNA')
         tbObs = tables.table(filepath + '/OBSERVATION')

--- a/pyuvdata/ms.py
+++ b/pyuvdata/ms.py
@@ -194,7 +194,7 @@ class MS(UVData):
             self.integration_time = np.ones_like(self.time_array, dtype=np.float64)
         else:
             # assume that all times in the file are the same size
-            dt = times_unique[1] - times_unique[0]) * 3600. * 24.
+            dt = (times_unique[1] - times_unique[0]) * 3600. * 24.
             self.integration_time = np.ones_like(self.time_array, dtype=np.float64) * dt
         # open table with antenna location information
         tbAnt = tables.table(filepath + '/ANTENNA')

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -728,8 +728,9 @@ def test_readWriteReadMiriad():
     uvtest.checkWarnings(uv_in.read, [testfile], {'read_data': False}, known_warning='miriad')
     nt.assert_equal(uv_in.time_array, None)
     nt.assert_equal(uv_in.data_array, None)
+    nt.assert_equal(uv_in.integration_time, None)
     metadata = ['antenna_positions', 'antenna_names', 'antenna_positions', 'channel_width',
-                'integration_time', 'history', 'vis_units', 'telescope_location']
+                'history', 'vis_units', 'telescope_location']
     for m in metadata:
         nt.assert_true(getattr(uv_in, m) is not None)
 

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -832,7 +832,7 @@ def test_select_times():
 
     # check for errors associated with times not included in data
     nt.assert_raises(ValueError, uv_object.select, times=[
-                     np.min(unique_times) - uv_object.integration_time])
+                     np.min(unique_times) - uv_object.integration_time[0]])
 
 
 def test_select_frequencies():

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3033,3 +3033,19 @@ class UVData(UVBase):
                           .format(p=(',').join(warned_pols).upper()))
 
         return ant_pairs_nums, polarizations
+
+    def _calc_single_integration_time(self):
+        """Calculate a single integration time for a UVData object when not otherwise specified.
+
+        Args:
+            None
+
+        Returns:
+            int_time: integration time to be assigned to all samples in the data.
+
+        Notes:
+            This funciton computes the shortest time difference present in a UVData object's time_array,
+            and returns that as the integration time to be used for all samples. Also, the time_array
+            is in units of days, and integration_time has units of seconds, so we need to convert.
+        """
+        return np.diff(np.sort(list(set(self.time_array))))[0] * 86400

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -156,6 +156,7 @@ class UVData(UVBase):
 
         self._integration_time = uvp.UVParameter('integration_time',
                                                  description='Length of the integration (s)',
+                                                 form=('Nblts',),
                                                  expected_type=np.float, tols=1e-3)  # 1 ms
         self._channel_width = uvp.UVParameter('channel_width',
                                               description='Width of frequency channels (Hz)',
@@ -930,8 +931,8 @@ class UVData(UVBase):
 
         # Check objects are compatible
         # But phase_center should be the same, even if in drift (empty parameters)
-        compatibility_params = ['_vis_units', '_integration_time', '_channel_width',
-                                '_object_name', '_telescope_name', '_instrument',
+        compatibility_params = ['_vis_units', '_channel_width', '_object_name',
+                                '_telescope_name', '_instrument',
                                 '_telescope_location', '_phase_type',
                                 '_Nants_telescope', '_antenna_names',
                                 '_antenna_numbers', '_antenna_positions',
@@ -1017,6 +1018,8 @@ class UVData(UVBase):
                                              other.uvw_array[bnew_inds, :]], axis=0)[blt_order, :]
             this.time_array = np.concatenate([this.time_array,
                                               other.time_array[bnew_inds]])[blt_order]
+            this.integration_time = np.concatenate([this.integration_time,
+                                                    other.integration_time[bnew_inds]])[blt_order]
             this.lst_array = np.concatenate(
                 [this.lst_array, other.lst_array[bnew_inds]])[blt_order]
             this.ant_1_array = np.concatenate([this.ant_1_array,
@@ -1401,6 +1404,7 @@ class UVData(UVBase):
             self.baseline_array = self.baseline_array[blt_inds]
             self.Nbls = len(np.unique(self.baseline_array))
             self.time_array = self.time_array[blt_inds]
+            self.integration_time = self.integration_time[blt_inds]
             self.lst_array = self.lst_array[blt_inds]
             self.uvw_array = self.uvw_array[blt_inds, :]
 

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -104,19 +104,13 @@ class UVFITS(UVData):
                                  * const.c.to('m/s').value).T
 
         if 'INTTIM' in vis_hdu.data.parnames:
-            inttim = vis_hdu.data.par('INTTIM')
-            if len(inttim) == 1:
-                # assume that all integration times in the file are the same
-                self.integration_time = (np.ones_like(self.time_array, dtype=np.float64)
-                                         * inttim[0])
-            else:
-                self.integration_time = inttim
+            self.integration_time = vis_hdu.data.par('INTTIM')
         else:
             if self.Ntimes > 1:
                 # assume that all integration times in the file are the same
+                int_time = self._calc_single_integration_time()
                 self.integration_time = (np.ones_like(self.time_array, dtype=np.float64)
-                                         * np.diff(np.sort(list(set(self.time_array))))
-                                         [0]) * 86400
+                                         * int_time)
             else:
                 raise ValueError('integration time not specified and only '
                                  'one time present')

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -107,7 +107,7 @@ class UVH5(UVData):
 
         # get time information
         self.time_array = header['time_array'].value
-        self.integration_time = float(header['integration_time'].value)
+        self.integration_time = header['integration_time'].value
         self.lst_array = header['lst_array'].value
 
         # get frequency information


### PR DESCRIPTION
To support baseline-dependent averaging, the `integration_time` attribute on a UVData object should be an array of size Nblts, instead of a single number. Miriad and uvfits support this feature, and so I/O routines were modified to correctly account for this.

Fixes #426.