### PR TITLE
Remove use of dataset.value

### DIFF
--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -290,6 +290,10 @@ def test_UVH5PartialWrite():
     uvtest.checkWarnings(full_uvh5.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
     testfile = os.path.join(DATA_PATH, 'test', 'outtest.uvh5')
     full_uvh5.telescope_name = "PAPER"
+    # cut down the file size to decrease testing time
+    full_uvh5.select(antenna_nums=[3, 7, 24])
+    full_uvh5.lst_array = uvutils.get_lst_for_time(full_uvh5.time_array,
+                                                   *full_uvh5.telescope_location_lat_lon_alt_degrees)
     full_uvh5.write_uvh5(testfile, clobber=True)
     full_uvh5.read(testfile)
 

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -891,7 +891,7 @@ def test_UVH5SingleIntegrationTime():
 
     # change integration_time in file to be a single number
     with h5py.File(testfile, 'r+') as f:
-        int_time = f['/Header/integration_time'].value[0]
+        int_time = f['/Header/integration_time'][0]
         del(f['/Header/integration_time'])
         f['/Header/integration_time'] = int_time
     uvtest.checkWarnings(uv_out.read_uvh5, [testfile], message='outtest_uvfits.uvh5 appears to be an old uvh5 format')
@@ -925,7 +925,7 @@ def test_UVH5LstArray():
     # now change what's in the file and make sure a warning is raised
     uv_in.write_uvh5(testfile, clobber=True)
     with h5py.File(testfile, 'r+') as f:
-        lst_array = f['/Header/lst_array'].value
+        lst_array = f['/Header/lst_array'][:]
         del(f['/Header/lst_array'])
         f['/Header/lst_array'] = 2 * lst_array
     uvtest.checkWarnings(uv_out.read_uvh5, [testfile],


### PR DESCRIPTION
Using the `dataset.value` syntax in h5py now causes a `DeprecationWarning` in v2.9.0. This PR now explicitly accesses datasets using numpy slice notation. For scalar datasets, an empty tuple is used.