### PR TITLE
Fix tests in python 2.7 when IERS url is down

### DIFF
--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -903,7 +903,7 @@ def test_antpos_units():
     nt.assert_true(np.allclose(aantpos, uv.antenna_positions))
 
 
-def test_readMiriadwriteMiraid_check_time_format():
+def test_readMiriadwriteMiriad_check_time_format():
     """
     test time_array is converted properly from Miriad format
     """
@@ -920,7 +920,8 @@ def test_readMiriadwriteMiraid_check_time_format():
     t1 = Time(uv['time'], format='jd', location=(lon, lat))
     dt = TimeDelta(uv['inttime'] / 2, format='sec')
     t2 = t1 + dt
-    delta_lst = t2.sidereal_time('apparent').radian - t1.sidereal_time('apparent').radian
+    lsts = uvutils.get_lst_for_time(np.array([t1.jd, t2.jd]), lat, lon, alt)
+    delta_lst = lsts[1] - lsts[0]
     uv_l = uv['lst'] + delta_lst
 
     # assert starting time array and lst array are shifted by half integration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reduce the tolerance on an LST calculation in test_miriad.py in python 2.7 when the IERS url is down. 

## Motivation and Context
prevent PRs from failing because IERS isn't available
Fixes #535  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change introduces new functionality that should be highlighted in the tutorial.
  - [ ] I have updated the tutorial accordingly.
- [ ] If this is a bug fix, it includes a new test that breaks as a result of the bug (if possible)
- [ ] If this is a breaking change, it includes backwards compatibility and deprecation warnings (if possible)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass in both python 2 and python 3.
- [ ] My change requires an update to the [CHANGELOG](CHANGELOG.md).
  - [ ] I have updated the [CHANGELOG](CHANGELOG.md) accordingly.
