### PR TITLE
Vectorize baseline_to_antnums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Fixed a bug in select that caused bls and antenna_names/numbers to be or'ed rather than and'ed together.
+- Fixed a bug where `baseline_to_antnums` could accept a numpy array as input but not other array_like objects.
 
 ## [1.4.0] - 2019-05-23
 

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -316,6 +316,18 @@ def test_baseline_to_antnums(uvdata_baseline):
         assert pair == ant_pair_out
 
 
+def test_baseline_to_antnums_vectorized(uvdata_baseline):
+    """Test vectorized antnum to baseline conversion."""
+    ant_1 = [10, 280]
+    ant_2 = [20, 310]
+    baseline_array = uvdata_baseline.uv_object.antnums_to_baseline(ant_1, ant_2)
+    assert np.array_equal(baseline_array, [88085, 641335])
+    ant_1_out, ant_2_out = uvdata_baseline.uv_object.baseline_to_antnums(baseline_array.tolist())
+    print('out:', ant_1_out, ant_2_out)
+    assert np.array_equal(ant_1, ant_1_out)
+    assert np.array_equal(ant_2, ant_2_out)
+
+
 def test_antnums_to_baselines(uvdata_baseline):
     """Test antums to baseline conversion for 256 & larger conventions."""
     assert uvdata_baseline.uv_object.antnums_to_baseline(0, 0) == 67585

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -297,7 +297,10 @@ def uvdata_baseline():
 def test_baseline_to_antnums(uvdata_baseline):
     """Test baseline to antnum conversion for 256 & larger conventions."""
     assert uvdata_baseline.uv_object.baseline_to_antnums(67585) == (0, 0)
-    pytest.raises(Exception, uvdata_baseline.uv_object2.baseline_to_antnums, 67585)
+    with pytest.raises(Exception) as cm:
+        uvdata_baseline.uv_object2.baseline_to_antnums(67585)
+    assert str(cm.value).startswith('error Nants={Nants}>2048'
+                                    ' not supported'.format(Nants=uvdata_baseline.uv_object2.Nants_telescope))
 
     ant_pairs = [(10, 20), (280, 310)]
     for pair in ant_pairs:

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -988,16 +988,25 @@ def baseline_to_antnums(baseline, Nants_telescope):
     """
     Get the antenna numbers corresponding to a given baseline number.
 
-    Args:
-        baseline: integer baseline number
-        Nant_telescope: integer number of antennas
+    Parameters
+    ----------
+    baseline : int or array_like of ints
+        baseline number
+    Nant_telescope : int
+        number of antennas
 
-    Returns:
-        tuple with the two antenna numbers corresponding to the baseline.
+    Returns
+    -------
+    int or array_like of int
+        first antenna number(s)
+    int or array_like of int
+        second antenna number(s)
     """
     if Nants_telescope > 2048:
         raise Exception('error Nants={Nants}>2048 not '
                         'supported'.format(Nants=Nants_telescope))
+
+    baseline = np.asarray(baseline, dtype=np.int64)
     if np.min(baseline) > 2**16:
         ant2 = (baseline - 2**16) % 2048 - 1
         ant1 = (baseline - 2**16 - (ant2 + 1)) / 2048 - 1

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1020,16 +1020,23 @@ def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False):
     """
     Get the baseline number corresponding to two given antenna numbers.
 
-    Args:
-        ant1: first antenna number (integer)
-        ant2: second antenna number (integer)
-        Nant_telescope: integer number of antennas
-        attempt256: Option to try to use the older 256 standard used in
-            many uvfits files (will use 2048 standard if there are more
-            than 256 antennas). Default is False.
+    Parameters
+    ----------
+    ant1 : int or array_like of int
+        first antenna number
+    ant2 : int or array_like of int
+        second antenna number
+    Nant_telescope : int
+        number of antennas
+    attempt256 : bool
+        Option to try to use the older 256 standard used in
+        many uvfits files (will use 2048 standard if there are more
+        than 256 antennas). Default is False.
 
-    Returns:
-        integer baseline number corresponding to the two antenna numbers.
+    Returns
+    -------
+    int or array of int
+        baseline number corresponding to the two antenna numbers.
     """
     ant1, ant2 = np.int64((ant1, ant2))
     if Nants_telescope is not None and Nants_telescope > 2048:

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -595,9 +595,9 @@ class UVData(UVBase):
 
         Parameters
         ----------
-        ant1 : int
+        ant1 : int or array_like of int
             first antenna number
-        ant2 : int
+        ant2 : int or array_like of int
             second antenna number
         attempt256 : bool
             Option to try to use the older 256 standard used in many uvfits files
@@ -605,7 +605,7 @@ class UVData(UVBase):
 
         Returns
         -------
-        int
+        int or array of int
             baseline number corresponding to the two antenna numbers.
         """
         return uvutils.antnums_to_baseline(ant1, ant2, self.Nants_telescope, attempt256=attempt256)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -577,15 +577,15 @@ class UVData(UVBase):
 
         Parameters
         ----------
-        baseline : int
+        baseline : int or array_like of int
             baseline number
 
         Returns
         -------
-        int
-            first antenna number
-        int
-            second antenna number
+        int or array_like of int
+            first antenna number(s)
+        int or array_like of int
+            second antenna number(s)
         """
         return uvutils.baseline_to_antnums(baseline, self.Nants_telescope)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
allows array_like inputs to `baseline_to_antnums`
## Description
<!--- Describe your changes in detail -->
casts input of `baseline_to_antnums` to `np.asarray` to perform vectorized operations on baseline numbers given as lists. 

updated docstring to numpy style
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
allows for more consistent behavior in `baseline_to_antnums` between numpy arrays and other array_like objects.
closes #619
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
