### PR TITLE
combine order_pols and reorder_pols into one method

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,3 @@
 codecov:
   ci:
-    - !travis  # ignore CI builds by Travis
+    - !travis-ci  # ignore CI builds by Travis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Deprecated
+- `UVData.order_pols` method in favor of `UVData.reorder_pols`.
 
 ## [1.3.7] - 2019-04-02
 

--- a/pyuvdata/ms.py
+++ b/pyuvdata/ms.py
@@ -326,6 +326,6 @@ class MS(UVData):
         tbField.close()
         tb.close()
         # order polarizations
-        self.order_pols(pol_order)
+        self.reorder_pols(order=pol_order)
         if run_check:
             self.check(check_extra=check_extra, run_check_acceptability=run_check_acceptability)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1153,6 +1153,9 @@ def test_reorder_pols():
     # check error on unknown order
     nt.assert_raises(ValueError, uv2.reorder_pols, {'order': 'foo'})
 
+    # check error if order is an array of the wrong length
+    nt.assert_raises(ValueError, uv2.reorder_pols, {'order': [3, 2, 1]})
+
     # check warning for order_pols:
     uvtest.checkWarnings(uv2.order_pols, [], {'order': 'AIPS'},
                          message=('order_pols method will soon be deprecated in '

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1154,7 +1154,10 @@ def test_reorder_pols():
     nt.assert_raises(ValueError, uv2.reorder_pols, {'order': 'foo'})
 
     # check error if order is an array of the wrong length
-    nt.assert_raises(ValueError, uv2.reorder_pols, {'order': [3, 2, 1]})
+    with nt.assert_raises(ValueError) as cm:
+        uv2.reorder_pols(order=[3, 2, 1])
+    ex = cm.exception  # raised exception is available through exception property of context
+    nt.assert_true(ex.args[0].startswith('If order is an index array, it must'))
 
     # check warning for order_pols:
     uvtest.checkWarnings(uv2.order_pols, [], {'order': 'AIPS'},

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1151,6 +1151,12 @@ def test_reorder_pols():
     nt.assert_equal(uv1, uv2)
     nt.assert_raises(ValueError, uv2.reorder_pols, ['unknown'])
 
+    # check warning for order_pols:
+    uvtest.checkWarnings(uv2.order_pols, [], {'order': 'AIPS'},
+                         message=('order_pols method will soon be deprecated in '
+                                  'favor of reorder_pols'),
+                         category=PendingDeprecationWarning)
+
 
 def test_add():
     uv_full = UVData()

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1149,7 +1149,9 @@ def test_reorder_pols():
     uv2.reorder_pols(order='AIPS')
     # check that we have aips ordering again
     nt.assert_equal(uv1, uv2)
-    nt.assert_raises(ValueError, uv2.reorder_pols, ['unknown'])
+
+    # check error on unknown order
+    nt.assert_raises(ValueError, uv2.reorder_pols, {'order': 'foo'})
 
     # check warning for order_pols:
     uvtest.checkWarnings(uv2.order_pols, [], {'order': 'AIPS'},

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -80,31 +80,6 @@ class TestUVDataInit(object):
         """Test teardown: delete object."""
         del(self.uv_object)
 
-    def test_order_pols(self):
-        test_uv1 = UVData()
-        testfile = os.path.join(
-            DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-        uvtest.checkWarnings(test_uv1.read_uvfits, [testfile],
-                             message='Telescope EVLA is not')
-        test_uv1.order_pols(order='AIPS')
-        # check that we have aips ordering
-        aips_pols = np.array([-1, -2, -3, -4]).astype(int)
-        nt.assert_true(np.all(test_uv1.polarization_array == aips_pols))
-        test_uv2 = copy.deepcopy(test_uv1)
-        test_uv2.order_pols(order='CASA')
-        casa_pols = np.array([-1, -3, -4, -2]).astype(int)
-        nt.assert_true(np.all(test_uv2.polarization_array == casa_pols))
-        order = np.array([0, 2, 3, 1])
-        nt.assert_true(np.all(test_uv2.data_array == test_uv1.data_array[:, :, :, order]))
-        nt.assert_true(np.all(test_uv2.flag_array == test_uv1.flag_array[:, :, :, order]))
-        # check that we have casa ordering
-        test_uv2.order_pols(order='AIPS')
-        # check that we have aips ordering again
-        nt.assert_equal(test_uv1, test_uv2)
-        uvtest.checkWarnings(test_uv2.order_pols, ['unknown'], message='Invalid order supplied')
-        del(test_uv1)
-        del(test_uv2)
-
     def test_parameter_iter(self):
         "Test expected parameters."
         all = []
@@ -1156,6 +1131,25 @@ def test_reorder_pols():
     uvtest.checkWarnings(uv1.read_uvfits, [testfile], message='Telescope EVLA is not')
     uv2.reorder_pols()
     nt.assert_equal(uv1, uv2)
+
+    uv1.reorder_pols(order='AIPS')
+    # check that we have aips ordering
+    aips_pols = np.array([-1, -2, -3, -4]).astype(int)
+    nt.assert_true(np.all(uv1.polarization_array == aips_pols))
+
+    uv2 = copy.deepcopy(uv1)
+    uv2.reorder_pols(order='CASA')
+    # check that we have casa ordering
+    casa_pols = np.array([-1, -3, -4, -2]).astype(int)
+    nt.assert_true(np.all(uv2.polarization_array == casa_pols))
+    order = np.array([0, 2, 3, 1])
+    nt.assert_true(np.all(uv2.data_array == uv1.data_array[:, :, :, order]))
+    nt.assert_true(np.all(uv2.flag_array == uv1.flag_array[:, :, :, order]))
+
+    uv2.reorder_pols(order='AIPS')
+    # check that we have aips ordering again
+    nt.assert_equal(uv1, uv2)
+    nt.assert_raises(ValueError, uv2.reorder_pols, ['unknown'])
 
 
 def test_add():

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -936,6 +936,17 @@ class UVData(UVBase):
             self.check(check_extra=check_extra,
                        run_check_acceptability=run_check_acceptability)
 
+    def order_pols(self, order='AIPS'):
+        """
+        Soon to be deprecated method, now just calls reorder_pols.
+
+        Args:
+            order: string, either 'CASA' or 'AIPS'. Default='AIPS'
+        """
+        warnings.warn('order_pols method will soon be deprecated in favor of '
+                      'reorder_pols', PendingDeprecationWarning)
+        self.reorder_pols(order=order)
+
     def __add__(self, other, run_check=True, check_extra=True,
                 run_check_acceptability=True, inplace=False):
         """

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -886,8 +886,8 @@ class UVData(UVBase):
             self.phase(phase_center_ra, phase_center_dec, phase_center_epoch,
                        phase_frame=output_phase_frame)
 
-    def reorder_pols(self, order='AIPS', desired_order=None, run_check=True,
-                     check_extra=True, run_check_acceptability=True):
+    def reorder_pols(self, order='AIPS', run_check=True, check_extra=True,
+                     run_check_acceptability=True):
         """
         Rearrange polarizations in the event they are not uvfits compatible.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Combine `order_pols` and `reorder_pols` into one method that keeps the functionality of both.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
We should not have two methods to do this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change introduces new functionality that should be highlighted in the tutorial.
  - [ ] I have updated the tutorial accordingly.
- [ ] If this is a bug fix, it includes a new test that breaks as a result of the bug (if possible)
- [x] If this is a breaking change, it includes backwards compatibility and deprecation warnings (if possible)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] My change requires an update to the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
  - [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md) accordingly.
