### PR TITLE
Fix string handling in miriad in python3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- long strings are saved correctly in miriad files from python3
 
 ## [1.3.3] - 2018-11-01
 ### Added

--- a/pyuvdata/src/aipy_compat.h
+++ b/pyuvdata/src/aipy_compat.h
@@ -12,23 +12,7 @@
 # define PyString_Check PyUnicode_Check
 # define PyString_Size PyUnicode_GET_LENGTH
 # define PyString_FromStringAndSize PyUnicode_FromStringAndSize
-
-static char *
-PyString_AsString(PyObject *ob)
-{
-    PyObject *enc;
-    char *cstr;
-
-    enc = PyUnicode_AsEncodedString(ob, "utf-8", "Error");
-    if (enc == NULL) {
-        PyErr_Format(PyExc_ValueError, "Cannot encode string");
-        return NULL;
-    }
-
-    cstr = PyBytes_AsString(enc);
-    Py_XDECREF(enc);
-    return cstr;
-}
+# define PyString_AsString PyUnicode_AsUTF8
 #endif
 
 #ifndef PyMODINIT_FUNC

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -479,6 +479,14 @@ def test_miriad_extra_keywords():
     uv_in.extra_keywords.pop('float1')
     uv_in.extra_keywords.pop('float2')
 
+    # check handling of very long strings
+    long_string = 'this is a very long string ' * 1000
+    uv_in.extra_keywords['longstr'] = long_string
+    uv_in.write_miriad(testfile, clobber=True)
+    uv_out.read(testfile)
+    nt.assert_equal(uv_in, uv_out)
+    uv_in.extra_keywords.pop('longstr')
+
     # check handling of complex-like keywords
     # currently they are NOT supported
     uv_in.extra_keywords['complex1'] = np.complex64(5.3 + 1.2j)


### PR DESCRIPTION
There was an odd bug when writing miriad files from python3 where long strings (>~750 characters) on linux-based systems would have their ends mangled. (Interestingly, local testing on macOS did not reproduce this bug.) The bug seems to stem from a custom-built replacement for the Python/C API function `PyString_AsString` for python3. Replacing this custom-built function with the provided `PyUnicode_AsUTF8` seems to resolve the issue. A test for writing long strings has been added.