### PR TITLE
added utils.parse_polstr function

### DIFF
--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -269,6 +269,13 @@ def test_pol_funcs():
     nt.assert_raises(KeyError, uvutils.polstr2num, 'foo')
     nt.assert_raises(ValueError, uvutils.polstr2num, 1)
     nt.assert_raises(ValueError, uvutils.polnum2str, 7.3)
+    # Check parse
+    nt.assert_equal(uvutils.parse_polstr("xX"), 'xx')
+    nt.assert_equal(uvutils.parse_polstr("XX"), 'xx')
+    nt.assert_equal(uvutils.parse_polstr('i'), 'pI')
+    nt.assert_equal(uvutils.parse_jpolstr('x'), 'Jxx')
+    nt.assert_equal(uvutils.parse_jpolstr('xy'), 'Jxy')
+    nt.assert_equal(uvutils.parse_jpolstr('XY'), 'Jxy')
 
 
 def test_jones_num_funcs():

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -566,6 +566,34 @@ def jnum2str(jnum):
     return out
 
 
+def parse_polstr(polstr):
+    """
+    Parse a polarization string and return in AIPS Memo 117
+    standard. See utils.POL_STR2NUM_DICT for options.
+
+    Args:
+        polstr: polarization string
+
+    Returns:
+        AIPS Memo 117 standard string
+    """
+    return polnum2str(polstr2num(polstr))
+
+
+def parse_jpolstr(jpolstr):
+    """
+    Parse a Jones polarization string and return in AIPS Memo 117
+    standard. See utils.JONES_STR2NUM_DICT for options.
+
+    Args:
+        jpolstr: Jones polarization string
+
+    Returns:
+        AIPS Memo 117 standard string
+    """
+    return jnum2str(jstr2num(jpolstr))
+
+
 def conj_pol(pol):
     """
     Returns the polarization for the conjugate baseline.


### PR DESCRIPTION
A recent change to `pyuvdata` polarization standard broke tests in `hera_qm` because we didn't have a way to converting a polarization string into the `pyuvdata` standard. This adds a function to do that to help in future cases.