### PR TITLE
Check extra metadata in add function

### DIFF
--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1549,6 +1549,7 @@ def test_break_add():
 
     # Wrong class
     uv1 = copy.deepcopy(uv_full)
+    uv1.select(freq_chans=np.arange(0, 32))
     nt.assert_raises(ValueError, uv1.__iadd__, np.zeros(5))
 
     # One phased, one not
@@ -1560,11 +1561,18 @@ def test_break_add():
 
     # Different units
     uv2 = copy.deepcopy(uv_full)
+    uv2.select(freq_chans=np.arange(32, 64))
     uv2.vis_units = "Jy"
     nt.assert_raises(ValueError, uv1.__iadd__, uv2)
 
     # Overlapping data
     uv2 = copy.deepcopy(uv_full)
+    nt.assert_raises(ValueError, uv1.__iadd__, uv2)
+
+    # Different integration_time
+    uv2 = copy.deepcopy(uv_full)
+    uv2.select(freq_chans=np.arange(32, 64))
+    uv2.integration_time *= 2
     nt.assert_raises(ValueError, uv1.__iadd__, uv2)
 
 

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -929,7 +929,7 @@ class UVData(UVBase):
                                  'added to a UVData (or subclass) object')
         other.check(check_extra=check_extra, run_check_acceptability=run_check_acceptability)
 
-        # Check objects are compatible
+        # Define parameters that must be the same to add objects
         # But phase_center should be the same, even if in drift (empty parameters)
         compatibility_params = ['_vis_units', '_channel_width', '_object_name',
                                 '_telescope_name', '_instrument',
@@ -938,11 +938,6 @@ class UVData(UVBase):
                                 '_antenna_numbers', '_antenna_positions',
                                 '_phase_center_ra', '_phase_center_dec',
                                 '_phase_center_epoch']
-        for a in compatibility_params:
-            if getattr(this, a) != getattr(other, a):
-                msg = 'UVParameter ' + \
-                    a[1:] + ' does not match. Cannot combine objects.'
-                raise ValueError(msg)
 
         # Build up history string
         history_update_string = ' Combined data along '
@@ -978,6 +973,9 @@ class UVData(UVBase):
             n_axes += 1
         else:
             bnew_inds, new_blts = ([], [])
+            # add metadata to be checked to compatibility params
+            extra_params = ['_integration_time', '_uvw_array', '_lst_array']
+            compatibility_params.extend(extra_params)
 
         temp = np.nonzero(
             ~np.in1d(other.freq_array[0, :], this.freq_array[0, :]))[0]
@@ -1004,6 +1002,14 @@ class UVData(UVBase):
             n_axes += 1
         else:
             pnew_inds, new_pols = ([], [])
+
+        # Actually check compatibility parameters
+        for a in compatibility_params:
+            if getattr(this, a) != getattr(other, a):
+                msg = 'UVParameter ' + \
+                    a[1:] + ' does not match. Cannot combine objects.'
+                raise ValueError(msg)
+
         # Pad out self to accommodate new data
         if len(bnew_inds) > 0:
             this_blts = np.concatenate((this_blts, new_blts))


### PR DESCRIPTION
This PR ensures that additional metadata is checked if two UVData objects are being added, but not along the blt axis. It was possible for the objects to have different values, and lead to an inconsistent output.

Fixes #433.