### PR TITLE
Save lat/lon in degrees in uvh5 files instead of radians

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - support for python3.7
 
+### Changed
+- latitude and longitude in uvh5 files are written in degrees instead of radians.
+
 ### Fixed
 - `_key2inds` now properly reorders polarization axis for conjugated visibilities. This also effects the `get_data` function.
 - long strings are saved correctly in miriad files from python3

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -977,7 +977,7 @@ def test_UVH5ReadHeaderSpecialCases():
         f['Header/phase_type'] = np.string_('blah')
         f['Header/latitude'] = uv_in.telescope_location_lat_lon_alt[0]
         f['Header/longitude'] = uv_in.telescope_location_lat_lon_alt[1]
-    uvtest.checkWarnings(uv_out.read_uvh5, [testfile],
+    uvtest.checkWarnings(uv_out.read_uvh5, [testfile], category=DeprecationWarning,
                          message='It seems that the latitude and longitude are in radians')
 
     # make input and output values match now

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -64,7 +64,7 @@ def test_ReadUVFITSWriteUVH5ReadUVH5():
     testfile = os.path.join(DATA_PATH, 'test', 'outtest_uvfits.uvh5')
     uvtest.checkWarnings(uv_in.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile)
+    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
     nt.assert_equal(uv_in, uv_out)
 
     # clean up
@@ -102,7 +102,7 @@ def test_WriteUVH5Errors():
 
     # use clobber=True to write out anyway
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile)
+    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
     nt.assert_equal(uv_in, uv_out)
 
     # clean up
@@ -129,7 +129,7 @@ def test_UVH5OptionalParameters():
 
     # write out and read back in
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile)
+    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
     nt.assert_equal(uv_in, uv_out)
 
     # clean up
@@ -152,7 +152,7 @@ def test_UVH5CompressionOptions():
     # write out and read back in
     uv_in.write_uvh5(testfile, clobber=True, data_compression="lzf",
                      flags_compression=None, nsample_compression=None)
-    uv_out.read(testfile)
+    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
     nt.assert_equal(uv_in, uv_out)
 
     # clean up
@@ -177,7 +177,8 @@ def test_UVH5ReadMultiple_files():
     uv2.select(freq_chans=np.arange(32, 64))
     uv1.write_uvh5(testfile1, clobber=True)
     uv2.write_uvh5(testfile2, clobber=True)
-    uv1.read([testfile1, testfile2])
+    uvtest.checkWarnings(uv1.read, [[testfile1, testfile2]], nwarnings=2,
+                         message='Telescope EVLA is not')
     # Check history is correct, before replacing and doing a full object check
     nt.assert_true(uvutils._check_histories(uv_full.history + '  Downselected to '
                                             'specific frequencies using pyuvdata. '
@@ -203,6 +204,7 @@ def test_UVH5PartialRead():
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     uvtest.checkWarnings(uvh5_uv.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
     testfile = os.path.join(DATA_PATH, 'test', 'outtest.uvh5')
+    uvh5_uv.telescope_name = 'PAPER'
     uvh5_uv.write_uvh5(testfile, clobber=True)
 
     # select on antennas
@@ -279,6 +281,7 @@ def test_UVH5PartialWrite():
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     uvtest.checkWarnings(full_uvh5.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
     testfile = os.path.join(DATA_PATH, 'test', 'outtest.uvh5')
+    full_uvh5.telescope_name = "PAPER"
     full_uvh5.write_uvh5(testfile, clobber=True)
     full_uvh5.read(testfile)
 
@@ -422,6 +425,7 @@ def test_UVH5PartialWriteIrregular():
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     uvtest.checkWarnings(full_uvh5.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
     testfile = os.path.join(DATA_PATH, 'test', 'outtest.uvh5')
+    full_uvh5.telescope_name = "PAPER"
     full_uvh5.write_uvh5(testfile, clobber=True)
     full_uvh5.read(testfile)
 
@@ -768,6 +772,7 @@ def test_UVH5PartialWriteErrors():
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     uvtest.checkWarnings(full_uvh5.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
     testfile = os.path.join(DATA_PATH, 'test', 'outtest.uvh5')
+    full_uvh5.telescope_name = "PAPER"
     full_uvh5.write_uvh5(testfile, clobber=True)
     full_uvh5.read(testfile)
 
@@ -826,6 +831,7 @@ def test_UVH5InitializeFile():
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     uvtest.checkWarnings(full_uvh5.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
     testfile = os.path.join(DATA_PATH, 'test', 'outtest.uvh5')
+    full_uvh5.telescope_name = "PAPER"
     full_uvh5.write_uvh5(testfile, clobber=True)
     full_uvh5.read(testfile)
     full_uvh5.data_array = None
@@ -867,6 +873,7 @@ def test_UVH5SingleIntegrationTime():
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     testfile = os.path.join(DATA_PATH, 'test', 'outtest_uvfits.uvh5')
     uvtest.checkWarnings(uv_in.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
+    uv_in.telescope_name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
 
     # change integration_time in file to be a single number
@@ -893,6 +900,7 @@ def test_UVH5LstArray():
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     testfile = os.path.join(DATA_PATH, 'test', 'outtest_uvfits.uvh5')
     uvtest.checkWarnings(uv_in.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
+    uv_in.telescope_name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
 
     # remove lst_array from file; check that it's correctly computed on read
@@ -928,6 +936,7 @@ def test_UVH5StringBackCompat():
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     testfile = os.path.join(DATA_PATH, 'test', 'outtest_uvfits.uvh5')
     uvtest.checkWarnings(uv_in.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
+    uv_in.telescope_name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
 
     # write a string-type data as-is, without casting to np.string_
@@ -954,6 +963,7 @@ def test_UVH5ReadHeaderSpecialCases():
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     testfile = os.path.join(DATA_PATH, 'test', 'outtest_uvfits.uvh5')
     uvtest.checkWarnings(uv_in.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
+    uv_in.telescope_name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
 
     # change some of the metadata to trip certain if/else clauses
@@ -961,9 +971,14 @@ def test_UVH5ReadHeaderSpecialCases():
         del(f['Header/history'])
         del(f['Header/vis_units'])
         del(f['Header/phase_type'])
+        del(f['Header/latitude'])
+        del(f['Header/longitude'])
         f['Header/history'] = np.string_('blank history')
         f['Header/phase_type'] = np.string_('blah')
-    uv_out.read_uvh5(testfile)
+        f['Header/latitude'] = uv_in.telescope_location_lat_lon_alt[0]
+        f['Header/longitude'] = uv_in.telescope_location_lat_lon_alt[1]
+    uvtest.checkWarnings(uv_out.read_uvh5, [testfile],
+                         message='It seems that the latitude and longitude are in radians')
 
     # make input and output values match now
     uv_in.history = uv_out.history

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -74,7 +74,7 @@ class UVH5(UVData):
             warnings.warn("It seems that the latitude and longitude are in radians; "
                           "support for interpreting these quantities in radians will "
                           "not be supported in future versions. Rewrite with write_uvh5 "
-                          "to ensure future compatibility.")
+                          "to ensure future compatibility.", DeprecationWarning)
             self.telescope_location_lat_lon_alt = (latitude, longitude, altitude)
         else:
             self.telescope_location_lat_lon_alt_degrees = (latitude, longitude, altitude)


### PR DESCRIPTION
Because the lat/lon values are internally stored in radians in UVData objects, uvh5 inherited this behavior. It makes more sense for the values to be written in degrees, to line up with "real world" surveyed values more closely. This is changed for files going forward, and backwards compatibility with previously written files is accomplished by checking for "small" values (absolute value less than pi). If they are, the values are interpreted as radians. (Geographically, these latitudes and longitudes correspond to the middle of the Atlantic Ocean, where no current radio telescopes are known to exist...)

This PR also runs the `self.set_telescope_params()` function on uvh5 objects as they are being read in, which is done for uvfits files. This helps ensure the metadata is self-consistent for known telescope objects, like HERA.