### PR TITLE
Fixes a bug related to boolean arrays/lists in the get_baseline_reduncies method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - latitude and longitude in uvh5 files are written in degrees instead of radians.
+- Fixes a bug in redundancy methods for when there are no redundant baselines.
 
 ### Fixed
 - `_key2inds` now properly reorders polarization axis for conjugated visibilities. This also effects the `get_data` function.

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -443,6 +443,30 @@ def test_redundancy_finder():
             nt.assert_true(np.isclose(np.sqrt(np.dot(bl_vec, vec_bin_centers[gi])), lens[gi], atol=tol))
 
 
+def test_redundancy_conjugates():
+    # Check that the correct baselines are flipped when returning redundancies with conjugates.
+
+    Nants = 10
+    tol = 0.5
+    ant1_arr = np.tile(np.arange(Nants), Nants)
+    ant2_arr = np.repeat(np.arange(Nants), Nants)
+    Nbls = ant1_arr.size
+    bl_inds = uvutils.antnums_to_baseline(ant1_arr, ant2_arr, Nants)
+
+    maxbl = 100.
+    bl_vecs = np.random.uniform(-maxbl, maxbl, (Nbls, 3))
+    bl_vecs[0, 0] = 0
+    bl_vecs[1, 0:2] = 0
+
+    expected_conjugates = []
+    for i, (u, v, w) in enumerate(bl_vecs):
+        if (u < 0) or (v < 0 and u == 0) or (w < 0 and u == v == 0):
+            expected_conjugates.append(bl_inds[i])
+    bl_gps, vecs, lens, conjugates = uvutils.get_baseline_redundancies(bl_inds, bl_vecs, tol=tol, with_conjugates=True)
+
+    nt.assert_equal(sorted(conjugates), sorted(expected_conjugates))
+
+
 def test_reraise_context():
     with nt.assert_raises(ValueError) as cm:
         try:

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -808,6 +808,7 @@ def get_baseline_redundancies(baseline_inds, baseline_vecs, tol=1.0, with_conjug
                     conjugates.append(bl[1] < 0)
             else:
                 conjugates.append(bl[0] < 0)
+        conjugates = np.array(conjugates, dtype=bool)
         baseline_vecs[conjugates] *= (-1)
         baseline_ind_conj = baseline_inds[conjugates]
         bl_gps, vec_bin_centers, lens = get_baseline_redundancies(baseline_inds, baseline_vecs, tol=tol, with_conjugates=False)
@@ -842,7 +843,6 @@ def get_baseline_redundancies(baseline_inds, baseline_vecs, tol=1.0, with_conjug
 
     # We end up with multiple copies of each redundant group, so remove duplicates
     bl_gps = np.unique(bl_gps).tolist()
-
     N_unique = len(bl_gps)
     vec_bin_centers = np.zeros((N_unique, 3))
     for gi, gp in enumerate(bl_gps):

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -846,7 +846,7 @@ def get_baseline_redundancies(baseline_inds, baseline_vecs, tol=1.0, with_conjug
 
     # If all groups are one-element, the unique will flatten the list.
     if isinstance(bl_gps[0], int):
-        bl_gps = map(lambda x: [x], bl_gps)
+        bl_gps = list(map(lambda x: [x], bl_gps))
 
     N_unique = len(bl_gps)
     vec_bin_centers = np.zeros((N_unique, 3))

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -843,6 +843,11 @@ def get_baseline_redundancies(baseline_inds, baseline_vecs, tol=1.0, with_conjug
 
     # We end up with multiple copies of each redundant group, so remove duplicates
     bl_gps = np.unique(bl_gps).tolist()
+
+    # If all groups are one-element, the unique will flatten the list.
+    if isinstance(bl_gps[0], int):
+        bl_gps = map(lambda x: [x], bl_gps)
+
     N_unique = len(bl_gps)
     vec_bin_centers = np.zeros((N_unique, 3))
     for gi, gp in enumerate(bl_gps):


### PR DESCRIPTION
I was getting a warning about using boolean lists as index arrays in numpy, and it turns out that numpy was interpreting [True, False, True, True....] as [1,0,1,1,...], and making a new array with repetitions of the first two elements of the original.

This fix tells numpy that the index array is a boolean array, and now it shows the correct behavior. I'm not sure if this is a result of the version of numpy I'm using (1.15?).