### PR TITLE
Catch warnings in redundancy tests

### DIFF
--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -2777,9 +2777,23 @@ def test_redundancy_contract_expand():
     uv2 = uv0.compress_by_redundancy(tol=tol, inplace=False)
     uv0.compress_by_redundancy(tol=tol)
     nt.assert_equal(uv0, uv2)  # Compare in-place to separated compression.
-    uv2.inflate_by_redundancy(tol=tol)
+    uvtest.checkWarnings(
+        uv2.inflate_by_redundancy,
+        [tol],
+        nwarnings=2,
+        category=[DeprecationWarning, UserWarning],
+        message=['The default for the `center` keyword has changed.',
+                 'Missing some redundant groups. Filling in available data.']
+    )
     uv3 = uv2.compress_by_redundancy(tol=tol, inplace=False)
-    uv3.inflate_by_redundancy(tol=tol)
+    uvtest.checkWarnings(
+        uv3.inflate_by_redundancy,
+        [tol],
+        nwarnings=2,
+        category=[DeprecationWarning, UserWarning],
+        message=['The default for the `center` keyword has changed.',
+                 'Missing some redundant groups. Filling in available data.']
+    )
     # Inflation changes the baseline ordering into the order of the redundant groups.
     # Confirm that we get the same result looping inflate -> compress -> inflate.
     uv2.history = uv3.history


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Catches warnings on the `inflate_by_redundancy` calls in `test_uvdata.py`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Uncaught warnings in tests, following a recent PR.
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #543 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change introduces new functionality that should be highlighted in the tutorial.
  - [ ] I have updated the tutorial accordingly.
- [ ] If this is a bug fix, it includes a new test that breaks as a result of the bug (if possible)
- [ ] If this is a breaking change, it includes backwards compatibility and deprecation warnings (if possible)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass in both python 2 and python 3.
- [ ] My change requires an update to the [CHANGELOG](CHANGELOG.md).
  - [ ] I have updated the [CHANGELOG](CHANGELOG.md) accordingly.
