### PR TITLE
Enable efield_to_pstokes when in az_za coordinates

### DIFF
--- a/pyuvdata/tests/test_uvbeam.py
+++ b/pyuvdata/tests/test_uvbeam.py
@@ -211,16 +211,15 @@ def test_efield_to_pstokes():
     pstokes_beam_2 = copy.deepcopy(efield_beam)
     pstokes_beam_2.interpolation_function = 'az_za_simple'
     pstokes_beam_2.to_healpix()
+    # convert to pstokes after interpolating
     beam_return = pstokes_beam_2.efield_to_pstokes(inplace=False)
 
     pstokes_beam = copy.deepcopy(efield_beam)
 
+    # interpolate after converting to pstokes
     pstokes_beam.interpolation_function = 'az_za_simple'
     pstokes_beam.efield_to_pstokes()
     pstokes_beam.to_healpix()
-
-    # beam_return = to_healpix() -> efield_to_pstokes()    (interpolation of efield)
-    # pstokes_beam = efield_to_pstokes() -> to_healpix()   (interpolation of pstokes)
 
     pstokes_beam.peak_normalize()
     beam_return.peak_normalize()

--- a/pyuvdata/tests/test_uvbeam.py
+++ b/pyuvdata/tests/test_uvbeam.py
@@ -208,15 +208,28 @@ def test_efield_to_pstokes():
     pstokes_beam.to_healpix()
     pstokes_beam.efield_to_pstokes()
 
+    pstokes_beam_2 = copy.deepcopy(efield_beam)
+    pstokes_beam_2.interpolation_function = 'az_za_simple'
+    pstokes_beam_2.to_healpix()
+    beam_return = pstokes_beam_2.efield_to_pstokes(inplace=False)
+
+#    nt.assert_equal(beam_return, pstokes_beam)
+
     pstokes_beam = copy.deepcopy(efield_beam)
+
     pstokes_beam.interpolation_function = 'az_za_simple'
+    pstokes_beam.efield_to_pstokes()
     pstokes_beam.to_healpix()
-    beam_return = pstokes_beam.efield_to_pstokes(inplace=False)
 
-    pstokes_beam = copy.deepcopy(efield_beam)
-    nt.assert_raises(ValueError, pstokes_beam.efield_to_pstokes)
+    # beam_return = to_healpix() -> efield_to_pstokes()    (interpolation of efield)
+    # pstokes_beam = efield_to_pstokes() -> to_healpix()   (interpolation of pstokes)
 
-    pstokes_beam = copy.deepcopy(efield_beam)
+    pstokes_beam.peak_normalize()
+    beam_return.peak_normalize()
+
+    # NOTE:  So far, the following doesn't hold unless the beams are peak_normalized again.
+    #        This seems to be the fault of interpolation
+    nt.assert_true(np.allclose(pstokes_beam.data_array, beam_return.data_array, atol=1e-2))
 
     power_beam = UVBeam()
     power_beam.read_cst_beam(cst_files, beam_type='power', frequency=[150e6, 123e6],

--- a/pyuvdata/tests/test_uvbeam.py
+++ b/pyuvdata/tests/test_uvbeam.py
@@ -213,8 +213,6 @@ def test_efield_to_pstokes():
     pstokes_beam_2.to_healpix()
     beam_return = pstokes_beam_2.efield_to_pstokes(inplace=False)
 
-#    nt.assert_equal(beam_return, pstokes_beam)
-
     pstokes_beam = copy.deepcopy(efield_beam)
 
     pstokes_beam.interpolation_function = 'az_za_simple'
@@ -237,8 +235,6 @@ def test_efield_to_pstokes():
                              feed_version='0.1', feed_pol=['x'],
                              model_name='E-field pattern - Rigging height 4.9m',
                              model_version='1.0')
-    nt.assert_raises(ValueError, power_beam.efield_to_pstokes)
-
     nt.assert_raises(ValueError, power_beam.efield_to_pstokes)
 
 
@@ -1533,8 +1529,6 @@ def test_healpix():
                               feed_version='0.1',
                               model_name='E-field pattern - Rigging height 4.9m',
                               model_version='1.0')
-
-    nt.assert_raises(ValueError, efield_beam.efield_to_pstokes, 'pI')
 
     efield_beam.interpolation_function = 'az_za_simple'
     efield_beam.to_healpix()

--- a/pyuvdata/uvbeam.py
+++ b/pyuvdata/uvbeam.py
@@ -569,7 +569,6 @@ class UVBeam(UVBase):
 
         efield_data = beam_object.data_array
         _sh = beam_object.data_array.shape
-        efield_data = beam_object.data_array
         Nfreqs = beam_object.Nfreqs
 
         if self.pixel_coordinate_system != 'healpix':


### PR DESCRIPTION
Some minor changes that enable efield beams to be converted to pstokes while still in az/za coordinates. I'm leaving this as "work in progress" because my unit test shows some substantial discrepancy between two different paths:
az_za efield -> pstokes -> healpix
az_za_efield -> healpix -> pstokes

The healpix interpolation is done in power for the first path and in e-field components for the second, so it's not all that surprising that they're different. If I peak_normalize the results of both, I can get them to match at a tolerance of 0.01.