### PR TITLE
enforce boolean flags, adds ordered kwarg to `antpair2ind` method, & integration_time dtype

### DIFF
--- a/pyuvdata/fhd.py
+++ b/pyuvdata/fhd.py
@@ -246,7 +246,7 @@ class FHD(UVData):
             self.integration_time = (np.ones_like(self.time_array, dtype=np.float64)
                                      * time_res[0])
         else:
-            self.integration_time = time_res
+            self.integration_time = np.asarray(time_res, dtype=np.float64)
         self.channel_width = float(obs['FREQ_RES'][0])
 
         # # --- observation information ---

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -350,7 +350,7 @@ class Miriad(UVData):
         # also, int_grid is in units of seconds, so we need to convert to days
         self.time_array = t_grid + int_grid / (24 * 3600.) / 2
 
-        self.integration_time = int_grid
+        self.integration_time = np.asarray(int_grid, dtype=np.float64)
 
         self.ant_1_array = ant_i_grid.astype(int)
         self.ant_2_array = ant_j_grid.astype(int)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1576,25 +1576,6 @@ def test_break_add():
     nt.assert_raises(ValueError, uv1.__iadd__, uv2)
 
 
-def test_antpair2ind():
-    # testing function for the antpair2ind method
-    # most of this is tested indirectly by key2inds
-    # so this just catches what is left-over
-    uv = UVData()
-    testfile = os.path.join(
-        DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
-
-    # test antpair2ind and _antpair2ind agree
-    # TODO: Get rid of this test when antpair2ind is
-    # is deprecated for _antpair2ind
-    inds1 = uvtest.checkWarnings(uv.antpair2ind, [20, 21],
-                                 message="UVData.antpair2ind will soon be moved")
-    inds2 = uv._antpair2ind(20, 21)
-    np.testing.assert_array_equal(inds1, inds2)
-
-
 def test_key2inds():
     # Test function to interpret key as antpair, pol
     uv = UVData()
@@ -1950,7 +1931,7 @@ def test_get_nsamples():
     nt.assert_true(np.all(dcheck == d))
 
 
-def test_get_blt_inds():
+def test_antpair2ind():
     # Test for baseline-time axis indexer
     uv = UVData()
     testfile = os.path.join(
@@ -1959,14 +1940,16 @@ def test_get_blt_inds():
                          message='Telescope EVLA is not')
 
     # get indices
-    inds = uv.get_blt_inds(20, 24)
+    inds = uv.antpair2ind(20, 24, ordered=False)
     np.testing.assert_array_equal(inds, np.array([71, 271, 424, 577, 713, 883, 1036, 1189, 1342]))
     nt.assert_true(inds.dtype == np.int)
 
     # conjugate (and use key rather than arg expansion)
-    inds2 = uv.get_blt_inds((24, 20))
+    inds2 = uv.antpair2ind((24, 20), ordered=False)
     np.testing.assert_array_equal(inds, inds2)
 
+    # ordered = True is already tested by _key2inds testing
+    
 
 def test_get_times():
     # Test function for easy access to times, to work in conjunction with get_data

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1931,6 +1931,24 @@ def test_get_nsamples():
     nt.assert_true(np.all(dcheck == d))
 
 
+def test_get_blts_inds():
+    # Test for baseline-time axis indexer
+    uv = UVData()
+    testfile = os.path.join(
+        DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+
+    # get indices
+    inds = uv.get_blts_inds((20, 24))
+    np.testing.assert_array_equal(inds, np.array([71, 271, 424, 577, 713, 883, 1036, 1189, 1342]))
+    nt.assert_true(inds.dtype == np.int)
+
+    # conjugate
+    inds2 = uv.get_blts_inds((24, 20))
+    np.testing.assert_array_equal(inds, inds2)
+
+
 def test_get_times():
     # Test function for easy access to times, to work in conjunction with get_data
     uv = UVData()

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1963,7 +1963,7 @@ def test_antpair2ind():
     nt.assert_raises(ValueError, uv.antpair2ind, 1)
     nt.assert_raises(ValueError, uv.antpair2ind, 'bar', 'foo')
     nt.assert_raises(ValueError, uv.antpair2ind, 0, 1, 'foo')
-    
+
 
 def test_get_times():
     # Test function for easy access to times, to work in conjunction with get_data

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1949,7 +1949,6 @@ def test_antpair2ind():
     np.testing.assert_array_equal(inds, inds2)
 
     # ordered = True is already tested by _key2inds testing
-    
 
 def test_get_times():
     # Test function for easy access to times, to work in conjunction with get_data

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1949,6 +1949,7 @@ def test_get_nsamples():
     d = uv.get_nsamples(pol)
     nt.assert_true(np.all(dcheck == d))
 
+
 def test_get_blt_inds():
     # Test for baseline-time axis indexer
     uv = UVData()
@@ -1965,6 +1966,7 @@ def test_get_blt_inds():
     # conjugate (and use key rather than arg expansion)
     inds2 = uv.get_blt_inds((24, 20))
     np.testing.assert_array_equal(inds, inds2)
+
 
 def test_get_times():
     # Test function for easy access to times, to work in conjunction with get_data

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1935,20 +1935,29 @@ def test_antpair2ind():
     # Test for baseline-time axis indexer
     uv = UVData()
     testfile = os.path.join(
-        DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+        DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
+    uvtest.checkWarnings(uv.read_miriad, [testfile],
+                         message='Altitude is not present in Miriad file')
 
     # get indices
-    inds = uv.antpair2ind(20, 24, ordered=False)
-    np.testing.assert_array_equal(inds, np.array([71, 271, 424, 577, 713, 883, 1036, 1189, 1342]))
+    inds = uv.antpair2ind(0, 1, ordered=False)
+    np.testing.assert_array_equal(inds, np.array([1, 22, 43, 64, 85, 106, 127, 148, 169,
+                                                  190, 211, 232, 253, 274, 295, 316,
+                                                  337, 358, 379]))
     nt.assert_true(inds.dtype == np.int)
 
     # conjugate (and use key rather than arg expansion)
-    inds2 = uv.antpair2ind((24, 20), ordered=False)
+    inds2 = uv.antpair2ind((1, 0), ordered=False)
     np.testing.assert_array_equal(inds, inds2)
 
-    # ordered = True is already tested by _key2inds testing
+    # test ordered
+    inds3 = uv.antpair2ind(1, 0, ordered=True)
+    np.testing.assert_array_equal(inds, inds2)
+
+    # test autos w/ and w/o ordered
+    inds4 = uv.antpair2ind(0, 0, ordered=True)
+    inds5 = uv.antpair2ind(0, 0, ordered=False)
+    np.testing.assert_array_equal(inds4, inds5)
 
 
 def test_get_times():

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1959,6 +1959,11 @@ def test_antpair2ind():
     inds5 = uv.antpair2ind(0, 0, ordered=False)
     np.testing.assert_array_equal(inds4, inds5)
 
+    # test exceptions
+    nt.assert_raises(ValueError, uv.antpair2ind, 1)
+    nt.assert_raises(ValueError, uv.antpair2ind, 'bar', 'foo')
+    nt.assert_raises(ValueError, uv.antpair2ind, 0, 1, 'foo')
+    
 
 def test_get_times():
     # Test function for easy access to times, to work in conjunction with get_data

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1950,6 +1950,7 @@ def test_antpair2ind():
 
     # ordered = True is already tested by _key2inds testing
 
+
 def test_get_times():
     # Test function for easy access to times, to work in conjunction with get_data
     uv = UVData()

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1576,6 +1576,25 @@ def test_break_add():
     nt.assert_raises(ValueError, uv1.__iadd__, uv2)
 
 
+def test_antpair2ind():
+    # testing function for the antpair2ind method
+    # most of this is tested indirectly by key2inds
+    # so this just catches what is left-over
+    uv = UVData()
+    testfile = os.path.join(
+        DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+
+    # test antpair2ind and _antpair2ind agree
+    # TODO: Get rid of this test when antpair2ind is
+    # is deprecated for _antpair2ind
+    inds1 = uvtest.checkWarnings(uv.antpair2ind, [20, 21],
+                                 message="UVData.antpair2ind will soon be moved")
+    inds2 = uv._antpair2ind(20, 21)
+    np.testing.assert_array_equal(inds1, inds2)
+
+
 def test_key2inds():
     # Test function to interpret key as antpair, pol
     uv = UVData()
@@ -1930,8 +1949,7 @@ def test_get_nsamples():
     d = uv.get_nsamples(pol)
     nt.assert_true(np.all(dcheck == d))
 
-
-def test_get_blts_inds():
+def test_get_blt_inds():
     # Test for baseline-time axis indexer
     uv = UVData()
     testfile = os.path.join(
@@ -1940,14 +1958,13 @@ def test_get_blts_inds():
                          message='Telescope EVLA is not')
 
     # get indices
-    inds = uv.get_blts_inds((20, 24))
+    inds = uv.get_blt_inds(20, 24)
     np.testing.assert_array_equal(inds, np.array([71, 271, 424, 577, 713, 883, 1036, 1189, 1342]))
     nt.assert_true(inds.dtype == np.int)
 
-    # conjugate
-    inds2 = uv.get_blts_inds((24, 20))
+    # conjugate (and use key rather than arg expansion)
+    inds2 = uv.get_blt_inds((24, 20))
     np.testing.assert_array_equal(inds, inds2)
-
 
 def test_get_times():
     # Test function for easy access to times, to work in conjunction with get_data

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1886,6 +1886,7 @@ def test_get_flags():
     # Check conjugation
     d = uv.get_flags(ant2, ant1, pol)
     nt.assert_true(np.all(dcheck == d))
+    nt.assert_equal(d.dtype, np.bool)
 
     # Antpair only
     dcheck = np.squeeze(uv.flag_array[bltind, :, :, :])

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -2537,11 +2537,9 @@ class UVData(UVBase):
                 "antpair2ind must be fed an antpair tuple or expand it as arguments"
             ant2 = ant1[1]
             ant1 = ant1[0]
-        if isinstance(ant1, tuple):
-            assert ant2 is None, \
+        else:
+            assert isinstance(ant1, (int, np.integer)), \
                 "antpair2ind must be fed an antpair tuple or expand it as arguments"
-            ant2 = ant1[1]
-            ant1 = ant1[0]
         assert isinstance(ordered, (bool, np.bool)), "ordered must be a boolean"
 
         # get indices

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -2514,16 +2514,16 @@ class UVData(UVBase):
         else:
             return list(set(''.join(self.get_pols())))
 
-    def antpair2ind(self, ant1, ant2=None, pol=None, ordered=True):
+    def antpair2ind(self, ant1, ant2=None, ordered=True):
         """
-        Given an antenna pair (pol) key, return indices along the baseline-time axis.
+        Given an antenna pair key, return indices along the baseline-time axis.
         This will search for either the key as specified, or the key and its
         conjugate.
 
         Args:
-            ant1, ant2, pol:
-                Either an antenna-pair-pol key, or key expanded as arguments.
-                Example: antpair2ind( (10, 20) ) or antpair2ind(10, 20, 'xx')
+            ant1, ant2:
+                Either an antenna-pair key, or key expanded as arguments.
+                Example: antpair2ind( (10, 20) ) or antpair2ind(10, 20)
             ordered : Boolean, if True, search for antpair as provided, else
                 search for it and it conjugate.
 
@@ -2531,15 +2531,15 @@ class UVData(UVBase):
             inds: int-64 ndarray containing indices of the antpair along the
                 baseline-time axis.
         """
-        # check for expanded antpair-pol, or key
+        # check for expanded antpair or key
         if ant2 is None:
             assert isinstance(ant1, tuple), \
-            "antpair2ind must be fed an antpair tuple or expand it as arguments"
+                "antpair2ind must be fed an antpair tuple or expand it as arguments"
             ant2 = ant1[1]
             ant1 = ant1[0]
         if isinstance(ant1, tuple):
-            assert ant2 is None and pol is None, \
-            "antpair2ind must be fed an antpair tuple or expand it as arguments"
+            assert ant2 is None, \
+                "antpair2ind must be fed an antpair tuple or expand it as arguments"
             ant2 = ant1[1]
             ant1 = ant1[0]
         assert isinstance(ordered, (bool, np.bool)), "ordered must be a boolean"
@@ -2551,7 +2551,7 @@ class UVData(UVBase):
         else:
             ind2 = np.where((self.ant_1_array == ant2) & (self.ant_2_array == ant1))[0]
             inds = np.asarray(np.append(inds, ind2), dtype=np.int64)
-            return inds 
+            return inds
 
     def _key2inds(self, key):
         """

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -2534,13 +2534,13 @@ class UVData(UVBase):
         # check for expanded antpair or key
         if ant2 is None:
             if not isinstance(ant1, tuple):
-                raise ValueError("antpair2ind must be fed an antpair tuple " \
+                raise ValueError("antpair2ind must be fed an antpair tuple "
                                  "or expand it as arguments")
             ant2 = ant1[1]
             ant1 = ant1[0]
         else:
             if not isinstance(ant1, (int, np.integer)):
-                raise ValueError("antpair2ind must be fed an antpair tuple or " \
+                raise ValueError("antpair2ind must be fed an antpair tuple or "
                                  "expand it as arguments")
         if not isinstance(ordered, (bool, np.bool)):
             raise ValueError("ordered must be a boolean")

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -2542,6 +2542,10 @@ class UVData(UVBase):
                 "antpair2ind must be fed an antpair tuple or expand it as arguments"
         assert isinstance(ordered, (bool, np.bool)), "ordered must be a boolean"
 
+        # if getting auto-corr, ordered must be True
+        if ant1 == ant2:
+            ordered = True
+
         # get indices
         inds = np.where((self.ant_1_array == ant1) & (self.ant_2_array == ant2))[0]
         if ordered:

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -2516,10 +2516,16 @@ class UVData(UVBase):
 
     def _antpair2ind(self, ant1, ant2):
         """
-        Get blt indices for given (ordered) antenna pair. See self.get_blts_inds for
+        Get blt indices for given (ordered) antenna pair. See self.get_blt_inds for
         indices given an unordered pair.
         """
         return np.where((self.ant_1_array == ant1) & (self.ant_2_array == ant2))[0]
+
+    def antpair2ind(self, *args):
+        """ Backwards Compatability method, but will soon be deprecated """
+        warnings.warn("UVData.antpair2ind will soon be moved to UVData._antpair2ind.\n"
+                      "Try using UVData.get_blt_inds() as a replacement function.")
+        return self._antpair2ind(*args)
 
     def _key2inds(self, key):
         """
@@ -2625,10 +2631,25 @@ class UVData(UVBase):
             blt_ind2 = np.array([], dtype=np.int64)
         return (blt_ind1, blt_ind2, pol_ind)
 
-    def get_blts_inds(self, key):
+    def get_blt_inds(self, *args):
         """
-        Given an unordered antpair key, return indices along baseline-time axis.
+        Given an unordered antpair key, return indices along the baseline-time axis.
+        'Unordered' means that both the key and its conjugate are searched for and
+        their indices concatenated and returned.
+
+        Args:
+            args: Either an antenna-pair key, or antenna-pair expanded as arguments.
+                Example: get_blt_inds(10, 20) or get_blt_inds( (10, 20) )
+
+        Returns:
+            inds: int-64 ndarray containing indices of the antpair along the
+                baseline-time axis.
         """
+        # check for expanded antpair, or antpair-key
+        if isinstance(args[0], (int, np.integer)):
+            key = args
+        else:
+            key = args[0]
         ind1, ind2, indp = self._key2inds(key)
 
         return np.append(ind1, ind2).astype(np.int64)
@@ -2812,12 +2833,12 @@ class UVData(UVBase):
 
         Args:
             *args: parameters or tuple of parameters defining the key to identify
-                   desired data. See get_blts_inds for formatting.
+                   desired data. See get_blt_inds for formatting.
 
         Returns:
             Numpy array of times corresonding to key.
         """
-        inds = self.get_blts_inds(args)
+        inds = self.get_blt_inds(args)
         return self.time_array[inds]
 
     def antpairpol_iter(self, squeeze='default'):

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -2771,7 +2771,7 @@ class UVData(UVBase):
             Numpy array of flags corresponding to key.
         """
         ind1, ind2, indp = self._key2inds(args)
-        out = self._smart_slicing(self.flag_array, ind1, ind2, indp, **kwargs)
+        out = self._smart_slicing(self.flag_array, ind1, ind2, indp, **kwargs).astype(np.bool)
         return out
 
     def get_nsamples(self, *args, **kwargs):

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -2533,14 +2533,17 @@ class UVData(UVBase):
         """
         # check for expanded antpair or key
         if ant2 is None:
-            assert isinstance(ant1, tuple), \
-                "antpair2ind must be fed an antpair tuple or expand it as arguments"
+            if not isinstance(ant1, tuple):
+                raise ValueError("antpair2ind must be fed an antpair tuple " \
+                                 "or expand it as arguments")
             ant2 = ant1[1]
             ant1 = ant1[0]
         else:
-            assert isinstance(ant1, (int, np.integer)), \
-                "antpair2ind must be fed an antpair tuple or expand it as arguments"
-        assert isinstance(ordered, (bool, np.bool)), "ordered must be a boolean"
+            if not isinstance(ant1, (int, np.integer)):
+                raise ValueError("antpair2ind must be fed an antpair tuple or " \
+                                 "expand it as arguments")
+        if not isinstance(ordered, (bool, np.bool)):
+            raise ValueError("ordered must be a boolean")
 
         # if getting auto-corr, ordered must be True
         if ant1 == ant2:

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -104,7 +104,7 @@ class UVFITS(UVData):
                                  * const.c.to('m/s').value).T
 
         if 'INTTIM' in vis_hdu.data.parnames:
-            self.integration_time = vis_hdu.data.par('INTTIM')
+            self.integration_time = np.asarray(vis_hdu.data.par('INTTIM'), dtype=np.float64)
         else:
             if self.Ntimes > 1:
                 # assume that all integration times in the file are the same


### PR DESCRIPTION
to fix #431.

This also updates a `antpair2ind()` method to `UVData` to do unordered antpair slicing along `blts` axis, such that we can easily get any array of len baseline-time. Ex, in lieu of a `get_integrations` function, we can also just do `uvd.integration_time[uvd.antpair2ind(key, ordered=False)]`.

Also enforces the `integration_time` attribute to be `np.float64` upon read-in from every `read_*` function in `UVData`