### PR TITLE
added add_to_history kwarg to UVH5.write_uvh5_part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added `add_to_history` kwarg to UVH5.write_uvh5_part
 - Support for a yaml settings file to collect and propagate metadata for CST beam files.
 
 ### Fixed

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -534,7 +534,7 @@ class Miriad(UVData):
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters before writing the file. Default is True.
             clobber: Option to overwrite the filename if the file already exists.
-                Default is False.
+                Default is False. If False and file exists, raises an IOError.
             no_antnums: Option to not write the antnums variable to the file.
                 Should only be used for testing purposes.
         """
@@ -557,7 +557,7 @@ class Miriad(UVData):
                 print('File exists: clobbering')
                 shutil.rmtree(filepath)
             else:
-                raise ValueError('File exists: skipping')
+                raise IOError('File exists: skipping')
 
         if self.Nfreqs > 1:
             freq_spacing = self.freq_array[0, 1:] - self.freq_array[0, :-1]

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -556,7 +556,7 @@ def test_readWriteReadMiriad():
     nt.assert_equal(uv_in2, uv_out)
 
     # check that trying to overwrite without clobber raises an error
-    nt.assert_raises(ValueError, uv_in.write_miriad, write_file)
+    nt.assert_raises(IOError, uv_in.write_miriad, write_file, clobber=False)
 
     # check that if x_orientation is set, it's read back out properly
     uv_in.x_orientation = 'east'

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -95,31 +95,6 @@ def test_ReadUVH5Errors():
 
 
 @uvtest.skipIf_no_h5py
-def test_WriteUVH5Errors():
-    """
-    Test raising errors in write_uvh5 function
-    """
-    uv_in = UVData()
-    uv_out = UVData()
-    uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_in.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
-    testfile = os.path.join(DATA_PATH, 'test', 'outtest_uvfits.uvh5')
-    with open(testfile, 'a'):
-        os.utime(testfile, None)
-    nt.assert_raises(ValueError, uv_in.write_uvh5, testfile)
-
-    # use clobber=True to write out anyway
-    uv_in.write_uvh5(testfile, clobber=True)
-    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
-    nt.assert_equal(uv_in, uv_out)
-
-    # clean up
-    os.remove(testfile)
-
-    return
-
-
-@uvtest.skipIf_no_h5py
 def test_UVH5OptionalParameters():
     """
     Test reading and writing optional parameters not in sample files

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -93,6 +93,32 @@ def test_ReadUVH5Errors():
 
     return
 
+@uvtest.skipIf_no_h5py
+def test_WriteUVH5Errors():
+    """
+    Test raising errors in write_uvh5 function
+    """
+    uv_in = UVData()
+    uv_out = UVData()
+    uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv_in.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
+    testfile = os.path.join(DATA_PATH, 'test', 'outtest_uvfits.uvh5')
+    with open(testfile, 'a'):
+        os.utime(testfile, None)
+
+    # no errors in function yet, but test that write w/ clobber = False doesn't raise an error
+    uv_in.write_uvh5(testfile, clobber=False)
+
+    # use clobber=True to write out anyway
+    uv_in.write_uvh5(testfile, clobber=True)
+    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
+    nt.assert_equal(uv_in, uv_out)
+
+    # clean up
+    os.remove(testfile)
+
+    return
+
 
 @uvtest.skipIf_no_h5py
 def test_UVH5OptionalParameters():
@@ -844,6 +870,9 @@ def test_UVH5InitializeFile():
     # read it in and make sure that the metadata matches the original
     partial_uvh5.read(partial_testfile, read_data=False)
     nt.assert_equal(partial_uvh5, full_uvh5)
+
+    # check that an error is not raised then when clobber == False
+    partial_uvh5.initialize_uvh5_file(partial_testfile, clobber=False)
 
     # add options for compression
     partial_uvh5.initialize_uvh5_file(partial_testfile, clobber=True, data_compression="lzf",

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -851,9 +851,6 @@ def test_UVH5InitializeFile():
     partial_uvh5.read(partial_testfile, read_data=False)
     nt.assert_equal(partial_uvh5, full_uvh5)
 
-    # check that an error is raised then file exists and clobber is False
-    nt.assert_raises(ValueError, partial_uvh5.initialize_uvh5_file, partial_testfile, clobber=False)
-
     # clean up
     os.remove(testfile)
     os.remove(partial_testfile)

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -107,8 +107,8 @@ def test_WriteUVH5Errors():
     with open(testfile, 'a'):
         os.utime(testfile, None)
 
-    # no errors in function yet, but test that write w/ clobber = False doesn't raise an error
-    uv_in.write_uvh5(testfile, clobber=False)
+    # assert IOError if file exists
+    nt.assert_raises(IOError, uv_in.write_uvh5, testfile, clobber=False)
 
     # use clobber=True to write out anyway
     uv_in.write_uvh5(testfile, clobber=True)
@@ -872,8 +872,8 @@ def test_UVH5InitializeFile():
     partial_uvh5.read(partial_testfile, read_data=False)
     nt.assert_equal(partial_uvh5, full_uvh5)
 
-    # check that an error is not raised then when clobber == False
-    partial_uvh5.initialize_uvh5_file(partial_testfile, clobber=False)
+    # check that IOError is raised then when clobber == False
+    nt.assert_raises(IOError, partial_uvh5.initialize_uvh5_file, partial_testfile, clobber=False)
 
     # add options for compression
     partial_uvh5.initialize_uvh5_file(partial_testfile, clobber=True, data_compression="lzf",

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -320,6 +320,16 @@ def test_UVH5PartialWrite():
     partial_uvh5.read(partial_testfile)
     nt.assert_equal(full_uvh5, partial_uvh5)
 
+    # test add_to_history
+    key = antpairpols[0]
+    data = full_uvh5.get_data(key, squeeze='none')
+    flags = full_uvh5.get_flags(key, squeeze='none')
+    nsamples = full_uvh5.get_nsamples(key, squeeze='none')
+    partial_uvh5.write_uvh5_part(partial_testfile, data, flags, nsamples,
+                                 bls=key, add_to_history="foo")
+    partial_uvh5.read(partial_testfile, read_data=False)
+    nt.assert_true('foo' in partial_uvh5.history)
+
     # start over, and write frequencies
     partial_uvh5 = copy.deepcopy(full_uvh5)
     partial_uvh5.data_array = None

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -93,6 +93,7 @@ def test_ReadUVH5Errors():
 
     return
 
+
 @uvtest.skipIf_no_h5py
 def test_WriteUVH5Errors():
     """

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -2186,7 +2186,7 @@ class UVData(UVBase):
     def write_uvh5_part(self, filename, data_array, flags_array, nsample_array, check_header=True,
                         antenna_nums=None, antenna_names=None, ant_str=None, bls=None,
                         frequencies=None, freq_chans=None, times=None, polarizations=None,
-                        blt_inds=None, run_check_acceptability=True):
+                        blt_inds=None, run_check_acceptability=True, add_to_history=None):
         """
         Write data to a UVH5 file that has already been initialized.
 
@@ -2237,6 +2237,7 @@ class UVData(UVBase):
                 This is not commonly used.
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters before writing the file. Default is True.
+            add_to_history: String to append to history before write out. Default is no appending.
 
         Returns:
             None
@@ -2248,7 +2249,8 @@ class UVData(UVBase):
                                  frequencies=frequencies, freq_chans=freq_chans,
                                  times=times, polarizations=polarizations,
                                  blt_inds=blt_inds,
-                                 run_check_acceptability=run_check_acceptability)
+                                 run_check_acceptability=run_check_acceptability,
+                                 add_to_history=add_to_history)
         del(uvh5_obj)
 
     def read(self, filename, file_type=None, antenna_nums=None, antenna_names=None,

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -594,7 +594,7 @@ class UVH5(UVData):
     def write_uvh5(self, filename, run_check=True, check_extra=True,
                    run_check_acceptability=True, clobber=False,
                    data_compression=None, flags_compression="lzf", nsample_compression="lzf",
-                   data_write_dtype=None):
+                   data_write_dtype=None, add_to_history=None):
         """
         Write an in-memory UVData object to a UVH5 file.
 
@@ -642,7 +642,7 @@ class UVH5(UVData):
             if clobber:
                 print("File exists; clobbering")
             else:
-                raise ValueError("File exists; skipping")
+                print("File exists; skipping")
 
         # open file for writing
         with h5py.File(filename, 'w') as f:
@@ -722,7 +722,7 @@ class UVH5(UVData):
             if clobber:
                 print("File exists; clobbering")
             else:
-                raise ValueError("File exists; skipping")
+                print("File exists; skipping")
 
         # write header and empty arrays to file
         with h5py.File(filename, 'w') as f:
@@ -806,7 +806,7 @@ class UVH5(UVData):
     def write_uvh5_part(self, filename, data_array, flags_array, nsample_array, check_header=True,
                         antenna_nums=None, antenna_names=None, ant_str=None, bls=None,
                         frequencies=None, freq_chans=None, times=None, polarizations=None,
-                        blt_inds=None, run_check_acceptability=True):
+                        blt_inds=None, run_check_acceptability=True, add_to_history=None):
         """
         Write out a part of a UVH5 file that has been previously initialized.
 
@@ -858,6 +858,7 @@ class UVH5(UVData):
             polarizations: The polarizations to include when writing data to the file.
             blt_inds: The baseline-time indices to include when writing data to the file.
                 This is not commonly used.
+            add_to_history: String to append to history before write out. Default is no appending.
 
         Returns:
             None
@@ -1021,5 +1022,13 @@ class UVH5(UVData):
                                 visdata_dset[blt_idx, :, freq_idx, pol_idx] = data_array[iblt, :, ifreq, ipol]
                             flags_dset[blt_idx, :, freq_idx, pol_idx] = flags_array[iblt, :, ifreq, ipol]
                             nsamples_dset[blt_idx, :, freq_idx, pol_idx] = nsample_array[iblt, :, ifreq, ipol]
+
+            # append to history if desired
+            if add_to_history is not None:
+                history = self.history + add_to_history
+                if 'history' in f['Header']:
+                    # erase dataset first b/c it has fixed-length string datatype
+                    del f['Header']['history']
+                f['Header']['history'] = np.string_(history)
 
         return

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -1027,7 +1027,7 @@ class UVH5(UVData):
 
             # append to history if desired
             if add_to_history is not None:
-                history = self.history + np.string_(add_to_history)
+                history = np.string_(self.history) + np.string_(add_to_history)
                 if 'history' in f['Header']:
                     # erase dataset first b/c it has fixed-length string datatype
                     del f['Header']['history']

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -606,7 +606,8 @@ class UVH5(UVData):
                 ones. Default is True.
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters before writing the file. Default is True.
-            clobber: Option to overwrite the file if it already exists. Default is False.
+            clobber: Option to overwrite the file if it already exists.
+                Default is False. If False and file exists, raises an IOError.
             data_compression: HDF5 filter to apply when writing the data_array. Default is
                  None (no filter/compression).
             flags_compression: HDF5 filter to apply when writing the flags_array. Default is
@@ -642,7 +643,7 @@ class UVH5(UVData):
             if clobber:
                 print("File exists; clobbering")
             else:
-                print("File exists; skipping")
+                raise IOError("File exists; skipping")
 
         # open file for writing
         with h5py.File(filename, 'w') as f:
@@ -684,7 +685,8 @@ class UVH5(UVData):
 
         Args:
             filename: The UVH5 file to write to.
-            clobber: Option to overwrite the file if it already exists. Default is False.
+            clobber: Option to overwrite the file if it already exists.
+                Default is False. If False and file exists, raises an IOError.
             data_compression: HDF5 filter to apply when writing the data_array. Default is
                  None (no filter/compression).
             flags_compression: HDF5 filter to apply when writing the flags_array. Default is
@@ -722,7 +724,7 @@ class UVH5(UVData):
             if clobber:
                 print("File exists; clobbering")
             else:
-                print("File exists; skipping")
+                raise IOError("File exists; skipping")
 
         # write header and empty arrays to file
         with h5py.File(filename, 'w') as f:
@@ -1025,7 +1027,7 @@ class UVH5(UVData):
 
             # append to history if desired
             if add_to_history is not None:
-                history = self.history + add_to_history
+                history = self.history + np.string_(add_to_history)
                 if 'history' in f['Header']:
                     # erase dataset first b/c it has fixed-length string datatype
                     del f['Header']['history']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A very small PR that adds ability to append to history when performing UVH5 partial writing.
Also changes a ValueError to a simple print statement when UVH5 writes to a file that already exists (i.e `clobber=False`).
This was very annoying when looping over file writes and I think was not supposed to be the intended behavior.

## Description
<!--- Describe your changes in detail -->
A very small PR that adds ability to append to history when performing UVH5 partial writing.
Also changes a ValueError to a simple print statement when UVH5 writes to a file that already exists (i.e `clobber=False`).
This was very annoying when looping over file writes and I think was not supposed to be the intended behavior.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] My change introduces new functionality that should be highlighted in the tutorial.
  - [ ] I have updated the tutorial accordingly.
- [ ] If this is a bug fix, it includes a new test that breaks as a result of the bug (if possible)
- [ ] If this is a breaking change, it includes backwards compatibility and deprecation warnings (if possible)
- [x] I have added tests to cover my changes.
- [] All new and existing tests pass in both python 2 and python 3.
- [x] My change requires an update to the [CHANGELOG](CHANGELOG.md).
  - [x] I have updated the [CHANGELOG](CHANGELOG.md) accordingly.
