### PR TITLE
Redundancy branch cut fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - `UVFlag` inherits from `UVBase` object.
 
 ### Fixed
+- A bug in get_antenna_redundancies for nearly N-S baselines.
 - A bug where `conj_pol` could not handle cardinal direction polarizations.
 - A bug that gave the wrong error message when calling `UVData.phase_to_time` without an Astropy Time object.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -980,7 +980,8 @@ The method :meth:`~pyuvdata.UVData.get_redundancies` is provided as a convenienc
 run with the `use_antpos` option, it will mimic the behavior of `utils.get_antenna_redundancies`.
 Otherwise it will return redundancies in the existing data using `utils.get_baseline_redundancies`.
 If run with `use_antpos` and the `conjugate_bls` option, it will also adjust the data_array and baseline_array
-so that the baselines on the object will match the baseline numbers in the returned list of groups.
+so that the baselines in the returned groups correspond with the baselines listed on the object (i.e., except for
+antenna pairs with no associated data).
 
 ::
 

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -3616,8 +3616,8 @@ def test_redundancy_contract_expand_nblts_not_nbls_times_ntimes():
     # check inflating gets back to the original
     uvtest.checkWarnings(uv2.inflate_by_redundancy, {tol: tol},
                          nwarnings=3, category=[DeprecationWarning, DeprecationWarning, UserWarning],
-                         message=['The default for the `center` keyword']*2\
-                                  + ['Missing some redundant groups. Filling in available data.'])
+                         message=['The default for the `center` keyword'] * 2
+                         + ['Missing some redundant groups. Filling in available data.'])
 
     uv2.history = uv0.history
     # Inflation changes the baseline ordering into the order of the redundant groups.

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1062,6 +1062,14 @@ def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False):
         return np.int64(baseline)
 
 
+def baseline_index_flip(baseline, Nants_telescope):
+    """
+    Change baseline number to reverse antenna order.
+    """
+    ant1, ant2 = baseline_to_antnums(baseline, Nants_telescope)
+    return antnums_to_baseline(ant2, ant1, Nants_telescope)
+
+
 def get_baseline_redundancies(baselines, baseline_vecs, tol=1.0, with_conjugates=False):
     """
     Find redundant baseline groups
@@ -1098,14 +1106,14 @@ def get_baseline_redundancies(baselines, baseline_vecs, tol=1.0, with_conjugates
 
     if with_conjugates:
         conjugates = []
-        for bl in baseline_vecs:
-            if bl[0] == 0:
-                if bl[1] == 0:
-                    conjugates.append(bl[2] < 0)
-                else:
-                    conjugates.append(bl[1] < 0)
-            else:
-                conjugates.append(bl[0] < 0)
+        for bv in baseline_vecs:
+            uneg = bv[0] < -tol
+            uzer = np.isclose(bv[0], 0.0, atol=tol)
+            vneg = bv[1] < -tol
+            vzer = np.isclose(bv[1], 0.0, atol=tol)
+            wneg = bv[2] < -tol
+            conjugates.append(uneg or (uzer and vneg) or (uzer and vzer and wneg))
+
         conjugates = np.array(conjugates, dtype=bool)
         baseline_vecs[conjugates] *= (-1)
         baseline_ind_conj = baselines[conjugates]
@@ -1164,8 +1172,6 @@ def get_antenna_redundancies(antenna_numbers, antenna_positions, tol=1.0, includ
     """
     Find redundant baseline groups based on antenna positions.
 
-    Include all possible redundant baselines based on antenna positions.
-
     Parameters
     ----------
     antenna_numbers : array_like of int
@@ -1185,8 +1191,24 @@ def get_antenna_redundancies(antenna_numbers, antenna_positions, tol=1.0, includ
         List of vectors describing redundant group centers
     lengths : list of float
         List of redundant group baseline lengths in meters
+
+    Notes
+    -----
+
+    The baseline numbers refer to antenna pairs (a1, a2) such that
+    the baseline vector formed from ENU antenna positions,
+        blvec = enu[a1] - enu[a2]
+    is close to the other baselines in the group.
+
+    This is achieved by putting baselines in a form of the u>0
+    convention, but with a tolerance in defining the signs of
+    vector components.
+
+    To guarantee that the same baseline numbers are present in a UVData
+    object, ``UVData.conjugate_bls('u>0', uvw_tol=tol)``, where `tol` is
+    the tolerance used here.
     """
-    Nants = antenna_numbers.shape[0]
+    Nants = antenna_numbers.size
 
     bls = []
     bl_vecs = []
@@ -1197,18 +1219,20 @@ def get_antenna_redundancies(antenna_numbers, antenna_positions, tol=1.0, includ
             mini = aj
         for ai in range(mini, Nants):
             anti, antj = antenna_numbers[ai], antenna_numbers[aj]
-            bidx = antnums_to_baseline(anti, antj, Nants)
-            bv = antenna_positions[aj] - antenna_positions[ai]
-            # Enforce u-positive orientation
-            if (bv[0] < 0 or ((bv[0] == 0) and bv[1] < 0)
-                    or ((bv[0] == 0) and (bv[1] == 0) and bv[2] < 0)):
-                bv *= (-1)
-                bidx = antnums_to_baseline(antj, anti, Nants)
+            bidx = antnums_to_baseline(antj, anti, Nants)
+            bv = antenna_positions[ai] - antenna_positions[aj]
             bl_vecs.append(bv)
             bls.append(bidx)
     bls = np.array(bls)
     bl_vecs = np.array(bl_vecs)
-    return get_baseline_redundancies(bls, bl_vecs, tol=tol, with_conjugates=False)
+    gps, vecs, lens, conjs = get_baseline_redundancies(bls, bl_vecs, tol=tol, with_conjugates=True)
+    # Flip the baselines in the groups.
+    for gi, gp in enumerate(gps):
+        for bi, bl in enumerate(gp):
+            if bl in conjs:
+                gps[gi][bi] = baseline_index_flip(bl, Nants)
+
+    return gps, vecs, lens
 
 
 def _reraise_context(fmt, *args):

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -4571,7 +4571,7 @@ class UVData(UVBase):
         """
 
         self.conjugate_bls(convention='u>0')
-        red_gps, centers, lengths, _, = self.get_redundancies(tol=tol, use_antpos=True)
+        red_gps, centers, lengths = self.get_redundancies(tol=tol, use_antpos=True, conjugate_bls=True)
 
         # Stack redundant groups into one array.
         group_index, bl_array_full = zip(*[(i, bl) for i, gp in enumerate(red_gps) for bl in gp])

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1033,7 +1033,7 @@ class UVData(UVBase):
             self.phase(phase_center_ra, phase_center_dec, phase_center_epoch,
                        phase_frame=output_phase_frame)
 
-    def conjugate_bls(self, convention='ant1<ant2', use_enu=True):
+    def conjugate_bls(self, convention='ant1<ant2', use_enu=True, uvw_tol=0.0):
         """
         Conjugate baselines according to one of the supported conventions.
 
@@ -4431,7 +4431,7 @@ class UVData(UVBase):
         return np.diff(np.sort(list(set(self.time_array))))[0] * 86400
 
     def get_redundancies(self, tol=1.0, use_antpos=False,
-                         include_conjugates=True, include_autos=True,
+                         include_conjugates=False, include_autos=True,
                          conjugate_bls=False):
         """
         Get redundant baselines to a given tolerance. This can be used to identify
@@ -4504,7 +4504,7 @@ class UVData(UVBase):
                       "and will be removed in version 1.6.",
                       DeprecationWarning)
         kwargs['use_antpos'] = True
-        red_gps, blvecs, lens, conjs = self.get_redundancies(*args, **kwargs)
+        red_gps, blvecs, lens = self.get_redundancies(*args, **kwargs)
         return red_gps, blvecs, lens
 
     def get_baseline_redundancies(self, *args, **kwargs):
@@ -4547,7 +4547,7 @@ class UVData(UVBase):
             if inplace is False, return the compressed UVData object
         """
 
-        red_gps, centers, lengths, conjugates = self.get_redundancies(tol)
+        red_gps, centers, lengths, conjugates = self.get_redundancies(tol, include_conjugates=True)
 
         bl_ants = [self.baseline_to_antnums(gp[0]) for gp in red_gps]
         return self.select(bls=bl_ants, inplace=inplace, metadata_only=metadata_only,

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -4431,7 +4431,8 @@ class UVData(UVBase):
         return np.diff(np.sort(list(set(self.time_array))))[0] * 86400
 
     def get_redundancies(self, tol=1.0, use_antpos=False,
-                         include_conjugates=True, include_autos=True):
+                         include_conjugates=True, include_autos=True
+                         conjugate_bls=False):
         """
         Get redundant baselines to a given tolerance. This can be used to identify
         redundant baselines present in the data, or find all possible redundant
@@ -4451,6 +4452,9 @@ class UVData(UVBase):
         include_autos : bool
             Option to include autocorrelations in the full redundancy list.
             Only used if use_antpos is True.
+        conjugate_bls : bool
+            If using antenna positions, this will conjugate baselines on this
+            object so that the baseline numbers returned exist in the baseline_array.
 
         Returns
         -------
@@ -4460,7 +4464,7 @@ class UVData(UVBase):
             List of vectors describing redundant group uvw centers
         lengths : list of float
             List of redundant group baseline lengths in meters
-        conjugate_bls : list of int, or None, optional
+        conjugates : list of int, or None, optional
             List of indices for baselines that must be conjugated to fit into their
             redundant groups.
             Will return None if use_antpos is True and include_conjugates is True
@@ -4476,6 +4480,9 @@ class UVData(UVBase):
             antpos, numbers = self.get_ENU_antpos(center=False)
             result = uvutils.get_antenna_redundancies(numbers, antpos, tol=tol,
                                                       include_autos=include_autos)
+            if conjugate_bls:
+                self.conjugate_bls(convention='u>0', uvw_tol=tol)
+
             if include_conjugates:
                 result = result + (None,)
             return result
@@ -4496,8 +4503,6 @@ class UVData(UVBase):
         warnings.warn("UVData.get_antenna_redundancies has been replaced with get_redundancies,"
                       "and will be removed in version 1.6.",
                       DeprecationWarning)
-        if kwargs.pop('conjugate_bls', False):
-            self.conjugate_bls('u>0')
         kwargs['use_antpos'] = True
         red_gps, blvecs, lens, conjs = self.get_redundancies(*args, **kwargs)
         return red_gps, blvecs, lens

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1090,17 +1090,17 @@ class UVData(UVBase):
             elif convention == 'ant2<ant1':
                 index_array = np.asarray(self.ant_2_array > self.ant_1_array).nonzero()
             elif convention == 'u<0':
-                    index_array = np.asarray((uvw_array_use[:, 0] > uvw_tol)
-                                             | (uvw_array_use[:, 1] > uvw_tol) & np.isclose(uvw_array_use[:, 0], 0, atol=uvw_tol)
-                                             | (uvw_array_use[:, 2] > uvw_tol)
-                                             & np.isclose(uvw_array_use[:, 0], 0, atol=uvw_tol)
-                                             & np.isclose(uvw_array_use[:, 1], 0, atol=uvw_tol)).nonzero()
+                index_array = np.asarray((uvw_array_use[:, 0] > uvw_tol)
+                                         | (uvw_array_use[:, 1] > uvw_tol) & np.isclose(uvw_array_use[:, 0], 0, atol=uvw_tol)
+                                         | (uvw_array_use[:, 2] > uvw_tol)
+                                         & np.isclose(uvw_array_use[:, 0], 0, atol=uvw_tol)
+                                         & np.isclose(uvw_array_use[:, 1], 0, atol=uvw_tol)).nonzero()
             elif convention == 'u>0':
                 index_array = np.asarray((uvw_array_use[:, 0] < -uvw_tol)
                                          | ((uvw_array_use[:, 1] < -uvw_tol) & np.isclose(uvw_array_use[:, 0], 0, atol=uvw_tol))
                                          | ((uvw_array_use[:, 2] < -uvw_tol)
-                                            & np.isclose(uvw_array_use[:, 0], 0, atol=uvw_tol)
-                                            & np.isclose(uvw_array_use[:, 1], 0, atol=uvw_tol))).nonzero()
+                                         & np.isclose(uvw_array_use[:, 0], 0, atol=uvw_tol)
+                                         & np.isclose(uvw_array_use[:, 1], 0, atol=uvw_tol))).nonzero()
             elif convention == 'v<0':
                 index_array = np.asarray((uvw_array_use[:, 1] > uvw_tol)
                                          | (uvw_array_use[:, 0] > uvw_tol) & np.isclose(uvw_array_use[:, 1], 0, atol=uvw_tol)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -4454,7 +4454,7 @@ class UVData(UVBase):
             Only used if use_antpos is True.
         conjugate_bls : bool
             If using antenna positions, this will conjugate baselines on this
-            object so that the baseline numbers returned exist in the baseline_array.
+            object to correspond with those in the returned groups.
 
         Returns
         -------

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -4431,7 +4431,7 @@ class UVData(UVBase):
         return np.diff(np.sort(list(set(self.time_array))))[0] * 86400
 
     def get_redundancies(self, tol=1.0, use_antpos=False,
-                         include_conjugates=True, include_autos=True
+                         include_conjugates=True, include_autos=True,
                          conjugate_bls=False):
         """
         Get redundant baselines to a given tolerance. This can be used to identify


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a bug in `utils.get_antenna_redundancies` for North-South baselines. This method flipped baselines according to the u-positive convention. Under this convention, North-South baselines (u ~ 0) would be flipped only if u is exactly zero and v is negative. This means that a baseline with u = -ε and v < 0 would be flipped, but another with u = +ε w and v<0 would not. Redundancies among North-South baselines to the given tolerance are not identified.

This fixes that defining ` u = 0` as `np.isclose(u, 0, atol=tol)` (ie., the specified redundancy tolerance, and `u<0` as `u < -tol` (likewise for v and w). This means that very nearly north-south baselines will be flipped if v<0 (ie., pointing south), ensuring that North-south redundancies are identified.

The fix is tested using the example code from issue #650 .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixes a significant problem for the redundancy finder when handling realistic baselines.
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #650 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).