### PR TITLE
Fix IERS errors in CI

### DIFF
--- a/pyuvdata/tests/__init__.py
+++ b/pyuvdata/tests/__init__.py
@@ -118,7 +118,8 @@ def checkWarnings(func, func_args=[], func_kwargs={},
         warnings.filterwarnings("ignore", message="numpy.dtype size changed")
         warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 
-        # filter iers warnings if iers.conf.auto_max_age is set to None, as we do in testing if the iers url is down
+        # Filter iers warnings if iers.conf.auto_max_age is set to None, as we
+        # do in testing if the iers url is down. See conftest.py for more info.
         if iers.conf.auto_max_age is None:
             warnings.filterwarnings("ignore", message="failed to download")
             warnings.filterwarnings("ignore", message="time is out of IERS range")

--- a/pyuvdata/tests/conftest.py
+++ b/pyuvdata/tests/conftest.py
@@ -22,8 +22,11 @@ def setup_and_teardown_package():
         print('making test directory')
         os.mkdir(testdir)
 
-    # try to download the iers table. If it fails, turn off auto downloading for the tests
-    # and turn it back on in teardown_package (done by extending auto_max_age)
+    # Try to download the latest IERS table. If the download succeeds, run a
+    # computation that requires the values, so they are cached for all future
+    # tests. If it fails, turn off auto downloading for the tests and turn it
+    # back on once all tests are completed (done by extending auto_max_age).
+    # Also, the checkWarnings function will ignore IERS-related warnings.
     try:
         iers_a = iers.IERS_A.open(iers.IERS_A_URL)
         t1 = Time.now()

--- a/pyuvdata/tests/conftest.py
+++ b/pyuvdata/tests/conftest.py
@@ -9,6 +9,7 @@ import os
 import pytest
 import six.moves.urllib as urllib
 from astropy.utils import iers
+from astropy.time import Time
 
 from pyuvdata.data import DATA_PATH
 
@@ -25,6 +26,8 @@ def setup_and_teardown_package():
     # and turn it back on in teardown_package (done by extending auto_max_age)
     try:
         iers_a = iers.IERS_A.open(iers.IERS_A_URL)
+        t1 = Time.now()
+        t1.ut1
     except(urllib.error.URLError):
         iers.conf.auto_max_age = None
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR attempts to fix errors with CI services not being able to download the IERS table.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Recently we've been noticing some IERS outages that were causing builds to fail. We had tried to make things robust against outages, but it didn't seem to be working all the time. This change caches the values if they are available, so it makes us less sensitive to temporary outages. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
