### PR TITLE
fix coveralls for parallel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
   - "3.6"
-
+env:
+  global:
+    - COVERALLS_PARALLEL=true
 install:
   # ensure that we have the full tag information available for version.py
   - git fetch --unshallow --tags
@@ -38,3 +40,5 @@ script:
 
 after_success:
     - coveralls
+notifications:
+  webhooks: https://coveralls.io/webhook?repo_token=RsQW8tkbZdo9XYddTrOUPhtrUF74WDa7X


### PR DESCRIPTION
Should improve the accuracy of the coveralls report now that we're building on both python 2 & 3.