### PR TITLE
UVBeam interpolation spline reuse fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Changed the way interpolation splines are saved in UVBeam to fix errors related to polarization selections.
+
 ## [1.3.8] - 2019-05-01
 
 ### Added
@@ -18,7 +21,6 @@ All notable changes to this project will be documented in this file.
 - `UVData.order_pols` method in favor of `UVData.reorder_pols`.
 
 ### Fixed
-- Changed the way interpolation splines are saved in UVBeam to fix errors related to polarization selections.
 - Building pyuvdata on macOS now targets minimum macOS 10.9 if run on macOS 10.9 or above
 - Possible bug where `check_variables` dictionary can change size during `read_miriad` call
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - `UVData.order_pols` method in favor of `UVData.reorder_pols`.
 
 ### Fixed
+- Changed the way interpolation splines are saved in UVBeam to fix errors related to polarization selections.
 - Building pyuvdata on macOS now targets minimum macOS 10.9 if run on macOS 10.9 or above
 - Possible bug where `check_variables` dictionary can change size during `read_miriad` call
 

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -490,28 +490,29 @@ def test_redundancy_finder():
             bl_vec = bl_positions[bl_ind]
             nt.assert_true(np.allclose(np.sqrt(np.dot(bl_vec, vec_bin_centers[gi])), lens[gi], atol=tol))
 
-    # Now jostle the baselines around by up to 0.25m and see if we can recover the same redundancies to that tolerance.
+    # Now jostle the baselines around by 25cm and see if we can recover the same redundancies to that tolerance.
     tol = 0.25  # meters. Less than the smallest baseline in the file.
     Nbls = uvd.Nbls
-    shift_dists = np.random.uniform(low=0.0, high=tol / 2., size=Nbls)
-    shift_angs = np.random.uniform(low=0.0, high=2 * np.pi, size=Nbls)
-    shift_vecs = np.stack((shift_dists * np.cos(shift_angs), shift_dists * np.sin(shift_angs), np.zeros(Nbls))).T
+    Ntrials = 50
+    for i in range(Ntrials):
+        shift_dists = np.random.uniform(low=0.0, high=tol / 2.1, size=Nbls)
+        shift_angs = np.random.uniform(low=0.0, high=2 * np.pi, size=Nbls)
+        shift_vecs = np.stack((shift_dists * np.cos(shift_angs), shift_dists * np.sin(shift_angs), np.zeros(Nbls))).T
 
-    bl_positions_new = uvd.uvw_array + shift_vecs
+        bl_positions_new = uvd.uvw_array + shift_vecs
 
-    baseline_groups_new, vec_bin_centers, lens = uvutils.get_baseline_redundancies(uvd.baseline_array, bl_positions_new, tol=tol)
+        baseline_groups_new, vec_bin_centers, lens = uvutils.get_baseline_redundancies(uvd.baseline_array, bl_positions_new, tol=tol)
 
-    for gi, gp in enumerate(baseline_groups_new):
-        for bl in gp:
-            bl_ind = np.where(uvd.baseline_array == bl)
-            bl_vec = bl_positions[bl_ind]
-            nt.assert_true(np.allclose(np.sqrt(np.abs(np.dot(bl_vec, vec_bin_centers[gi]))), lens[gi], atol=tol))
+        for gi, gp in enumerate(baseline_groups_new):
+            for bl in gp:
+                bl_ind = np.where(uvd.baseline_array == bl)
+                bl_vec = bl_positions[bl_ind]
+                nt.assert_true(np.allclose(np.sqrt(np.abs(np.dot(bl_vec, vec_bin_centers[gi]))), lens[gi], atol=tol))
 
-    # Compare baseline groups:
-    for c, blg in enumerate(baseline_groups):
-        bl = blg[0]
-        ind = np.sum(np.where([bl in gp for gp in baseline_groups_new]))
-        nt.assert_equal(baseline_groups_new[ind], blg)
+        # Compare baseline groups:
+        a = [tuple(el) for el in baseline_groups]
+        b = [tuple(el) for el in baseline_groups_new]
+        nt.assert_equal(set(a), set(b))
 
     tol = 0.05
 

--- a/pyuvdata/tests/test_uvbeam.py
+++ b/pyuvdata/tests/test_uvbeam.py
@@ -427,7 +427,7 @@ def test_power_spatial_interpolation():
     power_beam = UVBeam()
     power_beam.read_cst_beam(cst_files, beam_type='power', frequency=[150e6, 123e6],
                              telescope_name='TEST', feed_name='bob',
-                             feed_version='0.1', feed_pol=['x','y'],
+                             feed_version='0.1', feed_pol=['x', 'y'],
                              model_name='E-field pattern - Rigging height 4.9m',
                              model_version='1.0')
 
@@ -506,6 +506,7 @@ def test_power_spatial_interpolation():
     nt.assert_raises(ValueError, power_beam.interp, az_array=az_interp_vals, za_array=za_interp_vals,
                      polarizations=['pI'])
 
+
 def test_efield_spatial_interpolation():
     efield_beam = UVBeam()
     efield_beam.read_cst_beam(cst_files, beam_type='efield', frequency=[150e6, 123e6],
@@ -540,7 +541,6 @@ def test_efield_spatial_interpolation():
     interp_data_array, interp_basis_vector = efield_beam.interp(az_array=az_interp_vals,
                                                                 za_array=za_interp_vals,
                                                                 freq_array=freq_interp_vals)
-
 
     # test reusing the spline fit
     orig_data_array, interp_basis_vector = efield_beam.interp(az_array=az_interp_vals,

--- a/pyuvdata/uvbeam.py
+++ b/pyuvdata/uvbeam.py
@@ -944,10 +944,6 @@ class UVBeam(UVBase):
                             if key in self.saved_interp_functions.keys():
                                 do_interp = False
                                 lut = self.saved_interp_functions[key]
-                                if lut is None:
-                                    do_interp = True
-                            else:
-                                self.saved_interp_functions[key] = None
 
                         if do_interp:
                             if np.iscomplexobj(input_data_array):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The way UVBeam was storing interpolation splines for reuse had several flaws that came up when trying to use `reuse_splines` while calling `interp` with specified polarizations.

## Description
<!--- Describe your changes in detail -->
The `saved_interp_functions` attribute is now simply a dictionary of functions, where each key specifies a single polarization (or feed), frequency, efield component, and spectral window.
I've also split the spatial interpolation test function into two (one for power, one for efield).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Originally, the `saved_interp_functions` dictionary had frequencies as keys, and each entry had a shape `(Naxes_vec, Nspws, Npols or Nfeeds`. This was fine if you ran `interp` without passing in a list of `polarizations`. However, if you passed in a specific polarization and then, on a subsequent call, requested a different polarization at the same frequency, the saved_interp_function entry for that frequency wouldn't have an entry for that polarization. The function would not carry out interpolation for the new polarization/feed.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change introduces new functionality that should be highlighted in the tutorial.
  - [ ] I have updated the tutorial accordingly.
- [x] If this is a bug fix, it includes a new test that breaks as a result of the bug (if possible)
- [ ] If this is a breaking change, it includes backwards compatibility and deprecation warnings (if possible)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] My change requires an update to the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
  - [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md) accordingly.
