### PR TITLE
remove support for astropy <1.3, fix travis 3.7 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - conda info -a
 
   # install dependencies
-  - conda install numpy scipy astropy nose pip h5py six healpy python-casacore pycodestyle coveralls
+  - conda install numpy scipy astropy nose pip h5py six healpy python-casacore pycodestyle coveralls python="$PYTHON_VERSION"
   - conda list
   - python --version
   - PYVER=`python -c "from __future__ import print_function; import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
     else
       conda install -c defaults -y 'libgfortran =3.0.0' libgfortran-ng;
     fi
-  - conda config --remove channels defaults && conda config --add channels conda-forge
+  - conda config --add channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
 
@@ -50,14 +50,12 @@ install:
   - conda install numpy scipy astropy nose pip h5py six healpy python-casacore pycodestyle coveralls python="$PYTHON_VERSION"
   - conda list
   - python --version
-  - PYVER=`python -c "from __future__ import print_function; import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
-script:
   # check that the python version matches the desired one; exit immediately if not
-  - set -e
+  - PYVER=`python -c "from __future__ import print_function; import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
   - if [[ $PYVER != $PYTHON_VERSION ]]; then
       exit 1;
     fi
-  - set +e
+script:
   - python setup.py build_ext --force --inplace
   - nosetests pyuvdata --with-coverage --cover-package=pyuvdata
   - python -m doctest docs/tutorial.rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,14 @@ install:
   - conda install numpy scipy astropy nose pip h5py six healpy python-casacore pycodestyle coveralls
   - conda list
   - python --version
+  - PYVER=`python -c "from __future__ import print_function; import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
 script:
+  # check that the python version matches the desired one; exit immediately if not
+  - set -e
+  - if [[ $PYVER != $PYTHON_VERSION ]]; then
+      exit 1;
+    fi
+  - set +e
   - python setup.py build_ext --force --inplace
   - nosetests pyuvdata --with-coverage --cover-package=pyuvdata
   - python -m doctest docs/tutorial.rst

--- a/pyuvdata/beamfits.py
+++ b/pyuvdata/beamfits.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import warnings
-import astropy
 from astropy.io import fits
 
 from . import UVBeam
@@ -644,7 +643,4 @@ class BeamFITS(UVBeam):
             bandpass_hdu.header['refzout'] = self.reference_output_impedance
         hdulist.append(bandpass_hdu)
 
-        if float(astropy.__version__[0:3]) < 1.3:  # pragma: no cover
-            hdulist.writeto(filename, clobber=clobber)
-        else:
-            hdulist.writeto(filename, overwrite=clobber)
+        hdulist.writeto(filename, overwrite=clobber)

--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import warnings
-import astropy
 from astropy.io import fits
 
 from . import UVCal
@@ -344,10 +343,7 @@ class CALFITS(UVCal):
             totqualhdu = fits.ImageHDU(data=totqualdata, header=totqualhdr)
             hdulist.append(totqualhdu)
 
-        if float(astropy.__version__[0:3]) < 1.3:
-            hdulist.writeto(filename, clobber=clobber)
-        else:
-            hdulist.writeto(filename, overwrite=clobber)
+        hdulist.writeto(filename, overwrite=clobber)
 
     def read_calfits(self, filename, run_check=True, check_extra=True,
                      run_check_acceptability=True, strict_fits=False):

--- a/pyuvdata/tests/test_beamfits.py
+++ b/pyuvdata/tests/test_beamfits.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, division, print_function
 import nose.tools as nt
 import os
 import numpy as np
-import astropy
 from astropy.io import fits
 
 from pyuvdata import UVBeam
@@ -82,10 +81,7 @@ def test_readCST_writereadFITS():
     prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
     hdulist = fits.HDUList([prihdu, bandpass_hdu])
 
-    if float(astropy.__version__[0:3]) < 1.3:
-        hdulist.writeto(write_file, clobber=True)
-    else:
-        hdulist.writeto(write_file, overwrite=True)
+    hdulist.writeto(write_file, overwrite=True)
 
     beam_out.read_beamfits(write_file)
     nt.assert_equal(beam_in, beam_out)
@@ -101,10 +97,7 @@ def test_readCST_writereadFITS():
     prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
     hdulist = fits.HDUList([prihdu, bandpass_hdu])
 
-    if float(astropy.__version__[0:3]) < 1.3:
-        hdulist.writeto(write_file, clobber=True)
-    else:
-        hdulist.writeto(write_file, overwrite=True)
+    hdulist.writeto(write_file, overwrite=True)
 
     beam_out.read_beamfits(write_file)
     nt.assert_equal(beam_in, beam_out)
@@ -122,10 +115,7 @@ def test_readCST_writereadFITS():
     prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
     hdulist = fits.HDUList([prihdu, bandpass_hdu])
 
-    if float(astropy.__version__[0:3]) < 1.3:
-        hdulist.writeto(write_file, clobber=True)
-    else:
-        hdulist.writeto(write_file, overwrite=True)
+    hdulist.writeto(write_file, overwrite=True)
 
     beam_out.read_beamfits(write_file)
     nt.assert_equal(beam_in, beam_out)
@@ -196,10 +186,7 @@ def test_writeread_healpix():
     prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
     hdulist = fits.HDUList([prihdu, hpx_hdu, bandpass_hdu])
 
-    if float(astropy.__version__[0:3]) < 1.3:
-        hdulist.writeto(write_file, clobber=True)
-    else:
-        hdulist.writeto(write_file, overwrite=True)
+    hdulist.writeto(write_file, overwrite=True)
 
     beam_out.read_beamfits(write_file)
     nt.assert_equal(beam_in, beam_out)
@@ -260,10 +247,7 @@ def test_errors():
         prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
         hdulist = fits.HDUList([prihdu, basisvec_hdu, bandpass_hdu])
 
-        if float(astropy.__version__[0:3]) < 1.3:
-            hdulist.writeto(write_file, clobber=True)
-        else:
-            hdulist.writeto(write_file, overwrite=True)
+        hdulist.writeto(write_file, overwrite=True)
 
         nt.assert_raises(ValueError, beam_out.read_beamfits, write_file)
 
@@ -305,10 +289,7 @@ def test_errors():
         basisvec_hdu = fits.ImageHDU(data=basisvec_data, header=basisvec_hdr)
         hdulist = fits.HDUList([prihdu, basisvec_hdu, bandpass_hdu])
 
-        if float(astropy.__version__[0:3]) < 1.3:
-            hdulist.writeto(write_file, clobber=True)
-        else:
-            hdulist.writeto(write_file, overwrite=True)
+        hdulist.writeto(write_file, overwrite=True)
 
         nt.assert_raises(ValueError, beam_out.read_beamfits, write_file)
 
@@ -359,10 +340,7 @@ def test_healpix_errors():
         prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
         hdulist = fits.HDUList([prihdu, basisvec_hdu, hpx_hdu, bandpass_hdu])
 
-        if float(astropy.__version__[0:3]) < 1.3:
-            hdulist.writeto(write_file, clobber=True)
-        else:
-            hdulist.writeto(write_file, overwrite=True)
+        hdulist.writeto(write_file, overwrite=True)
 
         nt.assert_raises(ValueError, beam_out.read_beamfits, write_file)
 
@@ -409,10 +387,7 @@ def test_healpix_errors():
         basisvec_hdu = fits.ImageHDU(data=basisvec_data, header=basisvec_hdr)
         hdulist = fits.HDUList([prihdu, basisvec_hdu, hpx_hdu, bandpass_hdu])
 
-        if float(astropy.__version__[0:3]) < 1.3:
-            hdulist.writeto(write_file, clobber=True)
-        else:
-            hdulist.writeto(write_file, overwrite=True)
+        hdulist.writeto(write_file, overwrite=True)
 
         nt.assert_raises(ValueError, beam_out.read_beamfits, write_file)
 

--- a/pyuvdata/tests/test_calfits.py
+++ b/pyuvdata/tests/test_calfits.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, division, print_function
 import nose.tools as nt
 import os
 import numpy as np
-import astropy
 from astropy.io import fits
 
 from pyuvdata import UVCal
@@ -126,10 +125,7 @@ def test_errors():
         totqualhdu = fits.ImageHDU(data=totqualhdu.data, header=totqualhdr)
         hdulist.append(totqualhdu)
 
-        if float(astropy.__version__[0:3]) < 1.3:
-            hdulist.writeto(write_file, clobber=True)
-        else:
-            hdulist.writeto(write_file, overwrite=True)
+        hdulist.writeto(write_file, overwrite=True)
 
         nt.assert_raises(ValueError, cal_out.read_calfits, write_file, strict_fits=True)
 
@@ -174,10 +170,7 @@ def test_errors():
         totqualhdu = fits.ImageHDU(data=totqualhdu.data, header=totqualhdr)
         hdulist.append(totqualhdu)
 
-        if float(astropy.__version__[0:3]) < 1.3:
-            hdulist.writeto(write_file, clobber=True)
-        else:
-            hdulist.writeto(write_file, overwrite=True)
+        hdulist.writeto(write_file, overwrite=True)
 
         nt.assert_raises(ValueError, cal_out.read_calfits, write_file, strict_fits=True)
 
@@ -313,10 +306,7 @@ def test_read_oldcalfits():
         totqualhdu = fits.ImageHDU(data=totqualhdu.data, header=totqualhdr)
         hdulist.append(totqualhdu)
 
-        if float(astropy.__version__[0:3]) < 1.3:
-            hdulist.writeto(write_file, clobber=True)
-        else:
-            hdulist.writeto(write_file, overwrite=True)
+        hdulist.writeto(write_file, overwrite=True)
 
         uvtest.checkWarnings(cal_out.read_calfits, [write_file], message=messages[i])
         nt.assert_equal(cal_in, cal_out)
@@ -371,10 +361,7 @@ def test_read_oldcalfits():
         totqualhdu = fits.ImageHDU(data=totqualhdu.data, header=totqualhdr)
         hdulist.append(totqualhdu)
 
-        if float(astropy.__version__[0:3]) < 1.3:
-            hdulist.writeto(write_file, clobber=True)
-        else:
-            hdulist.writeto(write_file, overwrite=True)
+        hdulist.writeto(write_file, overwrite=True)
 
         uvtest.checkWarnings(cal_out.read_calfits, [write_file], message=messages[i])
         nt.assert_equal(cal_in, cal_out)

--- a/pyuvdata/tests/test_uvfits.py
+++ b/pyuvdata/tests/test_uvfits.py
@@ -11,7 +11,6 @@ import numpy as np
 import copy
 import os
 import nose.tools as nt
-import astropy
 from astropy.io import fits
 
 from pyuvdata import UVData
@@ -143,10 +142,8 @@ def test_readwriteread():
         ant_hdu.header = ant_hdr
 
         hdulist = fits.HDUList(hdus=[vis_hdu, ant_hdu])
-        if float(astropy.__version__[0:3]) < 1.3:
-            hdulist.writeto(write_file, clobber=True)
-        else:
-            hdulist.writeto(write_file, overwrite=True)
+        hdulist.writeto(write_file, overwrite=True)
+
     uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
     nt.assert_equal(uv_out.telescope_name, 'EVLA')
     nt.assert_equal(uv_out.timesys, time_sys)
@@ -181,10 +178,8 @@ def test_readwriteread():
         ant_hdu = hdu_list[hdunames['AIPS AN']]
 
         hdulist = fits.HDUList(hdus=[vis_hdu, ant_hdu])
-        if float(astropy.__version__[0:3]) < 1.3:
-            hdulist.writeto(write_file, clobber=True)
-        else:
-            hdulist.writeto(write_file, overwrite=True)
+        hdulist.writeto(write_file, overwrite=True)
+
     uvtest.checkWarnings(nt.assert_raises, [ValueError, uv_out.read, write_file],
                          message=['Telescope EVLA is not',
                                   'ERFA function "utcut1" yielded 1 of "dubious year (Note 3)"',
@@ -449,10 +444,7 @@ def test_select_read():
 
         write_file = os.path.join(DATA_PATH, 'test/outtest_casa.uvfits')
         hdulist = fits.HDUList(hdus=[vis_hdu, ant_hdu])
-        if float(astropy.__version__[0:3]) < 1.3:
-            hdulist.writeto(write_file, clobber=True)
-        else:
-            hdulist.writeto(write_file, overwrite=True)
+        hdulist.writeto(write_file, overwrite=True)
 
     pols_to_keep = [-1, -2]
     uvtest.checkWarnings(uvfits_uv.read, [write_file],

--- a/pyuvdata/tests/test_uvfits.py
+++ b/pyuvdata/tests/test_uvfits.py
@@ -11,6 +11,7 @@ import numpy as np
 import copy
 import os
 import nose.tools as nt
+import astropy
 from astropy.io import fits
 
 from pyuvdata import UVData

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import warnings
-import astropy
 from astropy import constants as const
 from astropy.time import Time
 from astropy.io import fits
@@ -882,7 +881,4 @@ class UVFITS(UVData):
 
         # write the file
         hdulist = fits.HDUList(hdus=[hdu, ant_hdu])
-        if float(astropy.__version__[0:3]) < 1.3:  # pragma: no cover
-            hdulist.writeto(filename, clobber=True)
-        else:
-            hdulist.writeto(filename, overwrite=True)
+        hdulist.writeto(filename, overwrite=True)


### PR DESCRIPTION
In writing fits files, we were still testing for astropy <1.3, but our stated dependency is astropy >= 2.0

this PR removes the handling for old astropy, cleaning up the code and removing untested lines.

It also fixes a Travis issue where python 3.7 was being downgraded in the conda install step
