### PR TITLE
added run_check_accept to uvh5 read_header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Changed
+- Extends `run_acceptability_check` for UVH5 metadata in `check_header` function.
 
 ### Fixed
 - Antenna numbering bug in redundancy methods. It wasn't using the correct antenna numbers to make baseline indices.
 
 ## [1.3.5] - 2018-12-20
-### Changed
-- Extends `run_acceptability_check` for UVH5 metadata in `check_header` function.
 
 ## [1.3.4] - 2018-12-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - Antenna numbering bug in redundancy methods. It wasn't using the correct antenna numbers to make baseline indices.
 
 ## [1.3.5] - 2018-12-20
+### Changed
+- Extends `run_acceptability_check` for UVH5 metadata in `check_header` function.
 
 ## [1.3.4] - 2018-12-19
 ### Added

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -2112,7 +2112,7 @@ class UVData(UVBase):
     def write_uvh5_part(self, filename, data_array, flags_array, nsample_array, check_header=True,
                         antenna_nums=None, antenna_names=None, ant_str=None, bls=None,
                         frequencies=None, freq_chans=None, times=None, polarizations=None,
-                        blt_inds=None):
+                        blt_inds=None, run_check_acceptability=True):
         """
         Write data to a UVH5 file that has already been initialized.
 
@@ -2161,6 +2161,8 @@ class UVData(UVBase):
             polarizations: The polarizations to include when writing data to the file.
             blt_inds: The baseline-time indices to include when writing data to the file.
                 This is not commonly used.
+            run_check_acceptability: Option to check acceptable range of the values of
+                parameters before writing the file. Default is True.
 
         Returns:
             None
@@ -2171,7 +2173,8 @@ class UVData(UVBase):
                                  antenna_names=antenna_names, bls=bls, ant_str=ant_str,
                                  frequencies=frequencies, freq_chans=freq_chans,
                                  times=times, polarizations=polarizations,
-                                 blt_inds=blt_inds)
+                                 blt_inds=blt_inds,
+                                 run_check_acceptability=run_check_acceptability)
         del(uvh5_obj)
 
     def read(self, filename, file_type=None, antenna_nums=None, antenna_names=None,


### PR DESCRIPTION
This extends the `run_acceptability_check` kwarg for the UVH5 `_read_header` and `_check_header`
for doing certain acceptability checks on metadata, specifically, the checking of proper LST array values. This is important because it is actually a bottleneck when performing partial IO on a large file. My benchmarking shows that it takes 13 seconds just to do the `get_lst_for_time` (without loading any actual data in) for a file that extends across a large LST range