### PR TITLE
Add option for discarding unused antenna metadata after a selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
-- `keep_missing_antennas` keyword for optionally discarding unused antenna data when performing a select operation.
+- `keep_all_metadata` keyword for optionally discarding unused metadata when performing a select operation.
 
 ### Changed
 - Extends `run_acceptability_check` for UVH5 metadata in `check_header` function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- `keep_missing_antennas` keyword for optionally discarding unused antenna data when performing a select operation.
+
 ### Changed
 - Extends `run_acceptability_check` for UVH5 metadata in `check_header` function.
 

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -676,7 +676,7 @@ def test_select_antennas():
     for i in range(uv_object.Nants_telescope):
         uv_object.antenna_diameters += i
     uv_object4 = copy.deepcopy(uv_object)
-    uv_object4.select(antenna_nums=ants_to_keep, keep_missing_antennas=False)
+    uv_object4.select(antenna_nums=ants_to_keep, keep_all_metadata=False)
     nt.assert_equal(uv_object4.Nants_telescope, 9)
     nt.assert_equal(set(uv_object4.antenna_numbers), set(ants_to_keep))
     for a in ants_to_keep:

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -670,6 +670,26 @@ def test_select_antennas():
 
     nt.assert_equal(uv_object2, uv_object3)
 
+    # test removing metadata associated with antennas that are no longer present
+    # also add (different) antenna_diameters to test downselection
+    uv_object.antenna_diameters = 1. * np.ones((uv_object.Nants_telescope,), dtype=np.float)
+    for i in range(uv_object.Nants_telescope):
+        uv_object.antenna_diameters += i
+    uv_object4 = copy.deepcopy(uv_object)
+    uv_object4.select(antenna_nums=ants_to_keep, keep_missing_antennas=False)
+    nt.assert_equal(uv_object4.Nants_telescope, 9)
+    nt.assert_equal(set(uv_object4.antenna_numbers), set(ants_to_keep))
+    for a in ants_to_keep:
+        idx1 = uv_object.antenna_numbers.tolist().index(a)
+        idx2 = uv_object4.antenna_numbers.tolist().index(a)
+        nt.assert_equal(uv_object.antenna_names[idx1], uv_object4.antenna_names[idx2])
+        nt.assert_true(np.allclose(uv_object.antenna_positions[idx1, :],
+                                   uv_object4.antenna_positions[idx2, :]))
+        nt.assert_equal(uv_object.antenna_diameters[idx1], uv_object4.antenna_diameters[idx2])
+
+    # remove antenna_diameters from object
+    uv_object.antenna_diameters = None
+
     # check for errors associated with antennas not included in data, bad names or providing numbers and names
     nt.assert_raises(ValueError, uv_object.select,
                      antenna_nums=np.max(unique_ants) + np.arange(1, 3))

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1408,7 +1408,7 @@ class UVData(UVBase):
         return blt_inds, freq_inds, pol_inds, history_update_string
 
     def _select_metadata(self, blt_inds, freq_inds, pol_inds, history_update_string,
-                         keep_missing_antennas=True):
+                         keep_all_metadata=True):
         """
         Internal function to perform select on everything except the data-sized arrays.
 
@@ -1417,7 +1417,7 @@ class UVData(UVBase):
             freq_inds: list of frequency indices to keep. Can be None (to keep everything).
             pol_inds: list of polarization indices to keep. Can be None (to keep everything).
             history_update_string: string to append to the end of the history.
-            keep_antennas: whether to keep metadata for antennas that are no longer in the dataset.
+            keep_all_metadata: whether to keep metadata for antennas that are no longer in the dataset.
                 Defaults to True.
         """
         if blt_inds is not None:
@@ -1435,7 +1435,7 @@ class UVData(UVBase):
                 len(set(self.ant_1_array.tolist() + self.ant_2_array.tolist())))
 
             self.Ntimes = len(np.unique(self.time_array))
-            if not keep_missing_antennas:
+            if not keep_all_metadata:
                 ants_to_keep = set(self.ant_1_array.tolist() + self.ant_2_array.tolist())
                 inds_to_keep = [self.antenna_numbers.tolist().index(ant) for ant in ants_to_keep]
                 self.antenna_names = [self.antenna_names[ind] for ind in inds_to_keep]
@@ -1459,7 +1459,7 @@ class UVData(UVBase):
                bls=None, frequencies=None, freq_chans=None,
                times=None, polarizations=None, blt_inds=None, run_check=True,
                check_extra=True, run_check_acceptability=True, inplace=True,
-               metadata_only=False, keep_missing_antennas=True):
+               metadata_only=False, keep_all_metadata=True):
         """
         Select specific antennas, antenna pairs, frequencies, times and
         polarizations to keep in the object while discarding others.
@@ -1507,7 +1507,7 @@ class UVData(UVBase):
                 a new UVData object, which is a subselection of self (False)
             metadata_only: Option to only do the select on the metadata. Not allowed
                 if the data_array, flag_array or nsample_array is not None. (False)
-            keep_missing_antennas: Option to keep all the metadata associated with antennas,
+            keep_all_metadata: Option to keep all the metadata associated with antennas,
                 even those that do not remain after the select option. (True)
         """
         if metadata_only is True and (self.data_array is not None
@@ -1527,7 +1527,7 @@ class UVData(UVBase):
 
         # do select operations on everything except data_array, flag_array and nsample_array
         uv_object._select_metadata(blt_inds, freq_inds, pol_inds, history_update_string,
-                                   keep_missing_antennas)
+                                   keep_all_metadata)
 
         if metadata_only is True:
             if not inplace:
@@ -1588,7 +1588,7 @@ class UVData(UVBase):
                     freq_chans=None, times=None, polarizations=None, blt_inds=None,
                     read_data=True, read_metadata=True, run_check=True,
                     check_extra=True, run_check_acceptability=True,
-                    keep_missing_antennas=True):
+                    keep_all_metadata=True):
         """
         Read in header, metadata and data from uvfits file(s).
 
@@ -1646,7 +1646,7 @@ class UVData(UVBase):
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters after reading in the file. Default is True.
                 Ignored if read_data is False.
-            keep_missing_antennas: Option to keep all the metadata associated with antennas,
+            keep_all_metadata: Option to keep all the metadata associated with antennas,
                 even those that do not remain after the select option. Default is True.
         """
         from . import uvfits
@@ -1697,7 +1697,7 @@ class UVData(UVBase):
                              polarizations=polarizations, blt_inds=blt_inds,
                              run_check=run_check, check_extra=check_extra,
                              run_check_acceptability=run_check_acceptability,
-                             keep_missing_antennas=keep_missing_antennas)
+                             keep_all_metadata=keep_all_metadata)
             if len(filename) > 1:
                 for f in filename[1:]:
                     uv2 = UVData()
@@ -1708,7 +1708,7 @@ class UVData(UVBase):
                                     polarizations=polarizations, blt_inds=blt_inds,
                                     run_check=run_check, check_extra=check_extra,
                                     run_check_acceptability=run_check_acceptability,
-                                    keep_missing_antennas=keep_missing_antennas)
+                                    keep_all_metadata=keep_all_metadata)
                     self += uv2
                 del(uv2)
         else:
@@ -1722,7 +1722,7 @@ class UVData(UVBase):
                                        read_data=read_data, read_metadata=read_metadata,
                                        run_check=run_check, check_extra=check_extra,
                                        run_check_acceptability=run_check_acceptability,
-                                       keep_missing_antennas=keep_missing_antennas)
+                                       keep_all_metadata=keep_all_metadata)
                 self._convert_from_filetype(uvfits_obj)
                 del(uvfits_obj)
             elif func == 'read_uvfits_metadata':
@@ -1740,7 +1740,7 @@ class UVData(UVBase):
                                             polarizations=polarizations, blt_inds=blt_inds,
                                             run_check=run_check, check_extra=check_extra,
                                             run_check_acceptability=run_check_acceptability,
-                                            keep_missing_antennas=keep_missing_antennas)
+                                            keep_all_metadata=keep_all_metadata)
                 self._convert_from_filetype(uvfits_obj)
                 del(uvfits_obj)
 
@@ -1960,7 +1960,7 @@ class UVData(UVBase):
                   ant_str=None, bls=None, frequencies=None, freq_chans=None,
                   times=None, polarizations=None, blt_inds=None, read_data=True,
                   run_check=True, check_extra=True, run_check_acceptability=True,
-                  data_array_dtype=np.complex128, keep_missing_antennas=True):
+                  data_array_dtype=np.complex128, keep_all_metadata=True):
         """
         Read a UVH5 file.
 
@@ -2016,7 +2016,7 @@ class UVData(UVBase):
                 np.complex64 (single-precision real and imaginary) or np.complex128 (double-
                 precision real and imaginary). Only used if the datatype of the visibility
                 data on-disk is not 'c8' or 'c16'. Default is np.complex128.
-            keep_missing_antennas: Option to keep all the metadata associated with antennas,
+            keep_all_metadata: Option to keep all the metadata associated with antennas,
                 even those that do not remain after the select option. Default is True.
 
         Returns:
@@ -2035,7 +2035,7 @@ class UVData(UVBase):
                            check_extra=check_extra,
                            run_check_acceptability=run_check_acceptability,
                            data_array_dtype=data_array_dtype,
-                           keep_missing_antennas=keep_missing_antennas)
+                           keep_all_metadata=keep_all_metadata)
             if len(filename) > 1:
                 for f in filename[1:]:
                     uv2 = UVData()
@@ -2047,7 +2047,7 @@ class UVData(UVBase):
                                   run_check=run_check, check_extra=check_extra,
                                   run_check_acceptability=run_check_acceptability,
                                   data_array_dtype=data_array_dtype,
-                                  keep_missing_antennas=keep_missing_antennas)
+                                  keep_all_metadata=keep_all_metadata)
                     self += uv2
                 del(uv2)
         else:
@@ -2059,7 +2059,7 @@ class UVData(UVBase):
                                read_data=read_data, run_check=run_check, check_extra=check_extra,
                                run_check_acceptability=run_check_acceptability,
                                data_array_dtype=data_array_dtype,
-                               keep_missing_antennas=keep_missing_antennas)
+                               keep_all_metadata=keep_all_metadata)
             self._convert_from_filetype(uvh5_obj)
             del(uvh5_obj)
 
@@ -2216,7 +2216,7 @@ class UVData(UVBase):
              correct_lat_lon=True, use_model=False, data_column='DATA',
              pol_order='AIPS', run_check=True, check_extra=True,
              run_check_acceptability=True, data_array_dtype=np.complex128,
-             keep_missing_antennas=True):
+             keep_all_metadata=True):
         """
         Read a generic file into a UVData object.
 
@@ -2300,7 +2300,7 @@ class UVData(UVBase):
                 files. Must be either np.complex64 (single-precision real and imaginary) or
                 np.complex128 (double-precision real and imaginary). Only used if the datatype
                 of the visibility data on-disk is not 'c8' or 'c16'. Default is np.complex128.
-            keep_missing_antennas: Option to keep all the metadata associated with antennas,
+            keep_all_metadata: Option to keep all the metadata associated with antennas,
                 even those that do not remain after the select option. Default is True.
 
         Returns:
@@ -2371,7 +2371,7 @@ class UVData(UVBase):
                              read_data=read_data, read_metadata=read_metadata,
                              run_check=run_check, check_extra=check_extra,
                              run_check_acceptability=run_check_acceptability,
-                             keep_missing_antennas=keep_missing_antennas)
+                             keep_all_metadata=keep_all_metadata)
 
             if select:
                 unique_times = np.unique(self.time_array)
@@ -2379,7 +2379,7 @@ class UVData(UVBase):
                                                       & (unique_times <= np.max(time_range)))]
                 self.select(times=times_to_keep, run_check=run_check, check_extra=check_extra,
                             run_check_acceptability=run_check_acceptability,
-                            keep_missing_antennas=keep_missing_antennas)
+                            keep_all_metadata=keep_all_metadata)
 
         elif file_type == 'miriad':
             if (antenna_names is not None or frequencies is not None or freq_chans is not None
@@ -2415,7 +2415,7 @@ class UVData(UVBase):
                             freq_chans=freq_chans, times=times,
                             blt_inds=blt_inds, run_check=run_check, check_extra=check_extra,
                             run_check_acceptability=run_check_acceptability,
-                            keep_missing_antennas=keep_missing_antennas)
+                            keep_all_metadata=keep_all_metadata)
 
         elif file_type == 'fhd':
             if (antenna_nums is not None or antenna_names is not None
@@ -2442,7 +2442,7 @@ class UVData(UVBase):
                             polarizations=polarizations, blt_inds=blt_inds,
                             run_check=run_check, check_extra=check_extra,
                             run_check_acceptability=run_check_acceptability,
-                            keep_missing_antennas=keep_missing_antennas)
+                            keep_all_metadata=keep_all_metadata)
         elif file_type == 'ms':
             if (antenna_nums is not None or antenna_names is not None
                     or ant_str is not None or bls is not None
@@ -2468,7 +2468,7 @@ class UVData(UVBase):
                             polarizations=polarizations, blt_inds=blt_inds,
                             run_check=run_check, check_extra=check_extra,
                             run_check_acceptability=run_check_acceptability,
-                            keep_missing_antennas=keep_missing_antennas)
+                            keep_all_metadata=keep_all_metadata)
         elif file_type == 'uvh5':
             if (time_range is not None):
                 select = True
@@ -2485,7 +2485,7 @@ class UVData(UVBase):
                            read_data=read_data, run_check=run_check, check_extra=check_extra,
                            run_check_acceptability=run_check_acceptability,
                            data_array_dtype=data_array_dtype,
-                           keep_missing_antennas=keep_missing_antennas)
+                           keep_all_metadata=keep_all_metadata)
 
             if select:
                 unique_times = np.unique(self.time_array)
@@ -2493,7 +2493,7 @@ class UVData(UVBase):
                                                       & (unique_times <= np.max(time_range)))]
                 self.select(times=times_to_keep, run_check=run_check, check_extra=check_extra,
                             run_check_acceptability=run_check_acceptability,
-                            keep_missing_antennas=keep_missing_antennas)
+                            keep_all_metadata=keep_all_metadata)
 
     def reorder_pols(self, order=None, run_check=True, check_extra=True,
                      run_check_acceptability=True):
@@ -3253,7 +3253,7 @@ class UVData(UVBase):
         return uvutils.get_baseline_redundancies(baseline_inds, baseline_vecs, tol=tol, with_conjugates=True)
 
     def compress_by_redundancy(self, tol=1.0, inplace=True, metadata_only=False,
-                               keep_missing_antennas=True):
+                               keep_all_metadata=True):
         """
         Uses utility functions to find redundant baselines to the given tolerance, then select on those.
 
@@ -3262,7 +3262,7 @@ class UVData(UVBase):
             inplace: Do selection on current object.
             metadata_only: Option to only do the select on the metadata. Not allowed
                 if the data_array, flag_array or nsample_array is not None. (False)
-            keep_missing_antennas: Option to keep all the metadata associated with antennas,
+            keep_all_metadata: Option to keep all the metadata associated with antennas,
                 even those that do not remain after the select option. (True)
         Returns:
             UVData: if not inplace, returns the compressed UVData object
@@ -3272,7 +3272,7 @@ class UVData(UVBase):
 
         bl_ants = [self.baseline_to_antnums(gp[0]) for gp in red_gps]
         return self.select(bls=bl_ants, inplace=inplace, metadata_only=metadata_only,
-                           keep_missing_antennas=keep_missing_antennas)
+                           keep_all_metadata=keep_all_metadata)
 
     def _set_u_positive(self):
         """

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -110,7 +110,7 @@ class UVFITS(UVData):
     def _get_data(self, vis_hdu, antenna_nums, antenna_names, ant_str,
                   bls, frequencies, freq_chans, times, polarizations,
                   blt_inds, read_metadata, run_check, check_extra,
-                  run_check_acceptability):
+                  run_check_acceptability, keep_missing_antennas):
         """
         Internal function to read just the visibility and flag data of the uvfits file.
         Separated from full read so that header, metadata and data can be read independently.
@@ -155,7 +155,8 @@ class UVFITS(UVData):
                 raw_data_array = raw_data_array[:, np.newaxis, :, :]
         else:
             # do select operations on everything except data_array, flag_array and nsample_array
-            self._select_metadata(blt_inds, freq_inds, pol_inds, history_update_string)
+            self._select_metadata(blt_inds, freq_inds, pol_inds, history_update_string,
+                                  keep_missing_antennas)
 
             # just read in the right portions of the data and flag arrays
             if blt_frac == min_frac:
@@ -222,7 +223,8 @@ class UVFITS(UVData):
                     ant_str=None, bls=None, frequencies=None,
                     freq_chans=None, times=None, polarizations=None, blt_inds=None,
                     read_data=True, read_metadata=True,
-                    run_check=True, check_extra=True, run_check_acceptability=True):
+                    run_check=True, check_extra=True, run_check_acceptability=True,
+                    keep_missing_antennas=True):
         """
         Read in header, metadata and data from a uvfits file. Supports reading
         only selected portions of the data.
@@ -281,6 +283,8 @@ class UVFITS(UVData):
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters after reading in the file. Default is True.
                 Ignored if read_data is False.
+            keep_missing_antennas: Option to keep all the metadata associated with antennas,
+                even those that do not remain after the select option. Default is True.
         """
         if not read_data:
             run_check = False
@@ -454,7 +458,8 @@ class UVFITS(UVData):
             # Now read in the data
             self._get_data(vis_hdu, antenna_nums, antenna_names, ant_str,
                            bls, frequencies, freq_chans, times, polarizations,
-                           blt_inds, False, run_check, check_extra, run_check_acceptability)
+                           blt_inds, False, run_check, check_extra, run_check_acceptability,
+                           keep_missing_antennas)
 
     def read_uvfits_metadata(self, filename):
         """
@@ -480,7 +485,8 @@ class UVFITS(UVData):
                          ant_str=None, bls=None, frequencies=None,
                          freq_chans=None, times=None, polarizations=None,
                          blt_inds=None, read_metadata=True, run_check=True,
-                         check_extra=True, run_check_acceptability=True):
+                         check_extra=True, run_check_acceptability=True,
+                         keep_missing_antennas=True):
         """
         Read in data but not header info from a uvfits file
         (useful for an object that already has the associated header info).
@@ -529,6 +535,8 @@ class UVFITS(UVData):
                 ones. Default is True.
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters after reading in the file. Default is True.
+            keep_missing_antennas: Option to keep all the metadata associated with antennas,
+                even those that do not remain after the select option. Default is True.
         """
 
         with fits.open(filename, memmap=True) as hdu_list:
@@ -537,7 +545,7 @@ class UVFITS(UVData):
             self._get_data(vis_hdu, antenna_nums, antenna_names, ant_str,
                            bls, frequencies, freq_chans, times, polarizations,
                            blt_inds, read_metadata, run_check, check_extra,
-                           run_check_acceptability)
+                           run_check_acceptability, keep_missing_antennas)
 
         del(vis_hdu)
 

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -110,7 +110,7 @@ class UVFITS(UVData):
     def _get_data(self, vis_hdu, antenna_nums, antenna_names, ant_str,
                   bls, frequencies, freq_chans, times, polarizations,
                   blt_inds, read_metadata, run_check, check_extra,
-                  run_check_acceptability, keep_missing_antennas):
+                  run_check_acceptability, keep_all_metadata):
         """
         Internal function to read just the visibility and flag data of the uvfits file.
         Separated from full read so that header, metadata and data can be read independently.
@@ -156,7 +156,7 @@ class UVFITS(UVData):
         else:
             # do select operations on everything except data_array, flag_array and nsample_array
             self._select_metadata(blt_inds, freq_inds, pol_inds, history_update_string,
-                                  keep_missing_antennas)
+                                  keep_all_metadata)
 
             # just read in the right portions of the data and flag arrays
             if blt_frac == min_frac:
@@ -224,7 +224,7 @@ class UVFITS(UVData):
                     freq_chans=None, times=None, polarizations=None, blt_inds=None,
                     read_data=True, read_metadata=True,
                     run_check=True, check_extra=True, run_check_acceptability=True,
-                    keep_missing_antennas=True):
+                    keep_all_metadata=True):
         """
         Read in header, metadata and data from a uvfits file. Supports reading
         only selected portions of the data.
@@ -283,7 +283,7 @@ class UVFITS(UVData):
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters after reading in the file. Default is True.
                 Ignored if read_data is False.
-            keep_missing_antennas: Option to keep all the metadata associated with antennas,
+            keep_all_metadata: Option to keep all the metadata associated with antennas,
                 even those that do not remain after the select option. Default is True.
         """
         if not read_data:
@@ -459,7 +459,7 @@ class UVFITS(UVData):
             self._get_data(vis_hdu, antenna_nums, antenna_names, ant_str,
                            bls, frequencies, freq_chans, times, polarizations,
                            blt_inds, False, run_check, check_extra, run_check_acceptability,
-                           keep_missing_antennas)
+                           keep_all_metadata)
 
     def read_uvfits_metadata(self, filename):
         """
@@ -486,7 +486,7 @@ class UVFITS(UVData):
                          freq_chans=None, times=None, polarizations=None,
                          blt_inds=None, read_metadata=True, run_check=True,
                          check_extra=True, run_check_acceptability=True,
-                         keep_missing_antennas=True):
+                         keep_all_metadata=True):
         """
         Read in data but not header info from a uvfits file
         (useful for an object that already has the associated header info).
@@ -535,7 +535,7 @@ class UVFITS(UVData):
                 ones. Default is True.
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters after reading in the file. Default is True.
-            keep_missing_antennas: Option to keep all the metadata associated with antennas,
+            keep_all_metadata: Option to keep all the metadata associated with antennas,
                 even those that do not remain after the select option. Default is True.
         """
 
@@ -545,7 +545,7 @@ class UVFITS(UVData):
             self._get_data(vis_hdu, antenna_nums, antenna_names, ant_str,
                            bls, frequencies, freq_chans, times, polarizations,
                            blt_inds, read_metadata, run_check, check_extra,
-                           run_check_acceptability, keep_missing_antennas)
+                           run_check_acceptability, keep_all_metadata)
 
         del(vis_hdu)
 

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -291,7 +291,7 @@ class UVH5(UVData):
     def _get_data(self, dgrp, antenna_nums, antenna_names, ant_str,
                   bls, frequencies, freq_chans, times, polarizations,
                   blt_inds, run_check, check_extra, run_check_acceptability,
-                  data_array_dtype):
+                  data_array_dtype, keep_missing_antennas):
         """
         Internal function to read just the visibility, flag, and nsample data of the uvh5 file.
         Separated from full read so that header/metadata and data can be read independently.
@@ -339,7 +339,8 @@ class UVH5(UVData):
             self.nsample_array = dgrp['nsamples'][:, :, :, :]
         else:
             # do select operations on everything except data_array, flag_array and nsample_array
-            self._select_metadata(blt_inds, freq_inds, pol_inds, history_update_string)
+            self._select_metadata(blt_inds, freq_inds, pol_inds, history_update_string,
+                                  keep_missing_antennas)
 
             # open references to datasets
             visdata_dset = dgrp['visdata']
@@ -417,7 +418,7 @@ class UVH5(UVData):
                   ant_str=None, bls=None, frequencies=None, freq_chans=None,
                   times=None, polarizations=None, blt_inds=None, read_data=True,
                   run_check=True, check_extra=True, run_check_acceptability=True,
-                  data_array_dtype=np.complex128):
+                  data_array_dtype=np.complex128, keep_missing_antennas=True):
         """
         Read in data from a UVH5 file.
 
@@ -472,6 +473,8 @@ class UVH5(UVData):
                 np.complex64 (single-precision real and imaginary) or np.complex128 (double-
                 precision real and imaginary). Only used if the datatype of the visibility
                 data on-disk is not 'c8' or 'c16'. Default is np.complex128.
+            keep_missing_antennas: Option to keep all the metadata associated with antennas,
+                even those that do not remain after the select option. Default is True.
 
         Returns:
             None
@@ -498,7 +501,7 @@ class UVH5(UVData):
             self._get_data(dgrp, antenna_nums, antenna_names, ant_str,
                            bls, frequencies, freq_chans, times, polarizations,
                            blt_inds, run_check, check_extra, run_check_acceptability,
-                           data_array_dtype)
+                           data_array_dtype, keep_missing_antennas)
 
         return
 

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -291,7 +291,7 @@ class UVH5(UVData):
     def _get_data(self, dgrp, antenna_nums, antenna_names, ant_str,
                   bls, frequencies, freq_chans, times, polarizations,
                   blt_inds, run_check, check_extra, run_check_acceptability,
-                  data_array_dtype, keep_missing_antennas):
+                  data_array_dtype, keep_all_metadata):
         """
         Internal function to read just the visibility, flag, and nsample data of the uvh5 file.
         Separated from full read so that header/metadata and data can be read independently.
@@ -340,7 +340,7 @@ class UVH5(UVData):
         else:
             # do select operations on everything except data_array, flag_array and nsample_array
             self._select_metadata(blt_inds, freq_inds, pol_inds, history_update_string,
-                                  keep_missing_antennas)
+                                  keep_all_metadata)
 
             # open references to datasets
             visdata_dset = dgrp['visdata']
@@ -418,7 +418,7 @@ class UVH5(UVData):
                   ant_str=None, bls=None, frequencies=None, freq_chans=None,
                   times=None, polarizations=None, blt_inds=None, read_data=True,
                   run_check=True, check_extra=True, run_check_acceptability=True,
-                  data_array_dtype=np.complex128, keep_missing_antennas=True):
+                  data_array_dtype=np.complex128, keep_all_metadata=True):
         """
         Read in data from a UVH5 file.
 
@@ -473,7 +473,7 @@ class UVH5(UVData):
                 np.complex64 (single-precision real and imaginary) or np.complex128 (double-
                 precision real and imaginary). Only used if the datatype of the visibility
                 data on-disk is not 'c8' or 'c16'. Default is np.complex128.
-            keep_missing_antennas: Option to keep all the metadata associated with antennas,
+            keep_all_metadata: Option to keep all the metadata associated with antennas,
                 even those that do not remain after the select option. Default is True.
 
         Returns:
@@ -501,7 +501,7 @@ class UVH5(UVData):
             self._get_data(dgrp, antenna_nums, antenna_names, ant_str,
                            bls, frequencies, freq_chans, times, polarizations,
                            blt_inds, run_check, check_extra, run_check_acceptability,
-                           data_array_dtype, keep_missing_antennas)
+                           data_array_dtype, keep_all_metadata)
 
         return
 


### PR DESCRIPTION
This PR adds a keyword `keep_missing_antennas` (a name I don't love, so I'm open to other suggestions...) for allowing the user to discard metadata associated with antennas no longer in a UVData object after a selection operation. All metadata that has size `Nants_telescope` are adjusted. By default, this downselection is not invoked, so this does not break backwards compatibility.