### PR TITLE
uvh5 antenna names 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Fixed a bug in UVData when reading in an FHD file with a single time integration.
 - Fixed a bug in how the longitudinal branch cut was handled in beam interpolation
 - Changed the way interpolation splines are saved in UVBeam to fix errors related to polarization selections.
+- Python 3: `np.string_` call now uses `keepdims=True` to guard against `antenna_names` being cast as an array.
 
 ### Changed
 - Testing framework changed from `nose` to `pytest`.

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -8,6 +8,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import six
 import copy
 import numpy as np
 import pytest
@@ -1755,6 +1756,7 @@ def test_UVH5PartialWriteIntsIrregular():
 
 
 @uvtest.skipIf_no_h5py
+@pytest.mark.skipif(not six.PY3, reason="Skipping. This test is only relevant in python3.")
 def test_antenna_names_not_list():
     """Test if antenna_names is cast to an array, dimensions are preserved in np.string_ call during uvh5 write."""
     uv_in = UVData()

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -1752,3 +1752,34 @@ def test_UVH5PartialWriteIntsIrregular():
     os.remove(partial_testfile)
 
     return
+
+
+@uvtest.skipIf_no_h5py
+def test_antenna_names_not_list():
+    """Test if antenna_names is cast to an array, dimensions are preserved in np.string_ call during uvh5 write."""
+    uv_in = UVData()
+    uv_out = UVData()
+    uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    testfile = os.path.join(DATA_PATH, 'test', 'outtest_uvfits_ant_names.uvh5')
+    uvtest.checkWarnings(uv_in.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
+
+    # simulate a user defining antenna names as an array of unicode
+    uv_in.antenna_names = np.array(uv_in.antenna_names, dtype='U')
+
+    uv_in.write_uvh5(testfile, clobber=True)
+    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
+
+    # recast as list since antenna names should be a list and will be cast as list on read
+    uv_in.antenna_names = uv_in.antenna_names.tolist()
+    assert uv_in == uv_out
+
+    # also test writing double-precision data_array
+    uv_in.data_array = uv_in.data_array.astype(np.complex128)
+    uv_in.write_uvh5(testfile, clobber=True)
+    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
+    assert uv_in == uv_out
+
+    # clean up
+    os.remove(testfile)
+
+    return

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -1773,12 +1773,6 @@ def test_antenna_names_not_list():
     uv_in.antenna_names = uv_in.antenna_names.tolist()
     assert uv_in == uv_out
 
-    # also test writing double-precision data_array
-    uv_in.data_array = uv_in.data_array.astype(np.complex128)
-    uv_in.write_uvh5(testfile, clobber=True)
-    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
-    assert uv_in == uv_out
-
     # clean up
     os.remove(testfile)
 

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -549,7 +549,7 @@ class UVH5(UVData):
             dtype = "S{:d}".format(max_len_names)
             header.create_dataset('antenna_names', (n_names,), dtype=dtype, data=self.antenna_names)
         else:
-            header['antenna_names'] = np.string_(self.antenna_names)
+            header['antenna_names'] = np.string_(self.antenna_names, keepdims=True)
 
         # write out phasing information
         header['phase_type'] = np.string_(self.phase_type)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Users casting `antenna_name` to an numpy array will break the uvh5 saving file.
## Description
<!--- Describe your changes in detail -->
added test to see if  `antenna_name` can be cast to an array before writing to uvh5.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This test seems a little silly at first, since `antenna_names` is designed to be a list of string (or byte) of names. However I don't think it is inconceivable that a user could cast the names to an array or during an operation.  The uvh5 writer will write out the `antenna_names` as a single instance of a `bytes` object. It is very interesting resulting in something akin to a silent failure on write which cannot be read in.

It is easy to be robust against something like this by adding the `keepdims` keyword to the `np.string_` call while writing uvh5.

This is exclusively a python 3 issue.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
