### PR TITLE
Make string handling more precise for uvh5 files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda install -c anaconda -y 'libgfortran-ng =7.2.0'
+  - conda install -c defaults -y 'libgfortran =3.0.0' 'libgfortran-ng =7.2.0'
   - conda config --remove channels defaults && conda config --add channels conda-forge
   - conda update -q conda
   # Useful for debugging any issues with conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda install -c anaconda -y 'libgfortran =3.0.0' 'libgfortran-ng =7.2.0'
+  - conda install -c anaconda -y 'libgfortran-ng =7.2.0'
   - conda config --remove channels defaults && conda config --add channels conda-forge
   - conda update -q conda
   # Useful for debugging any issues with conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
   - conda install -c defaults -y 'libgfortran =3.0.0' 'libgfortran-ng =7.2.0'
   - conda config --remove channels defaults && conda config --add channels conda-forge
-  - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - option to save splines for reuse in UVBeam.interp function
 
 ### Changed
+- improve string handling for uvh5 files
 - changed top-level import structure to exclude file-specific class (e.g. `UVFITS`, `CALFITS`) and base classes (`UVBase`, `UVParameter`) and to not import utility functions into the top-level namespace
 
 ### Deprecated

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, division, print_function
 import os
 import nose.tools as nt
 import numpy as np
+import six
 from astropy import units
 from astropy.time import Time
 from astropy.coordinates import SkyCoord, Angle
@@ -466,3 +467,19 @@ def test_reraise_context():
             uvutils._reraise_context('Add some info')
     ex = cm.exception
     nt.assert_equal(ex.args[1], 'Add some info: some bad problem')
+
+
+def test_str_to_bytes():
+    test_str = 'HERA'
+    test_bytes = uvutils._str_to_bytes(test_str)
+    nt.assert_equal(type(test_bytes), six.binary_type)
+    nt.assert_equal(test_bytes, b'\x48\x45\x52\x41')
+    return
+
+
+def test_bytes_to_str():
+    test_bytes = b'\x48\x45\x52\x41'
+    test_str = uvutils._bytes_to_str(test_bytes)
+    nt.assert_equal(type(test_str), str)
+    nt.assert_equal(test_str, 'HERA')
+    return

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -40,7 +40,11 @@ def _read_uvh5_string(dataset, filename):
     if dataset.dtype.type is np.object_:
         warnings.warn("Strings in metadata of {file} are not the correct type; rewrite with "
                       "write_uvh5 to ensure future compatibility".format(file=filename))
-        return uvutils._bytes_to_str(dataset.value)
+        try:
+            return uvutils._bytes_to_str(dataset.value)
+        except AttributeError:
+            # dataset.value is already <str> type, and doesn't need to be decoded
+            return dataset.value
     else:
         return uvutils._bytes_to_str(dataset.value.tostring())
 

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -451,7 +451,7 @@ class UVH5(UVData):
         if self.extra_keywords:
             extra_keywords = header.create_group("extra_keywords")
             for k in self.extra_keywords.keys():
-                if isinstance(self.extra_keywords[k], six.text_type):
+                if isinstance(self.extra_keywords[k], str):
                     extra_keywords[k] = np.string_(self.extra_keywords[k])
                 else:
                     extra_keywords[k] = self.extra_keywords[k]

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -186,7 +186,7 @@ class UVH5(UVData):
         if "extra_keywords" in header:
             self.extra_keywords = {}
             for key in header["extra_keywords"].keys():
-                if header["extra_keywords"][key].dtype.type is np.string_:
+                if header["extra_keywords"][key].dtype.type in (np.string_, np.object_):
                     self.extra_keywords[key] = _read_uvh5_string(header["extra_keywords"][key], filename)
                 else:
                     self.extra_keywords[key] = header["extra_keywords"][key].value


### PR DESCRIPTION
This PR fixes the way strings are handled in I/O for uvh5 files. See http://docs.h5py.org/en/latest/strings.html for full details. The summary is that when writing to HDF5, strings are explicitly cast to `np.string_` objects, and when reading back again, the `pyuvdata.utils._bytes_to_str()` function is called. New tests pass locally, ~~and the change seems to be backwards compatible with old uvh5 files (written with python2, I'm not sure if the python version makes a difference).~~

The changes were no longer backwards compatible with old files, but explicit backwards compatibility has been added, with a warning to the user to rewrite the file if the deprecated style is detected.