### PR TITLE
Redundancies

### DIFF
--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -361,7 +361,6 @@ def test_redundancy_finder():
     """
     uvd = pyuvdata.UVData()
     uvd.read_uvfits(os.path.join(DATA_PATH, 'hera19_8hrs_uncomp_10MHz_000_05.003111-05.033750.uvfits'))
-    #uvd.read_miriad(os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcA'))
     uvd.select(times=uvd.time_array[0])
     uvd.unphase_to_drift()   # uvw_array is now equivalent to baseline
 
@@ -371,7 +370,6 @@ def test_redundancy_finder():
 
     baseline_groups, vec_bin_centers, lens = uvutils.get_baseline_redundancies(uvd.baseline_array, bl_positions, tol=tol)
 
-#    np.savez('redundancies_uvdata.npz', groups=baseline_groups, vectors=vec_bin_centers, lengths=lens)
     for gi, gp in enumerate(baseline_groups):
         for bl in gp:
             bl_ind = np.where(uvd.baseline_array == bl)

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -368,6 +368,7 @@ def test_redundancy_finder():
 
     bl_positions = uvd.uvw_array
 
+    nt.assert_raises(ValueError, uvutils.get_baseline_redundancies, uvd.baseline_array, bl_positions[0:2, 0:1])
     baseline_groups, vec_bin_centers, lens = uvutils.get_baseline_redundancies(uvd.baseline_array, bl_positions, tol=tol)
 
     for gi, gp in enumerate(baseline_groups):

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -355,9 +355,8 @@ def test_deprecated_funcs():
 
 def test_redundancy_finder():
     """
-        Confirm that get_baseline_redundancies returns baselines that have the same length.
-        Should probably check orientation too.
-        Will need a test file that is close to redundant, but not perfectly so.
+        Check that get_baseline_redundancies and get_antenna_redundancies return consistent
+        redundant groups for a test file with the HERA19 layout.
     """
     uvd = pyuvdata.UVData()
     uvd.read_uvfits(os.path.join(DATA_PATH, 'hera19_8hrs_uncomp_10MHz_000_05.003111-05.033750.uvfits'))

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -768,11 +768,11 @@ def get_antenna_redundancies(antenna_numbers, antenna_positions, tol=1.0, includ
     def antnum_to_baseline(ant1, ant2):
         return 2048 * (ant1 + 1) + (ant2 + 1) + 2**16
 
-    for ai in xrange(Nants):
+    for ai in range(Nants):
         maxj = ai
         if include_autos:
             maxj = ai + 1
-        for aj in xrange(maxj):
+        for aj in range(maxj):
             bl_inds.append(antnum_to_baseline(ai, aj))
             bl_vecs.append(antenna_positions[ai] - antenna_positions[aj])
     bl_inds = np.array(bl_inds)

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -684,6 +684,29 @@ def _combine_histories(history1, history2):
     return history1 + add_hist
 
 
+def baseline_to_antnums(baseline, Nants_telescope):
+    """
+    Get the antenna numbers corresponding to a given baseline number.
+
+    Args:
+        baseline: integer baseline number
+        Nant_telescope: integer number of antennas
+
+    Returns:
+        tuple with the two antenna numbers corresponding to the baseline.
+    """
+    if Nants_telescope > 2048:
+        raise Exception('error Nants={Nants}>2048 not '
+                        'supported'.format(Nants=Nants_telescope))
+    if np.min(baseline) > 2**16:
+        ant2 = (baseline - 2**16) % 2048 - 1
+        ant1 = (baseline - 2**16 - (ant2 + 1)) / 2048 - 1
+    else:
+        ant2 = (baseline) % 256 - 1
+        ant1 = (baseline - (ant2 + 1)) / 256 - 1
+    return np.int32(ant1), np.int32(ant2)
+
+
 def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False):
     """
     Get the baseline number corresponding to two given antenna numbers.
@@ -691,6 +714,7 @@ def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False):
     Args:
         ant1: first antenna number (integer)
         ant2: second antenna number (integer)
+        Nant_telescope: integer number of antennas
         attempt256: Option to try to use the older 256 standard used in
             many uvfits files (will use 2048 standard if there are more
             than 256 antennas). Default is False.

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -704,9 +704,9 @@ def get_baseline_redundancies(baseline_inds, baseline_vecs, tol=1.0):
     if not baseline_vecs.shape == (Nbls, 3):
         raise ValueError("Baseline vectors must be shape (Nbls, 3)")
 
-    # This works by finding pairs within the tolerance distance, then identifying cliques in the graph
+    # For each baseline, list all others that are within the tolerance distance.
 
-    adj = {}
+    adj = {}   # Adjacency list
 
     for bi, bv0 in enumerate(baseline_vecs):
         key0 = baseline_inds[bi]
@@ -717,8 +717,11 @@ def get_baseline_redundancies(baseline_inds, baseline_vecs, tol=1.0):
                 key1 = baseline_inds[bj]
                 adj[key0].append(key1)
 
+    # The adjacency list defines a set of graph edges.
+    # For each baseline b0, loop over its adjacency list ai \in adj[b0]
+    #   If adj[b0] is a subset of adj[ai], then ai is in a redundant group with b0
+
     bl_gps = []
-    used = []
     for k in adj.keys():
         a0 = adj[k] + [k, ]
         group = [k]
@@ -728,7 +731,8 @@ def get_baseline_redundancies(baseline_inds, baseline_vecs, tol=1.0):
         group.sort()
         bl_gps.append(group)
 
-    bl_gps = np.unique(bl_gps)      # Permutations end up in here.
+    # We end up with multiple copies of each redundant group, so remove duplicates
+    bl_gps = np.unique(bl_gps)
 
     N_unique = len(bl_gps)
     vec_bin_centers = np.zeros((N_unique, 3))

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1135,7 +1135,6 @@ class UVData(UVBase):
 
     def _select_preprocess(self, antenna_nums, antenna_names, ant_str, bls,
                            frequencies, freq_chans, times, polarizations, blt_inds):
-
         """
         Internal function to build up blt_inds, freq_inds, pol_inds
         and history_update_string for select.

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -484,16 +484,7 @@ class UVData(UVBase):
         Returns:
             tuple with the two antenna numbers corresponding to the baseline.
         """
-        if self.Nants_telescope > 2048:
-            raise Exception('error Nants={Nants}>2048 not '
-                            'supported'.format(Nants=self.Nants_telescope))
-        if np.min(baseline) > 2**16:
-            ant2 = (baseline - 2**16) % 2048 - 1
-            ant1 = (baseline - 2**16 - (ant2 + 1)) / 2048 - 1
-        else:
-            ant2 = (baseline) % 256 - 1
-            ant1 = (baseline - (ant2 + 1)) / 256 - 1
-        return np.int32(ant1), np.int32(ant2)
+        return uvutils.baseline_to_antnums(baseline, self.Nants_telescope)
 
     def antnums_to_baseline(self, ant1, ant2, attempt256=False):
         """

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -509,28 +509,7 @@ class UVData(UVBase):
         Returns:
             integer baseline number corresponding to the two antenna numbers.
         """
-        ant1, ant2 = np.int64((ant1, ant2))
-        if self.Nants_telescope is not None and self.Nants_telescope > 2048:
-            raise Exception('cannot convert ant1, ant2 to a baseline index '
-                            'with Nants={Nants}>2048.'
-                            .format(Nants=self.Nants_telescope))
-        if attempt256:
-            if (np.max(ant1) < 255 and np.max(ant2) < 255):
-                return 256 * (ant1 + 1) + (ant2 + 1)
-            else:
-                print('Max antnums are {} and {}'.format(
-                    np.max(ant1), np.max(ant2)))
-                message = 'antnums_to_baseline: found > 256 antennas, using ' \
-                          '2048 baseline indexing. Beware compatibility ' \
-                          'with CASA etc'
-                warnings.warn(message)
-
-        baseline = 2048 * (ant1 + 1) + (ant2 + 1) + 2**16
-
-        if isinstance(baseline, np.ndarray):
-            return np.asarray(baseline, dtype=np.int64)
-        else:
-            return np.int64(baseline)
+        return uvutils.antnums_to_baseline(ant1, ant2, self.Nants_telescope, attempt256=attempt256)
 
     def order_pols(self, order='AIPS'):
         '''


### PR DESCRIPTION
Adds functions for finding redundant baselines within a specified tolerance. I decided to write a new method instead of adding hera_cal as a dependency, but I've compared the results of this with those of `hera_cal.redcal.get_pos_reds`, and with some careful adjustment they match. There is a key difference between the redundancy conventions that should be considered before merging.

- `get_pos_reds` finds redundant *antenna pairs* under the condition that u>0, v>0 (if u=0), or w>0 (if u=v=0. Thus, none of the redundant groups have a mean `uvw` with negative `u`, etc. However, this means that some of the antenna pairs have `ant_1 < ant_2` and so `uvd.antnums_to_baseline(ant_1, ant_2)` will not be present in the baseline_array.
- `get_baseline_redundancies` finds redundant baselines through their uvw coordinates in the file. This ensures that ant_1> ant_2 for all baselines found, but allows for negative u, v, and w coordinates. It will find more redundant groups but have fewer baselines in each.

I'd argue that for my purposes the second convention is more useful, because I'm interested in simply selecting one baseline from each redundant group, using the uvdata object in a simulation, and then copying over the calculated visibility across redundant baselines. The first method would require keeping track of which baselines have to be flipped within each group... but I'd like to hear what other uses this will have. I could probably revise `get_baseline_redundancies` to optionally return antenna pairs in the same scheme as `get_pos_reds`.

This does not completely fix Issue 417, but it's a start.
