### PR TITLE
Futureproof collections

### DIFF
--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -16,6 +16,11 @@ from astropy.time import Time
 from astropy.coordinates import Angle
 from astropy.utils import iers
 
+if six.PY2:
+    from collections import Iterable
+else:
+    from collections.abc import Iterable
+
 # parameters for transforming between xyz & lat/lon/alt
 gps_b = 6356752.31424518
 gps_a = 6378137
@@ -483,7 +488,7 @@ def get_iterable(x):
 
 def _get_iterable(x):
     """Helper function to ensure iterability."""
-    if isinstance(x, collections.Iterable):
+    if isinstance(x, Iterable):
         return x
     else:
         return (x,)
@@ -642,7 +647,7 @@ def polstr2num(pol, x_orientation=None):
     poldict = {k.lower(): v for k, v in six.iteritems(dict_use)}
     if isinstance(pol, str):
         out = poldict[pol.lower()]
-    elif isinstance(pol, collections.Iterable):
+    elif isinstance(pol, Iterable):
         out = [poldict[key.lower()] for key in pol]
     else:
         raise ValueError('Polarization {p} cannot be converted to a polarization number.'.format(p=pol))
@@ -692,7 +697,7 @@ def polnum2str(num, x_orientation=None):
 
     if isinstance(num, six.integer_types + (np.int32, np.int64)):
         out = dict_use[num]
-    elif isinstance(num, collections.Iterable):
+    elif isinstance(num, Iterable):
         out = [dict_use[i] for i in num]
     else:
         raise ValueError('Polarization {p} cannot be converted to string.'.format(p=num))
@@ -741,7 +746,7 @@ def jstr2num(jstr, x_orientation=None):
     jdict = {k.lower(): v for k, v in six.iteritems(dict_use)}
     if isinstance(jstr, str):
         out = jdict[jstr.lower()]
-    elif isinstance(jstr, collections.Iterable):
+    elif isinstance(jstr, Iterable):
         out = [jdict[key.lower()] for key in jstr]
     else:
         raise ValueError('Jones polarization {j} cannot be converted to index.'.format(j=jstr))
@@ -788,7 +793,7 @@ def jnum2str(jnum, x_orientation=None):
 
     if isinstance(jnum, six.integer_types + (np.int32, np.int64)):
         out = dict_use[jnum]
-    elif isinstance(jnum, collections.Iterable):
+    elif isinstance(jnum, Iterable):
         out = [dict_use[i] for i in jnum]
     else:
         raise ValueError('Jones polarization {j} cannot be converted to string.'.format(j=jnum))
@@ -889,7 +894,7 @@ def conj_pol(pol):
             cpol = deprecated_jones_dict[pol.lower()]
         else:
             cpol = cpol_dict[pol.lower()]
-    elif isinstance(pol, collections.Iterable):
+    elif isinstance(pol, Iterable):
         cpol = [conj_pol(p) for p in pol]
     elif isinstance(pol, six.integer_types + (np.int32, np.int64)):
         cpol = polstr2num(cpol_dict[polnum2str(pol).lower()])
@@ -916,7 +921,7 @@ def reorder_conj_pols(pols):
     Returns:
         conj_order: Indices to reorder polarization axis
     """
-    if not isinstance(pols, collections.Iterable):
+    if not isinstance(pols, Iterable):
         raise ValueError('reorder_conj_pols must be given an array of polarizations.')
     cpols = np.array([conj_pol(p) for p in pols])  # Array needed for np.where
     conj_order = [np.where(cpols == p)[0][0] if p in cpols else -1 for p in pols]

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -8,7 +8,6 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
-import collections
 import six
 import warnings
 import copy

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import copy
-import collections
 import re
 import numpy as np
 import six
@@ -23,6 +22,11 @@ from .uvbase import UVBase
 from . import parameter as uvp
 from . import telescopes as uvtel
 from . import utils as uvutils
+
+if six.PY2:
+    from collections import Iterable
+else:
+    from collections.abc import Iterable
 
 
 class UVData(UVBase):
@@ -3707,7 +3711,7 @@ class UVData(UVBase):
                 raise KeyError('Polarization {pol} not found in data.'.format(pol=key))
         elif len(key) == 1:
             key = key[0]  # For simplicity
-            if isinstance(key, collections.Iterable):
+            if isinstance(key, Iterable):
                 # Nested tuple. Call function again.
                 blt_ind1, blt_ind2, pol_ind = self._key2inds(key)
             elif key < 5:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
import Iterable from collections.abc not collections in python 3 
## Description
<!--- Describe your changes in detail -->
imports Iterable from collections.abc
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
python 3.8 will remove the ability to import 'abc' classes from collections and must be imported from collections.abc
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Future-proof imports

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.