### PR TITLE
Fix pol conjugation again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Fixed
-- _key2inds now properly reorders polarization axis for conjugated visibilities. This also effects the get_data function.
+- `_key2inds` now properly reorders polarization axis for conjugated visibilities. This also effects the `get_data` function.
 - long strings are saved correctly in miriad files from python3
 
 ## [1.3.3] - 2018-11-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Fixed
+- _key2inds now properly reorders polarization axis for conjugated visibilities. This also effects the get_data function.
 - long strings are saved correctly in miriad files from python3
 
 ## [1.3.3] - 2018-11-01

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -483,3 +483,24 @@ def test_bytes_to_str():
     nt.assert_equal(type(test_str), str)
     nt.assert_equal(test_str, 'HERA')
     return
+
+
+def test_reorder_conj_pols_non_list():
+    nt.assert_raises(ValueError, uvutils.reorder_conj_pols, 4)
+
+
+def test_reorder_conj_pols_strings():
+    pols = ['xx', 'xy', 'yx']
+    corder = uvutils.reorder_conj_pols(pols)
+    nt.assert_true(np.array_equal(corder, [0, 2, 1]))
+
+
+def test_reorder_conj_pols_ints():
+    pols = [-5, -7, -8]  # 'xx', 'xy', 'yx'
+    corder = uvutils.reorder_conj_pols(pols)
+    nt.assert_true(np.array_equal(corder, [0, 2, 1]))
+
+
+def test_reorder_conj_pols_missing_conj():
+    pols = ['xx', 'xy']  # Missing 'yx'
+    nt.assert_raises(ValueError, uvutils.reorder_conj_pols, pols)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1667,6 +1667,41 @@ def test_key2inds():
     nt.assert_true(np.array_equal(ind2, []))
 
 
+def test_key2inds_conj_all_pols():
+    # Test function to interpret key as antpair, pol
+    uv = UVData()
+    testfile = os.path.join(
+        DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+
+    ant1 = uv.ant_1_array[0]
+    ant2 = uv.ant_2_array[0]
+    bltind = np.where((uv.ant_1_array == ant1) & (uv.ant_2_array == ant2))[0]
+    ind1, ind2, indp = uv._key2inds((ant2, ant1))
+
+    # Pols in data are 'rr', 'll', 'rl', 'lr'
+    # So conjugated order should be [0, 1, 3, 2]
+    nt.assert_true(np.array_equal(bltind, ind2))
+    nt.assert_true(np.array_equal(np.array([]), ind1))
+    nt.assert_true(np.array_equal(np.array([]), indp[0]))
+    nt.assert_true(np.array_equal([0, 1, 3, 2], indp[1]))
+
+
+def test_key2inds_conj_all_pols_missing_data():
+    # Test function to interpret key as antpair, pol
+    uv = UVData()
+    testfile = os.path.join(
+        DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    uv.select(polarizations=['rl'])
+    ant1 = uv.ant_1_array[0]
+    ant2 = uv.ant_2_array[0]
+
+    nt.assert_raises(KeyError, uv._key2inds, (ant2, ant1))
+
+
 def test_smart_slicing():
     # Test function to slice data
     uv = UVData()

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1668,7 +1668,6 @@ def test_key2inds():
 
 
 def test_key2inds_conj_all_pols():
-    # Test function to interpret key as antpair, pol
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
@@ -1688,8 +1687,53 @@ def test_key2inds_conj_all_pols():
     nt.assert_true(np.array_equal([0, 1, 3, 2], indp[1]))
 
 
+def test_key2inds_conj_all_pols_fringe():
+    uv = UVData()
+    testfile = os.path.join(
+        DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+
+    uv.select(polarizations=['rl'])
+    ant1 = uv.ant_1_array[0]
+    ant2 = uv.ant_2_array[0]
+    # Mix one instance of this baseline.
+    uv.ant_1_array[0] = ant2
+    uv.ant_2_array[0] = ant1
+    bltind = np.where((uv.ant_1_array == ant1) & (uv.ant_2_array == ant2))[0]
+    ind1, ind2, indp = uv._key2inds((ant1, ant2))
+
+    nt.assert_true(np.array_equal(bltind, ind1))
+    nt.assert_true(np.array_equal(np.array([]), ind2))
+    nt.assert_true(np.array_equal(np.array([0]), indp[0]))
+    nt.assert_true(np.array_equal(np.array([]), indp[1]))
+
+
+def test_key2inds_conj_all_pols_bl_fringe():
+    uv = UVData()
+    testfile = os.path.join(
+        DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+
+    uv.select(polarizations=['rl'])
+    ant1 = uv.ant_1_array[0]
+    ant2 = uv.ant_2_array[0]
+    # Mix one instance of this baseline.
+    uv.ant_1_array[0] = ant2
+    uv.ant_2_array[0] = ant1
+    uv.baseline_array[0] = uvutils.antnums_to_baseline(ant2, ant1, uv.Nants_telescope)
+    bl = uvutils.antnums_to_baseline(ant1, ant2, uv.Nants_telescope)
+    bltind = np.where((uv.ant_1_array == ant1) & (uv.ant_2_array == ant2))[0]
+    ind1, ind2, indp = uv._key2inds(bl)
+
+    nt.assert_true(np.array_equal(bltind, ind1))
+    nt.assert_true(np.array_equal(np.array([]), ind2))
+    nt.assert_true(np.array_equal(np.array([0]), indp[0]))
+    nt.assert_true(np.array_equal(np.array([]), indp[1]))
+
+
 def test_key2inds_conj_all_pols_missing_data():
-    # Test function to interpret key as antpair, pol
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
@@ -1700,6 +1744,41 @@ def test_key2inds_conj_all_pols_missing_data():
     ant2 = uv.ant_2_array[0]
 
     nt.assert_raises(KeyError, uv._key2inds, (ant2, ant1))
+
+
+def test_key2inds_conj_all_pols_bls():
+    uv = UVData()
+    testfile = os.path.join(
+        DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+
+    ant1 = uv.ant_1_array[0]
+    ant2 = uv.ant_2_array[0]
+    bl = uvutils.antnums_to_baseline(ant2, ant1, uv.Nants_telescope)
+    bltind = np.where((uv.ant_1_array == ant1) & (uv.ant_2_array == ant2))[0]
+    ind1, ind2, indp = uv._key2inds(bl)
+
+    # Pols in data are 'rr', 'll', 'rl', 'lr'
+    # So conjugated order should be [0, 1, 3, 2]
+    nt.assert_true(np.array_equal(bltind, ind2))
+    nt.assert_true(np.array_equal(np.array([]), ind1))
+    nt.assert_true(np.array_equal(np.array([]), indp[0]))
+    nt.assert_true(np.array_equal([0, 1, 3, 2], indp[1]))
+
+
+def test_key2inds_conj_all_pols_missing_data_bls():
+    uv = UVData()
+    testfile = os.path.join(
+        DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    uv.select(polarizations=['rl'])
+    ant1 = uv.ant_1_array[0]
+    ant2 = uv.ant_2_array[0]
+    bl = uvutils.antnums_to_baseline(ant2, ant1, uv.Nants_telescope)
+
+    nt.assert_raises(KeyError, uv._key2inds, bl)
 
 
 def test_smart_slicing():

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -633,6 +633,33 @@ def conj_pol(pol):
     return cpol
 
 
+def reorder_conj_pols(pols):
+    """
+    Reorders a list of pols, swapping pols that are conjugates of one another.
+    For example ('xx', 'xy', 'yx', 'yy') -> ('xx', 'yx', 'xy', 'yy')
+    This is useful for the _key2inds function in the case where an antenna
+    pair is specified but the conjugate pair exists in the data. The conjugated
+    data should be returned in the order of the polarization axis, so after conjugating
+    the data, the pols need to be reordered.
+    For example, if a file contains antpair (0, 1) and pols 'xy' and 'yx', but
+    the user requests antpair (1, 0), they should get:
+    [(1x, 0y), (1y, 0x)] = [conj(0y, 1x), conj(0x, 1y)]
+
+    Args:
+        pols: Polarization array (strings or ints)
+
+    Returns:
+        conj_order: Indices to reorder polarization axis
+    """
+    if not isinstance(pols, collections.Iterable):
+        raise ValueError('reorder_conj_pols must be given an array of polarizations.')
+    cpols = np.array([conj_pol(p) for p in pols])  # Array needed for np.where
+    conj_order = [np.where(cpols == p)[0][0] if p in cpols else -1 for p in pols]
+    if -1 in conj_order:
+        raise ValueError('Not all conjugate pols exist in the polarization array provided.')
+    return conj_order
+
+
 def check_history_version(history, version_string):
     warnings.warn('The check_history_version function is deprecated in favor of '
                   '_check_history_version because it is not API level code', DeprecationWarning)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -2619,6 +2619,7 @@ class UVData(UVBase):
                                            + ' array in data.'.format(bl=key))
                         else:
                             pol_ind2 = np.array([], dtype=np.int64)
+                            blt_ind2 = np.array([], dtype=np.int64)
                 else:
                     pol_ind2 = np.array([], dtype=np.int64)
                 pol_ind = (pol_ind1, pol_ind2)
@@ -2641,6 +2642,7 @@ class UVData(UVBase):
                                        + ' array in data.'.format(bl=key))
                     else:
                         pol_ind2 = np.array([], dtype=np.int64)
+                        blt_ind2 = np.array([], dtype=np.int64)
             else:
                 pol_ind2 = np.array([], dtype=np.int64)
             pol_ind = (pol_ind1, pol_ind2)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -2606,14 +2606,44 @@ class UVData(UVBase):
                 blt_ind2 = np.where(self.baseline_array == inv_bl)[0]
                 if len(blt_ind1) + len(blt_ind2) == 0:
                     raise KeyError('Baseline {bl} not found in data.'.format(bl=key))
-                pol_ind = (np.arange(self.Npols), np.arange(self.Npols))
+                if len(blt_ind1) > 0:
+                    pol_ind1 = np.arange(self.Npols)
+                else:
+                    pol_ind1 = np.array([], dtype=np.int64)
+                if len(blt_ind2) > 0:
+                    try:
+                        pol_ind2 = uvutils.reorder_conj_pols(self.polarization_array)
+                    except ValueError:
+                        if len(blt_ind1) == 0:
+                            raise KeyError('Baseline {bl} not found for polarization'
+                                           + ' array in data.'.format(bl=key))
+                        else:
+                            pol_ind2 = np.array([], dtype=np.int64)
+                else:
+                    pol_ind2 = np.array([], dtype=np.int64)
+                pol_ind = (pol_ind1, pol_ind2)
         elif len(key) == 2:
             # Key is an antenna pair
             blt_ind1 = self.antpair2ind(key[0], key[1])
             blt_ind2 = self.antpair2ind(key[1], key[0])
             if len(blt_ind1) + len(blt_ind2) == 0:
                 raise KeyError('Antenna pair {pair} not found in data'.format(pair=key))
-            pol_ind = (np.arange(self.Npols), np.arange(self.Npols))
+            if len(blt_ind1) > 0:
+                pol_ind1 = np.arange(self.Npols)
+            else:
+                pol_ind1 = np.array([], dtype=np.int64)
+            if len(blt_ind2) > 0:
+                try:
+                    pol_ind2 = uvutils.reorder_conj_pols(self.polarization_array)
+                except ValueError:
+                    if len(blt_ind1) == 0:
+                        raise KeyError('Baseline {bl} not found for polarization'
+                                       + ' array in data.'.format(bl=key))
+                    else:
+                        pol_ind2 = np.array([], dtype=np.int64)
+            else:
+                pol_ind2 = np.array([], dtype=np.int64)
+            pol_ind = (pol_ind1, pol_ind2)
         elif len(key) == 3:
             # Key is an antenna pair + pol
             blt_ind1 = self.antpair2ind(key[0], key[1])


### PR DESCRIPTION
Fixes #478 
We realized conjugated visibilities need their pols conjugated as well back in PR #399. But we neglected to reorder data when the user does not specify a polarization. The resulting data should be in the order of the polarization_axis, which means we need to reorder the data before conjugating it.