### PR TITLE
Add method to reorder data along the blt axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `UVData.conjugate_bls` method to conjugate baselines to get the desired baseline directions.
+- `UVData.reorder_blts` method to reorder the data along the blt axis (and optionally also conjugate baselines), and a new `blt_order` optional parameter on UVData objects to track the ordering (including through read/writes).
 - `lst_array` is now saved to UVFITS files (even though it's not a standard parameter) so that it doesn't have to be recalculated
 
 ### Fixed

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -662,7 +662,7 @@ and added to the previous.
   >>> filenames = ['tutorial1.uvfits', 'tutorial2.uvfits', 'tutorial3.uvfits']
   >>> uv.read(filenames)
 
-e) Fast concatenation of files.
+e) Fast concatenation
 *******************************
 As an alternative to the ``__add__`` operation, the ``fast_concat`` method can
 be used. The user specifies a UVData object to combine with the existing one,
@@ -869,8 +869,8 @@ support comparisons between UVData objects and software access patterns.
 a) Conjugating baselines
 ************************
 
-The `conjugate_bls` method will conjugate baselines to conform to various
-conventions ('ant1<ant2', 'ant2<ant1', 'u<0', 'u>0', 'v<0', v>0') or it can just
+The :meth:`pyuvdata.UVData.conjugate_bls` method will conjugate baselines to conform to various
+conventions (`'ant1<ant2'`, `'ant2<ant1'`, `'u<0'`, `'u>0'`, `'v<0'`, `'v>0'`) or it can just
 conjugate a set of specific baseline-time indices.
 
 ::
@@ -890,9 +890,9 @@ conjugate a set of specific baseline-time indices.
 b) Sorting along the baseline-time axis
 ***************************************
 
-The `reorder_blts` method will reorder the baseline-time axis by sorting by 'time',
-'baseline', 'ant1' or 'ant2' or according to an order preferred for data that
-have baseline dependent averaging 'bda'. A user can also just specify a desired
+The :meth:`pyuvdata.UVData.reorder_blts` method will reorder the baseline-time axis by sorting by `'time'`,
+`'baseline'`, `'ant1'` or `'ant2'` or according to an order preferred for data that
+have baseline dependent averaging `'bda'`. A user can also just specify a desired
 order by passing an array of baseline-time indices.
 
 ::
@@ -927,8 +927,8 @@ order by passing an array of baseline-time indices.
 c) Sorting along the polarization axis
 **************************************
 
-The `reorder_pols` method will reorder the polarization axis either following
-the 'AIPS' or 'CASA' convention, or by an explicit index ordering set by the user.
+The :meth:`pyuvdata.UVData.reorder_pols` method will reorder the polarization axis either following
+the `'AIPS'` or `'CASA'` convention, or by an explicit index ordering set by the user.
 
 ::
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -296,7 +296,7 @@ UVData: Plotting
 Making a simple waterfall plot.
 
 Note: there is now support for reading in only part of a uvfits, uvh5 or miriad file
-(see :ref:`UVData: Working with large files`), so you need not read in the
+(see :ref:`large_files`), so you need not read in the
 entire file to plot one waterfall.
 ::
 
@@ -359,7 +359,7 @@ antenna pairs, frequencies (in Hz or by channel number), times or polarizations
 to keep in the object while removing others.
 
 Note: The same select interface is now supported on the read for uvfits, uvh5
-and miriad files (see :ref:`UVData: Working with large files`), so you need not
+and miriad files (see :ref:`large_files`), so you need not
 read in the entire file before doing the select.
 
 a) Select 3 antennas to keep using the antenna number.
@@ -699,6 +699,8 @@ stored in the uvh5 format.
    >>> filenames = ['tutorial1.uvfits', 'tutorial2.uvfits', 'tutorial3.uvfits']
    >>> uv.read(filenames, axis='freq')
 
+.. _large_files:
+
 UVData: Working with large files
 ----------------------------------------------
 To save on memory and time, pyuvdata supports reading only parts of uvfits, uvh5 and
@@ -861,6 +863,7 @@ are written to the appropriate parts of the file on disk.
 
 
 .. _sorting_data:
+
 UVData: Sorting data along various axes
 ---------------------------------------
 A few methods exist for sorting (and conjugating) data along various axes to

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -870,7 +870,7 @@ a) Conjugating baselines
 ************************
 
 The :meth:`pyuvdata.UVData.conjugate_bls` method will conjugate baselines to conform to various
-conventions (`'ant1<ant2'`, `'ant2<ant1'`, `'u<0'`, `'u>0'`, `'v<0'`, `'v>0'`) or it can just
+conventions (``'ant1<ant2'``, ``'ant2<ant1'``, ``'u<0'``, ``'u>0'``, ``'v<0'``, ``'v>0'``) or it can just
 conjugate a set of specific baseline-time indices.
 
 ::
@@ -890,9 +890,9 @@ conjugate a set of specific baseline-time indices.
 b) Sorting along the baseline-time axis
 ***************************************
 
-The :meth:`pyuvdata.UVData.reorder_blts` method will reorder the baseline-time axis by sorting by `'time'`,
-`'baseline'`, `'ant1'` or `'ant2'` or according to an order preferred for data that
-have baseline dependent averaging `'bda'`. A user can also just specify a desired
+The :meth:`pyuvdata.UVData.reorder_blts` method will reorder the baseline-time axis by sorting by ``'time'``,
+``'baseline'``, ``'ant1'`` or ``'ant2'`` or according to an order preferred for data that
+have baseline dependent averaging ``'bda'``. A user can also just specify a desired
 order by passing an array of baseline-time indices.
 
 ::
@@ -928,7 +928,7 @@ c) Sorting along the polarization axis
 **************************************
 
 The :meth:`pyuvdata.UVData.reorder_pols` method will reorder the polarization axis either following
-the `'AIPS'` or `'CASA'` convention, or by an explicit index ordering set by the user.
+the ``'AIPS'`` or ``'CASA'`` convention, or by an explicit index ordering set by the user.
 
 ::
 

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -969,7 +969,6 @@ class Miriad(UVData):
             self.x_orientation = uv['xorient'].replace('\x00', '')
         if 'bltorder' in uv.vartable.keys():
             self.blt_order = uv['bltorder'].replace('\x00', '')
-        self.conj_convention = 'ant1<ant2'
 
         return default_miriad_variables, other_miriad_variables, extra_miriad_variables
 

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -500,7 +500,7 @@ def test_miriad_extra_keywords():
     pytest.raises(TypeError, uv_in.write_miriad, testfile, clobber=True)
 
 
-def test_roundtrip_blt_order():
+def test_roundtrip_optional_params():
     uv_in = UVData()
     uv_out = UVData()
     miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
@@ -508,7 +508,16 @@ def test_roundtrip_blt_order():
     uvtest.checkWarnings(uv_in.read, [miriad_file],
                          known_warning='miriad')
 
+    uv_in.x_orientation = 'east'
     uv_in.reorder_blts()
+
+    uv_in.write_miriad(testfile, clobber=True)
+    uv_out.read(testfile)
+
+    nt.assert_equal(uv_in, uv_out)
+
+    # test with bda as well (single entry in tuple)
+    uv_in.reorder_blts(order='bda')
 
     uv_in.write_miriad(testfile, clobber=True)
     uv_out.read(testfile)

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -500,6 +500,22 @@ def test_miriad_extra_keywords():
     pytest.raises(TypeError, uv_in.write_miriad, testfile, clobber=True)
 
 
+def test_roundtrip_blt_order():
+    uv_in = UVData()
+    uv_out = UVData()
+    miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
+    testfile = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    uvtest.checkWarnings(uv_in.read, [miriad_file],
+                         known_warning='miriad')
+
+    uv_in.reorder_blts()
+
+    uv_in.write_miriad(testfile, clobber=True)
+    uv_out.read(testfile)
+
+    nt.assert_equal(uv_in, uv_out)
+
+
 def test_breakReadMiriad():
     """Test Miriad file checking."""
     uv_in = UVData()

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -873,6 +873,8 @@ def test_multi_files():
     uvtest.checkWarnings(uv_full.unphase_to_drift, category=DeprecationWarning,
                          message='The xyz array in ENU_from_ECEF is being '
                                  'interpreted as (Npts, 3)')
+    uv_full.conjugate_bls('ant1<ant2')
+
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)
     uv1.select(freq_chans=np.arange(0, 32))

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -514,7 +514,7 @@ def test_roundtrip_optional_params():
     uv_in.write_miriad(testfile, clobber=True)
     uv_out.read(testfile)
 
-    nt.assert_equal(uv_in, uv_out)
+    assert uv_in == uv_out
 
     # test with bda as well (single entry in tuple)
     uv_in.reorder_blts(order='bda')
@@ -522,7 +522,7 @@ def test_roundtrip_optional_params():
     uv_in.write_miriad(testfile, clobber=True)
     uv_out.read(testfile)
 
-    nt.assert_equal(uv_in, uv_out)
+    assert uv_in == uv_out
 
 
 def test_breakReadMiriad():

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -473,7 +473,8 @@ def test_redundancy_finder():
 
     uvd.select(times=uvd.time_array[0])
     uvd.unphase_to_drift()   # uvw_array is now equivalent to baseline positions
-    uvtest.checkWarnings(uvd._set_u_positive, message=['The default for the `center`'],
+    uvtest.checkWarnings(uvd.conjugate_bls, {'convention': 'u>0', 'use_enu': True},
+                         message=['The default for the `center`'],
                          nwarnings=1, category=DeprecationWarning)
 
     tol = 0.05  # meters

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -473,7 +473,7 @@ def test_redundancy_finder():
 
     uvd.select(times=uvd.time_array[0])
     uvd.unphase_to_drift()   # uvw_array is now equivalent to baseline positions
-    uvtest.checkWarnings(uvd.conjugate_bls, {'convention': 'u>0', 'use_enu': True},
+    uvtest.checkWarnings(uvd.conjugate_bls, func_kwargs={'convention': 'u>0', 'use_enu': True},
                          message=['The default for the `center`'],
                          nwarnings=1, category=DeprecationWarning)
 

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1773,21 +1773,31 @@ def test_fast_concat():
     # Add baselines out of order
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)
-    ant_list = list(range(15))  # Roughly half the antennas in the data
-    # All blts where ant_1 is in list
-    ind1 = [i for i in range(uv1.Nblts) if uv1.ant_1_array[i] in ant_list]
-    ind2 = [i for i in range(uv1.Nblts) if uv1.ant_1_array[i] not in ant_list]
     uv1.select(blt_inds=ind1)
     uv2.select(blt_inds=ind2)
-    uv1.fast_concat(uv2, 'blt', inplace=True)
-    assert uv2._ant_1_array != uv_full._ant_1_array
-    assert uv2._ant_2_array != uv_full._ant_2_array
-    assert uv2._uvw_array != uv_full._uvw_array
-    assert uv2._time_array != uv_full._time_array
-    assert uv2._baseline_array != uv_full._baseline_array
-    assert uv2._data_array != uv_full._data_array
+    uv2.fast_concat(uv1, 'blt', inplace=True)
+    # test freq & pol arrays equal
+    assert uv2._freq_array == uv_full._freq_array
+    assert uv2._polarization_array == uv_full._polarization_array
 
-    # TODO: should reorder blts and test that they are equal once we have a blt reordering method
+    # test Nblt length arrays not equal but same shape
+    assert uv2._ant_1_array != uv_full._ant_1_array
+    assert uv2.ant_1_array.shape == uv_full.ant_1_array.shape
+    assert uv2._ant_2_array != uv_full._ant_2_array
+    assert uv2.ant_2_array.shape == uv_full.ant_2_array.shape
+    assert uv2._uvw_array != uv_full._uvw_array
+    assert uv2.uvw_array.shape == uv_full.uvw_array.shape
+    assert uv2._time_array != uv_full._time_array
+    assert uv2.time_array.shape == uv_full.time_array.shape
+    assert uv2._baseline_array != uv_full._baseline_array
+    assert uv2.baseline_array.shape == uv_full.baseline_array.shape
+    assert uv2._data_array != uv_full._data_array
+    assert uv2.data_array.shape == uv_full.data_array.shape
+
+    # reorder blts to enable comparison
+    uv2.reorder_blts()
+    uv2.history = uv_full.history
+    assert uv2 == uv_full
 
     # add baselines such that Nants_data needs to change
     uv1 = copy.deepcopy(uv_full)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1833,6 +1833,11 @@ def test_fast_concat():
     assert uv2._data_array != uv_full._data_array
     assert uv2.data_array.shape == uv_full.data_array.shape
 
+    # reorder blts to enable comparison
+    uv2.reorder_blts()
+    uv2.history = uv_full.history
+    nt.assert_equal(uv2, uv_full)
+
     # Add multiple axes
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1269,20 +1269,18 @@ def test_conjugate_bls():
     assert(np.min(uv2.uvw_array[:, 1]) >= 0)
 
     # test errors
-    with nt.assert_raises(ValueError) as cm:
+    with pytest.raises(ValueError) as cm:
         uv2.conjugate_bls(convention='foo')
-    ex = cm.exception  # raised exception is available through exception property of context
-    assert(ex.args[0].startswith('convention must be one of'))
+    assert str(cm.value).startswith('convention must be one of')
 
-    with nt.assert_raises(ValueError) as cm:
+    with pytest.raises(ValueError) as cm:
         uv2.conjugate_bls(convention=np.arange(5) - 1)
-    ex = cm.exception  # raised exception is available through exception property of context
-    assert(ex.args[0].startswith('If convention is an index array'))
+    assert str(cm.value).startswith('If convention is an index array')
 
-    with nt.assert_raises(ValueError) as cm:
+    with pytest.raises(ValueError) as cm:
         uv2.conjugate_bls(convention=[uv2.Nblts])
-    ex = cm.exception  # raised exception is available through exception property of context
-    assert(ex.args[0].startswith('If convention is an index array'))
+
+    assert str(cm.value).startswith('If convention is an index array')
 
 
 def test_reorder_pols():
@@ -1434,40 +1432,33 @@ def test_reorder_blts():
     assert(uv2 == uv3)
 
     # test errors
-    with nt.assert_raises(ValueError) as cm:
+    with pytest.raises(ValueError) as cm:
         uv3.reorder_blts(order='foo')
-    ex = cm.exception  # raised exception is available through exception property of context
-    assert(ex.args[0].startswith('order must be one of'))
+    assert str(cm.value).startswith('order must be one of')
 
-    with nt.assert_raises(ValueError) as cm:
+    with pytest.raises(ValueError) as cm:
         uv3.reorder_blts(order=np.arange(5))
-    ex = cm.exception  # raised exception is available through exception property of context
-    assert(ex.args[0].startswith('If order is an index array, it must'))
+    assert str(cm.value).startswith('If order is an index array, it must')
 
-    with nt.assert_raises(ValueError) as cm:
+    with pytest.raises(ValueError) as cm:
         uv3.reorder_blts(order=np.arange(5, dtype=np.float))
-    ex = cm.exception  # raised exception is available through exception property of context
-    assert(ex.args[0].startswith('If order is an index array, it must'))
+    assert str(cm.value).startswith('If order is an index array, it must')
 
-    with nt.assert_raises(ValueError) as cm:
+    with pytest.raises(ValueError) as cm:
         uv3.reorder_blts(order=np.arange(uv3.Nblts), minor_order='time')
-    ex = cm.exception  # raised exception is available through exception property of context
-    assert(ex.args[0].startswith('Minor order cannot be set if order is an index array'))
+    assert str(cm.value).startswith('Minor order cannot be set if order is an index array')
 
-    with nt.assert_raises(ValueError) as cm:
+    with pytest.raises(ValueError) as cm:
         uv3.reorder_blts(order='bda', minor_order='time')
-    ex = cm.exception  # raised exception is available through exception property of context
-    assert(ex.args[0].startswith('minor_order cannot be specified if order is'))
+    assert str(cm.value).startswith('minor_order cannot be specified if order is')
 
-    with nt.assert_raises(ValueError) as cm:
+    with pytest.raises(ValueError) as cm:
         uv3.reorder_blts(order='baseline', minor_order='ant1')
-    ex = cm.exception  # raised exception is available through exception property of context
-    assert(ex.args[0].startswith('minor_order conflicts with order'))
+    assert str(cm.value).startswith('minor_order conflicts with order')
 
-    with nt.assert_raises(ValueError) as cm:
+    with pytest.raises(ValueError) as cm:
         uv3.reorder_blts(order='time', minor_order='foo')
-    ex = cm.exception  # raised exception is available through exception property of context
-    assert(ex.args[0].startswith('minor_order can only be one of'))
+    assert str(cm.value).startswith('minor_order can only be one of')
 
 
 def test_add():
@@ -2049,7 +2040,7 @@ def test_fast_concat():
 
     # reorder blts to enable comparison
     uv2.reorder_blts()
-    nt.assert_equal(uv2.blt_order, ('time', 'baseline'))
+    assert uv2.blt_order == ('time', 'baseline')
     uv2.blt_order = None
     uv2.history = uv_full.history
     assert uv2 == uv_full
@@ -2090,10 +2081,10 @@ def test_fast_concat():
 
     # reorder blts to enable comparison
     uv2.reorder_blts()
-    nt.assert_equal(uv2.blt_order, ('time', 'baseline'))
+    assert uv2.blt_order == ('time', 'baseline')
     uv2.blt_order = None
     uv2.history = uv_full.history
-    nt.assert_equal(uv2, uv_full)
+    assert uv2 == uv_full
 
     # Add multiple axes
     uv1 = copy.deepcopy(uv_full)
@@ -3393,7 +3384,7 @@ def test_redundancy_contract_expand():
     tol = 0.02   # Fails at lower precision because some baselines falling into multiple redundant groups
 
     # Assign identical data to each redundant group:
-    uvtest.checkWarnings(uv0.conjugate_bls, {'convention': 'u>0', 'use_enu': True},
+    uvtest.checkWarnings(uv0.conjugate_bls, func_kwargs={'convention': 'u>0', 'use_enu': True},
                          message=['The default for the `center`'],
                          nwarnings=1, category=DeprecationWarning)
     red_gps, centers, lengths = uv0.get_antenna_redundancies(tol=tol)
@@ -3426,7 +3417,7 @@ def test_redundancy_contract_expand():
     uv2.reorder_blts()
     uv2._uvw_array.tols = [0, tol]
 
-    nt.assert_equal(uv2, uv0)
+    assert uv2 == uv0
 
     uv3 = uv2.compress_by_redundancy(tol=tol, inplace=False)
     uvtest.checkWarnings(
@@ -3450,7 +3441,7 @@ def test_compress_redundancy_metadata_only():
     tol = 0.01
 
     # Assign identical data to each redundant group:
-    uvtest.checkWarnings(uv0.conjugate_bls, {'convention': 'u>0', 'use_enu': True},
+    uvtest.checkWarnings(uv0.conjugate_bls, func_kwargs={'convention': 'u>0', 'use_enu': True},
                          message=['The default for the `center`'],
                          nwarnings=1, category=DeprecationWarning)
     red_gps, centers, lengths = uv0.get_antenna_redundancies(tol=tol)
@@ -3514,7 +3505,7 @@ def test_quick_redundant_vs_redundant_test_array():
     uv.read_uvfits(os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'))
     uv.select(times=uv.time_array[0])
     uv.unphase_to_drift()
-    uvtest.checkWarnings(uv.conjugate_bls, {'convention': 'u>0', 'use_enu': True},
+    uvtest.checkWarnings(uv.conjugate_bls, func_kwargs={'convention': 'u>0', 'use_enu': True},
                          message=['The default for the `center`'],
                          nwarnings=1, category=DeprecationWarning)
     tol = 0.05
@@ -3553,7 +3544,7 @@ def test_redundancy_finder_when_nblts_not_nbls_times_ntimes():
     uv = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     uvtest.checkWarnings(uv.read_uvfits, [testfile], message='Telescope EVLA is not')
-    uvtest.checkWarnings(uv.conjugate_bls, {'convention': 'u>0', 'use_enu': True},
+    uvtest.checkWarnings(uv.conjugate_bls, func_kwargs={'convention': 'u>0', 'use_enu': True},
                          message=['The default for the `center`'],
                          nwarnings=1, category=DeprecationWarning)
     # check that Nblts != Nbls * Ntimes

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -54,13 +54,14 @@ def uvdata_props():
 
     extra_parameters = ['_extra_keywords', '_antenna_positions',
                         '_x_orientation', '_antenna_diameters',
+                        '_blt_order',
                         '_gst0', '_rdate', '_earth_omega', '_dut1',
                         '_timesys', '_uvplane_reference_time',
                         '_phase_center_ra', '_phase_center_dec',
                         '_phase_center_epoch', '_phase_center_frame']
 
     extra_properties = ['extra_keywords', 'antenna_positions',
-                        'x_orientation', 'antenna_diameters', 'gst0',
+                        'x_orientation', 'antenna_diameters', 'blt_order', 'gst0',
                         'rdate', 'earth_omega', 'dut1', 'timesys',
                         'uvplane_reference_time',
                         'phase_center_ra', 'phase_center_dec',
@@ -1796,6 +1797,8 @@ def test_fast_concat():
 
     # reorder blts to enable comparison
     uv2.reorder_blts()
+    nt.assert_equal(uv2.blt_order, ('time', 'baseline'))
+    uv2.blt_order = None
     uv2.history = uv_full.history
     assert uv2 == uv_full
 
@@ -1835,6 +1838,8 @@ def test_fast_concat():
 
     # reorder blts to enable comparison
     uv2.reorder_blts()
+    nt.assert_equal(uv2.blt_order, ('time', 'baseline'))
+    uv2.blt_order = None
     uv2.history = uv_full.history
     nt.assert_equal(uv2, uv_full)
 

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1424,7 +1424,7 @@ def test_reorder_blts():
     assert(np.min(np.diff(uv3.ant_2_array)) >= 0)
 
     uv3.reorder_blts(order='bda')
-    assert(uv3.blt_order == ('bda'))
+    assert(uv3.blt_order == ('bda',))
     assert(np.min(np.diff(uv3.integration_time)) >= 0)
     assert(np.min(np.diff(uv3.baseline_array)) >= 0)
 

--- a/pyuvdata/tests/test_uvfits.py
+++ b/pyuvdata/tests/test_uvfits.py
@@ -398,6 +398,13 @@ def test_roundtrip_blt_order():
     uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
     nt.assert_equal(uv_in, uv_out)
 
+    # test with bda as well (single entry in tuple)
+    uv_in.reorder_blts(order='bda')
+
+    uv_in.write_uvfits(write_file)
+    uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
+    nt.assert_equal(uv_in, uv_out)
+
 
 def test_select_read():
     uvfits_uv = UVData()

--- a/pyuvdata/tests/test_uvfits.py
+++ b/pyuvdata/tests/test_uvfits.py
@@ -385,6 +385,20 @@ def test_extra_keywords():
     assert uv_in == uv_out
 
 
+def test_roundtrip_blt_order():
+    uv_in = UVData()
+    uv_out = UVData()
+    testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    write_file = os.path.join(DATA_PATH, 'test/outtest_casa.uvfits')
+    uvtest.checkWarnings(uv_in.read, [testfile], message='Telescope EVLA is not')
+
+    uv_in.reorder_blts()
+
+    uv_in.write_uvfits(write_file)
+    uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
+    nt.assert_equal(uv_in, uv_out)
+
+
 def test_select_read():
     uvfits_uv = UVData()
     uvfits_uv2 = UVData()

--- a/pyuvdata/tests/test_uvfits.py
+++ b/pyuvdata/tests/test_uvfits.py
@@ -396,14 +396,14 @@ def test_roundtrip_blt_order():
 
     uv_in.write_uvfits(write_file)
     uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
-    nt.assert_equal(uv_in, uv_out)
+    assert uv_in == uv_out
 
     # test with bda as well (single entry in tuple)
     uv_in.reorder_blts(order='bda')
 
     uv_in.write_uvfits(write_file)
     uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
-    nt.assert_equal(uv_in, uv_out)
+    assert uv_in == uv_out
 
 
 def test_select_read():

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -145,6 +145,13 @@ def test_UVH5OptionalParameters():
     uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
     assert uv_in == uv_out
 
+    # test with blt_order = bda as well (single entry in tuple)
+    uv_in.reorder_blts(order='bda')
+
+    uv_in.write_uvh5(testfile, clobber=True)
+    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
+    nt.assert_equal(uv_in, uv_out)
+
     # clean up
     os.remove(testfile)
 

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -150,7 +150,7 @@ def test_UVH5OptionalParameters():
 
     uv_in.write_uvh5(testfile, clobber=True)
     uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
-    nt.assert_equal(uv_in, uv_out)
+    assert uv_in == uv_out
 
     # clean up
     os.remove(testfile)

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -137,6 +137,9 @@ def test_UVH5OptionalParameters():
     uv_in.antenna_diameters = np.ones_like(uv_in.antenna_numbers) * 1.
     uv_in.uvplane_reference_time = 0
 
+    # reorder_blts
+    uv_in.reorder_blts()
+
     # write out and read back in
     uv_in.write_uvh5(testfile, clobber=True)
     uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -269,7 +269,7 @@ class UVBase(object):
                                              ' type. Is: ' + str(type(param.value))
                                              + '. Should be: ' + str(param.expected_type))
                     else:
-                        if isinstance(param.value, list):
+                        if isinstance(param.value, (list, tuple)):
                             # List needs to be handled differently than array
                             # list values may be different types, so they all need to be checked
                             for item in param.value:

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -270,13 +270,14 @@ class UVBase(object):
                                              + '. Should be: ' + str(param.expected_type))
                     else:
                         if isinstance(param.value, (list, tuple)):
-                            # List needs to be handled differently than array
+                            # List & tuples needs to be handled differently than array
                             # list values may be different types, so they all need to be checked
-                            for item in param.value:
+                            param_value_list = list(param.value)
+                            for item in param_value_list:
                                 if not isinstance(item, param.expected_type):
                                     raise ValueError('UVParameter ' + p + ' is not the'
                                                      ' appropriate type. Is: '
-                                                     + str(type(param.value[0])) + '. Should'
+                                                     + str(type(item)) + '. Should'
                                                      ' be: ' + str(param.expected_type))
                         else:
                             # Array

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1163,8 +1163,8 @@ class UVData(UVBase):
 
         if isinstance(order, str):
             if minor_order is None:
-                self.blt_order = (order)
-                self._blt_order.form = ()
+                self.blt_order = (order,)
+                self._blt_order.form = (1,)
             else:
                 self.blt_order = (order, minor_order)
                 # set it back to the right shape in case it was set differently before

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1038,29 +1038,31 @@ class UVData(UVBase):
                 raise ValueError("ant_order can only be one of: 'ant1', 'ant2'")
 
         if not isinstance(order, np.ndarray):
-            # create tuples for sorting
+            # Use lexsort to sort along different arrays in defined order.
+            # lexsort uses the listed arrays from last to first (so the primary sort is on the last one)
             if order == 'time':
                 if minor_order == 'ant1':
-                    sort_tuple = zip(self.time_array, self.ant_1_array, self.ant_2_array)
+                    index_array = np.lexsort((self.ant_2_array, self.ant_1_array, self.time_array))
                 elif minor_order == 'ant2':
-                    sort_tuple = zip(self.time_array, self.ant_2_array, self.ant_1_array)
+                    index_array = np.lexsort((self.ant_1_array, self.ant_2_array, self.time_array))
                 else:
-                    sort_tuple = zip(self.time_array, self.baseline_array)
+                    index_array = np.lexsort((self.baseline_array, self.time_array))
             elif order == 'ant1':
-                sort_tuple = zip(self.ant_1_array, self.ant_2_array, self.time_array)
+                index_array = np.lexsort((self.time_array, self.ant_1_array, self.ant_2_array))
             elif order == 'ant2':
-                sort_tuple = zip(self.ant_2_array, self.ant_1_array, self.time_array)
+                index_array = np.lexsort((self.time_array, self.ant_2_array, self.ant_1_array))
             elif order == 'baseline':
-                sort_tuple = zip(self.baseline_array, self.time_array)
+                index_array = np.lexsort((self.time_array, self.baseline_array))
             elif order == 'bda':
-                # Paul needs to write this part
+                # TODO: Paul needs to write this part
+                pass
 
-            index_array = np.argsort(sort_tuple)
         else:
             index_array = order
 
         if ant_order is not None:
-            # call method to do conjugations
+            # TODO: call method to do conjugations
+            pass
 
         # actually do the reordering
         self.ant_1_array = self.ant_1_array[index_array]

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -974,7 +974,7 @@ class UVData(UVBase):
                       'reorder_pols in version 1.5', DeprecationWarning)
         self.reorder_pols(order=order)
 
-    def reorder_blts(self, order='time', minor_order=None, ant_order=None,
+    def reorder_blts(self, order='time', minor_order=None, bl_ant_order=None,
                      run_check=True, check_extra=True,
                      run_check_acceptability=True):
         """
@@ -985,14 +985,14 @@ class UVData(UVBase):
                 Options are: 'time', 'baseline', 'ant1', 'ant2', 'bda' or an
                 index array of length Nblts that specifies the new order.
             minor_order(str): Optionally specify a secondary ordering. Default
-                depends on how order is set, if order is 'time', this defaults
+                depends on how order is set: if order is 'time', this defaults
                 to 'baseline', if order is 'ant1', or 'ant2' this defaults to
                 the other antenna, if order is 'baseline' the only allowed value
                 is 'time'. If this is the same as order, it is reset to the default.
-            ant_order(str): Optionally conjugate baselines to make the baselines
+            bl_ant_order(str): Optionally conjugate baselines to make the baselines
                 have the desired orientation. This will fail if only one of the
                 cross pols is present (because conjugation requires changing the
-                polarization number for cross pols)
+                polarization number for cross pols).
                 Options are: 'ant1' (meaning orient baselines so ant1>ant2), or
                 'ant2' (meaning orient baselines so ant2>ant1)
             run_check: Option to check for the existence and proper shapes of
@@ -1035,9 +1035,9 @@ class UVData(UVBase):
             elif order == 'ant2':
                 minor_order = 'ant1'
 
-        if ant_order is not None:
-            if ant_order not in ['ant1', 'ant2']:
-                raise ValueError("ant_order can only be one of: 'ant1', 'ant2'")
+        if bl_ant_order is not None:
+            if bl_ant_order not in ['ant1', 'ant2']:
+                raise ValueError("bl_ant_order can only be one of: 'ant1', 'ant2'")
 
         if not isinstance(order, np.ndarray):
             # Use lexsort to sort along different arrays in defined order.
@@ -1073,7 +1073,7 @@ class UVData(UVBase):
         else:
             index_array = order
 
-        if ant_order is not None:
+        if bl_ant_order is not None:
             # TODO: call method to do conjugations
             pass
 

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -561,6 +561,98 @@ class UVData(UVBase):
         """
         return uvutils.antnums_to_baseline(ant1, ant2, self.Nants_telescope, attempt256=attempt256)
 
+    def order_blts(self, order='time', minor_order=None, ant_order=None):
+        """
+        Arrange blt axis according to desired order. Optionally conjugate according to ant_order.
+
+        Args:
+            order (str): A string describing the desired order along the blt axis.
+                Options are: 'time', 'baseline', 'ant1', 'ant2', 'bda' or an
+                index array of length Nblts that specifies the new order.
+            minor_order(str): Optionally specify a secondary ordering. Default
+                depends on how order is set, if order is 'time', this defaults
+                to 'baseline', if order is 'baseline', 'ant1', or 'ant2' this
+                defaults to 'time'. If this is the same as order, it is reset
+                to the default.
+            ant_order(str): Optionally conjugate baselines to make the baselines
+                have the desired orientation. This will fail if only one of the
+                cross pols is present (because conjugation requires changing the
+                polarization number for cross pols)
+                Options are: 'ant1' (meaning orient baselines so ant1>ant2), or
+                'ant2' (meaning orient baselines so ant2>ant1)
+        """
+        if order not in ['time', 'baseline', 'ant1', 'ant2', 'bda']:
+            if isinstance(order, (np.ndarray, list, tuple)):
+                order = np.array(order)
+                if (order.size != self.Nblts
+                        or order.dtype not in [int, np.int, np.int32, np.int64]):
+                    raise ValueError('If order is an index array, it must '
+                                     'contain integers and be length Nblts.')
+            else:
+                raise ValueError("order must be one of 'time', 'baseline', "
+                                 "'ant1', 'ant2', 'bda' or an index array of "
+                                 "length Nblts")
+
+        if minor_order == order:
+            minor_order = None
+
+        if minor_order is not None:
+            if minor_order not in ['time', 'baseline', 'ant1', 'ant2']:
+                raise ValueError("minor_order can only be one of 'time', "
+                                 "'baseline', 'ant1', 'ant2'")
+            if isinstance(order, np.ndarray) or order == 'bda':
+                raise ValueError("minor_order cannot be specified if order is "
+                                 "'bda' or an index array.")
+            if order in ['baseline', 'ant1', 'ant2']:
+                if minor_order in ['baseline', 'ant1', 'ant2']:
+                    raise ValueError('minor_order conflicts with order')
+        else:
+            if order == 'time':
+                minor_order = 'baseline'
+            elif order in ['baseline', 'ant1', 'ant2']:
+                minor_order = 'time'
+
+        if ant_order is not None:
+            if ant_order not in ['ant1', 'ant2']:
+                raise ValueError("ant_order can only be one of: 'ant1', 'ant2'")
+
+        if not isinstance(order, np.ndarray):
+            # create tuples for sorting
+            if order == 'time':
+                if minor_order == 'ant1':
+                    sort_tuple = zip(self.time_array, self.ant_1_array, self.ant_2_array)
+                elif minor_order == 'ant2':
+                    sort_tuple = zip(self.time_array, self.ant_2_array, self.ant_1_array)
+                else:
+                    sort_tuple = zip(self.time_array, self.baseline_array)
+            elif order == 'ant1':
+                sort_tuple = zip(self.ant_1_array, self.ant_2_array, self.time_array)
+            elif order == 'ant2':
+                sort_tuple = zip(self.ant_2_array, self.ant_1_array, self.time_array)
+            elif order == 'baseline':
+                sort_tuple = zip(self.baseline_array, self.time_array)
+            elif order == 'bda':
+                # Paul needs to write this part
+
+            index_array = np.argsort(sort_tuple)
+        else:
+            index_array = order
+
+        if ant_order is not None:
+            # call method to do conjugations
+
+        # actually do the reordering
+        self.ant_1_array = self.ant_1_array[index_array]
+        self.ant_2_array = self.ant_2_array[index_array]
+        self.baseline_array = self.baseline_array[index_array]
+        self.uvw_array = self.uvw_array[index_array, :]
+        self.time_array = self.time_array[index_array]
+        self.lst_array = self.lst_array[index_array]
+        self.integration_time = self.integration_time[index_array]
+        self.data_array = self.data_array[index_array, :, :, :]
+        self.flag_array = self.flag_array[index_array, :, :, :]
+        self.nsample_array = self.nsample_array[index_array, :, :, :]
+
     def set_lsts_from_time_array(self):
         """Set the lst_array based from the time_array."""
         latitude, longitude, altitude = self.telescope_location_lat_lon_alt_degrees

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -354,7 +354,6 @@ class UVFITS(UVData):
             altitude = vis_hdr.pop('ALT', None)
             self.x_orientation = vis_hdr.pop('XORIENT', None)
             self.blt_order = vis_hdr.pop('BLTORDER', None)
-            self.conj_convention = vis_hdr.pop('CONJCONV', None)
             self.history = str(vis_hdr.get('HISTORY', ''))
             if not uvutils._check_history_version(self.history, self.pyuvdata_version_str):
                 self.history += self.pyuvdata_version_str
@@ -809,9 +808,6 @@ class UVFITS(UVData):
 
         if self.blt_order is not None:
             hdu.header['BLTORDER'] = self.blt_order
-
-        if self.conj_convention is not None:
-            hdu.header['CONJCONV'] = self.conj_convention
 
         for line in self.history.splitlines():
             hdu.header.add_history(line)

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -353,7 +353,11 @@ class UVFITS(UVData):
             longitude_degrees = vis_hdr.pop('LON', None)
             altitude = vis_hdr.pop('ALT', None)
             self.x_orientation = vis_hdr.pop('XORIENT', None)
-            self.blt_order = vis_hdr.pop('BLTORDER', None)
+            blt_order_str = vis_hdr.pop('BLTORDER', None)
+            if blt_order_str is not None:
+                self.blt_order = tuple(blt_order_str.split(', '))
+                if self.blt_order == ('bda',):
+                    self._blt_order.form = (1,)
             self.history = str(vis_hdr.get('HISTORY', ''))
             if not uvutils._check_history_version(self.history, self.pyuvdata_version_str):
                 self.history += self.pyuvdata_version_str
@@ -807,7 +811,8 @@ class UVFITS(UVData):
             hdu.header['XORIENT'] = self.x_orientation
 
         if self.blt_order is not None:
-            hdu.header['BLTORDER'] = self.blt_order
+            blt_order_str = ', '.join(self.blt_order)
+            hdu.header['BLTORDER'] = blt_order_str
 
         for line in self.history.splitlines():
             hdu.header.add_history(line)

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -353,6 +353,8 @@ class UVFITS(UVData):
             longitude_degrees = vis_hdr.pop('LON', None)
             altitude = vis_hdr.pop('ALT', None)
             self.x_orientation = vis_hdr.pop('XORIENT', None)
+            self.blt_order = vis_hdr.pop('BLTORDER', None)
+            self.conj_convention = vis_hdr.pop('CONJCONV', None)
             self.history = str(vis_hdr.get('HISTORY', ''))
             if not uvutils._check_history_version(self.history, self.pyuvdata_version_str):
                 self.history += self.pyuvdata_version_str
@@ -804,6 +806,12 @@ class UVFITS(UVData):
 
         if self.x_orientation is not None:
             hdu.header['XORIENT'] = self.x_orientation
+
+        if self.blt_order is not None:
+            hdu.header['BLTORDER'] = self.blt_order
+
+        if self.conj_convention is not None:
+            hdu.header['CONJCONV'] = self.conj_convention
 
         for line in self.history.splitlines():
             hdu.header.add_history(line)

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -192,6 +192,10 @@ class UVH5(UVData):
             self.timesys = _read_uvh5_string(header['timesys'], filename)
         if 'x_orientation' in header:
             self.x_orientation = _read_uvh5_string(header['x_orientation'], filename)
+        if 'blt_order' in header:
+            self.blt_order = _read_uvh5_string(header['blt_order'], filename)
+        if 'conj_convention' in header:
+            self.conj_convention = _read_uvh5_string(header['conj_convention'], filename)
         if 'antenna_diameters' in header:
             self.antenna_diameters = header['antenna_diameters'][()]
         if 'uvplane_reference_time' in header:
@@ -575,6 +579,10 @@ class UVH5(UVData):
             header['timesys'] = np.string_(self.timesys)
         if self.x_orientation is not None:
             header['x_orientation'] = np.string_(self.x_orientation)
+        if self.blt_order is not None:
+            header['blt_order'] = np.string_(self.blt_order)
+        if self.conj_convention is not None:
+            header['conj_convention'] = np.string_(self.conj_convention)
         if self.antenna_diameters is not None:
             header['antenna_diameters'] = self.antenna_diameters
         if self.uvplane_reference_time is not None:

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -194,8 +194,6 @@ class UVH5(UVData):
             self.x_orientation = _read_uvh5_string(header['x_orientation'], filename)
         if 'blt_order' in header:
             self.blt_order = _read_uvh5_string(header['blt_order'], filename)
-        if 'conj_convention' in header:
-            self.conj_convention = _read_uvh5_string(header['conj_convention'], filename)
         if 'antenna_diameters' in header:
             self.antenna_diameters = header['antenna_diameters'][()]
         if 'uvplane_reference_time' in header:
@@ -581,8 +579,6 @@ class UVH5(UVData):
             header['x_orientation'] = np.string_(self.x_orientation)
         if self.blt_order is not None:
             header['blt_order'] = np.string_(self.blt_order)
-        if self.conj_convention is not None:
-            header['conj_convention'] = np.string_(self.conj_convention)
         if self.antenna_diameters is not None:
             header['antenna_diameters'] = self.antenna_diameters
         if self.uvplane_reference_time is not None:

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -193,7 +193,11 @@ class UVH5(UVData):
         if 'x_orientation' in header:
             self.x_orientation = _read_uvh5_string(header['x_orientation'], filename)
         if 'blt_order' in header:
-            self.blt_order = _read_uvh5_string(header['blt_order'], filename)
+            blt_order_str = _read_uvh5_string(header['blt_order'], filename)
+            self.blt_order = tuple(blt_order_str.split(', '))
+            if self.blt_order == ('bda',):
+                self._blt_order.form = (1,)
+
         if 'antenna_diameters' in header:
             self.antenna_diameters = header['antenna_diameters'][()]
         if 'uvplane_reference_time' in header:
@@ -578,7 +582,7 @@ class UVH5(UVData):
         if self.x_orientation is not None:
             header['x_orientation'] = np.string_(self.x_orientation)
         if self.blt_order is not None:
-            header['blt_order'] = np.string_(self.blt_order)
+            header['blt_order'] = np.string_(', '.join(self.blt_order))
         if self.antenna_diameters is not None:
             header['antenna_diameters'] = self.antenna_diameters
         if self.uvplane_reference_time is not None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add two new methods:
- `UVData.conjugate_bls` to conjugate baselines to get the desired baseline directions
- `UVData.reorder_blts` to reorder the data along the blt axis (and optionally also conjugate baselines), which is needed for several different use cases.
- Also added support in read/write for a new `blt_order` optional parameter that can keep track of how the blt axis is ordered.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #427 
closes #502

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
