### PR TITLE
Redundant compress metadata only

### DIFF
--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -2761,6 +2761,33 @@ def test_redundancy_contract_expand():
     nt.assert_equal(uv2, uv3)
 
 
+def test_compress_redundancy_metadata_only():
+    uv0 = UVData()
+    uv0.read_uvfits(os.path.join(DATA_PATH, 'hera19_8hrs_uncomp_10MHz_000_05.003111-05.033750.uvfits'))
+    tol = 0.01
+
+    # Assign identical data to each redundant group:
+    uv0._set_u_positive()
+    red_gps, centers, lengths = uv0.get_antenna_redundancies(tol=tol)
+    for i, gp in enumerate(red_gps):
+        for bl in gp:
+            inds = np.where(bl == uv0.baseline_array)
+            uv0.data_array[inds] *= 0
+            uv0.data_array[inds] += complex(i)
+
+    uv2 = copy.deepcopy(uv0)
+    uv2.data_array = None
+    uv2.flag_array = None
+    uv2.nsample_array = None
+    uv2.compress_by_redundancy(tol=tol, inplace=True, metadata_only=True)
+
+    uv0.compress_by_redundancy(tol=tol)
+    uv0.data_array = None
+    uv0.flag_array = None
+    uv0.nsample_array = None
+    nt.assert_equal(uv0, uv2)
+
+
 def test_redundancy_missing_groups():
     # Check that if I try to inflate a compressed UVData that is missing redundant groups, it will
     # raise the right warnings and fill only what data are available.

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3198,21 +3198,23 @@ class UVData(UVBase):
 
         return uvutils.get_baseline_redundancies(baseline_inds, baseline_vecs, tol=tol, with_conjugates=True)
 
-    def compress_by_redundancy(self, tol=1.0, inplace=True):
+    def compress_by_redundancy(self, tol=1.0, inplace=True, metadata_only=False):
         """
         Uses utility functions to find redundant baselines to the given tolerance, then select on those.
 
         Args:
             tol: Redundancy tolerance in meters (default 1m)
             inplace: Do selection on current object.
-        Returns:
+            metadata_only: Option to only do the select on the metadata. Not allowed
+                if the data_array, flag_array or nsample_array is not None. (False)
+    Returns:
             UVData: if not inplace, returns the compressed UVData object
         """
 
         red_gps, centers, lengths, conjugates = self.get_baseline_redundancies(tol)
 
         bl_ants = [self.baseline_to_antnums(gp[0]) for gp in red_gps]
-        return self.select(bls=bl_ants, inplace=inplace)
+        return self.select(bls=bl_ants, inplace=inplace, metadata_only=metadata_only)
 
     def _set_u_positive(self):
         """


### PR DESCRIPTION
add `metadata_only` keyword to `compress_on_redundancy` (just pass it on to `select`). Needed for RadioAstronomySoftwareGroup/pyuvsim#98