### PR TITLE
fix install for mac osx > 10.9, based on pandas fix for the same

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,6 @@ jobs:
           name: install related repos
           command: |
             source activate ${ENV_NAME}
-            pip install cached_property
             pip install .
             pip install git+https://github.com/HERA-Team/linsolve.git
             pip install git+https://github.com/HERA-Team/hera_qm.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,7 @@ jobs:
           name: install related repos
           command: |
             source activate ${ENV_NAME}
+            pip install cached_property
             pip install .
             pip install git+https://github.com/HERA-Team/linsolve.git
             pip install git+https://github.com/HERA-Team/hera_qm.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,7 @@ jobs:
             pip install git+https://github.com/HERA-Team/linsolve.git
             pip install git+https://github.com/HERA-Team/hera_qm.git
             pip install git+https://github.com/HERA-Team/uvtools.git
+            pip install git+https://github.com/HERA-Team/hera_sim.git
       - run:
           name: run hera_cal tests
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Possible bug where `check_variables` dictionary can change size during `read_miriad` call
+- Building pyuvdata on macOS now targets minimum macOS 10.9 if run on macOS 10.9 or above
+
 
 ## [1.3.7] - 2019-04-02
 

--- a/ci/hera_cal.yml
+++ b/ci/hera_cal.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - aipy
   - astropy
+  - cached-property
   - h5py
   - healpy
   - matplotlib

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,10 @@ from setuptools import setup, Extension
 import glob
 import os
 import io
+import sys
+import platform
+from distutils.sysconfig import get_config_var
+from distutils.version import LooseVersion
 import numpy as np
 import json
 
@@ -23,6 +27,23 @@ with open(os.path.join('pyuvdata', 'GIT_INFO'), 'w') as outfile:
 with io.open('README.md', 'r', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
+
+def is_platform_mac():
+    return sys.platform == 'darwin'
+
+
+# For mac, ensure extensions are built for macos 10.9 when compiling on a
+# 10.9 system or above, overriding distuitls behaviour which is to target
+# the version that python was built for. This may be overridden by setting
+# MACOSX_DEPLOYMENT_TARGET before calling setup.py
+# implementation based on pandas, see https://github.com/pandas-dev/pandas/issues/23424
+if is_platform_mac():
+    if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
+        current_system = LooseVersion(platform.mac_ver()[0])
+        python_target = LooseVersion(
+            get_config_var('MACOSX_DEPLOYMENT_TARGET'))
+        if python_target < '10.9' and current_system >= '10.9':
+            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
 
 global_c_macros = [
     ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On Mac OSX > 10.9 there can be an issue with properly linking the standard c libraries. This can be fixed by properly setting the `MACOSX_DEPLOYMENT_TARGET` environment variable. For more detail see: https://github.com/pandas-dev/pandas/issues/23424

This PR is based on the PR that closed that issue on pandas.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes a problem seen more than once with installing on mac osx > 10.9. This is the error message:
```python setup.py build_ext --inplace
running build_ext
building 'pyuvdata._miriad' extension
creating build
creating build/temp.macosx-10.7-x86_64-3.6
creating build/temp.macosx-10.7-x86_64-3.6/pyuvdata
creating build/temp.macosx-10.7-x86_64-3.6/pyuvdata/src
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/bryna/anaconda/envs/py36/include -arch x86_64 -I/Users/bryna/anaconda/envs/py36/include -arch x86_64 -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/Users/bryna/anaconda/envs/py36/lib/python3.6/site-packages/numpy/core/include -Ipyuvdata/src -I/Users/bryna/anaconda/envs/py36/include/python3.6m -c pyuvdata/src/miriad_wrap.cpp -o build/temp.macosx-10.7-x86_64-3.6/pyuvdata/src/miriad_wrap.o
warning: include path for stdlibc++ headers not found; pass '-stdlib=libc++' on
      the command line to use the libc++ standard library instead
      [-Wstdlibcxx-not-found]
pyuvdata/src/miriad_wrap.cpp:3:10: fatal error: 'string' file not found
#include <string>
         ^~~~~~~~
1 warning and 1 error generated.
error: command 'gcc' failed with exit status 1
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change introduces new functionality that should be highlighted in the tutorial.
  - [ ] I have updated the tutorial accordingly.
- [ ] If this is a bug fix, it includes a new test that breaks as a result of the bug (if possible)
- [ ] If this is a breaking change, it includes backwards compatibility and deprecation warnings (if possible)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] My change requires an update to the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
  - [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md) accordingly.
