### PR TITLE
Added more Circleci testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,38 @@
 version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.2 # to get this to work, had to opt-in to using third party orbs in Organization Security settings.
+commands: # reusable commands with parameters
+  config_conda:
+    parameters:
+      python_version:
+        type: string
+      env_name:
+        type: string
+    steps:
+      - run: # use the python version and envname to set up the conda environment
+          name: configure conda environment
+          environment:
+            PYTHON: << parameters.python_version >>
+            ENV_NAME: << parameters.env_name >>
+          command: ./ci/install-circle.sh
+
 jobs:
   pyuvdata-3_6:
     docker:
       - image: continuumio/miniconda:latest
-    environment:
-      PYTHON: "3.6"
-      ENV_NAME: "pyuvdata_tests"
+    # environment:
+    #   PYTHON: "3.6"
+    #   ENV_NAME: "pyuvdata_tests"
     steps:
       - checkout
       - restore_cache:
           key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
-      - run:
-          name: configure conda environment
-          command: ./ci/install-circle.sh
+      # - run:
+      #     name: configure conda environment
+      #     command: ./ci/install-circle.sh
+      - config_conda:
+          python_version: "3.6"
+          env_name: "pyuvdata_tests"
       - run:
           name: install
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,9 @@ jobs:
           command: ./ci/install-circle.sh
       - run:
           name: linting for PEP8 compliance
-          command: pycodestyle --ignore=E501,W503
+          command: |
+            source activate ${ENV_NAME}
+            pycodestyle --ignore=E501,W503
       - save_cache:
           key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,13 @@ jobs:
       - codecov/upload:
           file: ./coverage.xml
   hera_cal:
+    parameters:
+      python_version:
+        type: string
     docker:
       - image: continuumio/miniconda:latest
     environment:
-      PYTHON: "3.6"
+      PYTHON: << parameters.python_version >>
       ENV_NAME: "hera_cal"
     steps:
       - checkout
@@ -80,10 +83,13 @@ jobs:
       - store_artifacts:
           path: hera_cal/test-reports
   hera_qm:
+    parameters:
+      python_version:
+        type: string
     docker:
       - image: continuumio/miniconda:latest
     environment:
-      PYTHON: "3.6"
+      PYTHON: << parameters.python_version >>
       ENV_NAME: "hera_qm"
     steps:
       - checkout
@@ -125,5 +131,7 @@ workflows:
     jobs:
       - pyuvdata:
           python_version: "3.6"
+      - pyuvdata:
+          python_version: "2.7"
       - hera_cal
       - hera_qm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.2
 jobs:
-  pyuvdata-3.6:
+  pyuvdata-3_6:
     docker:
       - image: continuumio/miniconda:latest
     environment:
@@ -118,6 +118,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - pyuvdata-3.6
+      - pyuvdata-3_6
       - hera_cal
       - hera_qm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  codecov: codecov/codecov@1.0.2
+  codecov: codecov/codecov@1.0.2 # to get this to work, had to opt-in to using third party orbs in Organization Security settings.
 jobs:
   pyuvdata-3_6:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.2
 jobs:
-  pyuvdata3.6:
+  pyuvdata-3.6:
     docker:
       - image: continuumio/miniconda:latest
     environment:
@@ -10,8 +10,8 @@ jobs:
       ENV_NAME: "pyuvdata_tests"
     steps:
       - checkout
-      # - restore_cache:
-      #     key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
+      - restore_cache:
+          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
       - run:
           name: configure conda environment
           command: ./ci/install-circle.sh
@@ -26,10 +26,10 @@ jobs:
             source activate ${ENV_NAME}
             mkdir test-reports
             nosetests pyuvdata -v --with-xunit --xunit-file=test-reports/xunit.xml --with-coverage --cover-package=pyuvdata
-      # - save_cache:
-      #     key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
-      #     paths:
-      #       - "/opt/conda/envs/${ENV_NAME}/"
+      - save_cache:
+          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
+          paths:
+            - "/opt/conda/envs/${ENV_NAME}/"
       - store_test_results:
           path: test-reports
       - store_artifacts:
@@ -118,6 +118,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - pyuvdata3.6
+      - pyuvdata-3.6
       - hera_cal
       - hera_qm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
-orbs:
-  codecov: codecov/codecov@1.0.2
+# orbs:
+#   codecov: codecov/codecov@1.0.2
 jobs:
   pyuvdata3.6:
     docker:
@@ -10,8 +10,8 @@ jobs:
       ENV_NAME: "pyuvdata_tests"
     steps:
       - checkout
-      - restore_cache:
-          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
+      # - restore_cache:
+      #     key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
       - run:
           name: configure conda environment
           command: ./ci/install-circle.sh
@@ -26,16 +26,16 @@ jobs:
             source activate ${ENV_NAME}
             mkdir test-reports
             nosetests pyuvdata -v --with-xunit --xunit-file=test-reports/xunit.xml --with-coverage --cover-package=pyuvdata
-      - save_cache:
-          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
-          paths:
-            - "/opt/conda/envs/${ENV_NAME}/"
+      # - save_cache:
+      #     key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
+      #     paths:
+      #       - "/opt/conda/envs/${ENV_NAME}/"
       - store_test_results:
           path: test-reports
       - store_artifacts:
           path: test-reports
-      - codecov/upload:
-          file: {{ .coverage }}
+      # - codecov/upload:
+      #     file: {{ .coverage }}
   hera_cal:
     docker:
       - image: continuumio/miniconda:latest
@@ -74,7 +74,6 @@ jobs:
           path: hera_cal/test-reports
       - store_artifacts:
           path: hera_cal/test-reports
-
   hera_qm:
     docker:
       - image: continuumio/miniconda:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: install
           command: |
             source activate ${ENV_NAME}
-            pip install .
+            python setup.py build_ext --force --inplace
       - run:
           name: run pyuvdata tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - store_artifacts:
           path: test-reports
       - codecov/upload:
-          file: {{ .coverage }}
+          file: {{ ".coverage" }}
   hera_cal:
     docker:
       - image: continuumio/miniconda:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,30 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.2 # to get this to work, had to opt-in to using third party orbs in Organization Security settings.
 jobs:
+  linter:
+    parameters:
+      python_version:
+        type: string
+    docker:
+      - image: continuumio/miniconda:latest
+    environment:
+      PYTHON: << parameters.python_version >>
+      ENV_NAME: pyuvdata_linting
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_linting.yml" }}
+      - run:
+          name: configure conda environment
+          command: ./ci/install-circle.sh
+      - run:
+          name: linting for PEP8 compliance
+          command: pycodestyle --ignore=E501,W503
+      - save_cache:
+          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
+          paths:
+            - "/opt/conda/envs/${ENV_NAME}/"
+
   pyuvdata:
     parameters:
       python_version:
@@ -39,6 +63,38 @@ jobs:
           path: test-reports
       - codecov/upload:
           file: ./coverage.xml
+
+  doctest:
+    parameters:
+      python_version:
+        type: string
+    docker:
+      - image: continuumio/miniconda:latest
+    environment:
+      PYTHON: << parameters.python_version >>
+      ENV_NAME: pyuvdata_tests
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
+      - run:
+          name: configure conda environment
+          command: ./ci/install-circle.sh
+      - run:
+          name: install
+          command: |
+            source activate ${ENV_NAME}
+            python setup.py build_ext --force --inplace
+      - run:
+          name: run tutorial tests
+          command: |
+            source activate ${ENV_NAME}
+            python -m doctest docs/tutorial.rst
+      - save_cache:
+          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
+          paths:
+            - "/opt/conda/envs/${ENV_NAME}/"
+
   hera_cal:
     parameters:
       python_version:
@@ -80,6 +136,7 @@ jobs:
           path: hera_cal/test-reports
       - store_artifacts:
           path: hera_cal/test-reports
+
   hera_qm:
     parameters:
       python_version:
@@ -127,6 +184,8 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - linter:
+          python_version: "3.6"
       - pyuvdata:
           name: pyuvdata_2.7
           python_version: "2.7"
@@ -136,6 +195,8 @@ workflows:
       - pyuvdata:
           name: pyuvdata_3.7
           python_version: "3.7"
+      - doctest:
+          python_version: "3.6"
       - hera_cal:
           python_version: "3.6"
       - hera_qm:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,11 @@ jobs:
           name: install
           command: |
             source activate ${ENV_NAME}
-            conda info --envs
-            conda list
+          # check that the python version matches the desired one; exit immediately if not
+            PYVER=`python -c "from __future__ import print_function; import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
+            if [[ $PYVER != $PYTHON_VERSION ]]; then
+              exit 1;
+            fi
             python setup.py build_ext --force --inplace
       - run:
           name: run pyuvdata tests
@@ -130,8 +133,13 @@ workflows:
   build_and_test:
     jobs:
       - pyuvdata:
+          name: pyuvdata_3.7
+          python_version: "3.7"
+      - pyuvdata:
+          name: pyuvdata_3.6
           python_version: "3.6"
       - pyuvdata:
+          name: pyuvdata_2.7
           python_version: "2.7"
       - hera_cal:
           python_version: "3.6"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - store_artifacts:
           path: test-reports
       - codecov/upload:
-          file: {{ ".coverage" }}
+          file: ./.coverage
   hera_cal:
     docker:
       - image: continuumio/miniconda:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,38 +1,23 @@
 version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.2 # to get this to work, had to opt-in to using third party orbs in Organization Security settings.
-commands: # reusable commands with parameters
-  config_conda:
+jobs:
+  pyuvdata:
     parameters:
       python_version:
         type: string
-      env_name:
-        type: string
-    steps:
-      - run: # use the python version and envname to set up the conda environment
-          name: configure conda environment
-          environment:
-            PYTHON: << parameters.python_version >>
-            ENV_NAME: << parameters.env_name >>
-          command: ./ci/install-circle.sh
-
-jobs:
-  pyuvdata-3_6:
     docker:
       - image: continuumio/miniconda:latest
-    # environment:
-    #   PYTHON: "3.6"
-    #   ENV_NAME: "pyuvdata_tests"
+    environment:
+      PYTHON: << parameters.python_version >>
+      ENV_NAME: pyuvdata_tests
     steps:
       - checkout
       - restore_cache:
           key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
-      # - run:
-      #     name: configure conda environment
-      #     command: ./ci/install-circle.sh
-      - config_conda:
-          python_version: "3.6"
-          env_name: "pyuvdata_tests"
+      - run:
+          name: configure conda environment
+          command: ./ci/install-circle.sh
       - run:
           name: install
           command: |
@@ -138,6 +123,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - pyuvdata-3_6
+      - pyuvdata:
+          python_version: "3.6"
       - hera_cal
       - hera_qm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,6 @@ jobs:
           name: install
           command: |
             source activate ${ENV_NAME}
-          # check that the python version matches the desired one; exit immediately if not
-            PYVER=`python -c "from __future__ import print_function; import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
-            if [[ $PYVER != $PYTHON_VERSION ]]; then
-              exit 1;
-            fi
             python setup.py build_ext --force --inplace
       - run:
           name: run pyuvdata tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,41 @@
 version: 2
+orbs:
+  codecov: codecov/codecov@1.0.2
 jobs:
+  pyuvdata3.6:
+    docker:
+      - image: continuumio/miniconda:latest
+    environment:
+      PYTHON: "3.6"
+      ENV_NAME: "pyuvdata_tests"
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata3.6.yml" }}
+      - run:
+          name: configure conda environment
+          command: ./ci/install-circle.sh
+      - run:
+          name: install
+          command: |
+            source activate ${ENV_NAME}
+            pip install .
+      - run:
+          name: run pyuvdata tests
+          command: |
+            source activate ${ENV_NAME}
+            mkdir test-reports
+            nosetests pyuvdata -v --with-xunit --xunit-file=test-reports/xunit.xml --with-coverage --cover-package=pyuvdata
+      - save_cache:
+          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata3.6.yml" }}
+          paths:
+            - "/opt/conda/envs/${ENV_NAME}/"
+      - store_test_results:
+          path: test-reports
+      - store_artifacts:
+          path: test-reports
+      - codecov/upload:
+          file: {{ .coverage }}
   hera_cal:
     docker:
       - image: continuumio/miniconda:latest
@@ -83,5 +119,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - pyuvdata3.6
       - hera_cal
       - hera_qm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           command: |
             source activate ${ENV_NAME}
             mkdir test-reports
-            nosetests pyuvdata -v --with-xunit --xunit-file=test-reports/xunit.xml --with-coverage --cover-package=pyuvdata
+            nosetests pyuvdata -v --with-xunit --xunit-file=test-reports/xunit.xml --with-coverage --cover-package=pyuvdata --cover-xml
       - save_cache:
           key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
           paths:
@@ -35,7 +35,7 @@ jobs:
       - store_artifacts:
           path: test-reports
       - codecov/upload:
-          file: ./.coverage
+          file: ./coverage.xml
   hera_cal:
     docker:
       - image: continuumio/miniconda:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,5 +133,7 @@ workflows:
           python_version: "3.6"
       - pyuvdata:
           python_version: "2.7"
-      - hera_cal
-      - hera_qm
+      - hera_cal:
+          python_version: "3.6"
+      - hera_qm:
+          python_version: "3.6"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
-# orbs:
-#   codecov: codecov/codecov@1.0.2
+orbs:
+  codecov: codecov/codecov@1.0.2
 jobs:
   pyuvdata3.6:
     docker:
@@ -34,8 +34,8 @@ jobs:
           path: test-reports
       - store_artifacts:
           path: test-reports
-      # - codecov/upload:
-      #     file: {{ .coverage }}
+      - codecov/upload:
+          file: {{ .coverage }}
   hera_cal:
     docker:
       - image: continuumio/miniconda:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,8 @@ jobs:
           name: install
           command: |
             source activate ${ENV_NAME}
+            conda info --envs
+            conda list
             python setup.py build_ext --force --inplace
       - run:
           name: run pyuvdata tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,14 +128,14 @@ workflows:
   build_and_test:
     jobs:
       - pyuvdata:
-          name: pyuvdata_3.7
-          python_version: "3.7"
+          name: pyuvdata_2.7
+          python_version: "2.7"
       - pyuvdata:
           name: pyuvdata_3.6
           python_version: "3.6"
       - pyuvdata:
-          name: pyuvdata_2.7
-          python_version: "2.7"
+          name: pyuvdata_3.7
+          python_version: "3.7"
       - hera_cal:
           python_version: "3.6"
       - hera_qm:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata3.6.yml" }}
+          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
       - run:
           name: configure conda environment
           command: ./ci/install-circle.sh
@@ -27,7 +27,7 @@ jobs:
             mkdir test-reports
             nosetests pyuvdata -v --with-xunit --xunit-file=test-reports/xunit.xml --with-coverage --cover-package=pyuvdata
       - save_cache:
-          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata3.6.yml" }}
+          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
           paths:
             - "/opt/conda/envs/${ENV_NAME}/"
       - store_test_results:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 dist: trusty
 os:
-  - linux
   - osx
 env:
   global:
@@ -61,8 +60,6 @@ install:
 script:
   - python setup.py build_ext --force --inplace
   - nosetests pyuvdata --with-coverage --cover-package=pyuvdata
-  - python -m doctest docs/tutorial.rst
-  - pycodestyle --ignore=E501,W503
 
 after_success:
     - coveralls

--- a/ci/install-circle.sh
+++ b/ci/install-circle.sh
@@ -5,7 +5,8 @@ conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda config --add channels conda-forge
 conda info -a
-conda env create -f ci/${ENV_NAME}.yml --name=${ENV_NAME}  python=$PYTHON --quiet
+conda env create --name=${ENV_NAME}  python=$PYTHON --quiet
+conda env update -f ci/${ENV_NAME}.yml
 source activate ${ENV_NAME}
 conda list -n ${ENV_NAME}
 # check that the python version matches the desired one; exit immediately if not

--- a/ci/install-circle.sh
+++ b/ci/install-circle.sh
@@ -8,3 +8,8 @@ conda info -a
 conda env create -f ci/${ENV_NAME}.yml --name=${ENV_NAME}  python=$PYTHON --quiet
 source activate ${ENV_NAME}
 conda list -n ${ENV_NAME}
+# check that the python version matches the desired one; exit immediately if not
+PYVER=`python -c "from __future__ import print_function; import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
+if [[ $PYVER != $PYTHON_VERSION ]]; then
+  exit 1;
+fi

--- a/ci/install-circle.sh
+++ b/ci/install-circle.sh
@@ -10,6 +10,6 @@ source activate ${ENV_NAME}
 conda list -n ${ENV_NAME}
 # check that the python version matches the desired one; exit immediately if not
 PYVER=`python -c "from __future__ import print_function; import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
-if [[ $PYVER != $PYTHON_VERSION ]]; then
+if [[ $PYVER != $PYTHON ]]; then
   exit 1;
 fi

--- a/ci/install-circle.sh
+++ b/ci/install-circle.sh
@@ -5,7 +5,7 @@ conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda config --add channels conda-forge
 conda info -a
-conda env create --name=${ENV_NAME}  python=$PYTHON --quiet
+conda create --name=${ENV_NAME}  python=$PYTHON --quiet
 conda env update -f ci/${ENV_NAME}.yml
 source activate ${ENV_NAME}
 conda list -n ${ENV_NAME}

--- a/ci/pyuvdata_linting.yml
+++ b/ci/pyuvdata_linting.yml
@@ -1,0 +1,6 @@
+name: pyuvdata_linting
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - pycodestyle

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -1,0 +1,15 @@
+name: pyuvdata_tests
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - aipy
+  - astropy
+  - h5py
+  - healpy
+  - nose
+  - numpy
+  - python-casacore
+  - scipy
+  - six
+  - coveralls


### PR DESCRIPTION
It looks like Travis might be in danger of disappearing, so this PR extends the testing on circleci so that it can take over for Travis if there's a problem.

## Description
Added linting, doc testing and unit testing of pyuvdata on circleci.

## Motivation and Context
Travis may be in trouble, we want to have a backup that works if there's a problem with Travis. This will also serve as an example for other repositories that want to start using circleci. A few notes:
 * Circleci does not have free testing on Mac OS X, so that remains unique to Travis.
 * Currently the linting and doctests are only running for python 3.6, it's easy to add the other versions if we think it's useful.
* Each separate job in the workflow shows up as a separate line item in the PR checks. That's nice because there's more transparency about what's breaking, but does generate a little more noise.
* I'm currently using codecov rather than coveralls for reporting the coverage based on the circleci tests. This was basically an opportunity to explore an alternative to coveralls. I think long term we probably want to pick one or the other and have all the coverage reports go to one service.
* Tests run substantially faster on Circleci.
* Circleci only tests the branch, it doesn't test the post-merge repo (like Travis does) so there's a chance something could pass that would break master after the merge.

After some discussion, this PR removes linux builds, linting and doctesting in Travis builds because those are now covered by circleci and that may speed up Travis builds.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change introduces new functionality that should be highlighted in the tutorial.
  - [ ] I have updated the tutorial accordingly.
- [ ] If this is a bug fix, it includes a new test that breaks as a result of the bug (if possible)
- [ ] If this is a breaking change, it includes backwards compatibility and deprecation warnings (if possible)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass in both python 2 and python 3.
- [ ] My change requires an update to the [CHANGELOG](CHANGELOG.md).
  - [ ] I have updated the [CHANGELOG](CHANGELOG.md) accordingly.
