### PR TITLE
miriad_to_uvfits --> convert_to_uvfits

### DIFF
--- a/scripts/convert_to_uvfits.py
+++ b/scripts/convert_to_uvfits.py
@@ -5,7 +5,7 @@
 
 """
 A command-line script for converting
-a Miriad file to UVFITS format
+any pyuvdata compatible file to UVFITS format
 """
 
 from __future__ import absolute_import, division, print_function
@@ -17,8 +17,8 @@ import pyuvdata
 from astropy.time import Time
 
 # setup argparse
-a = argparse.ArgumentParser(description="A command-line script for converting a Miriad file to UVFITS format.")
-a.add_argument("files", type=str, nargs='*', help="Miriad files to convert to uvfits.")
+a = argparse.ArgumentParser(description="A command-line script for converting file(s) to UVFITS format.")
+a.add_argument("files", type=str, nargs='*', help="pyuvdata-compatible file(s) to convert to uvfits.")
 a.add_argument("--phase_time", type=float, default=None, help="Julian Date to phase data to. Default is the first integration of the file.")
 a.add_argument("--overwrite", default=False, action='store_true', help="overwrite output file if it already exists.")
 a.add_argument("--verbose", default=False, action='store_true', help="report feedback to stdout.")
@@ -38,7 +38,7 @@ for filename in args.files:
 
     # read in file
     UV = pyuvdata.UVData()
-    UV.read_miriad(filename)
+    UV.read(filename)
 
     if UV.phase_type == 'drift':
         # phase data

--- a/scripts/convert_to_uvfits.py
+++ b/scripts/convert_to_uvfits.py
@@ -19,9 +19,11 @@ from astropy.time import Time
 # setup argparse
 a = argparse.ArgumentParser(description="A command-line script for converting file(s) to UVFITS format.")
 a.add_argument("files", type=str, nargs='*', help="pyuvdata-compatible file(s) to convert to uvfits.")
+a.add_argument("--output_filename", type=str, default=None, help="Filepath of output file. Default is input with suffix replaced by .uvfits")
 a.add_argument("--phase_time", type=float, default=None, help="Julian Date to phase data to. Default is the first integration of the file.")
 a.add_argument("--overwrite", default=False, action='store_true', help="overwrite output file if it already exists.")
 a.add_argument("--verbose", default=False, action='store_true', help="report feedback to stdout.")
+
 
 # get args
 args = a.parse_args()
@@ -31,11 +33,18 @@ history = ' '.join(sys.argv)
 for filename in args.files:
 
     # check output
-    splitext = os.path.splitext(filename)[1]
-    if splitext[1] == '.uvh5':
-        outfilename = splitext[0] + '.uvfits'
+    if args.output_filename is None:
+        splitext = os.path.splitext(filename)[1]
+        if splitext[1] == '.uvh5':
+            outfilename = splitext[0] + '.uvfits'
+        elif splitext[1] in ['.ms', '.MS']:
+            outfilename = splitext[0] + '.uvfits'
+        elif splitext[1] == '.sav':
+            outfilename = splitext[0] + '.uvfits'
+        else:
+            outfilename = filename + '.uvfits'
     else:
-        outfilename = filename + '.uvfits'
+        outfilename = args.output_filename
     if os.path.exists(outfilename) and args.overwrite is False:
         print("{} exists, not overwriting...".format(outfilename))
         continue

--- a/scripts/convert_to_uvfits.py
+++ b/scripts/convert_to_uvfits.py
@@ -31,7 +31,11 @@ history = ' '.join(sys.argv)
 for filename in args.files:
 
     # check output
-    outfilename = filename + '.uvfits'
+    splitext = os.path.splitext(filename)[1]
+    if splitext[1] == '.uvh5':
+        outfilename = splitext[0] + '.uvfits'
+    else:
+        outfilename = filename + '.uvfits'
     if os.path.exists(outfilename) and args.overwrite is False:
         print("{} exists, not overwriting...".format(outfilename))
         continue


### PR DESCRIPTION
Changes name of `miriad_to_uvfits.py` script to `convert_to_uvfits.py` using file-agnostic `UVData.read` command.

This will help us convert various file types to `uvfits` more easily from the command line (specifically for imaging w/ CASA).