### PR TITLE
Fix import structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - option to save splines for reuse in UVBeam.interp function
 
+### Changed
+- changed top-level import structure to exclude file-specific and base classes
+
 ### Deprecated
 - Support for UVData objects without antenna_positions. Antenna positions will be required in a future version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 - option to save splines for reuse in UVBeam.interp function
 
 ### Changed
-- changed top-level import structure to exclude file-specific and base classes
+- changed top-level import structure to exclude file-specific class (e.g. `UVFITS`, `CALFITS`) and base classes (`UVBase`, `UVParameter`) and to not import utility functions into the top-level namespace
 
 ### Deprecated
 - Support for UVData objects without antenna_positions. Antenna positions will be required in a future version.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -36,7 +36,8 @@ b) uvfits -> miriad
 ::
 
   >>> from pyuvdata import UVData
-  >>> import shutil, os
+  >>> import shutil
+  >>> import os
   >>> UV = UVData()
   >>> uvfits_file = 'pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.uvfits'
 
@@ -78,7 +79,8 @@ d) FHD -> miriad
 ::
 
   >>> from pyuvdata import UVData
-  >>> import shutil, os
+  >>> import shutil
+  >>> import os
   >>> UV = UVData()
   >>> fhd_prefix = 'pyuvdata/data/fhd_vis_data/1061316296_'
 
@@ -98,11 +100,12 @@ e) CASA -> uvfits
 ::
 
   >>> from pyuvdata import UVData
-  >>> UV=UVData()
+  >>> UV = UVData()
   >>> ms_file = 'pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.ms'
 
   # Use either the file type specific read_ms or the generic read function,
   # optionally specify the file type
+  # note that reading CASA measurement sets requires casacore to be installed
   >>> UV.read_ms(ms_file)
   Successful readonly open of default-locked table pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.ms/SPECTRAL_WINDOW: 14 columns, 1 rows
   Successful readonly open of default-locked table pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.ms: 23 columns, 1360 rows
@@ -120,9 +123,12 @@ f) CASA -> miriad
 ::
 
   >>> from pyuvdata import UVData
-  >>> import shutil, os
+  >>> import shutil
+  >>> import os
   >>> UV=UVData()
   >>> ms_file = 'pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.ms'
+
+  # note that reading CASA measurement sets requires casacore to be installed
   >>> UV.read(ms_file)
   Successful readonly open of default-locked table pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.ms/SPECTRAL_WINDOW: 14 columns, 1 rows
   Successful readonly open of default-locked table pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.ms: 23 columns, 1360 rows
@@ -149,7 +155,8 @@ g) miriad -> uvh5
   >>> miriad_file = 'pyuvdata/data/new.uvA'
   >>> UV.read(miriad_file)
 
-  # Write out the uvfits file
+  # Write out the uvh5 file
+  # note that writing uvh5 files requires h5py to be installed
   >>> UV.write_uvh5('tutorial.uvh5')
 
 h) uvfits -> uvh5
@@ -162,7 +169,8 @@ h) uvfits -> uvh5
    >>> uvfits_file = 'pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.uvfits'
    >>> UV.read(uvfits_file)
 
-   # Write out the UVH5 file
+   # Write out the uvh5 file
+   # note that writing uvh5 files requires h5py to be installed
    >>> write_file = 'tutorial.uvh5'
    >>> if os.path.exists(write_file):
    ...    os.remove(write_file)
@@ -342,12 +350,13 @@ a) Getting antenna positions in topocentric frame in units of meters
 ::
 
   # directly from UVData object
+  >>> from pyuvdata import UVData
   >>> uvd = UVData()
   >>> uvd.read('pyuvdata/data/new.uvA')
   >>> antpos, ants = uvd.get_ENU_antpos()
 
-  # using uvutils
-  >>> from pyuvdata import uvutils, UVData
+  # using utils
+  >>> from pyuvdata import utils
   >>> uvd = UVData()
   >>> uvd.read('pyuvdata/data/new.uvA')
 
@@ -355,7 +364,7 @@ a) Getting antenna positions in topocentric frame in units of meters
   >>> antpos = uvd.antenna_positions + uvd.telescope_location
 
   # convert to topocentric (East, North, Up or ENU) coords.
-  >>> antpos = uvutils.ENU_from_ECEF(antpos, *uvd.telescope_location_lat_lon_alt)
+  >>> antpos = utils.ENU_from_ECEF(antpos, *uvd.telescope_location_lat_lon_alt)
 
 UVData: Selecting data
 -----------------------
@@ -780,7 +789,7 @@ done after the read, which does not save memory.
 
 UVData: Finding Redundant Baselines
 -----------------------------------
-uvutils contains functions for finding redundant groups of baselines in an array, either by antenna positions or uvw coordinates. Baselines are considered redundant if they are within a specified tolerance distance (default is 1 meter).
+pyuvdata.utils contains functions for finding redundant groups of baselines in an array, either by antenna positions or uvw coordinates. Baselines are considered redundant if they are within a specified tolerance distance (default is 1 meter).
 
 The ``get_baseline_redundancies`` function accepts an array of baseline indices and an array of baseline vectors (ie, uvw coordinates) as input, and finds redundancies among the vectors as given. If the ``with_conjugates`` option is selected, it will flip baselines such that ``u > 0``, or ``v > 0 if u = 0``, or ``w > 0 if u = v = 0``. In this case, a list of ``conjugates`` is returned as well, which contains indices for the baselines that were flipped for the redundant groups. In either mode of operation, this will only return baseline indices that are in the list passed in.
 
@@ -1138,6 +1147,8 @@ d) Writing a HEALPix beam FITS file
 
   # have to specify which interpolation function to use
   >>> beam.interpolation_function = 'az_za_simple'
+
+  # note that the `to_healpix` method requires healpy to be installed
   >>> beam.to_healpix()
   >>> beam.write_beamfits('tutorial.fits', clobber=True)
 
@@ -1242,7 +1253,7 @@ Generating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beams
 ::
 
   >>> from pyuvdata import UVBeam
-  >>> import pyuvdata.utils as uvutils
+  >>> from pyuvdata import utils as uvutils
   >>> import numpy as np
   >>> import healpy as hp
   >>> beam = UVBeam()
@@ -1268,7 +1279,6 @@ Calculating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beam area and beam squared ar
 
   >>> from pyuvdata import UVBeam
   >>> import numpy as np
-  >>> import healpy as hp
   >>> beam = UVBeam()
   >>> filenames = ['pyuvdata/data/HERA_NicCST_150MHz.txt', 'pyuvdata/data/HERA_NicCST_123MHz.txt']
   >>> beam.read_cst_beam(filenames, beam_type='efield', telescope_name='HERA',
@@ -1276,6 +1286,8 @@ Calculating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beam area and beam squared ar
   ...                    model_name='E-field pattern - Rigging height 4.9m',
   ...                    model_version='1.0')
   >>> beam.interpolation_function = 'az_za_simple'
+
+  # note that the `to_healpix` method requires healpy to be installed
   >>> pstokes_beam = beam.to_healpix(inplace=False)
   >>> pstokes_beam.efield_to_pstokes()
   >>> pstokes_beam.peak_normalize()

--- a/pyuvdata/__init__.py
+++ b/pyuvdata/__init__.py
@@ -11,7 +11,6 @@ from .uvdata import *
 from .telescopes import *
 from .uvcal import *
 from .uvbeam import *
-from .utils import *  # consider removing this import
 from . import version
 
 __version__ = version.version

--- a/pyuvdata/__init__.py
+++ b/pyuvdata/__init__.py
@@ -11,7 +11,7 @@ from .uvdata import *
 from .telescopes import *
 from .uvcal import *
 from .uvbeam import *
-from .utils import *
+from .utils import *  # consider removing this import
 from . import version
 
 __version__ = version.version

--- a/pyuvdata/__init__.py
+++ b/pyuvdata/__init__.py
@@ -7,18 +7,11 @@
 """
 from __future__ import absolute_import, division, print_function
 
-from .uvbase import *
-from .parameter import *
 from .uvdata import *
-from .utils import *
 from .telescopes import *
-from .uvfits import *
-from .fhd import *
-from .miriad import *
 from .uvcal import *
-from .calfits import *
 from .uvbeam import *
-from .uvh5 import *
+from .utils import *
 from . import version
 
 __version__ = version.version

--- a/pyuvdata/beamfits.py
+++ b/pyuvdata/beamfits.py
@@ -8,10 +8,11 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
+import warnings
 import astropy
 from astropy.io import fits
-import warnings
-from .uvbeam import UVBeam
+
+from . import UVBeam
 from . import utils as uvutils
 
 hpx_primary_ax_nums = {'pixel': 1, 'freq': 2, 'feed_pol': 3, 'spw': 4,

--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -4,11 +4,12 @@
 
 from __future__ import absolute_import, division, print_function
 
-import astropy
-from astropy.io import fits
 import numpy as np
 import warnings
-from .uvcal import UVCal
+import astropy
+from astropy.io import fits
+
+from . import UVCal
 from . import utils as uvutils
 
 

--- a/pyuvdata/cst_beam.py
+++ b/pyuvdata/cst_beam.py
@@ -9,7 +9,8 @@ import sys
 import re
 import numpy as np
 import warnings
-from .uvbeam import UVBeam
+
+from . import UVBeam
 from . import utils as uvutils
 
 

--- a/pyuvdata/fhd.py
+++ b/pyuvdata/fhd.py
@@ -7,12 +7,13 @@
 """
 from __future__ import absolute_import, division, print_function
 
-from astropy import constants as const
-from scipy.io.idl import readsav
 from itertools import islice
 import numpy as np
 import warnings
-from .uvdata import UVData
+from scipy.io.idl import readsav
+from astropy import constants as const
+
+from . import UVData
 from . import utils as uvutils
 from . import telescopes as uvtel
 

--- a/pyuvdata/fhd_cal.py
+++ b/pyuvdata/fhd_cal.py
@@ -4,12 +4,13 @@
 
 from __future__ import absolute_import, division, print_function
 
-from scipy.io.idl import readsav
 import os
 import numpy as np
 import six
 import warnings
-from .uvcal import UVCal
+from scipy.io.idl import readsav
+
+from . import UVCal
 from . import utils as uvutils
 from .fhd import get_fhd_history
 

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -7,18 +7,19 @@
 """
 from __future__ import absolute_import, division, print_function
 
-from astropy import constants as const
-from astropy.coordinates import Angle, SkyCoord
 import os
 import shutil
 import numpy as np
 import copy
+import itertools
 import six
 import warnings
-from .uvdata import UVData
+from astropy import constants as const
+from astropy.coordinates import Angle, SkyCoord
+
+from . import UVData
 from . import telescopes as uvtel
 from . import utils as uvutils
-import itertools
 
 from . import aipy_extracts
 

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import six
+
 from . import utils
 
 

--- a/pyuvdata/telescopes.py
+++ b/pyuvdata/telescopes.py
@@ -18,6 +18,7 @@ __all__ = [
 
 import numpy as np
 from astropy.coordinates import Angle
+
 from . import uvbase
 from . import parameter as uvp
 

--- a/pyuvdata/tests/test_aipy_extracts.py
+++ b/pyuvdata/tests/test_aipy_extracts.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, division, print_function
 import os
 import shutil
 import nose.tools as nt
+
 from .. import aipy_extracts as ae
 from ..data import DATA_PATH
 

--- a/pyuvdata/tests/test_calfits.py
+++ b/pyuvdata/tests/test_calfits.py
@@ -9,13 +9,14 @@ from __future__ import absolute_import, division, print_function
 
 import nose.tools as nt
 import os
+import numpy as np
 import astropy
 from astropy.io import fits
-from pyuvdata.uvcal import UVCal
+
+from pyuvdata import UVCal
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH
 import pyuvdata.utils as uvutils
-import numpy as np
 
 
 def test_readwriteread():

--- a/pyuvdata/tests/test_cst_beam.py
+++ b/pyuvdata/tests/test_cst_beam.py
@@ -8,6 +8,7 @@ import nose.tools as nt
 import os
 import numpy as np
 import copy
+
 from pyuvdata.data import DATA_PATH
 from pyuvdata import UVBeam
 from pyuvdata.cst_beam import CSTBeam

--- a/pyuvdata/tests/test_fhd_cal.py
+++ b/pyuvdata/tests/test_fhd_cal.py
@@ -9,10 +9,11 @@ from __future__ import absolute_import, division, print_function
 
 import nose.tools as nt
 import os
+import numpy as np
+
 from pyuvdata import UVCal
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH
-import numpy as np
 
 # set up FHD file list
 testdir = os.path.join(DATA_PATH, 'fhd_cal_data/')

--- a/pyuvdata/tests/test_ms.py
+++ b/pyuvdata/tests/test_ms.py
@@ -15,7 +15,7 @@ import numpy as np
 from pyuvdata import UVData
 from pyuvdata.data import DATA_PATH
 import pyuvdata.tests as uvtest
-from pyuvdata import UVFITS
+from pyuvdata.uvfits import UVFITS
 
 
 @uvtest.skipIf_no_casa

--- a/pyuvdata/tests/test_parameter.py
+++ b/pyuvdata/tests/test_parameter.py
@@ -6,8 +6,9 @@ from __future__ import absolute_import, division, print_function
 
 import nose.tools as nt
 import numpy as np
+
 from pyuvdata import parameter as uvp
-from pyuvdata import UVBase
+from pyuvdata.uvbase import UVBase
 
 
 def test_class_inequality():

--- a/pyuvdata/tests/test_telescopes.py
+++ b/pyuvdata/tests/test_telescopes.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import nose.tools as nt
+
 import pyuvdata
 
 required_parameters = ['_telescope_name', '_telescope_location']

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -14,6 +14,7 @@ from astropy import units
 from astropy.time import Time
 from astropy.coordinates import SkyCoord, Angle
 from astropy.io import fits
+
 import pyuvdata
 from pyuvdata.data import DATA_PATH
 import pyuvdata.utils as uvutils

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -28,45 +28,45 @@ ref_xyz = (-2562123.42683, 5094215.40141, -2848728.58869)
 
 def test_XYZ_from_LatLonAlt():
     """Test conversion from lat/lon/alt to ECEF xyz with reference values."""
-    out_xyz = pyuvdata.XYZ_from_LatLonAlt(ref_latlonalt[0], ref_latlonalt[1],
-                                          ref_latlonalt[2])
+    out_xyz = uvutils.XYZ_from_LatLonAlt(ref_latlonalt[0], ref_latlonalt[1],
+                                         ref_latlonalt[2])
     # Got reference by forcing http://www.oc.nps.edu/oc2902w/coord/llhxyz.htm
     # to give additional precision.
     nt.assert_true(np.allclose(ref_xyz, out_xyz, rtol=0, atol=1e-3))
 
     # test error checking
-    nt.assert_raises(ValueError, pyuvdata.XYZ_from_LatLonAlt, ref_latlonalt[0],
+    nt.assert_raises(ValueError, uvutils.XYZ_from_LatLonAlt, ref_latlonalt[0],
                      ref_latlonalt[1], np.array([ref_latlonalt[2], ref_latlonalt[2]]))
-    nt.assert_raises(ValueError, pyuvdata.XYZ_from_LatLonAlt, ref_latlonalt[0],
+    nt.assert_raises(ValueError, uvutils.XYZ_from_LatLonAlt, ref_latlonalt[0],
                      np.array([ref_latlonalt[1], ref_latlonalt[1]]), ref_latlonalt[2])
 
 
 def test_LatLonAlt_from_XYZ():
     """Test conversion from ECEF xyz to lat/lon/alt with reference values."""
-    out_latlonalt = pyuvdata.LatLonAlt_from_XYZ(ref_xyz)
+    out_latlonalt = uvutils.LatLonAlt_from_XYZ(ref_xyz)
     # Got reference by forcing http://www.oc.nps.edu/oc2902w/coord/llhxyz.htm
     # to give additional precision.
     nt.assert_true(np.allclose(ref_latlonalt, out_latlonalt, rtol=0, atol=1e-3))
-    nt.assert_raises(ValueError, pyuvdata.LatLonAlt_from_XYZ, ref_latlonalt)
+    nt.assert_raises(ValueError, uvutils.LatLonAlt_from_XYZ, ref_latlonalt)
 
     # test passing multiple values
     xyz_mult = np.stack((np.array(ref_xyz), np.array(ref_xyz)))
-    lat_vec, lon_vec, alt_vec = pyuvdata.LatLonAlt_from_XYZ(xyz_mult)
+    lat_vec, lon_vec, alt_vec = uvutils.LatLonAlt_from_XYZ(xyz_mult)
     nt.assert_true(np.allclose(ref_latlonalt, (lat_vec[1], lon_vec[1], alt_vec[1]), rtol=0, atol=1e-3))
     # check warning if array transposed
-    uvtest.checkWarnings(pyuvdata.LatLonAlt_from_XYZ, [xyz_mult.T],
+    uvtest.checkWarnings(uvutils.LatLonAlt_from_XYZ, [xyz_mult.T],
                          message='The expected shape of ECEF xyz array',
                          category=PendingDeprecationWarning)
     # check warning if  3 x 3 array
     xyz_3 = np.stack((np.array(ref_xyz), np.array(ref_xyz), np.array(ref_xyz)))
-    uvtest.checkWarnings(pyuvdata.LatLonAlt_from_XYZ, [xyz_3],
+    uvtest.checkWarnings(uvutils.LatLonAlt_from_XYZ, [xyz_3],
                          message='The xyz array in LatLonAlt_from_XYZ is',
                          category=PendingDeprecationWarning)
     # check error if only 2 coordinates
-    nt.assert_raises(ValueError, pyuvdata.LatLonAlt_from_XYZ, xyz_mult[:, 0:2])
+    nt.assert_raises(ValueError, uvutils.LatLonAlt_from_XYZ, xyz_mult[:, 0:2])
 
     # test error checking
-    nt.assert_raises(ValueError, pyuvdata.LatLonAlt_from_XYZ, ref_xyz[0:1])
+    nt.assert_raises(ValueError, uvutils.LatLonAlt_from_XYZ, ref_xyz[0:1])
 
 
 def test_ENU_tofrom_ECEF():
@@ -105,53 +105,53 @@ def test_ENU_tofrom_ECEF():
     up = [0.54883333, -0.35004539, -0.50007736, -0.70035299, -0.25148791, 0.33916067,
           -0.02019057, 0.16979185, 0.06945155, -0.64058124]
 
-    xyz = pyuvdata.XYZ_from_LatLonAlt(lats, lons, alts)
+    xyz = uvutils.XYZ_from_LatLonAlt(lats, lons, alts)
     nt.assert_true(np.allclose(np.stack((x, y, z), axis=1), xyz, atol=1e-3))
 
-    enu = pyuvdata.ENU_from_ECEF(xyz, center_lat, center_lon, center_alt)
+    enu = uvutils.ENU_from_ECEF(xyz, center_lat, center_lon, center_alt)
     nt.assert_true(np.allclose(np.stack((east, north, up), axis=1), enu, atol=1e-3))
     # check warning if array transposed
-    uvtest.checkWarnings(pyuvdata.ENU_from_ECEF, [xyz.T, center_lat, center_lon,
-                                                  center_alt],
+    uvtest.checkWarnings(uvutils.ENU_from_ECEF, [xyz.T, center_lat, center_lon,
+                                                 center_alt],
                          message='The expected shape of ECEF xyz array',
                          category=PendingDeprecationWarning)
     # check warning if  3 x 3 array
-    uvtest.checkWarnings(pyuvdata.ENU_from_ECEF, [xyz[0:3], center_lat, center_lon,
-                                                  center_alt],
+    uvtest.checkWarnings(uvutils.ENU_from_ECEF, [xyz[0:3], center_lat, center_lon,
+                                                 center_alt],
                          message='The xyz array in ENU_from_ECEF is',
                          category=PendingDeprecationWarning)
     # check error if only 2 coordinates
-    nt.assert_raises(ValueError, pyuvdata.ENU_from_ECEF, xyz[:, 0:2],
+    nt.assert_raises(ValueError, uvutils.ENU_from_ECEF, xyz[:, 0:2],
                      center_lat, center_lon, center_alt)
 
     # check that a round trip gives the original value.
-    xyz_from_enu = pyuvdata.ECEF_from_ENU(enu, center_lat, center_lon, center_alt)
+    xyz_from_enu = uvutils.ECEF_from_ENU(enu, center_lat, center_lon, center_alt)
     nt.assert_true(np.allclose(xyz, xyz_from_enu, atol=1e-3))
     # check warning if array transposed
-    uvtest.checkWarnings(pyuvdata.ECEF_from_ENU, [enu.T, center_lat, center_lon,
-                                                  center_alt],
+    uvtest.checkWarnings(uvutils.ECEF_from_ENU, [enu.T, center_lat, center_lon,
+                                                 center_alt],
                          message='The expected shape the ENU array',
                          category=PendingDeprecationWarning)
     # check warning if  3 x 3 array
-    uvtest.checkWarnings(pyuvdata.ECEF_from_ENU, [enu[0:3], center_lat, center_lon,
-                                                  center_alt],
+    uvtest.checkWarnings(uvutils.ECEF_from_ENU, [enu[0:3], center_lat, center_lon,
+                                                 center_alt],
                          message='The enu array in ECEF_from_ENU is',
                          category=PendingDeprecationWarning)
     # check error if only 2 coordinates
-    nt.assert_raises(ValueError, pyuvdata.ENU_from_ECEF, enu[:, 0:2], center_lat,
+    nt.assert_raises(ValueError, uvutils.ENU_from_ECEF, enu[:, 0:2], center_lat,
                      center_lon, center_alt)
 
     # check passing a single value
-    enu_single = pyuvdata.ENU_from_ECEF(xyz[0, :], center_lat, center_lon, center_alt)
+    enu_single = uvutils.ENU_from_ECEF(xyz[0, :], center_lat, center_lon, center_alt)
     nt.assert_true(np.allclose(np.array((east[0], north[0], up[0])), enu[0, :], atol=1e-3))
 
-    xyz_from_enu = pyuvdata.ECEF_from_ENU(enu_single, center_lat, center_lon, center_alt)
+    xyz_from_enu = uvutils.ECEF_from_ENU(enu_single, center_lat, center_lon, center_alt)
     nt.assert_true(np.allclose(xyz[0, :], xyz_from_enu, atol=1e-3))
 
     # error checking
-    nt.assert_raises(ValueError, pyuvdata.ENU_from_ECEF, xyz[:, 0:1], center_lat, center_lon, center_alt)
-    nt.assert_raises(ValueError, pyuvdata.ECEF_from_ENU, enu[:, 0:1], center_lat, center_lon, center_alt)
-    nt.assert_raises(ValueError, pyuvdata.ENU_from_ECEF, xyz / 2., center_lat, center_lon, center_alt)
+    nt.assert_raises(ValueError, uvutils.ENU_from_ECEF, xyz[:, 0:1], center_lat, center_lon, center_alt)
+    nt.assert_raises(ValueError, uvutils.ECEF_from_ENU, enu[:, 0:1], center_lat, center_lon, center_alt)
+    nt.assert_raises(ValueError, uvutils.ENU_from_ECEF, xyz / 2., center_lat, center_lon, center_alt)
 
 
 def test_mwa_ecef_conversion():

--- a/pyuvdata/tests/test_uvbase.py
+++ b/pyuvdata/tests/test_uvbase.py
@@ -10,7 +10,8 @@ from __future__ import absolute_import, division, print_function
 import nose.tools as nt
 import numpy as np
 import copy
-from pyuvdata import UVBase
+
+from pyuvdata.uvbase import UVBase
 from pyuvdata import parameter as uvp
 
 

--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -11,7 +11,8 @@ import nose.tools as nt
 import os
 import numpy as np
 import copy
-from pyuvdata.uvcal import UVCal
+
+from pyuvdata import UVCal
 import pyuvdata.utils as uvutils
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -14,6 +14,7 @@ import copy
 import six
 from astropy.time import Time
 from astropy.coordinates import Angle
+
 from pyuvdata import UVData
 import pyuvdata.utils as uvutils
 import pyuvdata.tests as uvtest

--- a/pyuvdata/tests/test_version.py
+++ b/pyuvdata/tests/test_version.py
@@ -11,9 +11,9 @@ import nose.tools as nt
 import sys
 import os
 import six
-from six import StringIO
 import subprocess
 import json
+
 import pyuvdata
 
 
@@ -82,7 +82,7 @@ def test_main():
 
     saved_stdout = sys.stdout
     try:
-        out = StringIO()
+        out = six.StringIO()
         sys.stdout = out
         pyuvdata.version.main()
         output = out.getvalue()

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import warnings
+
 from . import parameter as uvp
 from . import version as uvversion
 

--- a/pyuvdata/uvbeam.py
+++ b/pyuvdata/uvbeam.py
@@ -14,7 +14,7 @@ from scipy import interpolate
 
 from .uvbase import UVBase
 from . import parameter as uvp
-import pyuvdata.utils as uvutils
+from . import utils as uvutils
 
 
 class UVBeam(UVBase):

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 import warnings
 import copy
+
 from .uvbase import UVBase
 from . import parameter as uvp
 from . import utils as uvutils

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -7,21 +7,22 @@
 """
 from __future__ import absolute_import, division, print_function
 
+import os
+import copy
+import collections
+import re
+import numpy as np
+import six
+import warnings
 from astropy import constants as const
 import astropy.units as units
 from astropy.time import Time
 from astropy.coordinates import SkyCoord, EarthLocation, FK5, Angle
-import os
-import numpy as np
-import six
-import warnings
+
 from .uvbase import UVBase
 from . import parameter as uvp
 from . import telescopes as uvtel
 from . import utils as uvutils
-import copy
-import collections
-import re
 
 
 class UVData(UVBase):

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -7,13 +7,14 @@
 """
 from __future__ import absolute_import, division, print_function
 
-from astropy import constants as const
-import astropy
-from astropy.time import Time
-from astropy.io import fits
 import numpy as np
 import warnings
-from .uvdata import UVData
+import astropy
+from astropy import constants as const
+from astropy.time import Time
+from astropy.io import fits
+
+from . import UVData
 from . import parameter as uvp
 from . import utils as uvutils
 

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -10,8 +10,15 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 import os
 import warnings
-from .uvdata import UVData
+
+from . import UVData
 from . import utils as uvutils
+
+try:
+    import h5py
+except ImportError:  # pragma: no cover
+    uvutils._reraise_context('h5py is not installed but is required for '
+                             'uvh5 functionality')
 
 
 class UVH5(UVData):
@@ -311,12 +318,6 @@ class UVH5(UVData):
         Returns:
             None
         """
-        try:
-            import h5py
-        except ImportError:  # pragma: no cover
-            uvutils._reraise_context('h5py is not installed but is required for '
-                                     'uvh5 functionality')
-
         if not os.path.exists(filename):
             raise IOError(filename + ' not found')
 
@@ -456,12 +457,6 @@ class UVH5(UVData):
             on the system in a way that h5py can find it, no action needs to be taken to _read_ a
             data_array encoded with bitshuffle (or an error will be raised).
         """
-        try:
-            import h5py
-        except ImportError:  # pragma: no cover
-            uvutils._reraise_context('h5py is not installed but is required for '
-                                     'uvh5 functionality')
-
         if run_check:
             self.check(check_extra=check_extra,
                        run_check_acceptability=run_check_acceptability)
@@ -539,12 +534,6 @@ class UVH5(UVData):
             on the system in a way that h5py can find it, no action needs to be taken to _read_ a
             data_array encoded with bitshuffle (or an error will be raised).
         """
-        try:
-            import h5py
-        except ImportError:  # pragma: no cover
-            uvutils._reraise_context('h5py is not installed but is required for '
-                                     'uvh5 functionality')
-
         if os.path.exists(filename):
             if clobber:
                 print("File exists; clobbering")
@@ -596,12 +585,6 @@ class UVH5(UVData):
             on disk to compare with the object in memory. Note that this adds some small
             memory overhead, but this amount is typically much smaller than the size of the data.
         """
-        try:
-            import h5py
-        except ImportError:  # pragma: no cover
-            uvutils._reraise_context('h5py is not installed but is required for '
-                                     'uvh5 functionality')
-
         uvd_file = UVH5()
         with h5py.File(filename, 'r') as f:
             header = f['/Header']
@@ -702,12 +685,6 @@ class UVH5(UVData):
             that the object's metadata in-memory matches the header on-disk. See the tutorial for a
             worked example.
         """
-        try:
-            import h5py
-        except ImportError:  # pragma: no cover
-            uvutils._reraise_context('h5py is not installed but is required for '
-                                     'uvh5 functionality')
-
         # check that the file already exists
         if not os.path.exists(filename):
             raise AssertionError("{0} does not exists; please first initialize it with initialize_uvh5_file".format(


### PR DESCRIPTION
Remove file-specific and base objects from top-level imports. This nudges users into using the appropriate objects and makes isolating imports of optional packages easier.
This also removes the utils import at the top level, reflecting current usage.

This could be a breaking change if users are importing these objects or functions from the top-level namespace, so requires significant coordination with users before merging.