### PR TITLE
Add check for uvws based on antenna positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- A check that the uvws match the antenna positions, as part of the acceptability checking.
+
 ## [2.1.0] - 2020-7-08
 
 ### Added

--- a/ci/hera_cal.yml
+++ b/ci/hera_cal.yml
@@ -22,5 +22,5 @@ dependencies:
     - git+https://github.com/HERA-Team/hera_qm.git
     - git+https://github.com/HERA-Team/uvtools.git
     - git+https://github.com/HERA-Team/hera_sim.git
-    - git+https://github.com/RadioAstronomySoftwareGroup/pyuvsim.git
-    - git+https://github.com/RadioAstronomySoftwareGroup/pyradiosky.git
+    - pyuvsim
+    - pyradiosky

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1054,10 +1054,10 @@ done after the read, which does not save memory.
   [(9, 10), (9, 20)]
 
   # Select certain frequencies from a uvh5 file
-  >>> filename = os.path.join(DATA_PATH, 'zen.2458432.34569.uvh5')
-  >>> uv.read(filename, freq_chans=np.arange(32))
+  >>> filename = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
+  >>> uv.read(filename, freq_chans=np.arange(2))
   >>> print(uv.data_array.shape)
-  (80, 1, 32, 4)
+  (200, 1, 2, 2)
 
 c) Writing to a uvh5 file in parts
 **********************************
@@ -1082,7 +1082,7 @@ are written to the appropriate parts of the file on disk.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> uv = UVData()
-  >>> filename = os.path.join(DATA_PATH, 'zen.2458432.34569.uvh5')
+  >>> filename = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
   >>> uv.read(filename, read_data=False)
   >>> partfile = os.path.join(DATA_PATH, 'tutorial_output', 'tutorial_partial_io.uvh5')
   >>> uv.initialize_uvh5_file(partfile, clobber=True)

--- a/pyuvdata/conftest.py
+++ b/pyuvdata/conftest.py
@@ -67,6 +67,7 @@ def casa_uvfits(casa_uvfits_master):
 @pytest.fixture(scope="session")
 def paper_miriad_master():
     """Read in PAPER miriad file."""
+    pytest.importorskip("pyuvdata.uvdata.aipy_extracts")
     uv_in = UVData()
     uv_in.read(paper_miriad_file)
 

--- a/pyuvdata/conftest.py
+++ b/pyuvdata/conftest.py
@@ -11,11 +11,15 @@ from astropy.time import Time
 import numpy as np
 
 from pyuvdata.data import DATA_PATH
-from pyuvdata import UVBeam
+from pyuvdata import UVData, UVBeam
 
 filenames = ["HERA_NicCST_150MHz.txt", "HERA_NicCST_123MHz.txt"]
 cst_folder = "NicCSTbeams"
 cst_files = [os.path.join(DATA_PATH, cst_folder, f) for f in filenames]
+casa_tutorial_uvfits = os.path.join(
+    DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits"
+)
+paper_miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -37,6 +41,47 @@ def setup_and_teardown_package():
     yield
 
     iers.conf.auto_max_age = 30
+
+
+@pytest.fixture(scope="session")
+def casa_uvfits_master():
+    """Read in CASA tutorial uvfits file."""
+    uv_in = UVData()
+    uv_in.read(casa_tutorial_uvfits)
+
+    return uv_in
+
+
+@pytest.fixture(scope="function")
+def casa_uvfits(casa_uvfits_master):
+    """Make function level CASA tutorial uvfits object."""
+    casa_uvfits = casa_uvfits_master.copy()
+    yield casa_uvfits
+
+    # clean up when done
+    del casa_uvfits
+
+    return
+
+
+@pytest.fixture(scope="session")
+def paper_miriad_master():
+    """Read in PAPER miriad file."""
+    uv_in = UVData()
+    uv_in.read(paper_miriad_file)
+
+    return uv_in
+
+
+@pytest.fixture(scope="function")
+def paper_miriad(paper_miriad_master):
+    """Make function level PAPER miriad object."""
+    uv_in = paper_miriad_master.copy()
+
+    yield uv_in
+
+    # cleanup
+    del uv_in
 
 
 def make_cst_beam(beam_type, nfreq):

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -1357,6 +1357,7 @@ def test_and_collapse_errors():
     pytest.raises(ValueError, uvutils.and_collapse, data)
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvcalibrate_apply_gains_oldfiles():
     # read data
     uvd = UVData()
@@ -1434,6 +1435,7 @@ def test_uvcalibrate_apply_gains_oldfiles():
     assert uvdcal.vis_units == "Jy"
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvcalibrate_delay_oldfiles():
     uvd = UVData()
     uvd.read(os.path.join(DATA_PATH, "zen.2457698.40355.xx.HH.uvcAA.uvh5"))
@@ -1972,6 +1974,7 @@ def test_uvcalibrate_feedpol_mismatch(uvcalibrate_data):
     )
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_apply_uvflag():
     # load data and insert some flags
     uvd = UVData()

--- a/pyuvdata/uvdata/fhd.py
+++ b/pyuvdata/uvdata/fhd.py
@@ -110,6 +110,7 @@ class FHD(UVData):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
+        uvw_antpos_check_level="warn",
     ):
         """
         Read in data from a list of FHD files.
@@ -145,6 +146,10 @@ class FHD(UVData):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done).
+        uvw_antpos_check_level : string
+            Setting to control the strictness of the check that uvws match antenna
+            positions. Options are: ['strict', 'warn', 'off']. See the `UVData.check`
+            docstring for more details.
 
         Raises
         ------
@@ -624,5 +629,7 @@ class FHD(UVData):
         # check if object has all required uv_properties set
         if run_check:
             self.check(
-                check_extra=check_extra, run_check_acceptability=run_check_acceptability
+                check_extra=check_extra,
+                run_check_acceptability=run_check_acceptability,
+                uvw_antpos_check_level=uvw_antpos_check_level,
             )

--- a/pyuvdata/uvdata/fhd.py
+++ b/pyuvdata/uvdata/fhd.py
@@ -110,7 +110,7 @@ class FHD(UVData):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        uvw_antpos_check_level="warn",
+        strict_uvw_antpos_check=False,
     ):
         """
         Read in data from a list of FHD files.
@@ -146,10 +146,9 @@ class FHD(UVData):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done).
-        uvw_antpos_check_level : string
-            Setting to control the strictness of the check that uvws match antenna
-            positions. Options are: ['strict', 'warn', 'off']. See the `UVData.check`
-            docstring for more details.
+        strict_uvw_antpos_check : bool
+            Option to raise an error rather than a warning if the check that
+            uvws match antenna positions does not pass.
 
         Raises
         ------
@@ -631,5 +630,5 @@ class FHD(UVData):
             self.check(
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
-                uvw_antpos_check_level=uvw_antpos_check_level,
+                strict_uvw_antpos_check=strict_uvw_antpos_check,
             )

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -52,10 +52,11 @@ class Miriad(UVData):
         read_data=True,
         phase_type=None,
         correct_lat_lon=True,
+        background_lsts=True,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        background_lsts=True,
+        uvw_antpos_check_level="warn",
     ):
         """
         Read in data from a miriad file.
@@ -105,6 +106,8 @@ class Miriad(UVData):
         correct_lat_lon : bool
             Option to update the latitude and longitude from the known_telescopes
             list if the altitude is missing.
+        background_lsts : bool
+            When set to True, the lst_array is calculated in a background thread.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after after reading in the file (the default is True,
@@ -117,8 +120,10 @@ class Miriad(UVData):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done). Ignored if read_data is False.
-        background_lsts : bool
-            When set to True, the lst_array is calculated in a background thread.
+        uvw_antpos_check_level : string
+            Setting to control the strictness of the check that uvws match antenna
+            positions. Options are: ['strict', 'warn', 'off']. See the `UVData.check`
+            docstring for more details.
 
         Raises
         ------
@@ -708,7 +713,9 @@ class Miriad(UVData):
         # check if object has all required uv_properties set
         if run_check:
             self.check(
-                check_extra=check_extra, run_check_acceptability=run_check_acceptability
+                check_extra=check_extra,
+                run_check_acceptability=run_check_acceptability,
+                uvw_antpos_check_level=uvw_antpos_check_level,
             )
 
     def write_miriad(
@@ -773,6 +780,7 @@ class Miriad(UVData):
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
                 check_freq_spacing=True,
+                uvw_antpos_check_level="off",
             )
 
         # check for multiple spws

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -56,7 +56,7 @@ class Miriad(UVData):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        uvw_antpos_check_level="warn",
+        strict_uvw_antpos_check=False,
     ):
         """
         Read in data from a miriad file.
@@ -120,10 +120,9 @@ class Miriad(UVData):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done). Ignored if read_data is False.
-        uvw_antpos_check_level : string
-            Setting to control the strictness of the check that uvws match antenna
-            positions. Options are: ['strict', 'warn', 'off']. See the `UVData.check`
-            docstring for more details.
+        strict_uvw_antpos_check : bool
+            Option to raise an error rather than a warning if the check that
+            uvws match antenna positions does not pass.
 
         Raises
         ------
@@ -715,16 +714,17 @@ class Miriad(UVData):
             self.check(
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
-                uvw_antpos_check_level=uvw_antpos_check_level,
+                strict_uvw_antpos_check=strict_uvw_antpos_check,
             )
 
     def write_miriad(
         self,
         filepath,
+        clobber=False,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        clobber=False,
+        strict_uvw_antpos_check=False,
         no_antnums=False,
     ):
         """
@@ -734,6 +734,8 @@ class Miriad(UVData):
         ----------
         filename : str
             The miriad root directory to write to.
+        clobber : bool
+            Option to overwrite the filename if the file already exists.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after before writing the file (the default is True,
@@ -745,8 +747,9 @@ class Miriad(UVData):
             Option to check acceptable range of the values of parameters before
             writing the file (the default is True, meaning the acceptable
             range check will be done).
-        clobber : bool
-            Option to overwrite the filename if the file already exists.
+        strict_uvw_antpos_check : bool
+            Option to raise an error rather than a warning if the check that
+            uvws match antenna positions does not pass.
         no_antnums : bool
             Option to not write the antnums variable to the file.
             Should only be used for testing purposes.
@@ -780,7 +783,7 @@ class Miriad(UVData):
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
                 check_freq_spacing=True,
-                uvw_antpos_check_level="off",
+                strict_uvw_antpos_check=strict_uvw_antpos_check,
             )
 
         # check for multiple spws

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -137,10 +137,11 @@ class MS(UVData):
         filepath,
         data_column="DATA",
         pol_order="AIPS",
+        background_lsts=True,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        background_lsts=True,
+        uvw_antpos_check_level="warn",
     ):
         """
         Read in a casa measurement set.
@@ -155,6 +156,8 @@ class MS(UVData):
         pol_order : str
             Option to specify polarizations order convention, options are
             'CASA' or 'AIPS'.
+        background_lsts : bool
+            When set to True, the lst_array is calculated in a background thread.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after after reading in the file (the default is True,
@@ -166,8 +169,10 @@ class MS(UVData):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done).
-        background_lsts : bool
-            When set to True, the lst_array is calculated in a background thread.
+        uvw_antpos_check_level : string
+            Setting to control the strictness of the check that uvws match antenna
+            positions. Options are: ['strict', 'warn', 'off']. See the `UVData.check`
+            docstring for more details.
 
         Raises
         ------
@@ -436,5 +441,7 @@ class MS(UVData):
         self.reorder_pols(order=pol_order)
         if run_check:
             self.check(
-                check_extra=check_extra, run_check_acceptability=run_check_acceptability
+                check_extra=check_extra,
+                run_check_acceptability=run_check_acceptability,
+                uvw_antpos_check_level=uvw_antpos_check_level,
             )

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -141,7 +141,7 @@ class MS(UVData):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        uvw_antpos_check_level="warn",
+        strict_uvw_antpos_check=False,
     ):
         """
         Read in a casa measurement set.
@@ -169,10 +169,9 @@ class MS(UVData):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done).
-        uvw_antpos_check_level : string
-            Setting to control the strictness of the check that uvws match antenna
-            positions. Options are: ['strict', 'warn', 'off']. See the `UVData.check`
-            docstring for more details.
+        strict_uvw_antpos_check : bool
+            Option to raise an error rather than a warning if the check that
+            uvws match antenna positions does not pass.
 
         Raises
         ------
@@ -443,5 +442,5 @@ class MS(UVData):
             self.check(
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
-                uvw_antpos_check_level=uvw_antpos_check_level,
+                strict_uvw_antpos_check=strict_uvw_antpos_check,
             )

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -720,8 +720,10 @@ class MWACorrFITS(UVData):
                 )
 
             # check if object is self-consistent
+            # uvws are calcuated using pyuvdata, so turn off the check for speed.
             if run_check:
                 self.check(
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability,
+                    uvw_antpos_check_level="off",
                 )

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -163,6 +163,7 @@ class MWACorrFITS(UVData):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
+        strict_uvw_antpos_check=False,
     ):
         """
         Read in MWA correlator gpu box files.
@@ -233,6 +234,9 @@ class MWACorrFITS(UVData):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done).
+        strict_uvw_antpos_check : bool
+            Option to raise an error rather than a warning if the check that
+            uvws match antenna positions does not pass.
 
 
         Raises
@@ -725,5 +729,5 @@ class MWACorrFITS(UVData):
                 self.check(
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability,
-                    uvw_antpos_check_level="off",
+                    strict_uvw_antpos_check=strict_uvw_antpos_check,
                 )

--- a/pyuvdata/uvdata/tests/test_fhd.py
+++ b/pyuvdata/uvdata/tests/test_fhd.py
@@ -471,9 +471,7 @@ def test_multi_files_axis(fhd_model):
     fhd_uv2 = UVData()
     test1 = list(np.array(testfiles)[[0, 1, 2, 4, 6, 7]])
     test2 = list(np.array(testfiles)[[0, 2, 3, 5, 6, 7]])
-    fhd_uv1.read(
-        np.array([test1, test2]), use_model=True, file_type="fhd", axis="polarization"
-    )
+    fhd_uv1.read(np.array([test1, test2]), use_model=True, axis="polarization")
 
     fhd_uv2 = fhd_model
 

--- a/pyuvdata/uvdata/tests/test_fhd.py
+++ b/pyuvdata/uvdata/tests/test_fhd.py
@@ -94,6 +94,7 @@ def test_read_fhd_metadata_only_error():
         fhd_uv.read_fhd(testfiles[:7], read_data=False)
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_read_fhd_select():
     """
     test select on read with FHD files.
@@ -116,8 +117,10 @@ def test_read_fhd_select():
             "matches the known_telescopes values, using them.",
             "The uvw_array does not match the expected values given the antenna "
             "positions.",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
         ],
-        nwarnings=3,
+        nwarnings=4,
     )
 
     uvtest.checkWarnings(

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -80,8 +80,8 @@ def test_read_write_read_atca(tmp_path):
     uvtest.checkWarnings(
         uv_in.read,
         [atca_file],
-        nwarnings=4,
-        category=[UserWarning, UserWarning, UserWarning, UserWarning],
+        nwarnings=5,
+        category=[UserWarning] * 5,
         message=[
             "Altitude is not present in Miriad file, and "
             "telescope ATCA is not in known_telescopes. ",
@@ -92,6 +92,8 @@ def test_read_write_read_atca(tmp_path):
             "earth. Antenna positions do not appear to be on the surface of the "
             "earth and will be treated as relative.",
             "Telescope ATCA is not in known_telescopes.",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
         ],
     )
     uv_in.write_miriad(testfile, clobber=True)
@@ -134,11 +136,13 @@ def test_miriad_read_warning_lat_lon_corrected():
         miriad_uv.read,
         [miriad_file],
         {"correct_lat_lon": False},
-        nwarnings=1,
+        nwarnings=2,
         message=[
             "Altitude is not present in Miriad file, "
             "using known location altitude value for "
-            "PAPER and lat/lon from file."
+            "PAPER and lat/lon from file.",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
         ],
     )
 
@@ -250,29 +254,35 @@ def test_wronglatlon():
     uvtest.checkWarnings(
         uv_in.read,
         [latfile],
-        nwarnings=2,
+        nwarnings=3,
         message=[
             "Altitude is not present in file and latitude value does not match",
             "drift RA, Dec is off from lst, latitude by more than 1.0 deg",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
         ],
     )
     uvtest.checkWarnings(
         uv_in.read,
         [lonfile],
-        nwarnings=2,
+        nwarnings=3,
         message=[
             "Altitude is not present in file and longitude value does not match",
             "drift RA, Dec is off from lst, latitude by more than 1.0 deg",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
         ],
     )
     uvtest.checkWarnings(
         uv_in.read,
         func_args=[latlonfile],
         func_kwargs={"correct_lat_lon": False},
-        nwarnings=1,
+        nwarnings=2,
         message=[
             "Altitude is not present in file and latitude and longitude "
             "values do not match",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
         ],
     )
 
@@ -335,7 +345,7 @@ def test_miriad_location_handling(tmp_path):
     uvtest.checkWarnings(
         uv_out.read,
         [testfile],
-        nwarnings=4,
+        nwarnings=5,
         message=[
             "Altitude is not present in Miriad file, and "
             "telescope foo is not in known_telescopes. "
@@ -347,6 +357,8 @@ def test_miriad_location_handling(tmp_path):
             "telescope_position will be set using the mean "
             "of the antenna altitudes",
             "Telescope foo is not in known_telescopes.",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
         ],
     )
 
@@ -371,7 +383,7 @@ def test_miriad_location_handling(tmp_path):
     uvtest.checkWarnings(
         uv_out.read,
         [testfile],
-        nwarnings=5,
+        nwarnings=6,
         message=[
             "Altitude is not present in Miriad file, and "
             "telescope foo is not in known_telescopes. "
@@ -385,6 +397,8 @@ def test_miriad_location_handling(tmp_path):
             "value does not match",
             "drift RA, Dec is off from lst, latitude by more than 1.0 deg",
             "Telescope foo is not in known_telescopes.",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
         ],
     )
 
@@ -410,7 +424,7 @@ def test_miriad_location_handling(tmp_path):
     uvtest.checkWarnings(
         uv_out.read,
         [testfile],
-        nwarnings=5,
+        nwarnings=6,
         message=[
             "Altitude is not present in Miriad file, and "
             "telescope foo is not in known_telescopes. "
@@ -424,6 +438,8 @@ def test_miriad_location_handling(tmp_path):
             "value does not match",
             "drift RA, Dec is off from lst, latitude by more than 1.0 deg",
             "Telescope foo is not in known_telescopes.",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
         ],
     )
 
@@ -453,7 +469,7 @@ def test_miriad_location_handling(tmp_path):
     uvtest.checkWarnings(
         uv_out.read,
         [testfile],
-        nwarnings=5,
+        nwarnings=6,
         message=[
             "Altitude is not present in Miriad file, and "
             "telescope foo is not in known_telescopes. "
@@ -467,6 +483,8 @@ def test_miriad_location_handling(tmp_path):
             "longitude values do not match",
             "drift RA, Dec is off from lst, latitude by more than 1.0 deg",
             "Telescope foo is not in known_telescopes.",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
         ],
     )
 
@@ -500,7 +518,7 @@ def test_miriad_location_handling(tmp_path):
     uvtest.checkWarnings(
         uv_out.read,
         [testfile],
-        nwarnings=4,
+        nwarnings=5,
         message=[
             "Altitude is not present in Miriad file, and "
             "telescope foo is not in known_telescopes. "
@@ -512,6 +530,8 @@ def test_miriad_location_handling(tmp_path):
             "does not give a telescope_location on the "
             "surface of the earth.",
             "Telescope foo is not in known_telescopes.",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
         ],
     )
 
@@ -577,58 +597,60 @@ def test_poltoind():
     assert str(cm.value).startswith("multiple matches for pol=-7 in polarization_array")
 
 
+@pytest.mark.parametrize(
+    "kwd_name,kwd_value,warnstr,errstr",
+    (
+        [
+            "testdict",
+            {"testkey": 23},
+            "testdict in extra_keywords is a list, array or dict",
+            "Extra keyword testdict is of <class 'dict'>",
+        ],
+        [
+            "testlist",
+            [12, 14, 90],
+            "testlist in extra_keywords is a list, array or dict",
+            "Extra keyword testlist is of <class 'list'>",
+        ],
+        [
+            "testarr",
+            np.array([12, 14, 90]),
+            "testarr in extra_keywords is a list, array or dict",
+            "Extra keyword testarr is of <class 'numpy.ndarray'>",
+        ],
+        [
+            "test_long_key",
+            True,
+            "key test_long_key in extra_keywords is longer than 8 characters",
+            None,
+        ],
+    ),
+)
+def test_miriad_extra_keywords_errors(tmp_path, kwd_name, kwd_value, warnstr, errstr):
+    uv_in = UVData()
+    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    testfile = str(tmp_path / "outtest_miriad.uv")
+    uv_in.read(miriad_file)
+
+    # check for warnings & errors with extra_keywords that are dicts, lists or arrays
+    uv_in.extra_keywords[kwd_name] = kwd_value
+    with pytest.warns(UserWarning, match=warnstr):
+        uv_in.check(uvw_antpos_check_level="off")
+
+    if errstr is not None:
+        with pytest.raises(TypeError, match=errstr):
+            uv_in.write_miriad(testfile, clobber=True, run_check=False)
+    else:
+        with pytest.warns(UserWarning, match=warnstr):
+            uv_in.write_miriad(testfile, clobber=True, run_check=False)
+
+
 def test_miriad_extra_keywords(tmp_path):
     uv_in = UVData()
     uv_out = UVData()
     miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
     testfile = str(tmp_path / "outtest_miriad.uv")
     uv_in.read(miriad_file)
-
-    # check for warnings & errors with extra_keywords that are dicts, lists or arrays
-    uv_in.extra_keywords["testdict"] = {"testkey": 23}
-    uvtest.checkWarnings(
-        uv_in.check, message=["testdict in extra_keywords is a " "list, array or dict"]
-    )
-
-    with pytest.raises(TypeError) as cm:
-        uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    assert str(cm.value).startswith("Extra keyword testdict is of <class 'dict'>")
-
-    uv_in.extra_keywords.pop("testdict")
-
-    uv_in.extra_keywords["testlist"] = [12, 14, 90]
-    uvtest.checkWarnings(
-        uv_in.check, message=["testlist in extra_keywords is a " "list, array or dict"]
-    )
-    with pytest.raises(TypeError) as cm:
-        uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    assert str(cm.value).startswith("Extra keyword testlist is of <class 'list'>")
-    uv_in.extra_keywords.pop("testlist")
-
-    uv_in.extra_keywords["testarr"] = np.array([12, 14, 90])
-    uvtest.checkWarnings(
-        uv_in.check, message=["testarr in extra_keywords is a " "list, array or dict"]
-    )
-    with pytest.raises(TypeError) as cm:
-        uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    assert str(cm.value).startswith(
-        "Extra keyword testarr is of <class 'numpy.ndarray'>"
-    )
-    uv_in.extra_keywords.pop("testarr")
-
-    # check for warnings with extra_keywords keys that are too long
-    uv_in.extra_keywords["test_long_key"] = True
-    uvtest.checkWarnings(
-        uv_in.check,
-        message=["key test_long_key in extra_keywords " "is longer than 8 characters"],
-    )
-    uvtest.checkWarnings(
-        uv_in.write_miriad,
-        [testfile],
-        {"clobber": True, "run_check": False},
-        message=["key test_long_key in extra_keywords is longer than 8 characters"],
-    )
-    uv_in.extra_keywords.pop("test_long_key")
 
     # check handling of boolean keywords
     uv_in.extra_keywords["bool"] = True
@@ -671,17 +693,17 @@ def test_miriad_extra_keywords(tmp_path):
     # check handling of complex-like keywords
     # currently they are NOT supported
     uv_in.extra_keywords["complex1"] = np.complex64(5.3 + 1.2j)
-    with pytest.raises(TypeError) as cm:
+    with pytest.raises(
+        TypeError, match="Extra keyword complex1 is of <class 'numpy.complex64'>"
+    ):
         uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    assert str(cm.value).startswith(
-        "Extra keyword complex1 is of <class 'numpy.complex64'>"
-    )
     uv_in.extra_keywords.pop("complex1")
 
     uv_in.extra_keywords["complex2"] = 6.9 + 4.6j
-    with pytest.raises(TypeError) as cm:
+    with pytest.raises(
+        TypeError, match="Extra keyword complex2 is of <class 'complex'>"
+    ):
         uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    assert str(cm.value).startswith("Extra keyword complex2 is of <class 'complex'>")
 
 
 def test_roundtrip_optional_params(tmp_path):
@@ -1134,9 +1156,14 @@ def test_read_write_read_miriad_partial_with_warnings(tmp_path):
     ]
     uvtest.checkWarnings(
         uv_in.read,
-        [write_file],
-        {"times": times_to_keep},
-        message=["Warning: a select on read keyword is set"],
+        func_args=[write_file],
+        func_kwargs={"times": times_to_keep},
+        nwarnings=2,
+        message=[
+            "Warning: a select on read keyword is set",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
+        ],
     )
     exp_uv = full.select(times=times_to_keep, inplace=False)
     assert uv_in == exp_uv
@@ -1151,10 +1178,14 @@ def test_read_write_read_miriad_partial_with_warnings(tmp_path):
     ants_keep = [0, 2, 4]
     uvtest.checkWarnings(
         uv_in.read,
-        [write_file],
-        {"blt_inds": blts_select, "antenna_nums": ants_keep},
-        nwarnings=1,
-        message=["Warning: blt_inds is set along with select on read"],
+        func_args=[write_file],
+        func_kwargs={"blt_inds": blts_select, "antenna_nums": ants_keep},
+        nwarnings=2,
+        message=[
+            "Warning: blt_inds is set along with select on read",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
+        ],
     )
     exp_uv = full.select(blt_inds=blts_select, antenna_nums=ants_keep, inplace=False)
     assert uv_in != exp_uv
@@ -1203,6 +1234,8 @@ def test_read_write_read_miriad_partial_metadata_only(tmp_path):
     assert uv_in == uv_in2
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_read_ms_write_miriad_casa_history(tmp_path):
     """
     Read in .ms file.
@@ -1213,11 +1246,10 @@ def test_read_ms_write_miriad_casa_history(tmp_path):
     miriad_uv = UVData()
     ms_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.ms")
     testfile = str(tmp_path / "outtest_miriad")
-    uvtest.checkWarnings(
-        ms_uv.read, [ms_file], message="Telescope EVLA is not", nwarnings=0
-    )
+    ms_uv.read(ms_file)
+
     ms_uv.write_miriad(testfile, clobber=True)
-    uvtest.checkWarnings(miriad_uv.read, [testfile], message="Telescope EVLA is not")
+    miriad_uv.read(testfile)
 
     assert miriad_uv == ms_uv
 
@@ -1254,7 +1286,16 @@ def test_rwr_miriad_antpos_issues(tmp_path):
     ant_ind = np.where(uv_in.antenna_numbers == ants_with_data[0])[0]
     uv_in.antenna_positions[ant_ind, :] = [0, 0, 0]
     uv_in.write_miriad(write_file, clobber=True, no_antnums=True)
-    uvtest.checkWarnings(uv_out.read, [write_file], message=["antenna number"])
+    uvtest.checkWarnings(
+        uv_out.read,
+        func_args=[write_file],
+        nwarnings=2,
+        message=[
+            "antenna number",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
+        ],
+    )
 
     assert uv_in == uv_out
 
@@ -1287,6 +1328,7 @@ def test_rwr_miriad_antpos_issues(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_multi_files(tmp_path):
     """
     Reading multiple files at once.
@@ -1308,14 +1350,8 @@ def test_multi_files(tmp_path):
     uv2.write_miriad(testfile2, clobber=True)
     del uv1
     uv1 = UVData()
-    uvtest.checkWarnings(
-        uv1.read,
-        func_args=[[testfile1, testfile2]],
-        func_kwargs={"file_type": "miriad"},
-        message=["Telescope EVLA is not"],
-        category=2 * [UserWarning],
-        nwarnings=2,
-    )
+    uv1.read([testfile1, testfile2], file_type="miriad")
+
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
         uv_full.history + "  Downselected to "
@@ -1343,6 +1379,8 @@ def test_multi_files(tmp_path):
     assert uv1 == uv_full
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_antpos_units(tmp_path):
     """
     Read uvfits, write miriad. Check written antpos are in ns.
@@ -1350,7 +1388,7 @@ def test_antpos_units(tmp_path):
     uv = UVData()
     uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
     testfile = str(tmp_path / "uv_antpos_units")
-    uvtest.checkWarnings(uv.read_uvfits, [uvfits_file], message="Telescope EVLA is not")
+    uv.read_uvfits(uvfits_file)
     uv.write_miriad(testfile, clobber=True)
     auv = aipy_extracts.UV(testfile)
     aantpos = auv["antpos"].reshape(3, -1).T * const.c.to("m/ns").value

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -7,8 +7,8 @@
 Note that because of the way that file handling is done in the C++ API, a miriad
 file is not closed until the destructor function (tp_dealloc) is called.
 
-As of April 2020, the following lines were made before a major rewrite of
-the miriad interface. They should no longer necessarily be true,
+The following lines were made before a major rewrite of the miriad interface.
+As of April 2020, they should no longer necessarily be true,
 but are preserved here in case segfaults arise again.
 
 Due to implementation details of CPython, it is sometimes not enough to `del` the
@@ -22,7 +22,6 @@ on their own.
 """
 import os
 import shutil
-import copy
 import numpy as np
 import pytest
 from astropy.time import Time, TimeDelta
@@ -40,13 +39,13 @@ aipy_extracts = pytest.importorskip("pyuvdata.uvdata.aipy_extracts")
 # This does NOT break uvutils.checkWarnings tests for this warning
 pytestmark = pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad")
 
+paper_miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
 
-@pytest.fixture
-def uv_in_paper(tmp_path):
-    uv_in = UVData()
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+
+@pytest.fixture(scope="function")
+def uv_in_paper(paper_miriad, tmp_path):
+    uv_in = paper_miriad
     write_file = str(tmp_path / "outtest_miriad.uv")
-    uv_in.read(testfile)
     uv_in.write_miriad(write_file, clobber=True)
     uv_out = UVData()
 
@@ -56,13 +55,11 @@ def uv_in_paper(tmp_path):
     del uv_in, uv_out
 
 
-@pytest.fixture
-def uv_in_uvfits(tmp_path):
-    uv_in = UVData()
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+@pytest.fixture(scope="function")
+def uv_in_uvfits(paper_miriad, tmp_path):
+    uv_in = paper_miriad
     write_file = str(tmp_path / "outtest_miriad.uvfits")
 
-    uv_in.read(testfile)
     uv_out = UVData()
 
     yield uv_in, uv_out, write_file
@@ -72,6 +69,7 @@ def uv_in_uvfits(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:Telescope ATCA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_read_write_read_atca(tmp_path):
     uv_in = UVData()
     uv_out = UVData()
@@ -102,18 +100,18 @@ def test_read_write_read_atca(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_read_nrao_write_miriad_read_miriad(tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_read_nrao_write_miriad_read_miriad(casa_uvfits, tmp_path):
     """Test reading in a CASA tutorial uvfits file, writing and reading as miriad"""
-    uvfits_uv = UVData()
+    uvfits_uv = casa_uvfits
     miriad_uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
     writefile = str(tmp_path / "outtest_miriad.uv")
-    uvfits_uv.read_uvfits(testfile)
     uvfits_uv.write_miriad(writefile, clobber=True)
     miriad_uv.read(writefile)
     assert uvfits_uv == miriad_uv
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_read_miriad_write_uvfits(uv_in_uvfits):
     """
     Miriad to uvfits loopback test.
@@ -128,13 +126,13 @@ def test_read_miriad_write_uvfits(uv_in_uvfits):
     assert miriad_uv == uvfits_uv
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_miriad_read_warning_lat_lon_corrected():
     miriad_uv = UVData()
-    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
     # check warning when correct_lat_lon is set to False
     uvtest.checkWarnings(
         miriad_uv.read,
-        [miriad_file],
+        [paper_miriad_file],
         {"correct_lat_lon": False},
         nwarnings=2,
         message=[
@@ -147,6 +145,7 @@ def test_miriad_read_warning_lat_lon_corrected():
     )
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "err_type,write_kwargs,err_msg",
     [
@@ -164,9 +163,8 @@ def test_read_miriad_write_uvfits_phasing_errors(
     miriad_uv, uvfits_uv, testfile = uv_in_uvfits
 
     # check error if phase_type is wrong and force_phase not set
-    with pytest.raises(err_type) as cm:
+    with pytest.raises(err_type, match=err_msg):
         miriad_uv.write_uvfits(testfile, **write_kwargs)
-    assert str(cm.value).startswith(err_msg)
 
 
 @pytest.mark.parametrize(
@@ -182,22 +180,21 @@ def test_read_miriad_write_uvfits_phasing_errors(
 )
 def test_read_miriad_phasing_errors(err_type, read_kwargs, err_msg):
     miriad_uv = UVData()
-    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
     # check that setting the phase_type to something wrong errors
-    with pytest.raises(err_type) as cm:
-        miriad_uv.read(miriad_file, **read_kwargs)
-    assert str(cm.value).startswith(err_msg)
+    with pytest.raises(err_type, match=err_msg):
+        miriad_uv.read(paper_miriad_file, **read_kwargs)
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_read_miriad_write_uvfits_phasing_error(uv_in_uvfits):
     miriad_uv, uvfits_uv, testfile = uv_in_uvfits
 
     miriad_uv._set_unknown_phase_type()
-    with pytest.raises(ValueError) as cm:
+    with pytest.raises(ValueError, match="The phasing type of the data is unknown"):
         miriad_uv.write_uvfits(testfile, spoof_nonessential=True)
-    assert str(cm.value).startswith("The phasing type of the data is unknown")
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_wronglatlon():
     """
     Check for appropriate warnings with incorrect lat/lon values or missing telescope
@@ -303,18 +300,18 @@ def test_wronglatlon():
     )
 
 
-def test_miriad_location_handling(tmp_path):
-    uv_in = UVData()
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_miriad_location_handling(paper_miriad_master, tmp_path):
+    uv_in = paper_miriad_master
     uv_out = UVData()
-    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+
     testfile = str(tmp_path / "outtest_miriad.uv")
-    aipy_uv = aipy_extracts.UV(miriad_file)
+    aipy_uv = aipy_extracts.UV(paper_miriad_file)
 
     if os.path.exists(testfile):
         shutil.rmtree(testfile)
 
     # Test for using antenna positions to get telescope position
-    uv_in.read(miriad_file)
     # extract antenna positions and rotate them for miriad
     nants = aipy_uv["nants"]
     rel_ecef_antpos = np.zeros((nants, 3), dtype=uv_in.antenna_positions.dtype)
@@ -367,7 +364,7 @@ def test_miriad_location_handling(tmp_path):
     # make new file
     if os.path.exists(testfile):
         shutil.rmtree(testfile)
-    aipy_uv = aipy_extracts.UV(miriad_file)
+    aipy_uv = aipy_extracts.UV(paper_miriad_file)
     aipy_uv2 = aipy_extracts.UV(testfile, status="new")
     # initialize headers from old file
     # change telescope name (so the position isn't set from known_telescopes)
@@ -408,7 +405,7 @@ def test_miriad_location_handling(tmp_path):
     # make new file
     if os.path.exists(testfile):
         shutil.rmtree(testfile)
-    aipy_uv = aipy_extracts.UV(miriad_file)
+    aipy_uv = aipy_extracts.UV(paper_miriad_file)
     aipy_uv2 = aipy_extracts.UV(testfile, status="new")
     # initialize headers from old file
     # change telescope name (so the position isn't set from known_telescopes)
@@ -448,7 +445,7 @@ def test_miriad_location_handling(tmp_path):
     # make new file
     if os.path.exists(testfile):
         shutil.rmtree(testfile)
-    aipy_uv = aipy_extracts.UV(miriad_file)
+    aipy_uv = aipy_extracts.UV(paper_miriad_file)
     aipy_uv2 = aipy_extracts.UV(testfile, status="new")
     # initialize headers from old file
     # change telescope name (so the position isn't set from known_telescopes)
@@ -503,7 +500,7 @@ def test_miriad_location_handling(tmp_path):
     # make new file
     if os.path.exists(testfile):
         shutil.rmtree(testfile)
-    aipy_uv = aipy_extracts.UV(miriad_file)
+    aipy_uv = aipy_extracts.UV(paper_miriad_file)
     aipy_uv2 = aipy_extracts.UV(testfile, status="new")
     # initialize headers from old file
     # change telescope name (so the position isn't set from known_telescopes)
@@ -539,17 +536,15 @@ def test_miriad_location_handling(tmp_path):
     aipy_uv.close()
 
 
-def test_singletimeselect_drift(tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_singletimeselect_drift(uv_in_paper, tmp_path):
     """
     Check behavior with writing & reading after selecting a single time from
     a drift file.
     """
-    uv_in = UVData()
-    uv_out = UVData()
-    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    testfile = str(tmp_path / "outtest_miriad.uv")
-    uv_in.read(miriad_file)
+    uv_in, uv_out, testfile = uv_in_paper
 
+    uv_in_copy = uv_in.copy()
     uv_in.select(times=uv_in.time_array[0])
     uv_in.write_miriad(testfile, clobber=True)
     uv_out.read(testfile)
@@ -560,27 +555,26 @@ def test_singletimeselect_drift(tmp_path):
     assert uv_in == uv_out
 
     # check again with more than one time but only 1 unflagged time
-    uv_in.read(miriad_file)
-    time_gt0_array = np.where(uv_in.time_array > uv_in.time_array[0])[0]
-    uv_in.flag_array[time_gt0_array, :, :, :] = True
+    time_gt0_array = np.where(uv_in_copy.time_array > uv_in_copy.time_array[0])[0]
+    uv_in_copy.flag_array[time_gt0_array, :, :, :] = True
 
     # get unflagged blts
-    blt_good = np.where(~np.all(uv_in.flag_array, axis=(1, 2, 3)))
-    assert np.isclose(np.mean(np.diff(uv_in.time_array[blt_good])), 0.0)
+    blt_good = np.where(~np.all(uv_in_copy.flag_array, axis=(1, 2, 3)))
+    assert np.isclose(np.mean(np.diff(uv_in_copy.time_array[blt_good])), 0.0)
 
-    uv_in.write_miriad(testfile, clobber=True)
+    uv_in_copy.write_miriad(testfile, clobber=True)
     uv_out.read(testfile)
-    assert uv_in == uv_out
+    assert uv_in_copy == uv_out
 
     # check that setting the phase_type works
     uv_out.read(testfile, phase_type="drift")
-    assert uv_in == uv_out
+    assert uv_in_copy == uv_out
 
 
-def test_poltoind():
-    miriad_uv = UVData()
-    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    miriad_uv.read(miriad_file)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_poltoind(uv_in_paper):
+    miriad_uv, uv_out, testfile = uv_in_paper
+
     pol_arr = miriad_uv.polarization_array
 
     miriad = miriad_uv._convert_to_filetype("miriad")
@@ -624,18 +618,30 @@ def test_poltoind():
             "key test_long_key in extra_keywords is longer than 8 characters",
             None,
         ],
+        [
+            "complex1",
+            np.complex64(5.3 + 1.2j),
+            None,
+            "Extra keyword complex1 is of <class 'numpy.complex64'>",
+        ],
+        [
+            "complex2",
+            6.9 + 4.6j,
+            None,
+            "Extra keyword complex2 is of <class 'complex'>",
+        ],
     ),
 )
-def test_miriad_extra_keywords_errors(tmp_path, kwd_name, kwd_value, warnstr, errstr):
-    uv_in = UVData()
-    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    testfile = str(tmp_path / "outtest_miriad.uv")
-    uv_in.read(miriad_file)
+def test_miriad_extra_keywords_errors(
+    uv_in_paper, tmp_path, kwd_name, kwd_value, warnstr, errstr
+):
+    uv_in, uv_out, testfile = uv_in_paper
 
     # check for warnings & errors with extra_keywords that are dicts, lists or arrays
     uv_in.extra_keywords[kwd_name] = kwd_value
-    with pytest.warns(UserWarning, match=warnstr):
-        uv_in.check(uvw_antpos_check_level="off")
+    if warnstr is not None:
+        with pytest.warns(UserWarning, match=warnstr):
+            uv_in.check(uvw_antpos_check_level="off")
 
     if errstr is not None:
         with pytest.raises(TypeError, match=errstr):
@@ -645,73 +651,30 @@ def test_miriad_extra_keywords_errors(tmp_path, kwd_name, kwd_value, warnstr, er
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
 
 
-def test_miriad_extra_keywords(tmp_path):
-    uv_in = UVData()
-    uv_out = UVData()
-    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    testfile = str(tmp_path / "outtest_miriad.uv")
-    uv_in.read(miriad_file)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.parametrize(
+    "kwd_names,kwd_values",
+    (
+        [["bool", "bool2"], [True, False]],
+        [["int1", "int2"], [np.int(5), 7]],
+        [["float1", "float2"], [np.int64(5.3), 6.9]],
+        [["str", "longstr"], ["hello", "this is a very long string " * 1000]],
+    ),
+)
+def test_miriad_extra_keywords(uv_in_paper, tmp_path, kwd_names, kwd_values):
+    uv_in, uv_out, testfile = uv_in_paper
 
-    # check handling of boolean keywords
-    uv_in.extra_keywords["bool"] = True
-    uv_in.extra_keywords["bool2"] = False
+    for name, value in zip(kwd_names, kwd_values):
+        uv_in.extra_keywords[name] = value
     uv_in.write_miriad(testfile, clobber=True)
     uv_out.read(testfile)
 
     assert uv_in == uv_out
-    uv_in.extra_keywords.pop("bool")
-    uv_in.extra_keywords.pop("bool2")
-
-    # check handling of int-like keywords
-    uv_in.extra_keywords["int1"] = np.int(5)
-    uv_in.extra_keywords["int2"] = 7
-    uv_in.write_miriad(testfile, clobber=True)
-    uv_out.read(testfile)
-
-    assert uv_in == uv_out
-    uv_in.extra_keywords.pop("int1")
-    uv_in.extra_keywords.pop("int2")
-
-    # check handling of float-like keywords
-    uv_in.extra_keywords["float1"] = np.int64(5.3)
-    uv_in.extra_keywords["float2"] = 6.9
-    uv_in.write_miriad(testfile, clobber=True)
-    uv_out.read(testfile)
-
-    assert uv_in == uv_out
-    uv_in.extra_keywords.pop("float1")
-    uv_in.extra_keywords.pop("float2")
-
-    # check handling of very long strings
-    long_string = "this is a very long string " * 1000
-    uv_in.extra_keywords["longstr"] = long_string
-    uv_in.write_miriad(testfile, clobber=True)
-    uv_out.read(testfile)
-    assert uv_in == uv_out
-    uv_in.extra_keywords.pop("longstr")
-
-    # check handling of complex-like keywords
-    # currently they are NOT supported
-    uv_in.extra_keywords["complex1"] = np.complex64(5.3 + 1.2j)
-    with pytest.raises(
-        TypeError, match="Extra keyword complex1 is of <class 'numpy.complex64'>"
-    ):
-        uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    uv_in.extra_keywords.pop("complex1")
-
-    uv_in.extra_keywords["complex2"] = 6.9 + 4.6j
-    with pytest.raises(
-        TypeError, match="Extra keyword complex2 is of <class 'complex'>"
-    ):
-        uv_in.write_miriad(testfile, clobber=True, run_check=False)
 
 
-def test_roundtrip_optional_params(tmp_path):
-    uv_in = UVData()
-    uv_out = UVData()
-    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    testfile = str(tmp_path / "outtest_miriad.uv")
-    uv_in.read(miriad_file)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_roundtrip_optional_params(uv_in_paper, tmp_path):
+    uv_in, uv_out, testfile = uv_in_paper
 
     uv_in.x_orientation = "east"
     uv_in.reorder_blts()
@@ -730,20 +693,18 @@ def test_roundtrip_optional_params(tmp_path):
     assert uv_in == uv_out
 
 
-def test_breakread_miriad(tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_breakread_miriad(uv_in_paper, tmp_path):
     """Test Miriad file checking."""
-    uv_in = UVData()
-    uv_out = UVData()
+    uv_in, uv_out, testfile = uv_in_paper
+
     with pytest.raises(IOError) as cm:
         uv_in.read("foo", file_type="miriad")
     assert str(cm.value).startswith("foo not found")
 
-    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    testfile = str(tmp_path / "outtest_miriad.uv")
-    uv_in.read(miriad_file)
-
-    uv_in.Nblts += 10
-    uv_in.write_miriad(testfile, clobber=True, run_check=False)
+    uv_in_copy = uv_in.copy()
+    uv_in_copy.Nblts += 10
+    uv_in_copy.write_miriad(testfile, clobber=True, run_check=False)
     uvtest.checkWarnings(
         uv_out.read,
         [testfile],
@@ -751,9 +712,9 @@ def test_breakread_miriad(tmp_path):
         message=["Nblts does not match the number of unique blts in the data"],
     )
 
-    uv_in.read(miriad_file)
-    uv_in.Nbls += 10
-    uv_in.write_miriad(testfile, clobber=True, run_check=False)
+    uv_in_copy = uv_in.copy()
+    uv_in_copy.Nbls += 10
+    uv_in_copy.write_miriad(testfile, clobber=True, run_check=False)
     uvtest.checkWarnings(
         uv_out.read,
         [testfile],
@@ -761,9 +722,9 @@ def test_breakread_miriad(tmp_path):
         message=["Nbls does not match the number of unique baselines in the data"],
     )
 
-    uv_in.read(miriad_file)
-    uv_in.Ntimes += 10
-    uv_in.write_miriad(testfile, clobber=True, run_check=False)
+    uv_in_copy = uv_in.copy()
+    uv_in_copy.Ntimes += 10
+    uv_in_copy.write_miriad(testfile, clobber=True, run_check=False)
     uvtest.checkWarnings(
         uv_out.read,
         [testfile],
@@ -772,6 +733,7 @@ def test_breakread_miriad(tmp_path):
     )
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_read_write_read_miriad(uv_in_paper):
     """
     PAPER file Miriad loopback test.
@@ -785,7 +747,7 @@ def test_read_write_read_miriad(uv_in_paper):
     assert uv_in == uv_out
 
     # check that we can read & write phased data
-    uv_in2 = copy.deepcopy(uv_in)
+    uv_in2 = uv_in.copy()
     uv_in2.phase_to_time(Time(np.mean(uv_in2.time_array), format="jd"))
     uv_in2.write_miriad(write_file, clobber=True)
     uv_out.read(write_file)
@@ -805,6 +767,7 @@ def test_read_write_read_miriad(uv_in_paper):
     assert uv_in == uv_out
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_miriad_antenna_diameters(uv_in_paper):
     # check that if antenna_diameters is set, it's read back out properly
     uv_in, uv_out, write_file = uv_in_paper
@@ -822,17 +785,20 @@ def test_miriad_antenna_diameters(uv_in_paper):
     assert uv_in == uv_out
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_miriad_write_miriad_unkonwn_phase_error(uv_in_paper):
     uv_in, uv_out, write_file = uv_in_paper
     # check that trying to write a file with unknown phasing raises an error
     uv_in._set_unknown_phase_type()
-    with pytest.raises(ValueError) as cm:
+    with pytest.raises(ValueError, match="The phasing type of the data is unknown"):
         uv_in.write_miriad(write_file, clobber=True)
-    assert str(cm.value).startswith("The phasing type of the data is unknown")
 
 
-def test_miriad_write_read_diameters(uv_in_paper):
-    uv_in, uv_out, write_file = uv_in_paper
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_miriad_write_read_diameters(tmp_path):
+    uv_in = UVData()
+    uv_out = UVData()
+    write_file = str(tmp_path / "outtest_miriad.uv")
     # check for backwards compatibility with old keyword 'diameter' for
     # antenna diameters
     testfile_diameters = os.path.join(DATA_PATH, "zen.2457698.40355.xx.HH.uvcA")
@@ -842,11 +808,11 @@ def test_miriad_write_read_diameters(uv_in_paper):
     assert uv_in == uv_out
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_miriad_and_aipy_reads(uv_in_paper):
     uv_in, uv_out, write_file = uv_in_paper
     # check that variables 'ischan' and 'nschan' were written to new file
     # need to use aipy, since pyuvdata is not currently capturing these variables
-    uv_in.read(write_file)
     uv_aipy = aipy_extracts.UV(write_file)
     nfreqs = uv_in.Nfreqs
     nschan = uv_aipy["nschan"]
@@ -859,29 +825,26 @@ def test_miriad_and_aipy_reads(uv_in_paper):
 
 
 def test_miriad_telescope_locations():
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
     # test load_telescope_coords w/ blank Miriad
     uv_in = Miriad()
-    uv = aipy_extracts.UV(testfile)
+    uv = aipy_extracts.UV(paper_miriad_file)
     uv_in._load_telescope_coords(uv)
     assert uv_in.telescope_location_lat_lon_alt is not None
     uv.close()
     # test load_antpos w/ blank Miriad
     uv_in = Miriad()
-    uv = aipy_extracts.UV(testfile)
+    uv = aipy_extracts.UV(paper_miriad_file)
     uv_in._load_antpos(uv)
     assert uv_in.antenna_positions is not None
 
 
-def test_miriad_integration_time_precision(tmp_path):
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    write_file = str(tmp_path / "outtest_miriad.uv")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_miriad_integration_time_precision(uv_in_paper):
+    uv_in, uv_out, write_file = uv_in_paper
 
     # test that changing precision of integraiton_time is okay
     # tolerance of integration_time (1e-3) is larger than floating point type
     # conversions
-    uv_in = UVData()
-    uv_in.read(testfile)
     uv_in.integration_time = uv_in.integration_time.astype(np.float32)
     uv_in.write_miriad(write_file, clobber=True)
     new_uv = UVData()
@@ -889,6 +852,7 @@ def test_miriad_integration_time_precision(tmp_path):
     assert uv_in == new_uv
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "select_kwargs",
     [
@@ -900,13 +864,10 @@ def test_miriad_integration_time_precision(tmp_path):
         {"bls": [(4, 4, "xy")]},
     ],
 )
-def test_read_write_read_miriad_partial_bls(select_kwargs, tmp_path):
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    write_file = str(tmp_path / "outtest_miriad.uv")
-
+def test_read_write_read_miriad_partial_bls(uv_in_paper, select_kwargs, tmp_path):
     # check partial read selections
-    full = UVData()
-    full.read(testfile)
+    full, uv_out, write_file = uv_in_paper
+
     full.write_miriad(write_file, clobber=True)
     uv_in = UVData()
 
@@ -922,13 +883,11 @@ def test_read_write_read_miriad_partial_bls(select_kwargs, tmp_path):
     assert uv_in == exp_uv
 
 
-def test_read_write_read_miriad_partial_antenna_nums(tmp_path):
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    write_file = str(tmp_path / "outtest_miriad.uv")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_read_write_read_miriad_partial_antenna_nums(uv_in_paper, tmp_path):
+    full, uv_out, write_file = uv_in_paper
 
     # check partial read selections
-    full = UVData()
-    full.read(testfile)
     full.write_miriad(write_file, clobber=True)
     uv_in = UVData()
     # test all bls w/ 0 are loaded
@@ -941,6 +900,7 @@ def test_read_write_read_miriad_partial_antenna_nums(tmp_path):
     assert uv_in == exp_uv
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "select_kwargs",
     [
@@ -949,13 +909,10 @@ def test_read_write_read_miriad_partial_antenna_nums(tmp_path):
         {"time_range": [2456865.607, 2456865.609], "polarizations": [-7]},
     ],
 )
-def test_read_write_read_miriad_partial_times(select_kwargs, tmp_path):
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    write_file = str(tmp_path / "outtest_miriad.uv")
+def test_read_write_read_miriad_partial_times(uv_in_paper, select_kwargs, tmp_path):
+    full, uv_out, write_file = uv_in_paper
 
     # check partial read selections
-    full = UVData()
-    full.read(testfile)
     full.write_miriad(write_file, clobber=True)
     # test time loading
     uv_in = UVData()
@@ -974,14 +931,12 @@ def test_read_write_read_miriad_partial_times(select_kwargs, tmp_path):
     assert uv_in == exp_uv
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("pols", [["xy"], [-7]])
-def test_read_write_read_miriad_partial_pols(pols, tmp_path):
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    write_file = str(tmp_path / "outtest_miriad.uv")
+def test_read_write_read_miriad_partial_pols(uv_in_paper, pols, tmp_path):
+    full, uv_out, write_file = uv_in_paper
 
     # check partial read selections
-    full = UVData()
-    full.read(testfile)
     full.write_miriad(write_file, clobber=True)
 
     # test polarization loading
@@ -992,42 +947,29 @@ def test_read_write_read_miriad_partial_pols(pols, tmp_path):
     assert uv_in == exp_uv
 
 
-def test_read_write_read_miriad_partial_ant_str(tmp_path):
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    write_file = str(tmp_path / "outtest_miriad.uv")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_read_write_read_miriad_partial_ant_str(uv_in_paper, tmp_path):
+    full, uv_out, write_file = uv_in_paper
 
     # check partial read selections
-    full = UVData()
-    full.read(testfile)
     full.write_miriad(write_file, clobber=True)
-    uv_in = UVData()
     # test ant_str
-    del uv_in
     uv_in = UVData()
     uv_in.read(write_file, ant_str="auto")
     assert np.array([blp[0] == blp[1] for blp in uv_in.get_antpairs()]).all()
     exp_uv = full.select(ant_str="auto", inplace=False)
     assert uv_in == exp_uv
 
-    full = UVData()
-    full.read(testfile)
-    full.write_miriad(write_file, clobber=True)
-
-    uv_in = UVData()
     uv_in.read(write_file, ant_str="cross")
     assert np.array([blp[0] != blp[1] for blp in uv_in.get_antpairs()]).all()
     exp_uv = full.select(ant_str="cross", inplace=False)
     assert uv_in == exp_uv
 
-    full = UVData()
-    full.read(testfile)
-    full.write_miriad(write_file, clobber=True)
-
-    uv_in = UVData()
     uv_in.read(write_file, ant_str="all")
     assert uv_in == full
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "err_type,select_kwargs,err_msg",
     [
@@ -1106,14 +1048,11 @@ def test_read_write_read_miriad_partial_ant_str(tmp_path):
     ],
 )
 def test_read_write_read_miriad_partial_errors(
-    err_type, select_kwargs, err_msg, tmp_path
+    uv_in_paper, err_type, select_kwargs, err_msg, tmp_path
 ):
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    write_file = str(tmp_path / "outtest_miriad.uv")
+    full, uv_out, write_file = uv_in_paper
 
     # check partial read selections
-    full = UVData()
-    full.read(testfile)
     full.write_miriad(write_file, clobber=True)
     uv_in = UVData()
 
@@ -1122,13 +1061,11 @@ def test_read_write_read_miriad_partial_errors(
     assert str(cm.value).startswith(err_msg)
 
 
-def test_read_write_read_miriad_partial_error_special_cases(tmp_path):
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    write_file = str(tmp_path / "outtest_miriad.uv")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_read_write_read_miriad_partial_error_special_cases(uv_in_paper, tmp_path):
+    full, uv_out, write_file = uv_in_paper
 
     # check partial read selections
-    full = UVData()
-    full.read(testfile)
     full.write_miriad(write_file, clobber=True)
     uv_in = UVData()
 
@@ -1139,13 +1076,11 @@ def test_read_write_read_miriad_partial_error_special_cases(tmp_path):
     )
 
 
-def test_read_write_read_miriad_partial_with_warnings(tmp_path):
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    write_file = str(tmp_path / "outtest_miriad.uv")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_read_write_read_miriad_partial_with_warnings(uv_in_paper, tmp_path):
+    full, uv_out, write_file = uv_in_paper
 
     # check partial read selections
-    full = UVData()
-    full.read(testfile)
     full.write_miriad(write_file, clobber=True)
 
     uv_in = UVData()
@@ -1168,10 +1103,6 @@ def test_read_write_read_miriad_partial_with_warnings(tmp_path):
     exp_uv = full.select(times=times_to_keep, inplace=False)
     assert uv_in == exp_uv
 
-    full = UVData()
-    full.read(testfile)
-    full.write_miriad(write_file, clobber=True)
-
     uv_in = UVData()
     # check handling for generic read selections unsupported by read_miriad
     blts_select = np.where(full.time_array == unique_times[0])[0]
@@ -1191,17 +1122,17 @@ def test_read_write_read_miriad_partial_with_warnings(tmp_path):
     assert uv_in != exp_uv
 
 
-def test_read_write_read_miriad_partial_metadata_only(tmp_path):
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    write_file = str(tmp_path / "outtest_miriad.uv")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_read_write_read_miriad_partial_metadata_only(uv_in_paper, tmp_path):
+    uv_in, uv_out, write_file = uv_in_paper
     write_file2 = str(tmp_path / "outtest_miriad2.uv")
 
     # try metadata only read
-    uv_in = UVData()
-    uv_in.read(testfile, read_data=False)
-    assert uv_in.time_array is None
-    assert uv_in.data_array is None
-    assert uv_in.integration_time is None
+    uv_in_meta = UVData()
+    uv_in_meta.read(paper_miriad_file, read_data=False)
+    assert uv_in_meta.time_array is None
+    assert uv_in_meta.data_array is None
+    assert uv_in_meta.integration_time is None
     metadata = [
         "antenna_positions",
         "antenna_names",
@@ -1212,20 +1143,18 @@ def test_read_write_read_miriad_partial_metadata_only(tmp_path):
         "telescope_location",
     ]
     for m in metadata:
-        assert getattr(uv_in, m) is not None
+        assert getattr(uv_in_meta, m) is not None
 
     # metadata only multiple file read-in
-    del uv_in
+    del uv_in_meta
 
-    uv_in = UVData()
-    uv_in.read(testfile)
     new_uv = uv_in.select(freq_chans=np.arange(5), inplace=False)
     new_uv.write_miriad(write_file, clobber=True)
     new_uv = uv_in.select(freq_chans=np.arange(5) + 5, inplace=False)
     new_uv.write_miriad(write_file2, clobber=True)
 
-    uv_in.read(testfile)
     uv_in.select(freq_chans=np.arange(10))
+
     uv_in2 = UVData()
     uv_in2.read(np.array([write_file, write_file2]))
 
@@ -1254,20 +1183,19 @@ def test_read_ms_write_miriad_casa_history(tmp_path):
     assert miriad_uv == ms_uv
 
 
-def test_rwr_miriad_antpos_issues(tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_rwr_miriad_antpos_issues(uv_in_paper, tmp_path):
     """
     test warnings and errors associated with antenna position issues in Miriad files
 
     Read in Miriad PAPER file, mess with various antpos issues and write out as
     a new Miriad file, read back in and check for appropriate behavior.
     """
-    uv_in = UVData()
-    uv_out = UVData()
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    write_file = str(tmp_path / "outtest_miriad.uv")
-    uv_in.read(testfile)
-    uv_in.antenna_positions = None
-    uv_in.write_miriad(write_file, clobber=True, run_check=False)
+    uv_in, uv_out, write_file = uv_in_paper
+
+    uv_in_copy = uv_in.copy()
+    uv_in_copy.antenna_positions = None
+    uv_in_copy.write_miriad(write_file, clobber=True, run_check=False)
     uvtest.checkWarnings(
         uv_out.read,
         func_args=[write_file],
@@ -1279,13 +1207,13 @@ def test_rwr_miriad_antpos_issues(tmp_path):
         ],
         category=[UserWarning, UserWarning],
     )
+    assert uv_in_copy == uv_out
 
-    assert uv_in == uv_out
-    uv_in.read(testfile)
-    ants_with_data = list(set(uv_in.ant_1_array).union(uv_in.ant_2_array))
-    ant_ind = np.where(uv_in.antenna_numbers == ants_with_data[0])[0]
-    uv_in.antenna_positions[ant_ind, :] = [0, 0, 0]
-    uv_in.write_miriad(write_file, clobber=True, no_antnums=True)
+    uv_in_copy = uv_in.copy()
+    ants_with_data = list(set(uv_in_copy.ant_1_array).union(uv_in_copy.ant_2_array))
+    ant_ind = np.where(uv_in_copy.antenna_numbers == ants_with_data[0])[0]
+    uv_in_copy.antenna_positions[ant_ind, :] = [0, 0, 0]
+    uv_in_copy.write_miriad(write_file, clobber=True, no_antnums=True)
     uvtest.checkWarnings(
         uv_out.read,
         func_args=[write_file],
@@ -1297,9 +1225,8 @@ def test_rwr_miriad_antpos_issues(tmp_path):
         ],
     )
 
-    assert uv_in == uv_out
+    assert uv_in_copy == uv_out
 
-    uv_in.read(testfile)
     uv_in.antenna_positions = None
     ants_with_data = sorted(set(uv_in.ant_1_array).union(uv_in.ant_2_array))
     new_nums = []
@@ -1329,21 +1256,19 @@ def test_rwr_miriad_antpos_issues(tmp_path):
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_multi_files(tmp_path):
+def test_multi_files(casa_uvfits, tmp_path):
     """
     Reading multiple files at once.
     """
-    uv_full = UVData()
-    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
+    uv_full = casa_uvfits
     testfile1 = str(tmp_path / "uv1")
     testfile2 = str(tmp_path / "uv2")
-    uv_full.read_uvfits(uvfits_file)
     # rename telescope to avoid name warning
     uv_full.unphase_to_drift()
     uv_full.conjugate_bls("ant1<ant2")
 
-    uv1 = copy.deepcopy(uv_full)
-    uv2 = copy.deepcopy(uv_full)
+    uv1 = uv_full.copy()
+    uv2 = uv_full.copy()
     uv1.select(freq_chans=np.arange(0, 32))
     uv2.select(freq_chans=np.arange(32, 64))
     uv1.write_miriad(testfile1, clobber=True)
@@ -1381,14 +1306,12 @@ def test_multi_files(tmp_path):
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_antpos_units(tmp_path):
+def test_antpos_units(casa_uvfits, tmp_path):
     """
     Read uvfits, write miriad. Check written antpos are in ns.
     """
-    uv = UVData()
-    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
+    uv = casa_uvfits
     testfile = str(tmp_path / "uv_antpos_units")
-    uv.read_uvfits(uvfits_file)
     uv.write_miriad(testfile, clobber=True)
     auv = aipy_extracts.UV(testfile)
     aantpos = auv["antpos"].reshape(3, -1).T * const.c.to("m/ns").value
@@ -1400,6 +1323,7 @@ def test_antpos_units(tmp_path):
     assert np.allclose(aantpos, uv.antenna_positions)
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_readmiriad_write_miriad_check_time_format(tmp_path):
     """
     test time_array is converted properly from Miriad format

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -591,6 +591,7 @@ def test_poltoind(uv_in_paper):
     assert str(cm.value).startswith("multiple matches for pol=-7 in polarization_array")
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "kwd_name,kwd_value,warnstr,errstr",
     (
@@ -640,15 +641,17 @@ def test_miriad_extra_keywords_errors(
     # check for warnings & errors with extra_keywords that are dicts, lists or arrays
     uv_in.extra_keywords[kwd_name] = kwd_value
     if warnstr is not None:
-        with pytest.warns(UserWarning, match=warnstr):
-            uv_in.check(uvw_antpos_check_level="off")
+        with pytest.warns(UserWarning, match=warnstr) as record:
+            uv_in.check()
+        assert len(record) == 2
 
     if errstr is not None:
         with pytest.raises(TypeError, match=errstr):
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
     else:
-        with pytest.warns(UserWarning, match=warnstr):
+        with pytest.warns(UserWarning, match=warnstr) as record:
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
+        assert len(record) == 1
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
@@ -1093,9 +1096,11 @@ def test_read_write_read_miriad_partial_with_warnings(uv_in_paper, tmp_path):
         uv_in.read,
         func_args=[write_file],
         func_kwargs={"times": times_to_keep},
-        nwarnings=2,
+        nwarnings=3,
         message=[
             "Warning: a select on read keyword is set",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
             "The uvw_array does not match the expected values given the antenna "
             "positions.",
         ],
@@ -1111,9 +1116,11 @@ def test_read_write_read_miriad_partial_with_warnings(uv_in_paper, tmp_path):
         uv_in.read,
         func_args=[write_file],
         func_kwargs={"blt_inds": blts_select, "antenna_nums": ants_keep},
-        nwarnings=2,
+        nwarnings=3,
         message=[
             "Warning: blt_inds is set along with select on read",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
             "The uvw_array does not match the expected values given the antenna "
             "positions.",
         ],

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -112,6 +112,8 @@ def test_extra_pol_setup():
     shutil.rmtree(new_filename)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not in known_telescopes.")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_read_ms_read_uvfits():
     """
     Test that a uvdata object instantiated from an ms file created with CASA's
@@ -124,7 +126,7 @@ def test_read_ms_read_uvfits():
     uvfits_uv = UVData()
     ms_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.ms")
     uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uvtest.checkWarnings(uvfits_uv.read, [uvfits_file], message="Telescope EVLA is not")
+    uvfits_uv.read(uvfits_file)
     ms_uv.read(ms_file)
     # set histories to identical blank strings since we do not expect
     # them to be the same anyways.
@@ -157,6 +159,8 @@ def test_read_ms_read_uvfits():
     del uvfits_uv
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not in known_telescopes.")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_read_ms_write_uvfits(tmp_path):
     """
     read ms, write uvfits test.
@@ -169,13 +173,15 @@ def test_read_ms_write_uvfits(tmp_path):
     testfile = str(tmp_path / "outtest.uvfits")
     ms_uv.read(ms_file)
     ms_uv.write_uvfits(testfile, spoof_nonessential=True)
-    uvtest.checkWarnings(uvfits_uv.read, [testfile], message="Telescope EVLA is not")
+    uvfits_uv.read(testfile)
 
     assert uvfits_uv == ms_uv
     del ms_uv
     del uvfits_uv
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not in known_telescopes.")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_read_ms_write_miriad(tmp_path):
     """
     read ms, write miriad test.
@@ -189,11 +195,13 @@ def test_read_ms_write_miriad(tmp_path):
     testfile = str(tmp_path / "outtest_miriad")
     ms_uv.read(ms_file)
     ms_uv.write_miriad(testfile, clobber=True)
-    uvtest.checkWarnings(miriad_uv.read, [testfile], message="Telescope EVLA is not")
+    miriad_uv.read(testfile)
 
     assert miriad_uv == ms_uv
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not in known_telescopes.")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_multi_files():
     """
     Reading multiple files at once.
@@ -201,7 +209,7 @@ def test_multi_files():
     uv_full = UVData()
     uv_multi = UVData()
     uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uvtest.checkWarnings(uv_full.read, [uvfits_file], message="Telescope EVLA is not")
+    uv_full.read(uvfits_file)
     testfile1 = os.path.join(DATA_PATH, "multi_1.ms")
     testfile2 = os.path.join(DATA_PATH, "multi_2.ms")
     uv_multi.read(np.array([testfile1, testfile2]))
@@ -234,6 +242,8 @@ def test_multi_files():
     del uv_multi
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not in known_telescopes.")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_multi_files_axis():
     """
     Reading multiple files at once, setting axis keyword
@@ -241,7 +251,7 @@ def test_multi_files_axis():
     uv_full = UVData()
     uv_multi = UVData()
     uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uvtest.checkWarnings(uv_full.read, [uvfits_file], message="Telescope EVLA is not")
+    uv_full.read(uvfits_file)
     testfile1 = os.path.join(DATA_PATH, "multi_1.ms")
     testfile2 = os.path.join(DATA_PATH, "multi_2.ms")
     uv_multi.read([testfile1, testfile2], axis="freq")
@@ -279,6 +289,5 @@ def test_bad_col_name():
     uvobj = UVData()
     testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.ms")
 
-    with pytest.raises(ValueError) as cm:
+    with pytest.raises(ValueError, match="Invalid data_column value supplied"):
         uvobj.read_ms(testfile, data_column="FOO")
-    assert str(cm.value).startswith("Invalid data_column value supplied")

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -18,6 +18,17 @@ from ..uvfits import UVFITS
 pytest.importorskip("casacore")
 
 
+@pytest.fixture(scope="session")
+def nrao_uv():
+    uvobj = UVData()
+    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.ms")
+    uvobj.read(testfile)
+
+    yield uvobj
+
+    del uvobj
+
+
 def test_cotter_ms():
     """Test reading in an ms made from MWA data with cotter (no dysco compression)"""
     uvobj = UVData()
@@ -37,16 +48,16 @@ def test_cotter_ms():
     del uvobj
 
 
-def test_read_nrao():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_read_nrao(nrao_uv):
     """Test reading in a CASA tutorial ms file."""
-    uvobj = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.ms")
+    uvobj = nrao_uv
     expected_extra_keywords = ["DATA_COL"]
 
-    uvobj.read(testfile)
     assert sorted(expected_extra_keywords) == sorted(uvobj.extra_keywords.keys())
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_read_lwa():
     """Test reading in an LWA ms file."""
     uvobj = UVData()
@@ -68,6 +79,7 @@ def test_read_lwa():
     shutil.rmtree(new_filename)
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_no_spw():
     """Test reading in a PAPER ms converted by CASA from a uvfits with no spw axis."""
     uvobj = UVData()
@@ -93,6 +105,7 @@ def test_multi_len_spw():
     assert str(cm.value).startswith("Sorry.  Files with more than one spectral")
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_extra_pol_setup():
     """Test reading in an ms file with extra polarization setups (not used in data)."""
     uvobj = UVData()
@@ -114,7 +127,7 @@ def test_extra_pol_setup():
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not in known_telescopes.")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_read_ms_read_uvfits():
+def test_read_ms_read_uvfits(nrao_uv, casa_uvfits):
     """
     Test that a uvdata object instantiated from an ms file created with CASA's
     importuvfits is equal to a uvdata object instantiated from the original
@@ -122,12 +135,8 @@ def test_read_ms_read_uvfits():
     Since the histories are different, this test sets both uvdata
     histories to identical empty strings before comparing them.
     """
-    ms_uv = UVData()
-    uvfits_uv = UVData()
-    ms_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.ms")
-    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uvfits_uv.read(uvfits_file)
-    ms_uv.read(ms_file)
+    ms_uv = nrao_uv.copy()
+    uvfits_uv = casa_uvfits.copy()
     # set histories to identical blank strings since we do not expect
     # them to be the same anyways.
     ms_uv.history = ""
@@ -161,17 +170,15 @@ def test_read_ms_read_uvfits():
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not in known_telescopes.")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_read_ms_write_uvfits(tmp_path):
+def test_read_ms_write_uvfits(nrao_uv, tmp_path):
     """
     read ms, write uvfits test.
     Read in ms file, write out as uvfits, read back in and check for
     object equality.
     """
-    ms_uv = UVData()
+    ms_uv = nrao_uv
     uvfits_uv = UVData()
-    ms_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.ms")
     testfile = str(tmp_path / "outtest.uvfits")
-    ms_uv.read(ms_file)
     ms_uv.write_uvfits(testfile, spoof_nonessential=True)
     uvfits_uv.read(testfile)
 
@@ -182,18 +189,16 @@ def test_read_ms_write_uvfits(tmp_path):
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not in known_telescopes.")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_read_ms_write_miriad(tmp_path):
+def test_read_ms_write_miriad(nrao_uv, tmp_path):
     """
     read ms, write miriad test.
     Read in ms file, write out as miriad, read back in and check for
     object equality.
     """
     pytest.importorskip("pyuvdata._miriad")
-    ms_uv = UVData()
+    ms_uv = nrao_uv
     miriad_uv = UVData()
-    ms_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.ms")
     testfile = str(tmp_path / "outtest_miriad")
-    ms_uv.read(ms_file)
     ms_uv.write_miriad(testfile, clobber=True)
     miriad_uv.read(testfile)
 
@@ -202,17 +207,23 @@ def test_read_ms_write_miriad(tmp_path):
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not in known_telescopes.")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_multi_files():
+@pytest.mark.parametrize("axis", [None, "freq"])
+def test_multi_files(casa_uvfits, axis):
     """
     Reading multiple files at once.
     """
-    uv_full = UVData()
+    uv_full = casa_uvfits.copy()
+
     uv_multi = UVData()
-    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_full.read(uvfits_file)
     testfile1 = os.path.join(DATA_PATH, "multi_1.ms")
     testfile2 = os.path.join(DATA_PATH, "multi_2.ms")
-    uv_multi.read(np.array([testfile1, testfile2]))
+
+    filesread = [testfile1, testfile2]
+    # test once as list and once as an array
+    if axis is None:
+        filesread = np.array(filesread)
+
+    uv_multi.read(filesread, axis=axis)
     # Casa scrambles the history parameter. Replace for now.
     uv_multi.history = uv_full.history
 
@@ -240,46 +251,6 @@ def test_multi_files():
     assert uv_multi == uv_full
     del uv_full
     del uv_multi
-
-
-@pytest.mark.filterwarnings("ignore:Telescope EVLA is not in known_telescopes.")
-@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_multi_files_axis():
-    """
-    Reading multiple files at once, setting axis keyword
-    """
-    uv_full = UVData()
-    uv_multi = UVData()
-    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_full.read(uvfits_file)
-    testfile1 = os.path.join(DATA_PATH, "multi_1.ms")
-    testfile2 = os.path.join(DATA_PATH, "multi_2.ms")
-    uv_multi.read([testfile1, testfile2], axis="freq")
-    # Casa scrambles the history parameter. Replace for now.
-    uv_multi.history = uv_full.history
-
-    # the objects won't be equal because uvfits adds some optional parameters
-    # and the ms sets default antenna diameters even though the uvfits file
-    # doesn't have them
-    assert uv_multi != uv_full
-    # they are equal if only required parameters are checked:
-    assert uv_multi.__eq__(uv_full, check_extra=False)
-
-    # set those parameters to none to check that the rest of the objects match
-    uv_multi.antenna_diameters = None
-
-    for p in uv_full.extra():
-        fits_param = getattr(uv_full, p)
-        ms_param = getattr(uv_multi, p)
-        if fits_param.name in UVFITS.uvfits_required_extra and ms_param.value is None:
-            fits_param.value = None
-            setattr(uv_full, p, fits_param)
-
-    # extra keywords are also different, set both to empty dicts
-    uv_full.extra_keywords = {}
-    uv_multi.extra_keywords = {}
-
-    assert uv_multi == uv_full
 
 
 def test_bad_col_name():

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -181,8 +181,8 @@ def uvdata_props():
     return
 
 
-@pytest.fixture(scope="function")
-def resample_in_time_file():
+@pytest.fixture(scope="session")
+def hera_uvh5_master():
     # read in test file for the resampling in time functions
     uv_object = UVData()
     testfile = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
@@ -197,7 +197,48 @@ def resample_in_time_file():
 
 
 @pytest.fixture(scope="function")
-def bda_test_file():
+def hera_uvh5(hera_uvh5_master):
+    # read in test file for the resampling in time functions
+    uv_object = hera_uvh5_master.copy()
+
+    yield uv_object
+
+    # cleanup
+    del uv_object
+
+    return
+
+
+@pytest.fixture(scope="session")
+def paper_uvh5_master():
+    # read in test file for the resampling in time functions
+    uv_object = UVData()
+    uvh5_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA.uvh5")
+    uv_object.read_uvh5(uvh5_file)
+
+    yield uv_object
+
+    # cleanup
+    del uv_object
+
+    return
+
+
+@pytest.fixture(scope="function")
+def paper_uvh5(paper_uvh5_master):
+    # read in test file for the resampling in time functions
+    uv_object = paper_uvh5_master.copy()
+
+    yield uv_object
+
+    # cleanup
+    del uv_object
+
+    return
+
+
+@pytest.fixture(scope="session")
+def bda_test_file_master():
     # read in test file for BDA-like data
     uv_object = UVData()
     testfile = os.path.join(DATA_PATH, "simulated_bda_file.uvh5")
@@ -212,19 +253,21 @@ def bda_test_file():
 
 
 @pytest.fixture(scope="function")
-def uvdata_data():
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uvtest.checkWarnings(
-        uv_object.read_uvfits,
-        [testfile],
-        nwarnings=2,
-        message=[
-            "Telescope EVLA is not in known_telescopes.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-        ],
-    )
+def bda_test_file(bda_test_file_master):
+    # read in test file for BDA-like data
+    uv_object = bda_test_file_master.copy()
+
+    yield uv_object
+
+    # cleanup
+    del uv_object
+
+    return
+
+
+@pytest.fixture(scope="function")
+def uvdata_data(casa_uvfits):
+    uv_object = casa_uvfits
 
     class DataHolder:
         def __init__(self, uv_object):
@@ -263,15 +306,23 @@ def uvdata_baseline():
     return
 
 
-@pytest.fixture
-def uv1_2_set_uvws():
-    testfile = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-    uv1 = UVData()
-    uv1.read_uvh5(testfile)
+@pytest.fixture(scope="session")
+def set_uvws_master(hera_uvh5_master):
+    uv1 = hera_uvh5_master.copy()
     # uvws in the file are wrong. reset them.
     uv1.set_uvws_from_antenna_positions()
 
-    uv2 = uv1.copy()
+    yield uv1
+
+    del uv1
+
+    return
+
+
+@pytest.fixture
+def uv1_2_set_uvws(set_uvws_master):
+    uv1 = set_uvws_master.copy()
+    uv2 = set_uvws_master.copy()
 
     yield uv1, uv2
 
@@ -396,6 +447,8 @@ def test_properties(uvdata_props):
             raise
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_metadata_only_property(uvdata_data):
     uvdata_data.uv_object.data_array = None
     assert uvdata_data.uv_object.metadata_only is False
@@ -407,12 +460,16 @@ def test_metadata_only_property(uvdata_data):
     assert uvdata_data.uv_object.metadata_only is True
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_equality(uvdata_data):
     """Basic equality test."""
     assert uvdata_data.uv_object == uvdata_data.uv_object
 
 
 @pytest.mark.filterwarnings("ignore:Telescope location derived from obs")
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_check(uvdata_data):
     """Test simple check function."""
     assert uvdata_data.uv_object.check()
@@ -464,6 +521,8 @@ def test_check(uvdata_data):
     pytest.raises(ValueError, uvd.check)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_nants_data_telescope_larger(uvdata_data):
     # make sure it's okay for Nants_telescope to be strictly greater than Nants_data
     uvdata_data.uv_object.Nants_telescope += 1
@@ -480,6 +539,8 @@ def test_nants_data_telescope_larger(uvdata_data):
     assert uvdata_data.uv_object.check()
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_ant1_array_not_in_antnums(uvdata_data):
     # make sure an error is raised if antennas in ant_1_array not in antenna_numbers
     # remove antennas from antenna_names & antenna_numbers by hand
@@ -496,6 +557,8 @@ def test_ant1_array_not_in_antnums(uvdata_data):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_ant2_array_not_in_antnums(uvdata_data):
     # make sure an error is raised if antennas in ant_2_array not in antenna_numbers
     # remove antennas from antenna_names & antenna_numbers by hand
@@ -511,6 +574,8 @@ def test_ant2_array_not_in_antnums(uvdata_data):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_converttofiletype(uvdata_data):
     fhd_obj = uvdata_data.uv_object._convert_to_filetype("fhd")
     uvdata_data.uv_object._convert_from_filetype(fhd_obj)
@@ -595,10 +660,9 @@ def test_known_telescopes():
     )
 
 
-def test_hera_diameters():
-    uvh5_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA.uvh5")
-    uv_in = UVData()
-    uv_in.read_uvh5(uvh5_file)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_hera_diameters(paper_uvh5):
+    uv_in = paper_uvh5
 
     uv_in.telescope_name = "HERA"
     uvtest.checkWarnings(
@@ -613,6 +677,7 @@ def test_hera_diameters():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_generic_read():
     uv_in = UVData()
     uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
@@ -638,6 +703,7 @@ def test_generic_read():
     pytest.raises(ValueError, uv_in.read, "foo")
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "phase_kwargs",
     [
@@ -661,6 +727,7 @@ def test_phase_unphase_hera(uv1_2_set_uvws, phase_kwargs):
     assert uv_raw == uv1
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_phase_unphase_hera_one_bl(uv1_2_set_uvws):
     uv_phase, uv_raw = uv1_2_set_uvws
     # check that phase + unphase work with one baseline
@@ -671,6 +738,7 @@ def test_phase_unphase_hera_one_bl(uv1_2_set_uvws):
     assert uv_raw_small == uv_phase_small
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_phase_unphase_hera_antpos(uv1_2_set_uvws):
     uv_phase, uv_raw = uv1_2_set_uvws
     # check that they match if you phase & unphase using antenna locations
@@ -711,6 +779,7 @@ def test_phase_unphase_hera_antpos(uv1_2_set_uvws):
     assert uv_raw_new == uv_phase
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_phase_hera_zenith_timestamp_minimal_changes(uv1_2_set_uvws):
     uv_phase, uv_raw = uv1_2_set_uvws
     # check that phasing to zenith with one timestamp has small changes
@@ -729,6 +798,7 @@ def test_phase_hera_zenith_timestamp_minimal_changes(uv1_2_set_uvws):
     )
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_phase_to_time_jd_input(uv1_2_set_uvws):
     uv_phase, uv_raw = uv1_2_set_uvws
     uv_phase.phase_to_time(uv_raw.time_array[0])
@@ -736,6 +806,7 @@ def test_phase_to_time_jd_input(uv1_2_set_uvws):
     assert uv_phase == uv_raw
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_phase_to_time_error(uv1_2_set_uvws):
     uv_phase, uv_raw = uv1_2_set_uvws
     # check error if not passing a Time object to phase_to_time
@@ -744,6 +815,7 @@ def test_phase_to_time_error(uv1_2_set_uvws):
     assert str(cm.value).startswith("time must be an astropy.time.Time object")
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_unphase_drift_data_error(uv1_2_set_uvws):
     uv_phase, uv_raw = uv1_2_set_uvws
     # check error if not passing a Time object to phase_to_time
@@ -752,6 +824,7 @@ def test_unphase_drift_data_error(uv1_2_set_uvws):
     assert str(cm.value).startswith("The data is already drift scanning;")
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "phase_func,phase_kwargs,err_msg",
     [
@@ -791,6 +864,7 @@ def test_unknown_phase_unphase_hera_errors(
     assert str(cm.value).startswith(err_msg)
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "phase_func,phase_kwargs,err_msg",
     [
@@ -822,6 +896,7 @@ def test_phase_rephase_hera_errors(uv1_2_set_uvws, phase_func, phase_kwargs, err
     assert str(cm.value).startswith(err_msg)
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_phase_unphase_hera_bad_frame(uv1_2_set_uvws):
     uv_phase, uv_raw = uv1_2_set_uvws
     # check errors when trying to phase to an unsupported frame
@@ -925,10 +1000,9 @@ def test_phasing():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_set_phase_unknown():
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_set_phase_unknown(casa_uvfits):
+    uv_object = casa_uvfits
 
     uv_object._set_unknown_phase_type()
     assert uv_object.phase_type == "unknown"
@@ -938,10 +1012,9 @@ def test_set_phase_unknown():
     assert uv_object.check()
 
 
-def test_select_blts():
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA.uvh5")
-    uv_object.read_uvh5(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_blts(paper_uvh5):
+    uv_object = paper_uvh5
     old_history = uv_object.history
     # fmt: off
     blt_inds = np.array([172, 182, 132, 227, 144, 44, 16, 104, 385, 134, 326, 140, 116,
@@ -1016,10 +1089,9 @@ def test_select_blts():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_antennas():
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_antennas(casa_uvfits):
+    uv_object = casa_uvfits
     old_history = uv_object.history
     unique_ants = np.unique(
         uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist()
@@ -1133,10 +1205,9 @@ def sort_bl(p):
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_bls():
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_bls(casa_uvfits):
+    uv_object = casa_uvfits
     old_history = uv_object.history
     first_ants = [6, 2, 7, 2, 21, 27, 8]
     second_ants = [0, 20, 8, 1, 2, 3, 22]
@@ -1319,10 +1390,9 @@ def test_select_bls():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_times():
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_times(casa_uvfits):
+    uv_object = casa_uvfits
     old_history = uv_object.history
     unique_times = np.unique(uv_object.time_array)
     times_to_keep = unique_times[[0, 3, 5, 6, 7, 10, 14]]
@@ -1368,10 +1438,9 @@ def test_select_times():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_time_range():
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_time_range(casa_uvfits):
+    uv_object = casa_uvfits
     old_history = uv_object.history
     unique_times = np.unique(uv_object.time_array)
     mean_time = np.mean(unique_times)
@@ -1402,11 +1471,10 @@ def test_select_time_range():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_time_range_no_data():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_time_range_no_data(casa_uvfits):
     """Check for error associated with times not included in data."""
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read(testfile)
+    uv_object = casa_uvfits
     unique_times = np.unique(uv_object.time_array)
     with pytest.raises(ValueError) as cm:
         uv_object.select(
@@ -1419,11 +1487,10 @@ def test_select_time_range_no_data():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_time_and_time_range():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_time_and_time_range(casa_uvfits):
     """Check for error setting times and time_range."""
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read(testfile)
+    uv_object = casa_uvfits
     unique_times = np.unique(uv_object.time_array)
     mean_time = np.mean(unique_times)
     time_range = [np.min(unique_times), mean_time]
@@ -1434,11 +1501,10 @@ def test_select_time_and_time_range():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_time_range_one_elem():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_time_range_one_elem(casa_uvfits):
     """Check for error if time_range not length 2."""
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read(testfile)
+    uv_object = casa_uvfits
     unique_times = np.unique(uv_object.time_array)
     mean_time = np.mean(unique_times)
     time_range = [np.min(unique_times), mean_time]
@@ -1448,10 +1514,9 @@ def test_select_time_range_one_elem():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_frequencies_uvfits(tmp_path):
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_frequencies_uvfits(casa_uvfits, tmp_path):
+    uv_object = casa_uvfits
     old_history = uv_object.history
     freqs_to_keep = uv_object.freq_array[0, np.arange(12, 22)]
 
@@ -1527,11 +1592,10 @@ def test_select_frequencies_uvfits(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_frequencies_miriad(tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_frequencies_miriad(casa_uvfits, tmp_path):
     pytest.importorskip("pyuvdata._miriad")
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read_uvfits(testfile)
+    uv_object = casa_uvfits
     old_history = uv_object.history
     freqs_to_keep = uv_object.freq_array[0, np.arange(12, 22)]
 
@@ -1607,10 +1671,9 @@ def test_select_frequencies_miriad(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_freq_chans():
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_freq_chans(casa_uvfits):
+    uv_object = casa_uvfits
     old_history = uv_object.history
     chans_to_keep = np.arange(12, 22)
 
@@ -1658,10 +1721,9 @@ def test_select_freq_chans():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_polarizations(tmp_path):
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_polarizations(casa_uvfits, tmp_path):
+    uv_object = casa_uvfits
     old_history = uv_object.history
     pols_to_keep = [-1, -2]
 
@@ -1709,11 +1771,10 @@ def test_select_polarizations(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select(casa_uvfits):
     # now test selecting along all axes at once
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read_uvfits(testfile)
+    uv_object = casa_uvfits
     old_history = uv_object.history
     # fmt: off
     blt_inds = np.array([1057, 461, 1090, 354, 528, 654, 882, 775, 369, 906, 748,
@@ -1806,11 +1867,10 @@ def test_select():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_not_inplace():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_not_inplace(casa_uvfits):
     # Test non-inplace select
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read_uvfits(testfile)
+    uv_object = casa_uvfits
     old_history = uv_object.history
     uv1 = uv_object.select(freq_chans=np.arange(32), inplace=False)
     uv1 += uv_object.select(freq_chans=np.arange(32, 64), inplace=False)
@@ -1826,13 +1886,17 @@ def test_select_not_inplace():
     assert uv1 == uv_object
 
 
-@pytest.mark.parametrize("metadata_only", [True, False])
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_conjugate_bls(metadata_only):
-    uv1 = UVData()
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.parametrize("metadata_only", [True, False])
+def test_conjugate_bls(casa_uvfits, metadata_only):
     testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
 
-    uv1.read_uvfits(testfile, read_data=not (metadata_only))
+    if not metadata_only:
+        uv1 = casa_uvfits
+    else:
+        uv1 = UVData()
+        uv1.read_uvfits(testfile, read_data=False)
     if metadata_only:
         assert uv1.metadata_only
     # file comes in with ant1<ant2
@@ -1995,12 +2059,12 @@ def test_conjugate_bls(metadata_only):
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_reorder_pols():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_reorder_pols(casa_uvfits):
     # Test function to fix polarization order
-    uv1 = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv1.read_uvfits(testfile)
+    uv1 = casa_uvfits
     uv2 = uv1.copy()
+    uv3 = uv1.copy()
     # reorder uv2 manually
     order = [1, 3, 2, 0]
     uv2.polarization_array = uv2.polarization_array[order]
@@ -2011,7 +2075,7 @@ def test_reorder_pols():
     assert uv1 == uv2
 
     # Restore original order
-    uv1.read_uvfits(testfile)
+    uv1 = uv3.copy()
     uv2.reorder_pols()
     assert uv1 == uv2
 
@@ -2043,10 +2107,9 @@ def test_reorder_pols():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_reorder_blts():
-    uv1 = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv1.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_reorder_blts(casa_uvfits):
+    uv1 = casa_uvfits
 
     # test default reordering in detail
     uv2 = uv1.copy()
@@ -2171,11 +2234,10 @@ def test_reorder_blts():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_sum_vis():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_sum_vis(casa_uvfits):
     # check sum_vis
-    uv_full = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_full.read_uvfits(testfile)
+    uv_full = casa_uvfits
 
     uv_half = uv_full.copy()
     uv_half.data_array = uv_full.data_array / 2
@@ -2211,10 +2273,9 @@ def test_sum_vis():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_add():
-    uv_full = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_full.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_add(casa_uvfits):
+    uv_full = casa_uvfits
 
     # Add frequencies
     uv1 = uv_full.copy()
@@ -2508,10 +2569,9 @@ def test_add():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_add_drift():
-    uv_full = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_full.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_add_drift(casa_uvfits):
+    uv_full = casa_uvfits
     uv_full.unphase_to_drift()
 
     # Add frequencies
@@ -2729,11 +2789,10 @@ def test_add_drift():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_break_add():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_break_add(casa_uvfits):
     # Test failure modes of add function
-    uv_full = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_full.read_uvfits(testfile)
+    uv_full = casa_uvfits
 
     # Wrong class
     uv1 = uv_full.copy()
@@ -2764,13 +2823,12 @@ def test_break_add():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "test_func,extra_kwargs", [("__add__", {}), ("fast_concat", {"axis": "blt"})]
 )
-def test_add_error_drift_and_rephase(test_func, extra_kwargs):
-    uv_full = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_full.read_uvfits(testfile)
+def test_add_error_drift_and_rephase(casa_uvfits, test_func, extra_kwargs):
+    uv_full = casa_uvfits
 
     with pytest.raises(ValueError) as cm:
         getattr(uv_full, test_func)(
@@ -2781,6 +2839,7 @@ def test_add_error_drift_and_rephase(test_func, extra_kwargs):
     )
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "test_func,extra_kwargs", [("__add__", {}), ("fast_concat", {"axis": "blt"})]
 )
@@ -2808,6 +2867,7 @@ def test_add_this_phased_unphase_to_drift(uv_phase_time_split, test_func, extra_
     assert uv_out == uv_raw
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "test_func,extra_kwargs", [("__add__", {}), ("fast_concat", {"axis": "blt"})]
 )
@@ -2837,6 +2897,7 @@ def test_add_other_phased_unphase_to_drift(
     assert uv_out == uv_raw
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "test_func,extra_kwargs", [("__add__", {}), ("fast_concat", {"axis": "blt"})]
 )
@@ -2879,6 +2940,7 @@ def test_add_this_rephase_new_phase_center(
     assert uv_out == uv_raw
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "test_func,extra_kwargs", [("__add__", {}), ("fast_concat", {"axis": "blt"})]
 )
@@ -2925,6 +2987,7 @@ def test_add_other_rephase_new_phase_center(
     assert uv_out == uv_raw
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "test_func,extra_kwargs", [("__add__", {}), ("fast_concat", {"axis": "blt"})]
 )
@@ -2942,10 +3005,9 @@ def test_add_error_too_long_phase_center(uv_phase_time_split, test_func, extra_k
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_fast_concat():
-    uv_full = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_full.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_fast_concat(casa_uvfits):
+    uv_full = casa_uvfits
 
     # Add frequencies
     uv1 = uv_full.copy()
@@ -3243,10 +3305,9 @@ def test_fast_concat():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_fast_concat_errors():
-    uv_full = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_full.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_fast_concat_errors(casa_uvfits):
+    uv_full = casa_uvfits
 
     uv1 = uv_full.copy()
     uv2 = uv_full.copy()
@@ -3259,11 +3320,10 @@ def test_fast_concat_errors():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_key2inds():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_key2inds(casa_uvfits):
     # Test function to interpret key as antpair, pol
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+    uv = casa_uvfits
 
     # Get an antpair/pol combo
     ant1 = uv.ant_1_array[0]
@@ -3354,10 +3414,9 @@ def test_key2inds():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_key2inds_conj_all_pols():
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_key2inds_conj_all_pols(casa_uvfits):
+    uv = casa_uvfits
 
     ant1 = uv.ant_1_array[0]
     ant2 = uv.ant_2_array[0]
@@ -3373,10 +3432,9 @@ def test_key2inds_conj_all_pols():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_key2inds_conj_all_pols_fringe():
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_key2inds_conj_all_pols_fringe(casa_uvfits):
+    uv = casa_uvfits
 
     uv.select(polarizations=["rl"])
     ant1 = uv.ant_1_array[0]
@@ -3394,10 +3452,9 @@ def test_key2inds_conj_all_pols_fringe():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_key2inds_conj_all_pols_bl_fringe():
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_key2inds_conj_all_pols_bl_fringe(casa_uvfits):
+    uv = casa_uvfits
 
     uv.select(polarizations=["rl"])
     ant1 = uv.ant_1_array[0]
@@ -3417,10 +3474,10 @@ def test_key2inds_conj_all_pols_bl_fringe():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_key2inds_conj_all_pols_missing_data():
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_key2inds_conj_all_pols_missing_data(casa_uvfits):
+    uv = casa_uvfits
+
     uv.select(polarizations=["rl"])
     ant1 = uv.ant_1_array[0]
     ant2 = uv.ant_2_array[0]
@@ -3429,10 +3486,9 @@ def test_key2inds_conj_all_pols_missing_data():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_key2inds_conj_all_pols_bls():
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_key2inds_conj_all_pols_bls(casa_uvfits):
+    uv = casa_uvfits
 
     ant1 = uv.ant_1_array[0]
     ant2 = uv.ant_2_array[0]
@@ -3449,10 +3505,9 @@ def test_key2inds_conj_all_pols_bls():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_key2inds_conj_all_pols_missing_data_bls():
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_key2inds_conj_all_pols_missing_data_bls(casa_uvfits):
+    uv = casa_uvfits
     uv.select(polarizations=["rl"])
     ant1 = uv.ant_1_array[0]
     ant2 = uv.ant_2_array[0]
@@ -3462,11 +3517,10 @@ def test_key2inds_conj_all_pols_missing_data_bls():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_smart_slicing():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_smart_slicing(casa_uvfits):
     # Test function to slice data
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+    uv = casa_uvfits
 
     # ind1 reg, ind2 empty, pol reg
     ind1 = 10 * np.arange(9)
@@ -3627,11 +3681,10 @@ def test_smart_slicing():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_get_data():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_get_data(casa_uvfits):
     # Test get_data function for easy access to data
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+    uv = casa_uvfits
 
     # Get an antpair/pol combo
     ant1 = uv.ant_1_array[0]
@@ -3673,11 +3726,10 @@ def test_get_data():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_get_flags():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_get_flags(casa_uvfits):
     # Test function for easy access to flags
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+    uv = casa_uvfits
 
     # Get an antpair/pol combo
     ant1 = uv.ant_1_array[0]
@@ -3715,11 +3767,10 @@ def test_get_flags():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_get_nsamples():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_get_nsamples(casa_uvfits):
     # Test function for easy access to nsample array
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+    uv = casa_uvfits
 
     # Get an antpair/pol combo
     ant1 = uv.ant_1_array[0]
@@ -3755,11 +3806,10 @@ def test_get_nsamples():
     assert np.all(dcheck == d)
 
 
-def test_antpair2ind():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_antpair2ind(paper_uvh5):
     # Test for baseline-time axis indexer
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA.uvh5")
-    uv.read_uvh5(testfile)
+    uv = paper_uvh5
 
     # get indices
     inds = uv.antpair2ind(0, 1, ordered=False)
@@ -3780,11 +3830,10 @@ def test_antpair2ind():
     return
 
 
-def test_antpair2ind_conj():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_antpair2ind_conj(paper_uvh5):
     # conjugate (and use key rather than arg expansion)
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA.uvh5")
-    uv.read_uvh5(testfile)
+    uv = paper_uvh5
     inds = uv.antpair2ind(0, 1, ordered=False)
     inds2 = uv.antpair2ind((1, 0), ordered=False)
     np.testing.assert_array_equal(inds, inds2)
@@ -3793,11 +3842,10 @@ def test_antpair2ind_conj():
     return
 
 
-def test_antpair2ind_ordered():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_antpair2ind_ordered(paper_uvh5):
     # test ordered
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA.uvh5")
-    uv.read_uvh5(testfile)
+    uv = paper_uvh5
     inds = uv.antpair2ind(0, 1, ordered=False)
 
     # make sure conjugated baseline returns nothing
@@ -3812,11 +3860,10 @@ def test_antpair2ind_ordered():
     return
 
 
-def test_antpair2ind_autos():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_antpair2ind_autos(paper_uvh5):
     # test autos w/ and w/o ordered
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA.uvh5")
-    uv.read_uvh5(testfile)
+    uv = paper_uvh5
 
     inds = uv.antpair2ind(0, 0, ordered=True)
     inds2 = uv.antpair2ind(0, 0, ordered=False)
@@ -3827,11 +3874,10 @@ def test_antpair2ind_autos():
     return
 
 
-def test_antpair2ind_exceptions():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_antpair2ind_exceptions(paper_uvh5):
     # test exceptions
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA.uvh5")
-    uv.read_uvh5(testfile)
+    uv = paper_uvh5
 
     with pytest.raises(ValueError, match="antpair2ind must be fed an antpair tuple"):
         uv.antpair2ind(1)
@@ -3844,12 +3890,10 @@ def test_antpair2ind_exceptions():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_get_times():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_get_times(casa_uvfits):
     # Test function for easy access to times, to work in conjunction with get_data
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
-
+    uv = casa_uvfits
     # Get an antpair/pol combo (pol shouldn't actually effect result)
     ant1 = uv.ant_1_array[0]
     ant2 = uv.ant_2_array[0]
@@ -3883,12 +3927,10 @@ def test_get_times():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_antpairpol_iter():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_antpairpol_iter(casa_uvfits):
     # Test generator
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
-
+    uv = casa_uvfits
     pol_dict = {
         uvutils.polnum2str(uv.polarization_array[i]): i for i in range(uv.Npols)
     }
@@ -3908,11 +3950,10 @@ def test_antpairpol_iter():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_get_ants():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_get_ants(casa_uvfits):
     # Test function to get unique antennas in data
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+    uv = casa_uvfits
 
     ants = uv.get_ants()
     for ant in ants:
@@ -3923,6 +3964,7 @@ def test_get_ants():
         assert ant in ants
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_get_enu_antpos():
     uvd = UVData()
     uvd.read_uvh5(os.path.join(DATA_PATH, "zen.2457698.40355.xx.HH.uvcA.uvh5"))
@@ -3944,11 +3986,10 @@ def test_get_enu_antpos():
     assert np.isclose(antpos[0, 0], -0.0026981323386223721)
 
 
-def test_telescope_loc_xyz_check(tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_telescope_loc_xyz_check(paper_uvh5, tmp_path):
     # test that improper telescope locations can still be read
-    uvh5_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA.uvh5")
-    uv = UVData()
-    uv.read(uvh5_file)
+    uv = paper_uvh5
     uv.telescope_location = uvutils.XYZ_from_LatLonAlt(*uv.telescope_location)
     # fix LST values
     uv.set_lsts_from_time_array()
@@ -3963,20 +4004,18 @@ def test_telescope_loc_xyz_check(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_get_pols():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_get_pols(casa_uvfits):
     # Test function to get unique polarizations in string format
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+    uv = casa_uvfits
     pols = uv.get_pols()
     pols_data = ["rr", "ll", "lr", "rl"]
     assert sorted(pols) == sorted(pols_data)
 
 
-def test_get_pols_x_orientation():
-    uvh5_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA.uvh5")
-    uv_in = UVData()
-    uv_in.read(uvh5_file)
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_get_pols_x_orientation(paper_uvh5):
+    uv_in = paper_uvh5
 
     uv_in.x_orientation = "east"
 
@@ -3992,11 +4031,10 @@ def test_get_pols_x_orientation():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_get_feedpols():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_get_feedpols(casa_uvfits):
     # Test function to get unique antenna feed polarizations in data. String format.
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+    uv = casa_uvfits
     pols = uv.get_feedpols()
     pols_data = ["r", "l"]
     assert sorted(pols) == sorted(pols_data)
@@ -4007,11 +4045,10 @@ def test_get_feedpols():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_parse_ants():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_parse_ants(casa_uvfits):
     # Test function to get correct antenna pairs and polarizations
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+    uv = casa_uvfits
 
     # All baselines
     ant_str = "all"
@@ -4300,11 +4337,10 @@ def test_parse_ants():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_select_with_ant_str():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_with_ant_str(casa_uvfits):
     # Test select function with ant_str argument
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+    uv = casa_uvfits
     inplace = False
 
     # All baselines
@@ -4626,6 +4662,7 @@ def test_select_with_ant_str():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "kwargs,message",
     [
@@ -4657,10 +4694,8 @@ def test_select_with_ant_str():
         ({"ant_str": "none"}, "Unparsible argument none"),
     ],
 )
-def test_select_with_ant_str_errors(kwargs, message):
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+def test_select_with_ant_str_errors(casa_uvfits, kwargs, message):
+    uv = casa_uvfits
 
     with pytest.raises(ValueError, match=message):
         uv.select(**kwargs)
@@ -4953,11 +4988,10 @@ def test_redundancy_contract_expand_variable_data(method, flagging_level):
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("method", ("select", "average"))
-def test_redundancy_contract_expand_nblts_not_nbls_times_ntimes(method):
-    uv0 = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv0.read_uvfits(testfile)
+def test_redundancy_contract_expand_nblts_not_nbls_times_ntimes(method, casa_uvfits):
+    uv0 = casa_uvfits
 
     # check that Nblts != Nbls * Ntimes
     assert uv0.Nblts != uv0.Nbls * uv0.Ntimes
@@ -5191,12 +5225,11 @@ def test_quick_redundant_vs_redundant_test_array():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_redundancy_finder_when_nblts_not_nbls_times_ntimes():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_redundancy_finder_when_nblts_not_nbls_times_ntimes(casa_uvfits):
     """Test the redundancy finder functions when Nblts != Nbls * Ntimes."""
     tol = 1  # meter
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+    uv = casa_uvfits
     uv.conjugate_bls(convention="u>0", use_enu=True)
     # check that Nblts != Nbls * Ntimes
     assert uv.Nblts != uv.Nbls * uv.Ntimes
@@ -5235,11 +5268,10 @@ def test_redundancy_finder_when_nblts_not_nbls_times_ntimes():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_overlapping_data_add(tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_overlapping_data_add(casa_uvfits, tmp_path):
     # read in test data
-    uv = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv.read_uvfits(testfile)
+    uv = casa_uvfits
 
     # slice into four objects
     blts1 = np.arange(500)
@@ -5301,13 +5333,12 @@ def test_overlapping_data_add(tmp_path):
     return
 
 
-def test_lsts_from_time_with_only_unique():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_lsts_from_time_with_only_unique(paper_uvh5):
     """
     Test `set_lsts_from_time_array` with only unique values is identical to full array.
     """
-    uvh5_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA.uvh5")
-    uv = UVData()
-    uv.read_uvh5(uvh5_file)
+    uv = paper_uvh5
     lat, lon, alt = uv.telescope_location_lat_lon_alt_degrees
     # calculate the lsts for all elements in time array
     full_lsts = uvutils.get_lst_for_time(uv.time_array, lat, lon, alt)
@@ -5316,14 +5347,12 @@ def test_lsts_from_time_with_only_unique():
     assert np.array_equal(full_lsts, uv.lst_array)
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
-def test_lsts_from_time_with_only_unique_background():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_lsts_from_time_with_only_unique_background(paper_uvh5):
     """
     Test `set_lsts_from_time_array` with only unique values is identical to full array.
     """
-    uvh5_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA.uvh5")
-    uv = UVData()
-    uv.read_uvh5(uvh5_file)
+    uv = paper_uvh5
     lat, lon, alt = uv.telescope_location_lat_lon_alt_degrees
     # calculate the lsts for all elements in time array
     full_lsts = uvutils.get_lst_for_time(uv.time_array, lat, lon, alt)
@@ -5334,11 +5363,10 @@ def test_lsts_from_time_with_only_unique_background():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_copy():
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_copy(casa_uvfits):
     """Test the copy method"""
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_object.read_uvfits(testfile)
+    uv_object = casa_uvfits
 
     uv_object_copy = uv_object.copy()
     assert uv_object_copy == uv_object
@@ -5358,9 +5386,10 @@ def test_copy():
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_upsample_in_time(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_upsample_in_time(hera_uvh5):
     """Test the upsample_in_time method"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
 
     # reorder to make sure we get the right value later
@@ -5393,9 +5422,10 @@ def test_upsample_in_time(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_upsample_in_time_with_flags(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_upsample_in_time_with_flags(hera_uvh5):
     """Test the upsample_in_time method with flags"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
 
     # reorder to make sure we get the right value later
@@ -5428,9 +5458,10 @@ def test_upsample_in_time_with_flags(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_upsample_in_time_noninteger_resampling(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_upsample_in_time_noninteger_resampling(hera_uvh5):
     """Test the upsample_in_time method with a non-integer resampling factor"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
 
     # reorder to make sure we get the right value later
@@ -5461,9 +5492,10 @@ def test_upsample_in_time_noninteger_resampling(resample_in_time_file):
     return
 
 
-def test_upsample_in_time_errors(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_upsample_in_time_errors(hera_uvh5):
     """Test errors and warnings raised by upsample_in_time"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
 
     # test using a too-small integration time
@@ -5487,9 +5519,10 @@ def test_upsample_in_time_errors(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_upsample_in_time_summing_correlator_mode(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_upsample_in_time_summing_correlator_mode(hera_uvh5):
     """Test the upsample_in_time method with summing correlator mode"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
 
     # reorder to make sure we get the right value later
@@ -5524,9 +5557,10 @@ def test_upsample_in_time_summing_correlator_mode(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_upsample_in_time_summing_correlator_mode_with_flags(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_upsample_in_time_summing_correlator_mode_with_flags(hera_uvh5):
     """Test the upsample_in_time method with summing correlator mode and flags"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
 
     # reorder to make sure we get the right value later
@@ -5559,13 +5593,12 @@ def test_upsample_in_time_summing_correlator_mode_with_flags(resample_in_time_fi
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_upsample_in_time_summing_correlator_mode_nonint_resampling(
-    resample_in_time_file,
-):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_upsample_in_time_summing_correlator_mode_nonint_resampling(hera_uvh5,):
     """Test the upsample_in_time method with summing correlator mode
     and non-integer resampling
     """
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
 
     # reorder to make sure we get the right value later
@@ -5601,9 +5634,10 @@ def test_upsample_in_time_summing_correlator_mode_nonint_resampling(
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_partial_upsample_in_time(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_partial_upsample_in_time(hera_uvh5):
     """Test the upsample_in_time method with non-uniform upsampling"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
 
     # change a whole baseline's integration time
@@ -5644,9 +5678,10 @@ def test_partial_upsample_in_time(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_upsample_in_time_drift(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_upsample_in_time_drift(hera_uvh5):
     """Test the upsample_in_time method on drift mode data"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
 
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline")
@@ -5682,9 +5717,10 @@ def test_upsample_in_time_drift(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_upsample_in_time_drift_no_phasing(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_upsample_in_time_drift_no_phasing(hera_uvh5):
     """Test the upsample_in_time method on drift mode data without phasing"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
 
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline")
@@ -5721,9 +5757,10 @@ def test_upsample_in_time_drift_no_phasing(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_downsample_in_time(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time(hera_uvh5):
     """Test the downsample_in_time method"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -5771,9 +5808,10 @@ def test_downsample_in_time(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_downsample_in_time_partial_flags(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_partial_flags(hera_uvh5):
     """Test the downsample_in_time method with partial flagging"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -5818,9 +5856,10 @@ def test_downsample_in_time_partial_flags(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_downsample_in_time_totally_flagged(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_totally_flagged(hera_uvh5):
     """Test the downsample_in_time method with totally flagged integrations"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -5868,9 +5907,10 @@ def test_downsample_in_time_totally_flagged(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_downsample_in_time_uneven_samples(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_uneven_samples(hera_uvh5):
     """Test the downsample_in_time method with uneven downsampling"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -5921,9 +5961,10 @@ def test_downsample_in_time_uneven_samples(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_downsample_in_time_uneven_samples_keep_ragged(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_uneven_samples_keep_ragged(hera_uvh5):
     """Test downsample_in_time with uneven downsampling and keep_ragged=True."""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -5962,9 +6003,10 @@ def test_downsample_in_time_uneven_samples_keep_ragged(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_downsample_in_time_summing_correlator_mode(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_summing_correlator_mode(hera_uvh5):
     """Test the downsample_in_time method with summing correlator mode"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6004,13 +6046,12 @@ def test_downsample_in_time_summing_correlator_mode(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_downsample_in_time_summing_correlator_mode_partial_flags(
-    resample_in_time_file,
-):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_summing_correlator_mode_partial_flags(hera_uvh5,):
     """Test the downsample_in_time method with summing correlator mode and
     partial flags
     """
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6051,13 +6092,12 @@ def test_downsample_in_time_summing_correlator_mode_partial_flags(
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_downsample_in_time_summing_correlator_mode_totally_flagged(
-    resample_in_time_file,
-):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_summing_correlator_mode_totally_flagged(hera_uvh5,):
     """Test the downsample_in_time method with summing correlator mode and
     totally flagged integrations.
     """
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6099,13 +6139,12 @@ def test_downsample_in_time_summing_correlator_mode_totally_flagged(
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_downsample_in_time_summing_correlator_mode_uneven_samples(
-    resample_in_time_file,
-):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_summing_correlator_mode_uneven_samples(hera_uvh5,):
     """Test the downsample_in_time method with summing correlator mode and
     uneven samples.
     """
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6151,13 +6190,14 @@ def test_downsample_in_time_summing_correlator_mode_uneven_samples(
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_downsample_in_time_summing_correlator_mode_uneven_samples_drop_ragged(
-    resample_in_time_file,
+    hera_uvh5,
 ):
     """Test the downsample_in_time method with summing correlator mode and
     uneven samples, dropping ragged ones.
     """
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6196,9 +6236,10 @@ def test_downsample_in_time_summing_correlator_mode_uneven_samples_drop_ragged(
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_partial_downsample_in_time(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_partial_downsample_in_time(hera_uvh5):
     """Test the downsample_in_time method without uniform downsampling"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
 
     # change a whole baseline's integration time
@@ -6247,9 +6288,10 @@ def test_partial_downsample_in_time(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_downsample_in_time_drift(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_drift(hera_uvh5):
     """Test the downsample_in_time method on drift mode data"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
 
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6296,9 +6338,10 @@ def test_downsample_in_time_drift(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_downsample_in_time_drift_no_phasing(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_drift_no_phasing(hera_uvh5):
     """Test the downsample_in_time method on drift mode data without phasing"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
 
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6349,11 +6392,10 @@ def test_downsample_in_time_drift_no_phasing(resample_in_time_file):
     assert uv_object == uv_object2
 
 
-@pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
-@pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_downsample_in_time_nsample_precision(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_nsample_precision(hera_uvh5):
     """Test the downsample_in_time method with a half-precision nsample_array"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6404,9 +6446,10 @@ def test_downsample_in_time_nsample_precision(resample_in_time_file):
     return
 
 
-def test_downsample_in_time_errors(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_errors(hera_uvh5):
     """Test various errors and warnings are raised"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6489,11 +6532,12 @@ def test_downsample_in_time_errors(resample_in_time_file):
     return
 
 
-def test_downsample_in_time_int_time_mismatch_warning(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_int_time_mismatch_warning(hera_uvh5):
     """Test warning in downsample_in_time about mismatch between integration
     times and the time between integrations.
     """
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6531,11 +6575,12 @@ def test_downsample_in_time_int_time_mismatch_warning(resample_in_time_file):
     return
 
 
-def test_downsample_in_time_varying_integration_time(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_varying_integration_time(hera_uvh5):
     """Test downsample_in_time handling of file with integration time changing
     within a baseline
     """
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6587,11 +6632,12 @@ def test_downsample_in_time_varying_integration_time(resample_in_time_file):
     return
 
 
-def test_downsample_in_time_varying_int_time_partial_flags(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_varying_int_time_partial_flags(hera_uvh5):
     """Test downsample_in_time handling of file with integration time changing
     within a baseline and partial flagging.
     """
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6637,11 +6683,12 @@ def test_downsample_in_time_varying_int_time_partial_flags(resample_in_time_file
     return
 
 
-def test_downsample_in_time_varying_integration_time_warning(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_downsample_in_time_varying_integration_time_warning(hera_uvh5):
     """Test downsample_in_time handling of file with integration time changing
     within a baseline, but without adjusting the time_array so there is a mismatch.
     """
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
     uv_object.phase_to_time(Time(uv_object.time_array[0], format="jd"))
     # reorder to make sure we get the right value later
     uv_object.reorder_blts(order="baseline", minor_order="time")
@@ -6680,9 +6727,10 @@ def test_downsample_in_time_varying_integration_time_warning(resample_in_time_fi
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 @pytest.mark.filterwarnings("ignore:Data will be unphased and rephased")
-def test_upsample_downsample_in_time(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_upsample_downsample_in_time(hera_uvh5):
     """Test round trip works"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
 
     # set uvws from antenna positions so they'll agree later.
     # the fact that this is required is a bit concerning, it means that
@@ -6772,9 +6820,10 @@ def test_upsample_downsample_in_time(resample_in_time_file):
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 @pytest.mark.filterwarnings("ignore:Data will be unphased and rephased")
 @pytest.mark.filterwarnings("ignore:There is a gap in the times of baseline")
-def test_upsample_downsample_in_time_odd_resample(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_upsample_downsample_in_time_odd_resample(hera_uvh5):
     """Test round trip works with odd resampling"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
 
     # set uvws from antenna positions so they'll agree later.
     # the fact that this is required is a bit concerning, it means that
@@ -6818,9 +6867,10 @@ def test_upsample_downsample_in_time_odd_resample(resample_in_time_file):
 
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_upsample_downsample_in_time_metadata_only(resample_in_time_file):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_upsample_downsample_in_time_metadata_only(hera_uvh5):
     """Test round trip works with metadata-only objects"""
-    uv_object = resample_in_time_file
+    uv_object = hera_uvh5
 
     # drop the data arrays
     uv_object.data_array = None
@@ -7096,6 +7146,8 @@ def test_resample_in_time_warning():
     assert uv2 == uv
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_frequency_average(uvdata_data):
     """Test averaging in frequency."""
     eq_coeffs = np.tile(
@@ -7148,6 +7200,8 @@ def test_frequency_average(uvdata_data):
     assert not isinstance(uvdata_data.uv_object.nsample_array, np.ma.MaskedArray)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_frequency_average_uneven(uvdata_data):
     """Test averaging in frequency with a number that is not a factor of Nfreqs."""
     # check that there's no flagging
@@ -7194,6 +7248,8 @@ def test_frequency_average_uneven(uvdata_data):
     assert np.nonzero(uvdata_data.uv_object.flag_array)[0].size == 0
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_frequency_average_flagging(uvdata_data):
     """Test averaging in frequency with flagging all samples averaged."""
     # check that there's no flagging
@@ -7239,6 +7295,8 @@ def test_frequency_average_flagging(uvdata_data):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_frequency_average_flagging_partial(uvdata_data):
     """Test averaging in frequency with flagging only one sample averaged."""
     # check that there's no flagging
@@ -7279,6 +7337,8 @@ def test_frequency_average_flagging_partial(uvdata_data):
     assert np.nonzero(uvdata_data.uv_object.flag_array)[0].size == 0
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_frequency_average_flagging_full_and_partial(uvdata_data):
     """
     Test averaging in frequency with flagging all of one and only one of
@@ -7325,6 +7385,8 @@ def test_frequency_average_flagging_full_and_partial(uvdata_data):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_frequency_average_flagging_partial_twostage(uvdata_data):
     """
     Test averaging in frequency in two stages with flagging only one sample averaged.
@@ -7350,6 +7412,8 @@ def test_frequency_average_flagging_partial_twostage(uvdata_data):
     assert uvdata_data.uv_object == uv_object3
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_frequency_average_summing_corr_mode(uvdata_data):
     """Test averaging in frequency."""
     # check that there's no flagging
@@ -7383,6 +7447,8 @@ def test_frequency_average_summing_corr_mode(uvdata_data):
     assert not isinstance(uvdata_data.uv_object.nsample_array, np.ma.MaskedArray)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_frequency_average_propagate_flags(uvdata_data):
     """
     Test averaging in frequency with flagging all of one and only one of
@@ -7432,6 +7498,7 @@ def test_frequency_average_propagate_flags(uvdata_data):
     )
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_frequency_average_nsample_precision(uvdata_data):
     """Test averaging in frequency with a half-precision nsample_array."""
     eq_coeffs = np.tile(
@@ -7492,6 +7559,8 @@ def test_frequency_average_nsample_precision(uvdata_data):
     assert uvdata_data.uv_object.nsample_array.dtype.type is np.float16
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_remove_eq_coeffs_divide(uvdata_data):
     """Test using the remove_eq_coeffs method with divide convention."""
     # give eq_coeffs to the object
@@ -7517,6 +7586,8 @@ def test_remove_eq_coeffs_divide(uvdata_data):
     return
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_remove_eq_coeffs_multiply(uvdata_data):
     """Test using the remove_eq_coeffs method with multiply convention."""
     # give eq_coeffs to the object
@@ -7542,6 +7613,8 @@ def test_remove_eq_coeffs_multiply(uvdata_data):
     return
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_remove_eq_coeffs_errors(uvdata_data):
     """Test errors raised by remove_eq_coeffs method."""
     # raise error when eq_coeffs are not defined
@@ -7607,28 +7680,27 @@ def test_multifile_read_errors(read_func, filelist):
     )
 
 
-def test_multifile_read_check(tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_multifile_read_check(hera_uvh5, tmp_path):
     """Test setting skip_bad_files=True when reading in files"""
 
-    uv = UVData()
+    uvTrue = hera_uvh5
     uvh5_file = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
 
     # Create a test file and remove header info to 'corrupt' it
     testfile = str(tmp_path / "zen.2458661.23480.HH.uvh5")
-    uv.read(uvh5_file)
-    uv.write_uvh5(testfile)
+
+    uvTrue.write_uvh5(testfile)
     with h5py.File(testfile, "r+") as h5f:
         del h5f["Header/ant_1_array"]
 
+    uv = UVData()
     # Test that the expected error arises
     with pytest.raises(KeyError) as cm:
         uv.read(testfile, skip_bad_files=False)
     assert "Unable to open object (object 'ant_1_array' doesn't exist)" in str(cm.value)
 
     # Test when the corrupted file is at the beggining, skip_bad_files=False
-    uv = UVData()
-    uvTrue = UVData()
-    uvTrue.read(uvh5_file)
     fileList = [testfile, uvh5_file]
     with pytest.raises(KeyError) as cm:
         with pytest.warns(UserWarning, match="Failed to read"):
@@ -7637,9 +7709,6 @@ def test_multifile_read_check(tmp_path):
     assert uv != uvTrue
 
     # Test when the corrupted file is at the beggining, skip_bad_files=True
-    uv = UVData()
-    uvTrue = UVData()
-    uvTrue.read(uvh5_file)
     fileList = [testfile, uvh5_file]
     with pytest.warns(UserWarning, match="Failed to read") as record:
         uv.read(fileList, skip_bad_files=True)
@@ -7651,8 +7720,6 @@ def test_multifile_read_check(tmp_path):
     assert uv == uvTrue
 
     # Test when the corrupted file is at the end of a list
-    uvTrue = UVData()
-    uvTrue.read(uvh5_file)
     fileList = [uvh5_file, testfile]
     with pytest.warns(UserWarning, match="Failed to read") as cm:
         uv.read(fileList, skip_bad_files=True)
@@ -7664,14 +7731,14 @@ def test_multifile_read_check(tmp_path):
     return
 
 
-def test_multifile_read_check_long_list(tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_multifile_read_check_long_list(hera_uvh5, tmp_path):
     """
     Test setting skip_bad_files=True when reading in files for a list of length >2
     """
     # Create mini files for testing
-    uv = UVData()
-    uvh5_file = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-    uv.read(uvh5_file)
+    uv = hera_uvh5
+
     fileList = []
     for i in range(0, 4):
         uv2 = uv.select(
@@ -7814,6 +7881,7 @@ def test_deprecation_warnings_set_phased():
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not in known_telescopes.")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_read_background_lsts():
     """Test reading a file with the lst calc in the background."""
     uvd = UVData()

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -5633,7 +5633,7 @@ def test_upsample_in_time_summing_correlator_mode_with_flags(hera_uvh5):
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_upsample_in_time_summing_correlator_mode_nonint_resampling(hera_uvh5,):
+def test_upsample_in_time_summing_correlator_mode_nonint_resampling(hera_uvh5):
     """Test the upsample_in_time method with summing correlator mode
     and non-integer resampling
     """
@@ -6086,7 +6086,7 @@ def test_downsample_in_time_summing_correlator_mode(hera_uvh5):
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_downsample_in_time_summing_correlator_mode_partial_flags(hera_uvh5,):
+def test_downsample_in_time_summing_correlator_mode_partial_flags(hera_uvh5):
     """Test the downsample_in_time method with summing correlator mode and
     partial flags
     """
@@ -6132,7 +6132,7 @@ def test_downsample_in_time_summing_correlator_mode_partial_flags(hera_uvh5,):
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_downsample_in_time_summing_correlator_mode_totally_flagged(hera_uvh5,):
+def test_downsample_in_time_summing_correlator_mode_totally_flagged(hera_uvh5):
     """Test the downsample_in_time method with summing correlator mode and
     totally flagged integrations.
     """
@@ -6179,7 +6179,7 @@ def test_downsample_in_time_summing_correlator_mode_totally_flagged(hera_uvh5,):
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_downsample_in_time_summing_correlator_mode_uneven_samples(hera_uvh5,):
+def test_downsample_in_time_summing_correlator_mode_uneven_samples(hera_uvh5):
     """Test the downsample_in_time method with summing correlator mode and
     uneven samples.
     """

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -475,14 +475,45 @@ def test_check(uvdata_data):
     assert uvdata_data.uv_object.check()
     # Check variety of special cases
     uvdata_data.uv_object.Nants_data += 1
-    pytest.raises(ValueError, uvdata_data.uv_object.check)
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Nants_data must be equal to the number of unique values in "
+            "ant_1_array and ant_2_array"
+        ),
+    ):
+        uvdata_data.uv_object.check()
     uvdata_data.uv_object.Nants_data -= 1
     uvdata_data.uv_object.Nbls += 1
-    pytest.raises(ValueError, uvdata_data.uv_object.check)
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Nbls must be equal to the number of unique baselines in the data_array"
+        ),
+    ):
+        uvdata_data.uv_object.check()
     uvdata_data.uv_object.Nbls -= 1
     uvdata_data.uv_object.Ntimes += 1
-    pytest.raises(ValueError, uvdata_data.uv_object.check)
+    with pytest.raises(
+        ValueError,
+        match=("Ntimes must be equal to the number of unique times in the time_array"),
+    ):
+        uvdata_data.uv_object.check()
     uvdata_data.uv_object.Ntimes -= 1
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "The uvw_array does not match the expected values given the antenna "
+            "positions."
+        ),
+    ):
+        uvdata_data.uv_object.check(uvw_antpos_check_level="strict")
+
+    with pytest.raises(
+        ValueError, match=("uvw_antpos_check_level must be one of"),
+    ):
+        uvdata_data.uv_object.check(uvw_antpos_check_level="foo")
 
     # Check case where all data is autocorrelations
     # Currently only test files that have autos are fhd files
@@ -513,12 +544,20 @@ def test_check(uvdata_data):
 
     # make auto have non-zero uvw coords, assert ValueError
     uvd.uvw_array[auto_inds[0], 0] = 0.1
-    pytest.raises(ValueError, uvd.check)
+    with pytest.raises(
+        ValueError,
+        match=("Some auto-correlations have non-zero uvw_array coordinates."),
+    ):
+        uvd.check()
 
     # make cross have |uvw| zero, assert ValueError
     uvd.read_uvh5(os.path.join(DATA_PATH, "zen.2457698.40355.xx.HH.uvcA.uvh5"))
     uvd.uvw_array[cross_inds[0]][:] = 0.0
-    pytest.raises(ValueError, uvd.check)
+    with pytest.raises(
+        ValueError,
+        match=("Some cross-correlations have near-zero uvw_array magnitudes."),
+    ):
+        uvd.check()
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -5,7 +5,6 @@
 """Tests for UVFITS object.
 
 """
-import copy
 import os
 
 import pytest
@@ -18,66 +17,45 @@ import pyuvdata.utils as uvutils
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH
 
+casa_tutorial_uvfits = os.path.join(
+    DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits"
+)
 
-@pytest.fixture(scope="function")
-def casa_uvfits():
+paper_uvfits = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAAM.uvfits")
+
+
+@pytest.fixture(scope="session")
+def uvfits_nospw_master():
     uv_in = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_in.read(testfile)
+    # This file has a crazy epoch (2291.34057617) which breaks the uvw_antpos check
+    # Since it's a PAPER file, I think this is a bug in the file, not in the check.
+    uv_in.read(paper_uvfits, uvw_antpos_check_level="off")
 
     return uv_in
 
 
-def test_read_nrao():
+@pytest.fixture(scope="function")
+def uvfits_nospw(uvfits_nospw_master):
+    return uvfits_nospw_master.copy()
+
+
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+def test_read_nrao(casa_uvfits):
     """Test reading in a CASA tutorial uvfits file."""
-    uvobj = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
+    uvobj = casa_uvfits
     expected_extra_keywords = ["OBSERVER", "SORTORD", "SPECSYS", "RESTFREQ", "ORIGIN"]
-    uvtest.checkWarnings(
-        uvobj.read_uvfits,
-        func_args=[testfile],
-        nwarnings=2,
-        message=[
-            "Telescope EVLA is not in known_telescopes.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-        ],
-    )
     assert expected_extra_keywords.sort() == list(uvobj.extra_keywords.keys()).sort()
 
-    # test reading in header & metadata first, then data
+    # test reading metadata only
     uvobj2 = UVData()
-    uvtest.checkWarnings(
-        uvobj2.read,
-        func_args=[testfile],
-        func_kwargs={"read_data": False},
-        message="Telescope EVLA is not",
-    )
+    uvobj2.read(casa_tutorial_uvfits, read_data=False)
+
     assert expected_extra_keywords.sort() == list(uvobj2.extra_keywords.keys()).sort()
     assert uvobj2.check()
-    uvtest.checkWarnings(
-        uvobj2.read,
-        func_args=[testfile],
-        nwarnings=2,
-        message=[
-            "Telescope EVLA is not in known_telescopes.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-        ],
-    )
-    assert uvobj == uvobj2
 
-
-@pytest.mark.filterwarnings("ignore:Required Antenna frame keyword")
-@pytest.mark.filterwarnings("ignore:telescope_location is not set")
-def test_no_spw():
-    """Test reading in a PAPER uvfits file with no spw axis."""
-    uvobj = UVData()
-    testfile_no_spw = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAAM.uvfits")
-    # This file has a crazy epoch (2291.34057617) which breaks the uvw_antpos check
-    # Since it's a PAPER file, I think this is a bug in the file, not in the check.
-    uvobj.read(testfile_no_spw, uvw_antpos_check_level="off")
-    del uvobj
+    uvobj3 = uvobj.copy(metadata_only=True)
+    assert uvobj2 == uvobj3
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
@@ -85,19 +63,17 @@ def test_break_read_uvfits():
     """Test errors on reading in a uvfits file with subarrays and other problems."""
     uvobj = UVData()
     multi_subarray_file = os.path.join(DATA_PATH, "multi_subarray.uvfits")
-    with pytest.raises(ValueError) as cm:
+    with pytest.raises(ValueError, match="This file appears to have multiple subarray"):
         uvobj.read(multi_subarray_file)
-    assert str(cm.value).startswith("This file appears to have multiple subarray")
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_source_group_params(tmp_path):
+def test_source_group_params(casa_uvfits, tmp_path):
     # make a file with a single source to test that it works
-    uv_in = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
+    uv_in = casa_uvfits
     write_file = str(tmp_path / "outtest_casa.uvfits")
     write_file2 = str(tmp_path / "outtest_casa2.uvfits")
-    uv_in.read(testfile)
     uv_in.write_uvfits(write_file)
 
     with fits.open(write_file, memmap=True) as hdu_list:
@@ -147,14 +123,13 @@ def test_source_group_params(tmp_path):
     assert uv_in == uv_out
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_multisource_error(tmp_path):
+def test_multisource_error(casa_uvfits, tmp_path):
     # make a file with multiple sources to test error condition
-    uv_in = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
+    uv_in = casa_uvfits
     write_file = str(tmp_path / "outtest_casa.uvfits")
     write_file2 = str(tmp_path / "outtest_casa2.uvfits")
-    uv_in.read(testfile)
     uv_in.write_uvfits(write_file)
 
     with fits.open(write_file, memmap=True) as hdu_list:
@@ -251,6 +226,7 @@ def test_casa_nonascii_bytes_antenna_names():
     assert uv1.antenna_names == expected_ant_names
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_readwriteread(tmp_path, casa_uvfits):
     """
@@ -270,6 +246,7 @@ def test_readwriteread(tmp_path, casa_uvfits):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_readwriteread_no_lst(tmp_path, casa_uvfits):
     uv_in = casa_uvfits
@@ -284,6 +261,7 @@ def test_readwriteread_no_lst(tmp_path, casa_uvfits):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_readwriteread_x_orientation(tmp_path, casa_uvfits):
     uv_in = casa_uvfits
@@ -299,6 +277,7 @@ def test_readwriteread_x_orientation(tmp_path, casa_uvfits):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_readwriteread_antenna_diameters(tmp_path, casa_uvfits):
     uv_in = casa_uvfits
@@ -314,6 +293,7 @@ def test_readwriteread_antenna_diameters(tmp_path, casa_uvfits):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_readwriteread_large_antnums(tmp_path, casa_uvfits):
     uv_in = casa_uvfits
@@ -338,6 +318,7 @@ def test_readwriteread_large_antnums(tmp_path, casa_uvfits):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_readwriteread_missing_info(tmp_path, casa_uvfits):
     uv_in = casa_uvfits
@@ -375,6 +356,7 @@ def test_readwriteread_missing_info(tmp_path, casa_uvfits):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_readwriteread_error_timesys(tmp_path, casa_uvfits):
     uv_in = casa_uvfits
@@ -391,6 +373,7 @@ def test_readwriteread_error_timesys(tmp_path, casa_uvfits):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_readwriteread_error_single_time(tmp_path, casa_uvfits):
     uv_in = casa_uvfits
@@ -450,6 +433,7 @@ def test_readwriteread_error_single_time(tmp_path, casa_uvfits):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_readwriteread_unflagged_data_warnings(tmp_path, casa_uvfits):
     uv_in = casa_uvfits
@@ -465,6 +449,7 @@ def test_readwriteread_unflagged_data_warnings(tmp_path, casa_uvfits):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 @pytest.mark.parametrize(
     "kwd_name,kwd_value,warnstr,errstr",
@@ -495,11 +480,11 @@ def test_readwriteread_unflagged_data_warnings(tmp_path, casa_uvfits):
         ],
     ),
 )
-def test_extra_keywords_errors(tmp_path, kwd_name, kwd_value, warnstr, errstr):
-    uv_in = UVData()
-    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
+def test_extra_keywords_errors(
+    casa_uvfits, tmp_path, kwd_name, kwd_value, warnstr, errstr
+):
+    uv_in = casa_uvfits
     testfile = str(tmp_path / "outtest_casa.uvfits")
-    uv_in.read(uvfits_file)
 
     # check for warnings & errors with extra_keywords that are dicts, lists or arrays
     uv_in.extra_keywords[kwd_name] = kwd_value
@@ -514,73 +499,44 @@ def test_extra_keywords_errors(tmp_path, kwd_name, kwd_value, warnstr, errstr):
             uv_in.write_uvfits(testfile, run_check=False)
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_extra_keywords(tmp_path):
-    uv_in = UVData()
+@pytest.mark.parametrize(
+    "kwd_names,kwd_values",
+    (
+        [["bool", "bool2"], [True, False]],
+        [["int1", "int2"], [np.int(5), 7]],
+        [["float1", "float2"], [np.int64(5.3), 6.9]],
+        [["complex1", "complex2"], [np.complex64(5.3 + 1.2j), 6.9 + 4.6j]],
+        [
+            ["str", "comment"],
+            [
+                "hello",
+                "this is a very long comment that will be broken into several "
+                "lines\nif everything works properly.",
+            ],
+        ],
+    ),
+)
+def test_extra_keywords(casa_uvfits, tmp_path, kwd_names, kwd_values):
+    uv_in = casa_uvfits
     uv_out = UVData()
-    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
     testfile = str(tmp_path / "outtest_casa.uvfits")
-    uv_in.read(uvfits_file)
 
-    # check handling of boolean keywords
-    uv_in.extra_keywords["bool"] = True
-    uv_in.extra_keywords["bool2"] = False
-    uv_in.write_uvfits(testfile)
-    uv_out.read(testfile)
-
-    assert uv_in == uv_out
-    uv_in.extra_keywords.pop("bool")
-    uv_in.extra_keywords.pop("bool2")
-
-    # check handling of int-like keywords
-    uv_in.extra_keywords["int1"] = np.int(5)
-    uv_in.extra_keywords["int2"] = 7
-    uv_in.write_uvfits(testfile)
-    uv_out.read(testfile)
-
-    assert uv_in == uv_out
-    uv_in.extra_keywords.pop("int1")
-    uv_in.extra_keywords.pop("int2")
-
-    # check handling of float-like keywords
-    uv_in.extra_keywords["float1"] = np.int64(5.3)
-    uv_in.extra_keywords["float2"] = 6.9
-    uv_in.write_uvfits(testfile)
-    uv_out.read(testfile)
-
-    assert uv_in == uv_out
-    uv_in.extra_keywords.pop("float1")
-    uv_in.extra_keywords.pop("float2")
-
-    # check handling of complex-like keywords
-    uv_in.extra_keywords["complex1"] = np.complex64(5.3 + 1.2j)
-    uv_in.extra_keywords["complex2"] = 6.9 + 4.6j
-    uv_in.write_uvfits(testfile)
-    uv_out.read(testfile)
-
-    assert uv_in == uv_out
-    uv_in.extra_keywords.pop("complex1")
-    uv_in.extra_keywords.pop("complex2")
-
-    # check handling of comment keywords
-    uv_in.extra_keywords["comment"] = (
-        "this is a very long comment that will "
-        "be broken into several lines\nif "
-        "everything works properly."
-    )
+    for name, value in zip(kwd_names, kwd_values):
+        uv_in.extra_keywords[name] = value
     uv_in.write_uvfits(testfile)
     uv_out.read(testfile)
 
     assert uv_in == uv_out
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_roundtrip_blt_order(tmp_path):
-    uv_in = UVData()
+def test_roundtrip_blt_order(casa_uvfits, tmp_path):
+    uv_in = casa_uvfits
     uv_out = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
     write_file = str(tmp_path / "outtest_casa.uvfits")
-    uv_in.read(testfile)
 
     uv_in.reorder_blts()
 
@@ -597,117 +553,77 @@ def test_roundtrip_blt_order(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-@pytest.mark.filterwarnings("ignore:Required Antenna frame keyword")
-@pytest.mark.filterwarnings("ignore:telescope_location is not set")
-def test_select_read(tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.parametrize(
+    "select_kwargs",
+    [
+        {"antenna_nums": np.array([0, 19, 11, 24, 3, 23, 1, 20, 21])},
+        {"freq_chans": np.arange(12, 22)},
+        {"freq_chans": [0]},
+        {"polarizations": [-1, -2]},
+        {"time_inds": np.array([0, 1])},
+        {
+            "antenna_nums": np.array([0, 19, 11, 24, 3, 23, 1, 20, 21]),
+            "freq_chans": np.arange(12, 22),
+            "polarizations": [-1, -2],
+        },
+        {
+            "antenna_nums": np.array([0, 1]),
+            "freq_chans": np.arange(12, 22),
+            "polarizations": [-1, -2],
+        },
+        {
+            "antenna_nums": np.array([0, 1, 2, 3, 6, 7, 8, 11, 14, 18, 19, 20, 21, 22]),
+            "freq_chans": np.arange(12, 64),
+            "polarizations": [-1, -2],
+        },
+    ],
+)
+def test_select_read(casa_uvfits, tmp_path, select_kwargs):
     uvfits_uv = UVData()
     uvfits_uv2 = UVData()
-    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
 
-    # select on antennas
-    ants_to_keep = np.array([0, 19, 11, 24, 3, 23, 1, 20, 21])
-    uvfits_uv.read(uvfits_file, antenna_nums=ants_to_keep)
-    uvfits_uv2.read(uvfits_file)
-    uvfits_uv2.select(antenna_nums=ants_to_keep)
+    uvfits_uv2 = casa_uvfits
+    if "time_inds" in select_kwargs.keys():
+        time_inds = select_kwargs.pop("time_inds")
+        unique_times = np.unique(uvfits_uv2.time_array)
+        select_kwargs["time_range"] = unique_times[time_inds]
+
+    uvfits_uv.read(casa_tutorial_uvfits, **select_kwargs)
+    uvfits_uv2.select(**select_kwargs)
     assert uvfits_uv == uvfits_uv2
 
-    # select on frequency channels
-    chans_to_keep = np.arange(12, 22)
-    uvfits_uv.read(uvfits_file, freq_chans=chans_to_keep)
-    uvfits_uv2.read(uvfits_file)
-    uvfits_uv2.select(freq_chans=chans_to_keep)
-    assert uvfits_uv == uvfits_uv2
-
-    # check writing & reading single frequency files
-    uvfits_uv.select(freq_chans=[0])
     testfile = str(tmp_path / "outtest_casa.uvfits")
     uvfits_uv.write_uvfits(testfile)
     uvfits_uv2.read(testfile)
     assert uvfits_uv == uvfits_uv2
 
-    # select on pols
-    pols_to_keep = [-1, -2]
-    uvfits_uv.read(uvfits_file, polarizations=pols_to_keep)
-    uvfits_uv2.read(uvfits_file)
-    uvfits_uv2.select(polarizations=pols_to_keep)
-    assert uvfits_uv == uvfits_uv2
 
-    # select on read using time_range
-    unique_times = np.unique(uvfits_uv.time_array)
-    uvfits_uv.read(uvfits_file, time_range=[unique_times[0], unique_times[1]])
-    uvfits_uv2.read(uvfits_file)
-    uvfits_uv2.select(times=unique_times[0:2])
-    assert uvfits_uv == uvfits_uv2
+@pytest.mark.filterwarnings("ignore:Required Antenna frame keyword")
+@pytest.mark.filterwarnings("ignore:telescope_location is not set")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.parametrize(
+    "select_kwargs",
+    [{"antenna_nums": np.array([2, 4, 5])}, {"freq_chans": np.arange(4, 8)}],
+)
+def test_select_read_nospw(uvfits_nospw, tmp_path, select_kwargs):
+    uvfits_uv2 = uvfits_nospw
 
-    # now test selecting on multiple axes
-    # frequencies first
-    uvfits_uv.read(
-        uvfits_file,
-        antenna_nums=ants_to_keep,
-        freq_chans=chans_to_keep,
-        polarizations=pols_to_keep,
-    )
-    uvfits_uv2.read(uvfits_file)
-    uvfits_uv2.select(
-        antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
-    )
-    assert uvfits_uv == uvfits_uv2
-
-    # baselines first
-    ants_to_keep = np.array([0, 1])
-    uvfits_uv.read(
-        uvfits_file,
-        antenna_nums=ants_to_keep,
-        freq_chans=chans_to_keep,
-        polarizations=pols_to_keep,
-    )
-    uvfits_uv2.read(uvfits_file)
-    uvfits_uv2.select(
-        antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
-    )
-    assert uvfits_uv == uvfits_uv2
-
-    # polarizations first
-    ants_to_keep = np.array([0, 1, 2, 3, 6, 7, 8, 11, 14, 18, 19, 20, 21, 22])
-    chans_to_keep = np.arange(12, 64)
-    uvfits_uv.read(
-        uvfits_file,
-        antenna_nums=ants_to_keep,
-        freq_chans=chans_to_keep,
-        polarizations=pols_to_keep,
-    )
-    uvfits_uv2.read(uvfits_file)
-    uvfits_uv2.select(
-        antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
-    )
-    assert uvfits_uv == uvfits_uv2
-
-    # repeat with no spw file
-    uvfitsfile_no_spw = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAAM.uvfits")
+    uvfits_uv = UVData()
     # This file has a crazy epoch (2291.34057617) which breaks the uvw_antpos check
     # Since it's a PAPER file, I think this is a bug in the file, not in the check.
+    uvfits_uv.read(paper_uvfits, uvw_antpos_check_level="off", **select_kwargs)
 
-    # select on antennas
-    ants_to_keep = np.array([2, 4, 5])
-    uvfits_uv.read(
-        uvfitsfile_no_spw, uvw_antpos_check_level="off", antenna_nums=ants_to_keep
-    )
-    uvfits_uv2.read(uvfitsfile_no_spw, uvw_antpos_check_level="off")
-    uvfits_uv2.select(antenna_nums=ants_to_keep)
+    uvfits_uv2.select(**select_kwargs)
     assert uvfits_uv == uvfits_uv2
 
-    # select on frequency channels
-    chans_to_keep = np.arange(4, 8)
-    uvfits_uv.read(
-        uvfitsfile_no_spw, uvw_antpos_check_level="off", freq_chans=chans_to_keep
-    )
-    uvfits_uv2.read(uvfitsfile_no_spw, uvw_antpos_check_level="off")
-    uvfits_uv2.select(freq_chans=chans_to_keep)
-    assert uvfits_uv == uvfits_uv2
 
-    # select on pols
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_read_nospw_pol(casa_uvfits, tmp_path):
     # this requires writing a new file because the no spw file we have has only 1 pol
-    with fits.open(uvfits_file, memmap=True) as hdu_list:
+
+    with fits.open(casa_tutorial_uvfits, memmap=True) as hdu_list:
         hdunames = uvutils._fits_indexhdus(hdu_list)
         vis_hdu = hdu_list[0]
         vis_hdr = vis_hdu.header.copy()
@@ -754,25 +670,25 @@ def test_select_read(tmp_path):
         hdulist.writeto(write_file, overwrite=True)
 
     pols_to_keep = [-1, -2]
+    uvfits_uv = UVData()
     uvfits_uv.read(write_file, polarizations=pols_to_keep)
-    uvfits_uv2.read(uvfits_file)
+    uvfits_uv2 = casa_uvfits
     uvfits_uv2.select(polarizations=pols_to_keep)
     assert uvfits_uv == uvfits_uv2
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
-def test_read_uvfits_write_miriad(tmp_path):
+def test_read_uvfits_write_miriad(casa_uvfits, tmp_path):
     """
     read uvfits, write miriad test.
     Read in uvfits file, write out as miriad, read back in and check for
     object equality.
     """
     pytest.importorskip("pyuvdata._miriad")
-    uvfits_uv = UVData()
+    uvfits_uv = casa_uvfits
     miriad_uv = UVData()
-    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
     testfile = str(tmp_path / "outtest_miriad")
-    uvfits_uv.read(uvfits_file)
     uvfits_uv.write_miriad(testfile, clobber=True)
     miriad_uv.read_miriad(testfile)
 
@@ -782,11 +698,10 @@ def test_read_uvfits_write_miriad(tmp_path):
     miriad_uv.read_miriad(testfile, phase_type="phased")
 
     # check that setting the phase_type to drift raises an error
-    with pytest.raises(ValueError) as cm:
+    with pytest.raises(
+        ValueError, match='phase_type is "drift" but the RA values are constant.'
+    ):
         miriad_uv.read_miriad(testfile, phase_type="drift")
-    assert str(cm.value).startswith(
-        'phase_type is "drift" but the RA values are constant.'
-    )
 
     # check that setting it works after selecting a single time
     uvfits_uv.select(times=uvfits_uv.time_array[0])
@@ -798,17 +713,15 @@ def test_read_uvfits_write_miriad(tmp_path):
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_multi_files(tmp_path):
+def test_multi_files(casa_uvfits, tmp_path):
     """
     Reading multiple files at once.
     """
-    uv_full = UVData()
-    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
+    uv_full = casa_uvfits
     testfile1 = str(tmp_path / "uv1.uvfits")
     testfile2 = str(tmp_path / "uv2.uvfits")
-    uv_full.read(uvfits_file)
-    uv1 = copy.deepcopy(uv_full)
-    uv2 = copy.deepcopy(uv_full)
+    uv1 = uv_full.copy()
+    uv2 = uv_full.copy()
     uv1.select(freq_chans=np.arange(0, 32))
     uv2.select(freq_chans=np.arange(32, 64))
     uv1.write_uvfits(testfile1)
@@ -842,8 +755,7 @@ def test_multi_files(tmp_path):
     assert uv1 == uv_full
 
     # check with metadata_only
-    uv_full = UVData()
-    uv_full.read(uvfits_file, read_data=False)
+    uv_full = uv_full.copy(metadata_only=True)
     uv1 = UVData()
     uv1.read([testfile1, testfile2], read_data=False)
 
@@ -860,17 +772,16 @@ def test_multi_files(tmp_path):
     assert uv1 == uv_full
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
-def test_multi_unphase_on_read(tmp_path):
-    uv_full = UVData()
+def test_multi_unphase_on_read(casa_uvfits, tmp_path):
+    uv_full = casa_uvfits
     uv_full2 = UVData()
-    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
     testfile1 = str(tmp_path / "uv1.uvfits")
     testfile2 = str(tmp_path / "uv2.uvfits")
-    uv_full.read(uvfits_file)
-    uv1 = copy.deepcopy(uv_full)
-    uv2 = copy.deepcopy(uv_full)
+    uv1 = uv_full.copy()
+    uv2 = uv_full.copy()
     uv1.select(freq_chans=np.arange(0, 32))
     uv2.select(freq_chans=np.arange(32, 64))
     uv1.write_uvfits(testfile1)
@@ -911,7 +822,7 @@ def test_multi_unphase_on_read(tmp_path):
     # check unphasing when reading only one file
     uvtest.checkWarnings(
         uv_full2.read,
-        func_args=[uvfits_file],
+        func_args=[casa_tutorial_uvfits],
         func_kwargs={"unphase_to_drift": True},
         message=[
             "Telescope EVLA is not",
@@ -924,22 +835,21 @@ def test_multi_unphase_on_read(tmp_path):
     assert uv_full2 == uv_full
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
-def test_multi_phase_on_read(tmp_path):
-    uv_full = UVData()
+def test_multi_phase_on_read(casa_uvfits, tmp_path):
+    uv_full = casa_uvfits
     uv_full2 = UVData()
-    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
     testfile1 = str(tmp_path / "uv1.uvfits")
     testfile2 = str(tmp_path / "uv2.uvfits")
-    uv_full.read(uvfits_file)
     phase_center_radec = [
         uv_full.phase_center_ra + 0.01,
         uv_full.phase_center_dec + 0.01,
     ]
-    uv1 = copy.deepcopy(uv_full)
-    uv2 = copy.deepcopy(uv_full)
+    uv1 = uv_full.copy()
+    uv2 = uv_full.copy()
     uv1.select(freq_chans=np.arange(0, 32))
     uv2.select(freq_chans=np.arange(32, 64))
     uv1.write_uvfits(testfile1)
@@ -979,7 +889,7 @@ def test_multi_phase_on_read(tmp_path):
     # check phasing when reading only one file
     uvtest.checkWarnings(
         uv_full2.read,
-        func_args=[uvfits_file],
+        func_args=[casa_tutorial_uvfits],
         func_kwargs={"phase_center_radec": phase_center_radec},
         message=(
             [
@@ -994,10 +904,11 @@ def test_multi_phase_on_read(tmp_path):
     assert uv_full2 == uv_full
 
     with pytest.raises(ValueError) as cm:
-        uv_full2.read(uvfits_file, phase_center_radec=phase_center_radec[0])
+        uv_full2.read(casa_tutorial_uvfits, phase_center_radec=phase_center_radec[0])
     assert str(cm.value).startswith("phase_center_radec should have length 2.")
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_read_ms_write_uvfits_casa_history(tmp_path):
     """

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -26,35 +26,6 @@ pytestmark = [
 
 
 @pytest.fixture(scope="function")
-def uv_miriad():
-    # read in a miriad test file
-    pytest.importorskip("pyuvdata._miriad")
-    uv_miriad = UVData()
-    miriad_filename = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
-    uv_miriad.read_miriad(miriad_filename)
-    yield uv_miriad
-
-    # clean up when done
-    del uv_miriad
-
-    return
-
-
-@pytest.fixture(scope="function")
-def uv_uvfits():
-    # read in a uvfits test file
-    uv_uvfits = UVData()
-    uvfits_filename = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_uvfits.read_uvfits(uvfits_filename)
-    yield uv_uvfits
-
-    # clean up when done
-    del uv_uvfits
-
-    return
-
-
-@pytest.fixture(scope="function")
 def uv_uvh5():
     # read in a uvh5 test file
     uv_uvh5 = UVData()
@@ -72,11 +43,9 @@ def uv_uvh5():
 
 
 @pytest.fixture(scope="function")
-def uv_partial_write(tmp_path):
+def uv_partial_write(casa_uvfits, tmp_path):
     # convert a uvfits file to uvh5, cutting down the amount of data
-    uv_uvfits = UVData()
-    uvfits_filename = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-    uv_uvfits.read_uvfits(uvfits_filename)
+    uv_uvfits = casa_uvfits
     uv_uvfits.select(antenna_nums=[3, 7, 24])
     uv_uvfits.lst_array = uvutils.get_lst_for_time(
         uv_uvfits.time_array, *uv_uvfits.telescope_location_lat_lon_alt_degrees
@@ -145,11 +114,12 @@ def initialize_with_zeros_ints(uvd, filename):
     return
 
 
-def test_read_miriad_write_uvh5_read_uvh5(uv_miriad, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_read_miriad_write_uvh5_read_uvh5(paper_miriad, tmp_path):
     """
     Test a miriad file round trip.
     """
-    uv_in = uv_miriad
+    uv_in = paper_miriad
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_miriad.uvh5")
 
@@ -174,11 +144,12 @@ def test_read_miriad_write_uvh5_read_uvh5(uv_miriad, tmp_path):
     return
 
 
-def test_read_uvfits_write_uvh5_read_uvh5(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_read_uvfits_write_uvh5_read_uvh5(casa_uvfits, tmp_path):
     """
     Test a uvfits file round trip.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_uvfits.uvh5")
     uv_in.write_uvh5(testfile, clobber=True)
@@ -210,11 +181,12 @@ def test_read_uvh5_errors():
     return
 
 
-def test_write_uvh5_errors(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_write_uvh5_errors(casa_uvfits, tmp_path):
     """
     Test raising errors in write_uvh5 function.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_uvfits.uvh5")
     with open(testfile, "a"):
@@ -236,11 +208,12 @@ def test_write_uvh5_errors(uv_uvfits, tmp_path):
     return
 
 
-def test_uvh5_optional_parameters(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_uvh5_optional_parameters(casa_uvfits, tmp_path):
     """
     Test reading and writing optional parameters not in sample files.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_uvfits.uvh5")
 
@@ -270,13 +243,14 @@ def test_uvh5_optional_parameters(uv_uvfits, tmp_path):
     return
 
 
-def test_uvh5_compression_options(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_uvh5_compression_options(casa_uvfits, tmp_path):
     """
     Test writing data with compression filters.
     """
     import h5py
 
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_uvfits_compression.uvh5")
 
@@ -317,11 +291,11 @@ def test_uvh5_compression_options(uv_uvfits, tmp_path):
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not in known_telescopes.")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_uvh5_read_multiple_files(uv_uvfits, tmp_path):
+def test_uvh5_read_multiple_files(casa_uvfits, tmp_path):
     """
     Test reading multiple uvh5 files.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     testfile1 = str(tmp_path / "uv1.uvh5")
     testfile2 = str(tmp_path / "uv2.uvh5")
     uv1 = uv_in.copy()
@@ -350,11 +324,12 @@ def test_uvh5_read_multiple_files(uv_uvfits, tmp_path):
     return
 
 
-def test_uvh5_read_multiple_files_metadata_only(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_uvh5_read_multiple_files_metadata_only(casa_uvfits, tmp_path):
     """
     Test reading multiple uvh5 files with metadata only.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     testfile1 = str(tmp_path / "uv1.uvh5")
     testfile2 = str(tmp_path / "uv2.uvh5")
     uv1 = uv_in.copy()
@@ -386,11 +361,12 @@ def test_uvh5_read_multiple_files_metadata_only(uv_uvfits, tmp_path):
     return
 
 
-def test_uvh5_rea_multiple_files_axis(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_uvh5_rea_multiple_files_axis(casa_uvfits, tmp_path):
     """
     Test reading multiple uvh5 files with setting axis.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     testfile1 = str(tmp_path / "uv1.uvh5")
     testfile2 = str(tmp_path / "uv2.uvh5")
     uv1 = uv_in.copy()
@@ -418,11 +394,12 @@ def test_uvh5_rea_multiple_files_axis(uv_uvfits, tmp_path):
     return
 
 
-def test_uvh5_partial_read_antennas(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_uvh5_partial_read_antennas(casa_uvfits, tmp_path):
     """
     Test reading in only certain antennas from disk.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
     testfile = str(tmp_path / "outtest.uvh5")
@@ -444,11 +421,12 @@ def test_uvh5_partial_read_antennas(uv_uvfits, tmp_path):
     return
 
 
-def test_uvh5_partial_read_freqs(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_uvh5_partial_read_freqs(casa_uvfits, tmp_path):
     """
     Test reading in only certain frequencies from disk.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
     testfile = str(tmp_path / "outtest.uvh5")
@@ -470,12 +448,13 @@ def test_uvh5_partial_read_freqs(uv_uvfits, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected polarization values are not evenly spaced")
-def test_uvh5_partial_read_pols(uv_uvfits, tmp_path):
+def test_uvh5_partial_read_pols(casa_uvfits, tmp_path):
     """
     Test reading in only certain polarizations from disk.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
     testfile = str(tmp_path / "outtest.uvh5")
@@ -502,11 +481,12 @@ def test_uvh5_partial_read_pols(uv_uvfits, tmp_path):
     return
 
 
-def test_uvh5_partial_read_times(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_uvh5_partial_read_times(casa_uvfits, tmp_path):
     """
     Test reading in only certain times from disk.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
     testfile = str(tmp_path / "outtest.uvh5")
@@ -528,12 +508,13 @@ def test_uvh5_partial_read_times(uv_uvfits, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected polarization values are not evenly spaced")
-def test_uvh5_partial_read_multi1(uv_uvfits, tmp_path):
+def test_uvh5_partial_read_multi1(casa_uvfits, tmp_path):
     """
     Test select-on-read for multiple axes, frequencies being smallest fraction.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
     testfile = str(tmp_path / "outtest.uvh5")
@@ -589,13 +570,14 @@ def test_uvh5_partial_read_multi1(uv_uvfits, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected polarization values are not evenly spaced")
 @pytest.mark.filterwarnings("ignore:Selected frequencies are not evenly spaced")
-def test_uvh5_partial_read_multi2(uv_uvfits, tmp_path):
+def test_uvh5_partial_read_multi2(casa_uvfits, tmp_path):
     """
     Test select-on-read for multiple axes, baselines being smallest fraction.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
     testfile = str(tmp_path / "outtest.uvh5")
@@ -651,12 +633,13 @@ def test_uvh5_partial_read_multi2(uv_uvfits, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected frequencies are not evenly spaced")
-def test_uvh5_partial_read_multi3(uv_uvfits, tmp_path):
+def test_uvh5_partial_read_multi3(casa_uvfits, tmp_path):
     """
     Test select-on-read for multiple axes, polarizations being smallest fraction.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
     testfile = str(tmp_path / "outtest.uvh5")
@@ -713,12 +696,13 @@ def test_uvh5_partial_read_multi3(uv_uvfits, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected frequencies are not evenly spaced")
-def test_uvh5_read_multdim_index(tmp_path, uv_uvfits):
+def test_uvh5_read_multdim_index(tmp_path, casa_uvfits):
     """
     Test some odd cases for UVH5 multdim indexing
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     testfile = str(tmp_path / "outtest.uvh5")
     # change telescope name to avoid errors
     uv_in.telescope_name = "PAPER"
@@ -741,6 +725,7 @@ def test_uvh5_read_multdim_index(tmp_path, uv_uvfits):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_partial_write_antpairs(uv_partial_write, tmp_path):
     """
     Test writing an entire UVH5 file in pieces by antpairs.
@@ -787,6 +772,7 @@ def test_uvh5_partial_write_antpairs(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_partial_write_frequencies(uv_partial_write, tmp_path):
     """
     Test writing an entire UVH5 file in pieces by frequencies.
@@ -831,6 +817,7 @@ def test_uvh5_partial_write_frequencies(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_partial_write_blts(uv_partial_write, tmp_path):
     """
     Test writing an entire UVH5 file in pieces by blt.
@@ -875,6 +862,7 @@ def test_uvh5_partial_write_blts(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_partial_write_pols(uv_partial_write, tmp_path):
     """
     Test writing an entire UVH5 file in pieces by pol.
@@ -927,6 +915,7 @@ def test_uvh5_partial_write_pols(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_partial_write_irregular_blt(uv_partial_write, tmp_path):
     """
     Test writing a uvh5 file using irregular intervals for single blt.
@@ -976,6 +965,7 @@ def test_uvh5_partial_write_irregular_blt(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_partial_write_irregular_freq(uv_partial_write, tmp_path):
     """
     Test writing a uvh5 file using irregular intervals for single frequency.
@@ -1025,6 +1015,7 @@ def test_uvh5_partial_write_irregular_freq(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_partial_write_irregular_pol(uv_partial_write, tmp_path):
     """
     Test writing a uvh5 file using irregular intervals for single polarization.
@@ -1078,6 +1069,7 @@ def test_uvh5_partial_write_irregular_pol(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_partial_write_irregular_multi1(uv_partial_write, tmp_path):
     """
     Test writing a uvh5 file using irregular intervals for blts and freqs.
@@ -1144,6 +1136,7 @@ def test_uvh5_partial_write_irregular_multi1(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_partial_write_irregular_multi2(uv_partial_write, tmp_path):
     """
     Test writing a uvh5 file using irregular intervals for freqs and pols.
@@ -1217,6 +1210,7 @@ def test_uvh5_partial_write_irregular_multi2(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_partial_write_irregular_multi3(uv_partial_write, tmp_path):
     """
     Test writing a uvh5 file using irregular intervals for blts and pols.
@@ -1278,6 +1272,7 @@ def test_uvh5_partial_write_irregular_multi3(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_partial_write_irregular_multi4(uv_partial_write, tmp_path):
     """
     Test writing a uvh5 file using irregular intervals for all axes.
@@ -1363,6 +1358,7 @@ def test_uvh5_partial_write_irregular_multi4(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_partial_write_errors(uv_partial_write, tmp_path):
     """
     Test errors in uvh5_write_part method.
@@ -1431,6 +1427,7 @@ def test_uvh5_partial_write_errors(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_initialize_uvh5_file(uv_partial_write, tmp_path):
     """
     Test initializing a UVH5 file on disk.
@@ -1455,6 +1452,7 @@ def test_initialize_uvh5_file(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_initialize_uvh5_file_errors(uv_partial_write, tmp_path, capsys):
     """
     Test errors in initializing a UVH5 file on disk.
@@ -1484,6 +1482,7 @@ def test_initialize_uvh5_file_errors(uv_partial_write, tmp_path, capsys):
     return
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_initialize_uvh5_file_compression_opts(uv_partial_write, tmp_path):
     """
     Test initializing a uvh5 file with compression options.
@@ -1512,11 +1511,12 @@ def test_initialize_uvh5_file_compression_opts(uv_partial_write, tmp_path):
     return
 
 
-def test_uvh5_lst_array(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_uvh5_lst_array(casa_uvfits, tmp_path):
     """
     Test different cases of the lst_array.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_uvfits.uvh5")
     uv_in.telescope_name = "PAPER"
@@ -1553,11 +1553,12 @@ def test_uvh5_lst_array(uv_uvfits, tmp_path):
     return
 
 
-def test_uvh5_read_header_special_cases(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_uvh5_read_header_special_cases(casa_uvfits, tmp_path):
     """
     Test special cases values when reading files.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_uvfits.uvh5")
     uv_in.telescope_name = "PAPER"
@@ -2598,12 +2599,13 @@ def test_uvh5_partial_write_ints_irregular_multi4(uv_uvh5, tmp_path):
     return
 
 
-def test_antenna_names_not_list(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_antenna_names_not_list(casa_uvfits, tmp_path):
     """
     Test if antenna_names is cast to an array, dimensions are preserved in
     ``np.string_`` call during uvh5 write.
     """
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_uvfits_ant_names.uvh5")
 
@@ -2624,9 +2626,10 @@ def test_antenna_names_not_list(uv_uvfits, tmp_path):
     return
 
 
-def test_eq_coeffs_roundtrip(uv_uvfits, tmp_path):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_eq_coeffs_roundtrip(casa_uvfits, tmp_path):
     """Test reading and writing objects with eq_coeffs defined"""
-    uv_in = uv_uvfits
+    uv_in = casa_uvfits
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_eq_coeffs.uvh5")
     uv_in.eq_coeffs = np.ones((uv_in.Nants_telescope, uv_in.Nfreqs))
@@ -2642,7 +2645,8 @@ def test_eq_coeffs_roundtrip(uv_uvfits, tmp_path):
     return
 
 
-def test_read_slicing(uv_uvfits):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_read_slicing(casa_uvfits):
     """Test HDF5 slicing helper functions"""
     # check trivial slice representations
     slices, _ = uvh5._convert_to_slices([])

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -33,7 +33,7 @@ def uv_uvh5():
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    uv_uvh5.read_uvh5(uvh5_filename, uvw_antpos_check_level="off")
+    uv_uvh5.read_uvh5(uvh5_filename, run_check_acceptability=False)
     yield uv_uvh5
 
     # clean up when done
@@ -1595,19 +1595,19 @@ def test_uvh5_read_ints(uv_uvh5, tmp_path):
     uv_in = uv_uvh5
     uv_out = UVData()
     testfile = str(tmp_path / "outtest.uvh5")
-    uv_in.write_uvh5(testfile, clobber=True)
+    uv_in.write_uvh5(testfile, run_check_acceptability=False, clobber=True)
 
     # read it back in to make sure data is the same
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    uv_out.read(testfile, uvw_antpos_check_level="off")
+    uv_out.read(testfile, run_check_acceptability=False)
     assert uv_in == uv_out
 
     # now read in as np.complex128
     uvh5_filename = os.path.join(DATA_PATH, "zen.2458432.34569.uvh5")
     uv_in.read_uvh5(
-        uvh5_filename, uvw_antpos_check_level="off", data_array_dtype=np.complex128
+        uvh5_filename, run_check_acceptability=False, data_array_dtype=np.complex128
     )
     assert uv_in == uv_out
     assert uv_in.data_array.dtype == np.dtype(np.complex128)
@@ -1631,7 +1631,7 @@ def test_uvh5_read_ints_error():
     # raise error for bogus data_array_dtype
     with pytest.raises(ValueError) as cm:
         uv_in.read_uvh5(
-            uvh5_filename, uvw_antpos_check_level="off", data_array_dtype=np.int32
+            uvh5_filename, run_check_acceptability=False, data_array_dtype=np.int32
         )
     assert str(cm.value).startswith(
         "data_array_dtype must be np.complex64 or np.complex128"
@@ -1647,13 +1647,18 @@ def test_uvh5_write_ints(uv_uvh5, tmp_path):
     uv_in = uv_uvh5
     uv_out = UVData()
     testfile = str(tmp_path / "outtest.uvh5")
-    uv_in.write_uvh5(testfile, clobber=True, data_write_dtype=uvh5._hera_corr_dtype)
+    uv_in.write_uvh5(
+        testfile,
+        clobber=True,
+        data_write_dtype=uvh5._hera_corr_dtype,
+        run_check_acceptability=False,
+    )
 
     # read it back in to make sure data is the same
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    uv_out.read(testfile, uvw_antpos_check_level="off")
+    uv_out.read(testfile, run_check_acceptability=False)
     assert uv_in == uv_out
 
     # also check that the datatype on disk is the right type
@@ -1683,9 +1688,9 @@ def test_uvh5_partial_read_ints_antennas():
 
     # select on antennas
     ants_to_keep = np.array([0, 1])
-    uvh5_uv.read(uvh5_file, uvw_antpos_check_level="off", antenna_nums=ants_to_keep)
-    uvh5_uv2.read(uvh5_file, uvw_antpos_check_level="off")
-    uvh5_uv2.select(antenna_nums=ants_to_keep)
+    uvh5_uv.read(uvh5_file, run_check_acceptability=False, antenna_nums=ants_to_keep)
+    uvh5_uv2.read(uvh5_file, run_check_acceptability=False)
+    uvh5_uv2.select(antenna_nums=ants_to_keep, run_check_acceptability=False)
     assert uvh5_uv == uvh5_uv2
 
     return
@@ -1704,9 +1709,9 @@ def test_uvh5_partial_read_ints_freqs():
 
     # select on frequency channels
     chans_to_keep = np.arange(12, 22)
-    uvh5_uv.read(uvh5_file, uvw_antpos_check_level="off", freq_chans=chans_to_keep)
-    uvh5_uv2.read(uvh5_file, uvw_antpos_check_level="off")
-    uvh5_uv2.select(freq_chans=chans_to_keep)
+    uvh5_uv.read(uvh5_file, run_check_acceptability=False, freq_chans=chans_to_keep)
+    uvh5_uv2.read(uvh5_file, run_check_acceptability=False)
+    uvh5_uv2.select(freq_chans=chans_to_keep, run_check_acceptability=False)
     assert uvh5_uv == uvh5_uv2
 
     return
@@ -1725,9 +1730,9 @@ def test_uvh5_partial_read_ints_pols():
 
     # select on pols
     pols_to_keep = [-5, -6]
-    uvh5_uv.read(uvh5_file, uvw_antpos_check_level="off", polarizations=pols_to_keep)
-    uvh5_uv2.read(uvh5_file, uvw_antpos_check_level="off")
-    uvh5_uv2.select(polarizations=pols_to_keep)
+    uvh5_uv.read(uvh5_file, run_check_acceptability=False, polarizations=pols_to_keep)
+    uvh5_uv2.read(uvh5_file, run_check_acceptability=False)
+    uvh5_uv2.select(polarizations=pols_to_keep, run_check_acceptability=False)
     assert uvh5_uv == uvh5_uv2
 
     return
@@ -1745,15 +1750,15 @@ def test_uvh5_partial_read_ints_times():
     # which breaks the phasing when trying to check if the uvws match the antpos.
 
     # select on read using time_range
-    uvh5_uv.read_uvh5(uvh5_file, uvw_antpos_check_level="off", read_data=False)
+    uvh5_uv.read_uvh5(uvh5_file, run_check_acceptability=False, read_data=False)
     unique_times = np.unique(uvh5_uv.time_array)
     uvh5_uv.read(
         uvh5_file,
-        uvw_antpos_check_level="off",
+        run_check_acceptability=False,
         time_range=[unique_times[0], unique_times[1]],
     )
-    uvh5_uv2.read(uvh5_file, uvw_antpos_check_level="off")
-    uvh5_uv2.select(times=unique_times[0:2])
+    uvh5_uv2.read(uvh5_file, run_check_acceptability=False)
+    uvh5_uv2.select(times=unique_times[0:2], run_check_acceptability=False)
     assert uvh5_uv == uvh5_uv2
 
     return
@@ -1779,11 +1784,14 @@ def test_uvh5_partial_read_ints_multi1():
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
-        uvw_antpos_check_level="off",
+        run_check_acceptability=False,
     )
-    uvh5_uv2.read(uvh5_file, uvw_antpos_check_level="off")
+    uvh5_uv2.read(uvh5_file, run_check_acceptability=False)
     uvh5_uv2.select(
-        antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
+        antenna_nums=ants_to_keep,
+        freq_chans=chans_to_keep,
+        polarizations=pols_to_keep,
+        run_check_acceptability=False,
     )
     assert uvh5_uv == uvh5_uv2
 
@@ -1810,11 +1818,14 @@ def test_uvh5_partial_read_ints_multi2():
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
-        uvw_antpos_check_level="off",
+        run_check_acceptability=False,
     )
-    uvh5_uv2.read(uvh5_file, uvw_antpos_check_level="off")
+    uvh5_uv2.read(uvh5_file, run_check_acceptability=False)
     uvh5_uv2.select(
-        antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep,
+        antenna_nums=ants_to_keep,
+        freq_chans=chans_to_keep,
+        polarizations=pols_to_keep,
+        run_check_acceptability=False,
     )
     assert uvh5_uv == uvh5_uv2
 
@@ -1841,11 +1852,14 @@ def test_uvh5_partial_read_ints_multi3():
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
-        uvw_antpos_check_level="off",
+        run_check_acceptability=False,
     )
-    uvh5_uv2.read(uvh5_file, uvw_antpos_check_level="off")
+    uvh5_uv2.read(uvh5_file, run_check_acceptability=False)
     uvh5_uv2.select(
-        antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
+        antenna_nums=ants_to_keep,
+        freq_chans=chans_to_keep,
+        polarizations=pols_to_keep,
+        run_check_acceptability=False,
     )
     assert uvh5_uv == uvh5_uv2
 
@@ -1882,7 +1896,7 @@ def test_uvh5_partial_write_ints_antapirs(uv_uvh5, tmp_path):
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    partial_uvh5.read(partial_testfile, uvw_antpos_check_level="off")
+    partial_uvh5.read(partial_testfile, run_check_acceptability=False)
     assert full_uvh5 == partial_uvh5
 
     # clean up
@@ -1931,7 +1945,7 @@ def test_uvh5_partial_write_ints_frequencies(uv_uvh5, tmp_path):
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    partial_uvh5.read(partial_testfile, uvw_antpos_check_level="off")
+    partial_uvh5.read(partial_testfile, run_check_acceptability=False)
     assert full_uvh5 == partial_uvh5
 
     # clean up
@@ -1980,7 +1994,7 @@ def test_uvh5_partial_write_ints_blts(uv_uvh5, tmp_path):
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    partial_uvh5.read(partial_testfile, uvw_antpos_check_level="off")
+    partial_uvh5.read(partial_testfile, run_check_acceptability=False)
     assert full_uvh5 == partial_uvh5
 
     # clean up
@@ -2037,7 +2051,7 @@ def test_uvh5_partial_write_ints_pols(uv_uvh5, tmp_path):
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    partial_uvh5.read(partial_testfile, uvw_antpos_check_level="off")
+    partial_uvh5.read(partial_testfile, run_check_acceptability=False)
     assert full_uvh5 == partial_uvh5
 
     # clean up
@@ -2196,7 +2210,7 @@ def test_uvh5_partial_write_ints_irregular_blt(uv_uvh5, tmp_path):
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    partial_uvh5_file.read(partial_testfile, uvw_antpos_check_level="off")
+    partial_uvh5_file.read(partial_testfile, run_check_acceptability=False)
     assert partial_uvh5_file == partial_uvh5
 
     # clean up
@@ -2246,7 +2260,7 @@ def test_uvh5_partial_write_ints_irregular_freq(uv_uvh5, tmp_path):
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    partial_uvh5_file.read(partial_testfile, uvw_antpos_check_level="off")
+    partial_uvh5_file.read(partial_testfile, run_check_acceptability=False)
     assert partial_uvh5_file == partial_uvh5
 
     # clean up
@@ -2300,7 +2314,7 @@ def test_uvh5_partial_write_ints_irregular_pol(uv_uvh5, tmp_path):
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    partial_uvh5_file.read(partial_testfile, uvw_antpos_check_level="off")
+    partial_uvh5_file.read(partial_testfile, run_check_acceptability=False)
     assert partial_uvh5_file == partial_uvh5
 
     # clean up
@@ -2367,7 +2381,7 @@ def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, tmp_path):
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    partial_uvh5_file.read(partial_testfile, uvw_antpos_check_level="off")
+    partial_uvh5_file.read(partial_testfile, run_check_acceptability=False)
     assert partial_uvh5_file == partial_uvh5
 
     # clean up
@@ -2441,7 +2455,7 @@ def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, tmp_path):
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    partial_uvh5_file.read(partial_testfile, uvw_antpos_check_level="off")
+    partial_uvh5_file.read(partial_testfile, run_check_acceptability=False)
     assert partial_uvh5_file == partial_uvh5
 
     # clean up
@@ -2505,7 +2519,7 @@ def test_uvh5_partial_write_ints_irregular_multi3(uv_uvh5, tmp_path):
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    partial_uvh5_file.read(partial_testfile, uvw_antpos_check_level="off")
+    partial_uvh5_file.read(partial_testfile, run_check_acceptability=False)
     assert partial_uvh5_file == partial_uvh5
 
     # clean up
@@ -2590,7 +2604,7 @@ def test_uvh5_partial_write_ints_irregular_multi4(uv_uvh5, tmp_path):
     # This file has weird telescope or antenna location information
     # (not on the surface of the earth)
     # which breaks the phasing when trying to check if the uvws match the antpos.
-    partial_uvh5_file.read(partial_testfile, uvw_antpos_check_level="off")
+    partial_uvh5_file.read(partial_testfile, run_check_acceptability=False)
     assert partial_uvh5_file == partial_uvh5
 
     # clean up

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -824,7 +824,10 @@ class UVData(UVBase):
         )
 
     def check(
-        self, check_extra=True, run_check_acceptability=True, check_freq_spacing=False
+        self, check_extra=True,
+        run_check_acceptability=True,
+        check_freq_spacing=False,
+        run_check_uvw_antpos=None,
     ):
         """
         Add some extra checks on top of checks on UVBase class.
@@ -838,6 +841,9 @@ class UVData(UVBase):
             If true, check all parameters, otherwise only check required parameters.
         run_check_acceptability : bool
             Option to check if values in parameters are acceptable.
+        run_check_uvw_antpos : bool
+            Option to check if uvws match the expected values given the antenna
+            positions. Default is to have be the same as run_check_acceptability.
 
         Returns
         -------
@@ -850,6 +856,9 @@ class UVData(UVBase):
             if parameter shapes or types are wrong or do not have acceptable
             values (if run_check_acceptability is True)
         """
+        if run_check_uvw_antpos is None:
+            run_check_uvw_antpos = run_check_acceptability
+
         # first run the basic check from UVBase
         # set the phase type based on object's value
         if self.phase_type == "phased":
@@ -908,56 +917,64 @@ class UVData(UVBase):
                     "miriad file types".format(key=key)
                 )
 
-        # check that the uvws make sense given the antenna positions
-        # first, make a copy of this object with just the metadata
-        # new_obj = UVData()
-        # for param_name in self:
-        #     if param_name not in ['data_array', 'flag_array', 'nsample_array']:
-        #         setattr(new_obj, param_name, getattr(self, param_name))
-        new_obj = copy.deepcopy(self)
-        new_obj.data_array = None
-        new_obj.flag_array = None
-        new_obj.nsample_array = None
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            new_obj.set_uvws_from_antenna_positions(allow_phasing=True, metadata_only=True)
+        if run_check_uvw_antpos:
+            # check that the uvws make sense given the antenna positions
+            # first, make a copy of this object with just the metadata
+            # new_obj = UVData()
+            # for param_name in self:
+            #     if param_name not in ['data_array', 'flag_array', 'nsample_array']:
+            #         setattr(new_obj, param_name, getattr(self, param_name))
+            new_obj = copy.deepcopy(self)
+            new_obj.data_array = None
+            new_obj.flag_array = None
+            new_obj.nsample_array = None
+            if new_obj.phase_center_frame is not None:
+                output_phase_frame = new_obj.phase_center_frame
+            else:
+                output_phase_frame = 'icrs'
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                new_obj.set_uvws_from_antenna_positions(allow_phasing=True,
+                                                        output_phase_frame=output_phase_frame,
+                                                        metadata_only=True)
 
-        if new_obj._uvw_array != self._uvw_array:
-            print(np.max(np.abs(new_obj.uvw_array - self.uvw_array)))
-            raise ValueError('uvw_array does not match the expected values '
-                             'given the antenna positions.')
+            if not np.allclose(new_obj.uvw_array, self.uvw_array, atol=1):
+                print(np.max(np.abs(new_obj.uvw_array - self.uvw_array)))
+                raise ValueError('uvw_array does not match the expected values '
+                                 'given the antenna positions.')
 
         # check auto and cross-corrs have sensible uvws
-        autos = np.isclose(self.ant_1_array - self.ant_2_array, 0.0)
-        if not np.all(
-            np.isclose(
-                self.uvw_array[autos],
-                0.0,
-                rtol=self._uvw_array.tols[0],
-                atol=self._uvw_array.tols[1],
-            )
-        ):
-            raise ValueError(
-                "Some auto-correlations have non-zero " "uvw_array coordinates."
-            )
-        if np.any(
-            np.isclose(
-                # this line used to use np.linalg.norm but it turns out
-                # squaring and sqrt is slightly more efficient unless the array
-                # is "very large".
-                np.sqrt(
-                    self.uvw_array[~autos, 0] ** 2
-                    + self.uvw_array[~autos, 1] ** 2
-                    + self.uvw_array[~autos, 2] ** 2
-                ),
-                0.0,
-                rtol=self._uvw_array.tols[0],
-                atol=self._uvw_array.tols[1],
-            )
-        ):
-            raise ValueError(
-                "Some cross-correlations have near-zero " "uvw_array magnitudes."
-            )
+        if run_check_acceptability:
+            autos = np.isclose(self.ant_1_array - self.ant_2_array, 0.0)
+            if not np.all(
+                np.isclose(
+                    self.uvw_array[autos],
+                    0.0,
+                    rtol=self._uvw_array.tols[0],
+                    atol=self._uvw_array.tols[1],
+                )
+            ):
+                raise ValueError(
+                    "Some auto-correlations have non-zero " "uvw_array coordinates."
+                )
+            if np.any(
+                np.isclose(
+                    # this line used to use np.linalg.norm but it turns out
+                    # squaring and sqrt is slightly more efficient unless the array
+                    # is "very large".
+                    np.sqrt(
+                        self.uvw_array[~autos, 0] ** 2
+                        + self.uvw_array[~autos, 1] ** 2
+                        + self.uvw_array[~autos, 2] ** 2
+                    ),
+                    0.0,
+                    rtol=self._uvw_array.tols[0],
+                    atol=self._uvw_array.tols[1],
+                )
+            ):
+                raise ValueError(
+                    "Some cross-correlations have near-zero " "uvw_array magnitudes."
+                )
 
         if check_freq_spacing:
             self._check_freq_spacing()

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -908,6 +908,25 @@ class UVData(UVBase):
                     "miriad file types".format(key=key)
                 )
 
+        # check that the uvws make sense given the antenna positions
+        # first, make a copy of this object with just the metadata
+        # new_obj = UVData()
+        # for param_name in self:
+        #     if param_name not in ['data_array', 'flag_array', 'nsample_array']:
+        #         setattr(new_obj, param_name, getattr(self, param_name))
+        new_obj = copy.deepcopy(self)
+        new_obj.data_array = None
+        new_obj.flag_array = None
+        new_obj.nsample_array = None
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            new_obj.set_uvws_from_antenna_positions(allow_phasing=True, metadata_only=True)
+
+        if new_obj._uvw_array != self._uvw_array:
+            print(np.max(np.abs(new_obj.uvw_array - self.uvw_array)))
+            raise ValueError('uvw_array does not match the expected values '
+                             'given the antenna positions.')
+
         # check auto and cross-corrs have sensible uvws
         autos = np.isclose(self.ant_1_array - self.ant_2_array, 0.0)
         if not np.all(

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -919,31 +919,21 @@ class UVData(UVBase):
 
         if run_check_uvw_antpos:
             # check that the uvws make sense given the antenna positions
-            # first, make a copy of this object with just the metadata
-            # new_obj = UVData()
-            # for param_name in self:
-            #     if param_name not in ['data_array', 'flag_array', 'nsample_array']:
-            #         setattr(new_obj, param_name, getattr(self, param_name))
-            new_obj = UVData()
-            for param in new_obj:
-                param_obj = getattr(new_obj, param)
-                param_name = param_obj.name
-                if param_name not in ['data_array', 'flag_array', 'nsample_array']:
-                    setattr(new_obj, param_name, getattr(self, param_name))
+            # make a metadata only copy of this object to properly calculate uvws
+            temp_obj = self.copy(metadata_only=True)
 
-            if new_obj.phase_center_frame is not None:
-                output_phase_frame = new_obj.phase_center_frame
+            if temp_obj.phase_center_frame is not None:
+                output_phase_frame = temp_obj.phase_center_frame
             else:
                 output_phase_frame = 'icrs'
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                new_obj.set_uvws_from_antenna_positions(allow_phasing=True,
-                                                        output_phase_frame=output_phase_frame,
-                                                        metadata_only=True)
+                temp_obj.set_uvws_from_antenna_positions(
+                    allow_phasing=True, output_phase_frame=output_phase_frame)
 
-            if not np.allclose(new_obj.uvw_array, self.uvw_array, atol=1):
-                print(np.max(np.abs(new_obj.uvw_array - self.uvw_array)))
+            if not np.allclose(temp_obj.uvw_array, self.uvw_array, atol=1):
+                print(np.max(np.abs(temp_obj.uvw_array - self.uvw_array)))
                 raise ValueError('uvw_array does not match the expected values '
                                  'given the antenna positions.')
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -972,7 +972,7 @@ class UVData(UVBase):
                 )
             ):
                 raise ValueError(
-                    "Some auto-correlations have non-zero " "uvw_array coordinates."
+                    "Some auto-correlations have non-zero uvw_array coordinates."
                 )
             if np.any(
                 np.isclose(

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -924,14 +924,18 @@ class UVData(UVBase):
             # for param_name in self:
             #     if param_name not in ['data_array', 'flag_array', 'nsample_array']:
             #         setattr(new_obj, param_name, getattr(self, param_name))
-            new_obj = copy.deepcopy(self)
-            new_obj.data_array = None
-            new_obj.flag_array = None
-            new_obj.nsample_array = None
+            new_obj = UVData()
+            for param in new_obj:
+                param_obj = getattr(new_obj, param)
+                param_name = param_obj.name
+                if param_name not in ['data_array', 'flag_array', 'nsample_array']:
+                    setattr(new_obj, param_name, getattr(self, param_name))
+
             if new_obj.phase_center_frame is not None:
                 output_phase_frame = new_obj.phase_center_frame
             else:
                 output_phase_frame = 'icrs'
+
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 new_obj.set_uvws_from_antenna_positions(allow_phasing=True,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -7761,7 +7761,6 @@ class UVData(UVBase):
         blt_inds=None,
         add_to_history=None,
         run_check_acceptability=True,
-        strict_uvw_antpos_check=False,
     ):
         """
         Write data to a UVH5 file that has already been initialized.
@@ -7857,6 +7856,5 @@ class UVData(UVBase):
             blt_inds=blt_inds,
             add_to_history=add_to_history,
             run_check_acceptability=run_check_acceptability,
-            strict_uvw_antpos_check=strict_uvw_antpos_check,
         )
         del uvh5_obj

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -184,10 +184,11 @@ class UVFITS(UVData):
         polarizations,
         blt_inds,
         read_metadata,
+        keep_all_metadata,
         run_check,
         check_extra,
         run_check_acceptability,
-        keep_all_metadata,
+        uvw_antpos_check_level,
     ):
         """
         Read just the visibility and flag data of the uvfits file.
@@ -304,7 +305,9 @@ class UVFITS(UVData):
         # check if object has all required UVParameters set
         if run_check:
             self.check(
-                check_extra=check_extra, run_check_acceptability=run_check_acceptability
+                check_extra=check_extra,
+                run_check_acceptability=run_check_acceptability,
+                uvw_antpos_check_level=uvw_antpos_check_level,
             )
 
     def read_uvfits(
@@ -320,12 +323,13 @@ class UVFITS(UVData):
         time_range=None,
         polarizations=None,
         blt_inds=None,
+        keep_all_metadata=True,
         read_data=True,
+        background_lsts=True,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        keep_all_metadata=True,
-        background_lsts=True,
+        uvw_antpos_check_level="warn",
     ):
         """
         Read in header, metadata and data from a uvfits file.
@@ -394,6 +398,8 @@ class UVFITS(UVData):
             Read in the visibility, nsample and flag data. If set to False, only
             the metadata will be read in. Setting read_data to False results in
             a metadata only object.
+        background_lsts : bool
+            When set to True, the lst_array is calculated in a background thread.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after after reading in the file (the default is True,
@@ -406,8 +412,10 @@ class UVFITS(UVData):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done). Ignored if read_data is False.
-        background_lsts : bool
-            When set to True, the lst_array is calculated in a background thread.
+        uvw_antpos_check_level : string
+            Setting to control the strictness of the check that uvws match antenna
+            positions. Options are: ['strict', 'warn', 'off']. See the `UVData.check`
+            docstring for more details.
 
 
         Raises
@@ -621,10 +629,11 @@ class UVFITS(UVData):
                 polarizations,
                 blt_inds,
                 False,
+                keep_all_metadata,
                 run_check,
                 check_extra,
                 run_check_acceptability,
-                keep_all_metadata,
+                uvw_antpos_check_level,
             )
 
     def write_uvfits(
@@ -682,6 +691,7 @@ class UVFITS(UVData):
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
                 check_freq_spacing=True,
+                uvw_antpos_check_level="off",
             )
 
         if self.phase_type == "phased":

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -188,7 +188,7 @@ class UVFITS(UVData):
         run_check,
         check_extra,
         run_check_acceptability,
-        uvw_antpos_check_level,
+        strict_uvw_antpos_check,
     ):
         """
         Read just the visibility and flag data of the uvfits file.
@@ -307,7 +307,7 @@ class UVFITS(UVData):
             self.check(
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
-                uvw_antpos_check_level=uvw_antpos_check_level,
+                strict_uvw_antpos_check=strict_uvw_antpos_check,
             )
 
     def read_uvfits(
@@ -329,7 +329,7 @@ class UVFITS(UVData):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        uvw_antpos_check_level="warn",
+        strict_uvw_antpos_check=False,
     ):
         """
         Read in header, metadata and data from a uvfits file.
@@ -412,10 +412,9 @@ class UVFITS(UVData):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done). Ignored if read_data is False.
-        uvw_antpos_check_level : string
-            Setting to control the strictness of the check that uvws match antenna
-            positions. Options are: ['strict', 'warn', 'off']. See the `UVData.check`
-            docstring for more details.
+        strict_uvw_antpos_check : bool
+            Option to raise an error rather than a warning if the check that
+            uvws match antenna positions does not pass.
 
 
         Raises
@@ -633,7 +632,7 @@ class UVFITS(UVData):
                 run_check,
                 check_extra,
                 run_check_acceptability,
-                uvw_antpos_check_level,
+                strict_uvw_antpos_check,
             )
 
     def write_uvfits(
@@ -645,6 +644,7 @@ class UVFITS(UVData):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
+        strict_uvw_antpos_check=False,
     ):
         """
         Write the data to a uvfits file.
@@ -669,6 +669,9 @@ class UVFITS(UVData):
         run_check_acceptability : bool
             Option to check acceptable range of the values of parameters before
             writing the file.
+        strict_uvw_antpos_check : bool
+            Option to raise an error rather than a warning if the check that
+            uvws match antenna positions does not pass.
 
         Raises
         ------
@@ -691,7 +694,7 @@ class UVFITS(UVData):
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
                 check_freq_spacing=True,
-                uvw_antpos_check_level="off",
+                strict_uvw_antpos_check=strict_uvw_antpos_check,
             )
 
         if self.phase_type == "phased":

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -567,12 +567,13 @@ class UVH5(UVData):
         time_range,
         polarizations,
         blt_inds,
-        run_check,
-        check_extra,
-        run_check_acceptability,
         data_array_dtype,
         keep_all_metadata,
         multidim_index,
+        run_check,
+        check_extra,
+        run_check_acceptability,
+        uvw_antpos_check_level,
     ):
         """
         Read the data-size arrays (data, flags, nsamples) from a file.
@@ -823,7 +824,9 @@ class UVH5(UVData):
         # check if object has all required UVParameters set
         if run_check:
             self.check(
-                check_extra=check_extra, run_check_acceptability=run_check_acceptability
+                check_extra=check_extra,
+                run_check_acceptability=run_check_acceptability,
+                uvw_antpos_check_level=uvw_antpos_check_level,
             )
 
         return
@@ -841,14 +844,15 @@ class UVH5(UVData):
         time_range=None,
         polarizations=None,
         blt_inds=None,
+        keep_all_metadata=True,
         read_data=True,
+        data_array_dtype=np.complex128,
+        multidim_index=False,
+        background_lsts=True,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        data_array_dtype=np.complex128,
-        keep_all_metadata=True,
-        multidim_index=False,
-        background_lsts=True,
+        uvw_antpos_check_level="warn",
     ):
         """
         Read in data from a UVH5 file.
@@ -921,6 +925,13 @@ class UVH5(UVData):
             np.complex64 (single-precision real and imaginary) or np.complex128 (double-
             precision real and imaginary). Only used if the datatype of the visibility
             data on-disk is not 'c8' or 'c16'.
+        multidim_index : bool
+            If True, attempt to index the HDF5 dataset
+            simultaneously along all data axes. Otherwise index one axis at-a-time.
+            This only works if data selection is sliceable along all but one axis.
+            If indices are not well-matched to data chunks, this can be slow.
+        background_lsts : bool
+            When set to True, the lst_array is calculated in a background thread.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after after reading in the file (the default is True,
@@ -933,14 +944,10 @@ class UVH5(UVData):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done). Ignored if read_data is False.
-        multidim_index : bool
-            If True, attempt to index the HDF5 dataset
-            simultaneously along all data axes. Otherwise index one axis at-a-time.
-            This only works if data selection is sliceable along all but one axis.
-            If indices are not well-matched to data chunks, this can be slow.
-        background_lsts : bool
-            When set to True, the lst_array is calculated in a background thread.
-
+        uvw_antpos_check_level : string
+            Setting to control the strictness of the check that uvws match antenna
+            positions. Options are: ['strict', 'warn', 'off']. See the `UVData.check`
+            docstring for more details.
 
         Returns
         -------
@@ -990,12 +997,13 @@ class UVH5(UVData):
                 time_range,
                 polarizations,
                 blt_inds,
-                run_check,
-                check_extra,
-                run_check_acceptability,
                 data_array_dtype,
                 keep_all_metadata,
                 multidim_index,
+                run_check,
+                check_extra,
+                run_check_acceptability,
+                uvw_antpos_check_level,
             )
 
         return
@@ -1176,7 +1184,9 @@ class UVH5(UVData):
         """
         if run_check:
             self.check(
-                check_extra=check_extra, run_check_acceptability=run_check_acceptability
+                check_extra=check_extra,
+                run_check_acceptability=run_check_acceptability,
+                uvw_antpos_check_level="off",
             )
 
         if os.path.exists(filename):

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -573,7 +573,7 @@ class UVH5(UVData):
         run_check,
         check_extra,
         run_check_acceptability,
-        uvw_antpos_check_level,
+        strict_uvw_antpos_check,
     ):
         """
         Read the data-size arrays (data, flags, nsamples) from a file.
@@ -826,7 +826,7 @@ class UVH5(UVData):
             self.check(
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
-                uvw_antpos_check_level=uvw_antpos_check_level,
+                strict_uvw_antpos_check=strict_uvw_antpos_check,
             )
 
         return
@@ -852,7 +852,7 @@ class UVH5(UVData):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        uvw_antpos_check_level="warn",
+        strict_uvw_antpos_check=False,
     ):
         """
         Read in data from a UVH5 file.
@@ -944,10 +944,9 @@ class UVH5(UVData):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done). Ignored if read_data is False.
-        uvw_antpos_check_level : string
-            Setting to control the strictness of the check that uvws match antenna
-            positions. Options are: ['strict', 'warn', 'off']. See the `UVData.check`
-            docstring for more details.
+        strict_uvw_antpos_check : bool
+            Option to raise an error rather than a warning if the check that
+            uvws match antenna positions does not pass.
 
         Returns
         -------
@@ -1003,7 +1002,7 @@ class UVH5(UVData):
                 run_check,
                 check_extra,
                 run_check_acceptability,
-                uvw_antpos_check_level,
+                strict_uvw_antpos_check,
             )
 
         return
@@ -1108,9 +1107,6 @@ class UVH5(UVData):
     def write_uvh5(
         self,
         filename,
-        run_check=True,
-        check_extra=True,
-        run_check_acceptability=True,
         clobber=False,
         chunks=True,
         data_compression=None,
@@ -1118,6 +1114,10 @@ class UVH5(UVData):
         nsample_compression="lzf",
         data_write_dtype=None,
         add_to_history=None,
+        run_check=True,
+        check_extra=True,
+        run_check_acceptability=True,
+        strict_uvw_antpos_check=False,
     ):
         """
         Write an in-memory UVData object to a UVH5 file.
@@ -1126,14 +1126,6 @@ class UVH5(UVData):
         ----------
         filename : str
             The UVH5 file to write to.
-        run_check : bool
-            Option to check for the existence and proper shapes of parameters
-            before writing the file.
-        check_extra : bool
-            Option to check optional parameters as well as required ones.
-        run_check_acceptability : bool
-            Option to check acceptable range of the values of parameters before
-            writing the file.
         clobber : bool
             Option to overwrite the file if it already exists.
         chunks : tuple or bool
@@ -1155,6 +1147,17 @@ class UVH5(UVData):
             numpy dtype object must be specified with an 'r' field and an 'i'
             field for real and imaginary parts, respectively. See uvh5.py for
             an example of defining such a datatype.
+        run_check : bool
+            Option to check for the existence and proper shapes of parameters
+            before writing the file.
+        check_extra : bool
+            Option to check optional parameters as well as required ones.
+        run_check_acceptability : bool
+            Option to check acceptable range of the values of parameters before
+            writing the file.
+        strict_uvw_antpos_check : bool
+            Option to raise an error rather than a warning if the check that
+            uvws match antenna positions does not pass.
 
         Returns
         -------
@@ -1186,7 +1189,7 @@ class UVH5(UVData):
             self.check(
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
-                uvw_antpos_check_level="off",
+                strict_uvw_antpos_check=strict_uvw_antpos_check,
             )
 
         if os.path.exists(filename):


### PR DESCRIPTION
Add a check that the uvws match the expected values given the antenna positions, defaulted to warn rather than error if this is the case. ~There are also options to error and to turn the check off entirely.~ There is an option to error rather than warn. The check is only run if `run_check_acceptability` is True.

This check does take some time to run because it involves making a metadata only copy of the object and running `set_uvws_from_antenna_positions`, which has to unphase the object if it is phased to start with. ~So I've defaulted this check to be off for most of our internal methods (e.g. `select`, `add`, `write_*` etc) since I don't expect them to change anything on this front. I have defaulted it to be run on most of the reads (except for `mwa_corr_fits` which uses pyuvdata to calculate the uvws).~ The check is always run unless `run_check_acceptability` is turned off.

Note that most of our test files do not pass this check, thus the default to warn rather than error and to make the warning not too scary. I've had to add many `pytest.mark.filterwarnings` decorators.  I also consolidated many of the file reads using fixtures to lessen the hit to test run time.

closes #480 

This PR also includes a small change to the hera_cal environment yaml to fix the hera_cal tests.
