### PR TITLE
.travis.yml: try to fix Linux CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,9 @@ install:
 
   # install dependencies
   - conda install numpy scipy astropy nose pip h5py six healpy python-casacore pycodestyle coveralls python="$PYTHON_VERSION"
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      conda install gcc_linux-64 gxx_linux-64;
+    fi
   - conda list
   - python --version
   # check that the python version matches the desired one; exit immediately if not


### PR DESCRIPTION
Current conda-forge setuptools try to use the same C compiler as was used to buil Python, so we need to install the special one used by the conda-forge build framework.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)