### PR TITLE
Fix overlapping data addition bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Support for a yaml settings file to collect and propagate metadata for CST beam files.
 
+### Fixed
+- Combining UVData objects to overwrite invalid "dummy data" no longer produces errors.
+
 ## [1.3.6] - 2019-02-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 - Support for a yaml settings file to collect and propagate metadata for CST beam files.
 
 ### Fixed
-- Combining UVData objects to overwrite invalid "dummy data" no longer produces errors.
+- Combining overlapping data along multiple axes (most common when reading in multiple files) no longer errors.
 
 ## [1.3.6] - 2019-02-15
 

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -2956,10 +2956,10 @@ def test_overlapping_data_add():
     uvfull = uv1 + uv2
     uvfull += uv3
     uvfull += uv4
-    extra_history = ("  Downselected to specific baseline-times, polarizations using pyuvdata. "
+    extra_history = ("Downselected to specific baseline-times, polarizations using pyuvdata. "
                      "Combined data along polarization axis using pyuvdata. Combined data along "
                      "baseline-time axis using pyuvdata. Overwrote invalid data using pyuvdata.")
-    nt.assert_equal(uvfull.history, uv.history + extra_history)
+    nt.assert_true(uvutils._check_histories(uvfull.history, uv.history + extra_history))
     uvfull.history = uv.history  # make histories match
     nt.assert_equal(uv, uvfull)
 
@@ -2976,5 +2976,28 @@ def test_overlapping_data_add():
     uvfull += uv3
     nt.assert_raises(ValueError, uv4.__iadd__, uvfull)
     nt.assert_raises(ValueError, uv4.__add__, uv4, uvfull)
+
+    # write individual objects out, and make sure that we can read in the list
+    uv1_out = os.path.join(DATA_PATH, "uv1.uvfits")
+    uv1.write_uvfits(uv1_out)
+    uv2_out = os.path.join(DATA_PATH, "uv2.uvfits")
+    uv2.write_uvfits(uv2_out)
+    uv3_out = os.path.join(DATA_PATH, "uv3.uvfits")
+    uv3.write_uvfits(uv3_out)
+    uv4_out = os.path.join(DATA_PATH, "uv4.uvfits")
+    uv4.write_uvfits(uv4_out)
+
+    uvfull = UVData()
+    uvtest.checkWarnings(uvfull.read, [[uv1_out, uv2_out, uv3_out, uv4_out]],
+                         nwarnings=4, message='Telescope EVLA is not')
+    nt.assert_true(uvutils._check_histories(uvfull.history, uv.history + extra_history))
+    uvfull.history = uv.history  # make histories match
+    nt.assert_true(uvfull, uv)
+
+    # clean up after ourselves
+    os.remove(uv1_out)
+    os.remove(uv2_out)
+    os.remove(uv3_out)
+    os.remove(uv4_out)
 
     return

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -2936,3 +2936,27 @@ def test_redundancy_finder_when_nblts_not_nbls_times_ntimes():
     redundant_groups, centers, lengths, conj_inds = uv.get_baseline_redundancies(tol=tol)
     redundant_groups.sort(key=len)
     nt.assert_equal(groups, redundant_groups)
+
+
+def test_overlapping_data_add():
+    # read in test data
+    uv = UVData()
+    testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv.read_uvfits, [testfile], message='Telescope EVLA is not')
+
+    # slice into four objects
+    blts1 = np.arange(500)
+    blts2 = np.arange(500, 1360)
+    uv1 = uv.select(polarizations=[-1, -2], blt_inds=blts1, inplace=False)
+    uv2 = uv.select(polarizations=[-3, -4], blt_inds=blts1, inplace=False)
+    uv3 = uv.select(polarizations=[-1, -2], blt_inds=blts2, inplace=False)
+    uv4 = uv.select(polarizations=[-3, -4], blt_inds=blts2, inplace=False)
+
+    # combine and check for equality
+    uvfull = uv1 + uv2
+    uvfull += uv3
+    uvfull += uv4
+    uv.history = uvfull.history  # make histories match
+    nt.assert_equal(uv, uvfull)
+
+    return

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -2956,7 +2956,25 @@ def test_overlapping_data_add():
     uvfull = uv1 + uv2
     uvfull += uv3
     uvfull += uv4
-    uv.history = uvfull.history  # make histories match
+    extra_history = ("  Downselected to specific baseline-times, polarizations using pyuvdata. "
+                     "Combined data along polarization axis using pyuvdata. Combined data along "
+                     "baseline-time axis using pyuvdata. Overwrote invalid data using pyuvdata.")
+    nt.assert_equal(uvfull.history, uv.history + extra_history)
+    uvfull.history = uv.history  # make histories match
     nt.assert_equal(uv, uvfull)
+
+    # check combination not-in-place
+    uvfull = uv1 + uv2
+    uvfull += uv3
+    uvfull = uvfull + uv4
+    uvfull.history = uv.history  # make histories match
+    nt.assert_equal(uv, uvfull)
+
+    # test raising error for adding objects incorrectly (i.e., having the object
+    # with data to be overwritten come second)
+    uvfull = uv1 + uv2
+    uvfull += uv3
+    nt.assert_raises(ValueError, uv4.__iadd__, uvfull)
+    nt.assert_raises(ValueError, uv4.__add__, uv4, uvfull)
 
     return

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -974,11 +974,23 @@ class UVData(UVBase):
             if len(both_freq) > 0:
                 if len(both_blts) > 0:
                     # check that overlapping data is not valid
-                    all_zero = np.all(this.data_array[this_blts_ind][
+                    this_all_zero = np.all(this.data_array[this_blts_ind][
                         :, :, this_freq_ind][:, :, :, this_pol_ind] == 0)
-                    all_flag = np.all(this.flag_array[this_blts_ind][
+                    this_all_flag = np.all(this.flag_array[this_blts_ind][
                         :, :, this_freq_ind][:, :, :, this_pol_ind])
-                    if not (all_zero and all_flag):
+                    other_all_zero = np.all(other.data_array[other_blts_ind][
+                        :, :, other_freq_ind][:, :, :, other_pol_ind] == 0)
+                    other_all_flag = np.all(other.flag_array[other_blts_ind][
+                        :, :, other_freq_ind][:, :, :, other_pol_ind])
+                    if (this_all_zero and this_all_flag):
+                        # we're fine to overwrite; update history accordingly
+                        history_update_string = ' Overwrote invalid data using pyuvdata.'
+                        this.history += history_update_string
+                    elif (other_all_zero and other_all_flag):
+                        raise ValueError('To combine these data, please run the add operation again, '
+                                         'but with the object whose data is to be overwritten as the '
+                                         'first object in the add operation.')
+                    else:
                         raise ValueError('These objects have overlapping data and'
                                          ' cannot be combined.')
 

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1031,7 +1031,7 @@ class UVData(UVBase):
                                            other.integration_time[other_blts_ind],
                                            rtol=this._integration_time.tols[0],
                                            atol=this._integration_time.tols[1])
-            elif a ==  "_uvw_array":
+            elif a == "_uvw_array":
                 # only check that overlapping blt indices match
                 params_match = np.allclose(this.uvw_array[this_blts_ind, :],
                                            other.uvw_array[other_blts_ind, :],


### PR DESCRIPTION
## Description
This PR allows for combining two UVData objects that ostensibly overlap along the baseline-time, frequency, and polarization axes, but one contains "invalid" data (defined to have all zeros for the data array and be totally flagged). In such a case, the invalid data is overwritten by the valid data in the second object.

## Motivation and Context
When a UVData object is expanded to fill out "dummy indices" that are not part of the combined object but required to create a valid object, the dummy data are zero-valued and completely flagged. This PR makes changes such that if two UVData objects to be combined overlap, and the overlapping data is dummy-like, then it combines the objects anyway.

One caveat is that, due to the way that the objects are combined, the addition operation does _not_ commute in all cases anymore. (Under the hood, the overlapping bits of the first object are overwritten by the second one. If the second object contains more data than the first one, that data is not propagated to the combined object.) To protect against this edge case, an error is raised instructing the user to reorder the addition operation and try again. (As a possible solution, I tried to swap the "this" and "other" objects, which worked for combining not-in-place, but failed for in-place addition. Rather than make lots of complicated if/else blocks for what I assume will be an edge case, I opted for throwing an error instead.)

Fixes #455. 


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [contribution guide](.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change introduces new functionality that should be highlighted in the tutorial.
  - [ ] I have updated the tutorial accordingly.
- [x] If this is a bug fix, it includes a new test that breaks as a result of the bug (if possible)
- [ ] If this is a breaking change, it includes backwards compatibility and deprecation warnings (if possible)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] My change requires an update to the [CHANGELOG](CHANGELOG.md).
  - [x] I have updated the [CHANGELOG](CHANGELOG.md) accordingly.
