### PR TITLE
make inflate_by_redundancy not assume nblts=bls*ntimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `conjugate_bls` option to `UVData.get_antenna_redundancies`
 - `UVData.conjugate_bls` method to conjugate baselines to get the desired baseline directions.
 - `UVData.reorder_blts` method to reorder the data along the blt axis (and optionally also conjugate baselines), and a new `blt_order` optional parameter on UVData objects to track the ordering (including through read/writes).
 - `lst_array` is now saved to UVFITS files (even though it's not a standard parameter) so that it doesn't have to be recalculated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `lst_array` is now saved to UVFITS files (even though it's not a standard parameter) so that it doesn't have to be recalculated
 
 ### Fixed
+- Fixed a bug in `UVData.inflate_by_redundancy` when Nblts is not equal to Nbls * Ntimes.
 - Fixed a bug in UVData when reading in an FHD file with a single time integration.
 - Fixed a bug in how the longitudinal branch cut was handled in beam interpolation
 - Changed the way interpolation splines are saved in UVBeam to fix errors related to polarization selections.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1018,10 +1018,10 @@ b) Compressing/inflating on Redundant Baselines
 ***********************************************
 Since redundant baselines should have similar visibilities, some level of data
 compression can be achieved by only keeping one out of a set of redundant baselines.
-The function ``compress_by_redundancies`` will find groups of baselines that are
+The :meth:`~pyuvdata.UVData.compress_by_redundancy` method will find groups of baselines that are
 redundant to a given tolerance, choose one baseline from each group, and use the
-``select`` function to choose those baselines only. This action is (almost)
-inverted by the ``inflate_by_redundancies`` function, which finds all possible
+:meth:`~pyuvdata.UVData.select` method to choose those baselines only. This action is (almost)
+inverted by the :meth:`~pyuvdata.UVData.inflate_by_redundancy` method, which finds all possible
 baselines from the antenna positions and fills in the full data array based on redundancy.
 
 ::

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -465,8 +465,8 @@ def test_deprecated_funcs():
 
 def test_redundancy_finder():
     """
-        Check that get_baseline_redundancies and get_antenna_redundancies return consistent
-        redundant groups for a test file with the HERA19 layout.
+    Check that get_baseline_redundancies and get_antenna_redundancies return consistent
+    redundant groups for a test file with the HERA19 layout.
     """
     uvd = pyuvdata.UVData()
     uvd.read_uvfits(os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'))
@@ -481,38 +481,48 @@ def test_redundancy_finder():
 
     bl_positions = uvd.uvw_array
 
-    pytest.raises(ValueError, uvutils.get_baseline_redundancies, uvd.baseline_array, bl_positions[0:2, 0:1])
-    baseline_groups, vec_bin_centers, lens = uvutils.get_baseline_redundancies(uvd.baseline_array, bl_positions, tol=tol)
+    pytest.raises(ValueError, uvutils.get_baseline_redundancies,
+                  uvd.baseline_array, bl_positions[0:2, 0:1])
+    baseline_groups, vec_bin_centers, lens = uvutils.get_baseline_redundancies(
+        uvd.baseline_array, bl_positions, tol=tol)
 
-    baseline_groups, vec_bin_centers, lens = uvutils.get_baseline_redundancies(uvd.baseline_array, bl_positions, tol=tol)
+    baseline_groups, vec_bin_centers, lens = uvutils.get_baseline_redundancies(
+        uvd.baseline_array, bl_positions, tol=tol)
 
     for gi, gp in enumerate(baseline_groups):
         for bl in gp:
             bl_ind = np.where(uvd.baseline_array == bl)
             bl_vec = bl_positions[bl_ind]
-            assert np.allclose(np.sqrt(np.dot(bl_vec, vec_bin_centers[gi])), lens[gi], atol=tol)
+            assert np.allclose(np.sqrt(np.dot(bl_vec, vec_bin_centers[gi])),
+                               lens[gi], atol=tol)
 
-    # Shift the baselines around in a circle. Check that the same baselines are recovered to the corresponding tolerance increase.
-    # This moves one baseline at a time by a fixed displacement and checks that the redundant groups are the same.
+    # Shift the baselines around in a circle. Check that the same baselines are
+    # recovered to the corresponding tolerance increase.
+    # This moves one baseline at a time by a fixed displacement and checks that
+    # the redundant groups are the same.
 
     hightol = 0.25  # meters. Less than the smallest baseline in the file.
     Nbls = uvd.Nbls
     Nshifts = 5
     shift_angs = np.linspace(0, 2 * np.pi, Nshifts)
-    base_shifts = np.stack(((hightol - tol) * np.cos(shift_angs), (hightol - tol) * np.sin(shift_angs), np.zeros(Nshifts))).T
+    base_shifts = np.stack(((hightol - tol) * np.cos(shift_angs),
+                            (hightol - tol) * np.sin(shift_angs),
+                            np.zeros(Nshifts))).T
     for sh in base_shifts:
         for bi in range(Nbls):
             # Shift one baseline at a time.
             bl_positions_new = uvd.uvw_array
             bl_positions_new[bi] += sh
 
-            baseline_groups_new, vec_bin_centers, lens = uvutils.get_baseline_redundancies(uvd.baseline_array, bl_positions_new, tol=hightol)
+            baseline_groups_new, vec_bin_centers, lens = uvutils.get_baseline_redundancies(
+                uvd.baseline_array, bl_positions_new, tol=hightol)
 
             for gi, gp in enumerate(baseline_groups_new):
                 for bl in gp:
                     bl_ind = np.where(uvd.baseline_array == bl)
                     bl_vec = bl_positions[bl_ind]
-                    assert np.allclose(np.sqrt(np.abs(np.dot(bl_vec, vec_bin_centers[gi]))), lens[gi], atol=hightol)
+                    assert np.allclose(np.sqrt(np.abs(np.dot(bl_vec, vec_bin_centers[gi]))),
+                                       lens[gi], atol=hightol)
 
             # Compare baseline groups:
             a = [tuple(el) for el in baseline_groups]
@@ -521,22 +531,27 @@ def test_redundancy_finder():
 
     tol = 0.05
 
-    antpos, antnums = uvtest.checkWarnings(uvd.get_ENU_antpos, message=['The default for the `center`'],
+    antpos, antnums = uvtest.checkWarnings(uvd.get_ENU_antpos,
+                                           message=['The default for the `center`'],
                                            category=DeprecationWarning,
                                            nwarnings=1)
 
-    baseline_groups_ants, vec_bin_centers, lens = uvutils.get_antenna_redundancies(antnums, antpos, tol=tol, include_autos=False)
+    baseline_groups_ants, vec_bin_centers, lens = uvutils.get_antenna_redundancies(
+        antnums, antpos, tol=tol, include_autos=False)
     # Under these conditions, should see 19 redundant groups in the file.
     assert len(baseline_groups_ants) == 19
 
     # Check with conjugated baseline redundancies returned
     u16_0 = bl_positions[16, 0]
-    bl_positions[16, 0] = 0                 # Ensure at least one baseline has u==0 and v!=0 (for coverage of this case)
-    baseline_groups, vec_bin_centers, lens, conjugates = uvutils.get_baseline_redundancies(uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True)
+    # Ensure at least one baseline has u==0 and v!=0 (for coverage of this case)
+    bl_positions[16, 0] = 0
+    baseline_groups, vec_bin_centers, lens, conjugates = uvutils.get_baseline_redundancies(
+        uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True)
 
     # restore baseline (16,0) and repeat to get correct groups
     bl_positions[16, 0] = u16_0
-    baseline_groups, vec_bin_centers, lens, conjugates = uvutils.get_baseline_redundancies(uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True)
+    baseline_groups, vec_bin_centers, lens, conjugates = uvutils.get_baseline_redundancies(
+        uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True)
 
     # Should get the same groups as with the antenna method:
     baseline_groups_flipped = []
@@ -558,7 +573,8 @@ def test_redundancy_finder():
             bl_vec = bl_positions[bl_ind]
             if bl in conjugates:
                 bl_vec *= (-1)
-            assert np.isclose(np.sqrt(np.dot(bl_vec, vec_bin_centers[gi])), lens[gi], atol=tol)
+            assert np.isclose(np.sqrt(np.dot(bl_vec, vec_bin_centers[gi])),
+                              lens[gi], atol=tol)
 
 
 def test_redundancy_conjugates():
@@ -580,7 +596,8 @@ def test_redundancy_conjugates():
     for i, (u, v, w) in enumerate(bl_vecs):
         if (u < 0) or (v < 0 and u == 0) or (w < 0 and u == v == 0):
             expected_conjugates.append(bl_inds[i])
-    bl_gps, vecs, lens, conjugates = uvutils.get_baseline_redundancies(bl_inds, bl_vecs, tol=tol, with_conjugates=True)
+    bl_gps, vecs, lens, conjugates = uvutils.get_baseline_redundancies(
+        bl_inds, bl_vecs, tol=tol, with_conjugates=True)
 
     assert sorted(conjugates) == sorted(expected_conjugates)
 
@@ -594,7 +611,8 @@ def test_redundancy_finder_fully_redundant_array():
     tol = 1  # meters
     bl_positions = uvd.uvw_array
 
-    baseline_groups, vec_bin_centers, lens, conjugates = uvutils.get_baseline_redundancies(uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True)
+    baseline_groups, vec_bin_centers, lens, conjugates = uvutils.get_baseline_redundancies(
+        uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True)
 
     # Only 1 set of redundant baselines
     assert len(baseline_groups) == 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- make `inflate_by_redundancy` work in the case that nblts != bls*ntimes
- clarify in docstrings that redundancy methods return baseline numbers not inds
- add conjugation convenience option to get_antenna_redundancies
- update docstrings to numpy style.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #586

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).