### PR TITLE
Fix UVFlag init logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - `lst_array` is now saved to UVFITS files (even though it's not a standard parameter) so that it doesn't have to be recalculated
 
 ### Fixed
+- Fixed init logic in UVFlag.
 - Fixed a bug in how FHD uvw vectors were oriented (and visibilities were conjugated)
 - Fixed a bug in `UVData.inflate_by_redundancy` when Nblts is not equal to Nbls * Ntimes.
 - Fixed a bug in UVData when reading in an FHD file with a single time integration.

--- a/pyuvdata/tests/test_uvflag.py
+++ b/pyuvdata/tests/test_uvflag.py
@@ -180,6 +180,7 @@ def test_init_invalid_input():
     assert str(cm.value).startswith('input to UVFlag.__init__ must be one of:')
 
 
+@uvtest.skipIf_no_h5py
 def test_init_list_files_weights(tmpdir):
     # Test that weights are preserved when reading list of files
     tmp_path = tmpdir.strpath

--- a/pyuvdata/tests/test_uvflag.py
+++ b/pyuvdata/tests/test_uvflag.py
@@ -175,7 +175,9 @@ def test_init_waterfall_copy_flags():
 
 def test_init_invalid_input():
     # input is not UVData, UVCal, path, or list/tuple
-    pytest.raises(ValueError, UVFlag, 14)
+    with pytest.raises(ValueError) as cm:
+        foo = UVFlag(14)
+    assert str(cm.value).startswith('input to UVFlag.__init__ must be one of:')
 
 
 def test_init_list_files_weights(tmpdir):

--- a/pyuvdata/tests/test_uvflag.py
+++ b/pyuvdata/tests/test_uvflag.py
@@ -178,6 +178,23 @@ def test_init_invalid_input():
     pytest.raises(ValueError, UVFlag, 14)
 
 
+def test_init_list_files_weights(tmpdir):
+    # Test that weights are preserved when reading list of files
+    tmp_path = tmpdir.strpath
+    # Create two files to read
+    uvf = UVFlag(test_f_file)
+    np.random.seed(0)
+    wts1 = np.random.rand(*uvf.weights_array.shape)
+    uvf.weights_array = wts1.copy()
+    uvf.write(os.path.join(tmp_path, 'test1.h5'))
+    wts2 = np.random.rand(*uvf.weights_array.shape)
+    uvf.weights_array = wts2.copy()
+    uvf.write(os.path.join(tmp_path, 'test2.h5'))
+    uvf2 = UVFlag([os.path.join(tmp_path, 'test1.h5'),
+                   os.path.join(tmp_path, 'test2.h5')])
+    assert np.all(uvf2.weights_array == np.concatenate([wts1, wts2], axis=0))
+
+
 @uvtest.skipIf_no_h5py
 def test_read_write_loop():
     uv = UVData()

--- a/pyuvdata/tests/test_uvflag.py
+++ b/pyuvdata/tests/test_uvflag.py
@@ -173,6 +173,11 @@ def test_init_waterfall_copy_flags():
                   waterfall=True)
 
 
+def test_init_invalid_input():
+    # input is not UVData, UVCal, path, or list/tuple
+    pytest.raises(ValueError, UVFlag, 14)
+
+
 @uvtest.skipIf_no_h5py
 def test_read_write_loop():
     uv = UVData()

--- a/pyuvdata/tests/test_uvflag.py
+++ b/pyuvdata/tests/test_uvflag.py
@@ -169,18 +169,8 @@ def test_init_waterfall_flag():
 def test_init_waterfall_copy_flags():
     uv = UVCal()
     uv.read_calfits(test_c_file)
-    uvf = uvtest.checkWarnings(UVFlag, [uv], {'copy_flags': True, 'mode': 'flag', 'waterfall': True},
-                               nwarnings=1, message='Copying flags into waterfall')
-    assert not hasattr(uvf, 'flag_array')  # Should be metric due to copy flags
-    assert uvf.metric_array.shape == (uv.Ntimes, uv.Nfreqs, uv.Njones)
-    assert uvf.weights_array.shape == (uv.Ntimes, uv.Nfreqs, uv.Njones)
-    assert uvf.type == 'waterfall'
-    assert uvf.mode == 'metric'
-    assert np.all(uvf.time_array == np.unique(uv.time_array))
-    assert np.all(uvf.freq_array == uv.freq_array[0])
-    assert np.all(uvf.polarization_array == uv.jones_array)
-    assert 'Flag object with type "waterfall"' in uvf.history
-    assert pyuvdata_version_str in uvf.history
+    pytest.raises(NotImplementedError, UVFlag, uv, copy_flags=True, mode='flag',
+                  waterfall=True)
 
 
 @uvtest.skipIf_no_h5py

--- a/pyuvdata/uvflag.py
+++ b/pyuvdata/uvflag.py
@@ -55,13 +55,16 @@ class UVFlag(object):
             self.pyuvdata_version_str += ('  Git origin: ' + uvversion.git_origin
                                           + '.  Git hash: ' + uvversion.git_hash
                                           + '.  Git branch: ' + uvversion.git_branch
-                                          + '.  Git description: ' + uvversion.git_description + '.')
+                                          + '.  Git description: '
+                                          + uvversion.git_description + '.')
         self.label = ''  # Added to at the end
         if isinstance(input, (list, tuple)):
-            self.__init__(input[0], mode=mode, copy_flags=copy_flags, waterfall=waterfall, history=history)
+            self.__init__(input[0], mode=mode, copy_flags=copy_flags,
+                          waterfall=waterfall, history=history)
             if len(input) > 1:
                 for i in input[1:]:
-                    fobj = UVFlag(i, mode=mode, copy_flags=copy_flags, waterfall=waterfall, history=history)
+                    fobj = UVFlag(i, mode=mode, copy_flags=copy_flags,
+                                  waterfall=waterfall, history=history)
                     self += fobj
                 del(fobj)
 
@@ -70,7 +73,8 @@ class UVFlag(object):
             self.read(input, history)
         elif waterfall and issubclass(input.__class__, (UVData, UVCal)):
             self.type = 'waterfall'
-            self.history += 'Flag object with type "waterfall" created by ' + self.pyuvdata_version_str
+            self.history += ('Flag object with type "waterfall" created by '
+                             + self.pyuvdata_version_str)
             self.time_array, ri = np.unique(input.time_array, return_index=True)
             self.freq_array = input.freq_array[0, :]
             if issubclass(input.__class__, UVData):
@@ -94,7 +98,8 @@ class UVFlag(object):
 
         elif issubclass(input.__class__, UVData):
             self.type = 'baseline'
-            self.history += 'Flag object with type "baseline" created by ' + self.pyuvdata_version_str
+            self.history += ('Flag object with type "baseline" created by '
+                             + self.pyuvdata_version_str)
             self.baseline_array = input.baseline_array
             self.ant_1_array = input.ant_1_array
             self.ant_2_array = input.ant_2_array
@@ -117,7 +122,8 @@ class UVFlag(object):
 
         elif issubclass(input.__class__, UVCal):
             self.type = 'antenna'
-            self.history += 'Flag object with type "antenna" created by ' + self.pyuvdata_version_str
+            self.history += ('Flag object with type "antenna" created by '
+                             + self.pyuvdata_version_str)
             self.ant_array = input.ant_array
             self.time_array = input.time_array
             self.lst_array = lst_from_uv(input)
@@ -213,7 +219,8 @@ class UVFlag(object):
                 self.time_array = header['time_array'][()]
                 self.lst_array = header['lst_array'][()]
                 self.freq_array = header['freq_array'][()]
-                self.history = uvutils._bytes_to_str(header['history'][()]) + ' Read by ' + self.pyuvdata_version_str
+                self.history = (uvutils._bytes_to_str(header['history'][()])
+                                + ' Read by ' + self.pyuvdata_version_str)
                 self.history += history
                 if 'label' in header.keys():
                     self.label = uvutils._bytes_to_str(header['label'][()])
@@ -269,7 +276,8 @@ class UVFlag(object):
             header['lst_array'] = self.lst_array
             header['freq_array'] = self.freq_array
             header['polarization_array'] = self.polarization_array
-            header['history'] = uvutils._str_to_bytes(self.history + 'Written by ' + self.pyuvdata_version_str)
+            header['history'] = uvutils._str_to_bytes(self.history + 'Written by '
+                                                      + self.pyuvdata_version_str)
             header['label'] = uvutils._str_to_bytes(self.label)
 
             if self.type == 'baseline':
@@ -483,7 +491,8 @@ class UVFlag(object):
             darr = self.metric_array
         if len(self.polarization_array) > 1:
             # Collapse pol dimension. But note we retain a polarization axis.
-            d, w = uvutils.collapse(darr, method, axis=-1, weights=self.weights_array, return_weights=True)
+            d, w = uvutils.collapse(darr, method, axis=-1, weights=self.weights_array,
+                                    return_weights=True)
             darr = np.expand_dims(d, axis=d.ndim)
             self.weights_array = np.expand_dims(w, axis=w.ndim)
             self.polarization_array = np.array([','.join(map(str, self.polarization_array))],

--- a/pyuvdata/uvflag.py
+++ b/pyuvdata/uvflag.py
@@ -27,18 +27,24 @@ class UVFlag(object):
         Input lists or tuples are iterated through, treating each entry with an
         individual UVFlag init.
 
-        Args:
-            input: UVData object, UVCal object, or path to previously saved UVFlag object.
-                   Can also be a list of any compatible combination of the above options.
-                   UVData and UVCal objects cannot be directly combined, unless waterfall is True.
-            mode: "metric" (default) or "flag" to initialize UVFlag in given mode.
-                  The mode determines whether the object has a floating point metric_array
-                  or a boolean flag_array.
-            copy_flags: Whether to copy flags from input to new UVFlag object. Default is False.
-            waterfall: Whether to immediately initialize as a waterfall object,
-                       with flag/metric axes: time, frequency, polarization. Default is False.
-            history: History string to attach to object.
-            label: string used for labeling the object (e.g. 'FM')
+        Parameters
+        ----------
+        input : UVData or UVCal or str or list of compatible combination of options
+            Input to initialize UVFlag object. If str, assumed to be path to previously
+            saved UVFlag object. UVData and UVCal objects cannot be directly combined,
+            unless waterfall is True.
+        mode : {"metric", "flag"}, optional
+            The mode determines whether the object has a floating point metric_array
+            or a boolean flag_array. Default is "metric".
+        copy_flags : bool, optional
+            Whether to copy flags from input to new UVFlag object. Default is False.
+        waterfall : bool, optional
+            Whether to immediately initialize as a waterfall object, with flag/metric
+            axes: time, frequency, polarization. Default is False.
+        history : str, optional
+            History string to attach to object. Default is empty string.
+        label: str, optional
+            String used for labeling the object (e.g. 'FM'). Default is empty string.
         '''
 
         self.mode = mode.lower()  # Gets overwritten if reading file

--- a/pyuvdata/uvflag.py
+++ b/pyuvdata/uvflag.py
@@ -16,13 +16,13 @@ from six.moves import map
 
 
 class UVFlag(object):
-    ''' Object to handle flag arrays and waterfalls. Supports reading/writing,
+    """ Object to handle flag arrays and waterfalls. Supports reading/writing,
     and stores all relevant information to combine flags and apply to data.
-    '''
+    """
 
     def __init__(self, input, mode='metric', copy_flags=False, waterfall=False, history='',
                  label=''):
-        '''Initialize UVFlag object. Metadata is copied from input object. If input
+        """Initialize UVFlag object. Metadata is copied from input object. If input
         is subclass of UVData or UVCal, the weights_array will be set to all ones.
         Input lists or tuples are iterated through, treating each entry with an
         individual UVFlag init.
@@ -45,7 +45,7 @@ class UVFlag(object):
             History string to attach to object. Default is empty string.
         label: str, optional
             String used for labeling the object (e.g. 'FM'). Default is empty string.
-        '''
+        """
 
         self.mode = mode.lower()  # Gets overwritten if reading file
         self.history = ''  # Added to at the end
@@ -294,12 +294,12 @@ class UVFlag(object):
                                            compression=data_compression)
 
     def __add__(self, other, inplace=False, axis='time'):
-        '''Add two UVFlag objects together along a given axis.
+        """Add two UVFlag objects together along a given axis.
         Args:
             other: second UVFlag object to concatenate with self.
             inplace: Whether to concatenate to self, or create a new UVFlag object. Default is False.
             axis: Axis along which to combine UVFlag objects. Default is time.
-        '''
+        """
 
         # Handle in place
         if inplace:
@@ -377,11 +377,11 @@ class UVFlag(object):
         return self
 
     def __or__(self, other, inplace=False):
-        '''Combine two UVFlag objects in "flag" mode by "OR"-ing their flags.
+        """Combine two UVFlag objects in "flag" mode by "OR"-ing their flags.
         Args:
             other: second UVFlag object to combine with self.
             inplace: Whether to combine to self, or create a new UVFlag object. Default is False.
-        '''
+        """
         if (self.mode != 'flag') or (other.mode != 'flag'):
             raise ValueError('UVFlag object must be in "flag" mode to use "or" function.')
 
@@ -398,10 +398,10 @@ class UVFlag(object):
             return this
 
     def __ior__(self, other):
-        '''In place or
+        """In place or
         Args:
             other: second UVFlag object to combine with self.
-        '''
+        """
         self.__or__(other, inplace=True)
         return self
 
@@ -425,7 +425,7 @@ class UVFlag(object):
             del(self.flag_array)
 
     def copy(self):
-        ''' Simply return a copy of this object '''
+        """ Simply return a copy of this object """
         return copy.deepcopy(self)
 
     def combine_metrics(self, others, method='quadmean', inplace=True):
@@ -556,7 +556,7 @@ class UVFlag(object):
         self.clear_unused_attributes()
 
     def to_baseline(self, uv, force_pol=False):
-        '''Convert a UVFlag object of type "waterfall" to type "baseline".
+        """Convert a UVFlag object of type "waterfall" to type "baseline".
         Broadcasts the flag array to all baselines.
         This function does NOT apply flags to uv.
         Args:
@@ -565,7 +565,7 @@ class UVFlag(object):
                        Otherwise, will require polarizations match.
                        For example, this keyword is useful if one flags on all
                        pols combined, and wants to broadcast back to individual pols.
-        '''
+        """
         if self.type == 'baseline':
             return
         if not (issubclass(uv.__class__, UVData) or (isinstance(uv, UVFlag) and uv.type == 'baseline')):
@@ -618,7 +618,7 @@ class UVFlag(object):
         self.history += 'Broadcast to type "baseline" with ' + self.pyuvdata_version_str
 
     def to_antenna(self, uv, force_pol=False):
-        '''Convert a UVFlag object of type "waterfall" to type "antenna".
+        """Convert a UVFlag object of type "waterfall" to type "antenna".
         Broadcasts the flag array to all antennas.
         This function does NOT apply flags to uv.
         Args:
@@ -627,7 +627,7 @@ class UVFlag(object):
                        Otherwise, will require polarizations match.
                        For example, this keyword is useful if one flags on all
                        pols combined, and wants to broadcast back to individual pols.
-        '''
+        """
         if self.type == 'antenna':
             return
         if not (issubclass(uv.__class__, UVCal) or (isinstance(uv, UVFlag) and uv.type == 'antenna')):
@@ -673,13 +673,13 @@ class UVFlag(object):
         self.history += 'Broadcast to type "antenna" with ' + self.pyuvdata_version_str
 
     def to_flag(self, threshold=np.inf):
-        '''Convert to flag mode. NOT SMART. Removes metric_array and creates a
+        """Convert to flag mode. NOT SMART. Removes metric_array and creates a
         flag_array from a simple threshold on the metric values.
 
         Args:
             threshold (float): Metric value over which the corresponding flag is
                 set to True. Default is np.inf, which results in flags of all False.
-        '''
+        """
         if self.mode == 'flag':
             return
         elif self.mode == 'metric':
@@ -693,7 +693,7 @@ class UVFlag(object):
         self.clear_unused_attributes()
 
     def to_metric(self, convert_wgts=False):
-        '''Convert to metric mode. NOT SMART. Simply recasts flag_array as float
+        """Convert to metric mode. NOT SMART. Simply recasts flag_array as float
         and uses this as the metric array.
 
         Args:
@@ -703,7 +703,7 @@ class UVFlag(object):
                 flags as metrics to calculate flag fraction. Zero weighting
                 completely flagged rows/columns prevents those from counting
                 against a threshold along the other dimension.
-        '''
+        """
         if self.mode == 'metric':
             return
         elif self.mode == 'flag':
@@ -826,13 +826,13 @@ def and_rows_cols(waterfall):
 
 
 def lst_from_uv(uv):
-    ''' Calculate the lst_array for a UVData or UVCal object.
+    """ Calculate the lst_array for a UVData or UVCal object.
     Args:
         uv: a UVData or UVCal object.
     Returns:
         lst_array: lst_array corresponding to time_array and at telescope location.
                    Units are radian.
-    '''
+    """
     if not isinstance(uv, (UVCal, UVData)):
         raise ValueError('Function lst_from_uv can only operate on '
                          'UVCal or UVData object.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed support for a strange combination of keyword arguments in UVFlag init function, and replaced with `NotImplementedError`. Clarified the init docstring, and added a `ValueError` when the input to `UVFlag.__init__` is not valid.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The particular set of keywords `waterfall=True, copy_flags=True` for a UVData or UVCal input resulted in no consistent way to handle the weights_array.
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #571 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Breaking change checklist:  
- [x] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
