### PR TITLE
Compress on redundancies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - memo describing the UVH5 format
+- Methods on UVData objects to compress/inflate data by redundant baselines.
+- Convenience functions on UVData for finding redundant baselines (calling the corresponding utils functions)
 - read/write support for uvh5 files with integer datatypes for visibilities
 - support for python3.7
-- Compress/inflate data by redundant baselines.
-- Convenience functions in uvdata for finding redundant baselines (calling the corresponding utils functions)
 
 ### Changed
 - UVBeam.efield_to_pstokes() no longer restricted to healpix coordinates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
-- memo describing the UVH5 format
 - Methods on UVData objects to compress/inflate data by redundant baselines.
 - Convenience functions on UVData for finding redundant baselines (calling the corresponding utils functions)
+- memo describing the UVH5 format
 - read/write support for uvh5 files with integer datatypes for visibilities
 - support for python3.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 - memo describing the UVH5 format
 - read/write support for uvh5 files with integer datatypes for visibilities
 - support for python3.7
+- Compress/inflate data by redundant baselines.
+- Convenience functions in uvdata for finding redundant baselines (calling the corresponding utils functions)
 
 ### Changed
 - UVBeam.efield_to_pstokes() no longer restricted to healpix coordinates

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -878,6 +878,33 @@ The ``get_antenna_redundancies`` function accepts an array of antenna indices an
     >>> print(len(baseline_groups))
     30
 
+UVData: Compressing/inflating on Redundant Baselines
+----------------------------------------------------
+Since redundant baselines should have similar visibilities, some level of data compression can be achieved by only keeping one out of a set of redundant baselines. The function ``compress_by_redundancies`` will find groups of baselines that are redundant to a given tolerance, choose one baseline from each group, and use the ``select`` function to choose those baselines only. This action is (almost) inverted by the ``inflate_by_redundancies`` function, which finds all possible baselines from the antenna positions and fills in the full data array based on redundancy.
+
+::
+    >>> from pyuvdata import UVData
+    >>> import copy
+    >>> import numpy as np
+    >>> uv0 = UVData()
+    >>> uv0.read_uvfits("pyuvdata/data/hera19_8hrs_uncomp_10MHz_000_05.003111-05.033750.uvfits")
+    >>> tol = 0.01   # In meters
+
+    # Compression can be run in-place or return a separate UVData object.
+    >>> uv2 = uv0.compress_by_redundancy(tol=tol, inplace=False)
+    >>> uv_backup = copy.deepcopy(uv0)
+    >>> uv0.compress_by_redundancy(tol=tol)
+    >>> uv2 == uv0
+    True
+    
+    # Note -- Compressing and inflating changes the baseline order, so the inflated object may be different.
+    >>> uv0.inflate_by_redundancy(tol=tol)
+    >>> np.all(uv0.baseline_array == uv_backup.baseline_array)
+    False
+
+    >>> uv2.inflate_by_redundancy(tol=tol)
+    >>> uv2 == uv0
+    True
 
 ------
 UVCal

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3156,7 +3156,7 @@ class UVData(UVBase):
         Convenience method for getting baseline redundancies to a given tolerance
         from antenna positions.
 
-        Note that the baseline numbers returned will only correspond with those in the file under the 
+        Note that the baseline numbers returned will only correspond with those in the file under the
         u-positive convention.
 
         Args:

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3156,14 +3156,18 @@ class UVData(UVBase):
         Convenience method for getting baseline redundancies to a given tolerance
         from antenna positions.
 
-        Note that the baseline numbers returned will only correspond with those in the file under the
-        u-positive convention.
+        Note that the baseline numbers returned will only correspond with those in the baseline_array under the
+        u-positive convention. The function UVData._set_u_positive will flip all baselines in the UVData object
+        to follow this.
 
         Args:
             tol: Redundancy tolerance in meters (default 1m)
             include_autos: Include autocorrelations in the full redundancy list (default True)
 
-        Returns the output of utils.get_antenna_redundancies.
+        Returns:
+            baseline_groups: list of lists of redundant baseline indices
+            vec_bin_centers: List of vectors describing redundant group centers
+            lengths: List of redundant group baseline lengths in meters
         """
         antpos, numbers = self.get_ENU_antpos(center=False)
         return uvutils.get_antenna_redundancies(numbers, antpos, tol=tol, include_autos=include_autos)
@@ -3172,7 +3176,14 @@ class UVData(UVBase):
         """
         Convenience method for getting baseline redundancies to a given tolerance.
 
-        Returns the output of utils.get_baseline_redundancies.
+        Args:
+            tol: Redundancy tolerance in meters (default 1m)
+
+        Returns:
+            baseline_groups: list of lists of redundant baseline indices
+            vec_bin_centers: List of vectors describing redundant group centers
+            lengths: List of redundant group baseline lengths in meters
+            baseline_ind_conj: List of baselines that are redundant when reversed. (Only returned if with_conjugates is True)
         """
         baseline_vecs = self.uvw_array[:self.Nbls]
         baseline_inds = self.baseline_array[:self.Nbls]


### PR DESCRIPTION
Five new methods in UVData:

(For convenience) `UVData.get_antenna_redundancies` and `UVData.get_baseline_redundancies` return redundancies based on the UVData's antenna_positions and uvw_array parameters, respectively. Comparable to the functions of the same name in `utils.py`.

`UVData._set_u_positive` goes through the baseline array and flips baselines / antenna numbers to follow the rule that `u>0` or `v>0 if u==0` or `w>0 if u == v == 0`. This is required for inflation, because the inflate method uses `get_antenna_redundancies` which only returns baselines within this convention. I can potentially add another method that switches to the `ant_1  > ant_2` convention instead.

`UVData.compress_by_redundancy` does the redundancy selection as discussed, up to a given tolerance. Should I store this tolerance in metadata?

`UVData.inflate_by_redundancy` takes a UVData object with missing data (presumably after a compression, but doesn't require that) and fills out the full data array according to redundancy. Will skip over any missing data.

Note that inflation ***does not*** preserve baseline/time ordering. That is:
```
uv_backup = copy.deepcopy(uv)
uv.compress_by_redundancy()
uv.inflate_by_redundancy()
uv != uv_backup
```
This is because the inflation method is agnostic about any earlier compression operations, and baseline ordering is necessarily lost in compression. The data_array does line up correctly with the baseline_array and uvw_array entries, though.

Still a work in progress for now, but I want to see if this is what people have in mind and get some feedback.