### PR TITLE
Better error message for length zero bls

### DIFF
--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -895,15 +895,36 @@ def test_select_bls():
     assert list(set(sorted_pairs_object2)) == [(0, 6)]
 
     # check for errors associated with antenna pairs not included in data and bad inputs
-    pytest.raises(ValueError, uv_object.select,
-                  bls=list(zip(first_ants, second_ants)) + [0, 6])
-    pytest.raises(ValueError, uv_object.select,
-                  bls=[(uv_object.antenna_names[0], uv_object.antenna_names[1])])
-    pytest.raises(ValueError, uv_object.select, bls=(5, 1))
-    pytest.raises(ValueError, uv_object.select, bls=(0, 5))
-    pytest.raises(ValueError, uv_object.select, bls=(27, 27))
-    pytest.raises(ValueError, uv_object.select, bls=(6, 0, 'RR'), polarizations='RR')
-    pytest.raises(ValueError, uv_object.select, bls=(6, 0, 8))
+    with pytest.raises(ValueError) as cm:
+        uv_object.select(bls=list(zip(first_ants, second_ants)) + [0, 6])
+    assert str(cm.value).startswith('bls must be a list of tuples of antenna numbers')
+
+    with pytest.raises(ValueError) as cm:
+        uv_object.select(bls=[(uv_object.antenna_names[0], uv_object.antenna_names[1])])
+    assert str(cm.value).startswith('bls must be a list of tuples of antenna numbers')
+
+    with pytest.raises(ValueError) as cm:
+        uv_object.select(bls=(5, 1))
+    assert str(cm.value).startswith('Antenna number 5 is not present in the '
+                                    'ant_1_array or ant_2_array')
+    with pytest.raises(ValueError) as cm:
+        uv_object.select(bls=(0, 5))
+    assert str(cm.value).startswith('Antenna number 5 is not present in the '
+                                    'ant_1_array or ant_2_array')
+    with pytest.raises(ValueError) as cm:
+        uv_object.select(bls=(27, 27))
+    assert str(cm.value).startswith('Antenna pair (27, 27) does not have any data')
+    with pytest.raises(ValueError) as cm:
+        uv_object.select(bls=(6, 0, 'RR'), polarizations='RR')
+    assert str(cm.value).startswith('Cannot provide length-3 tuples and also '
+                                    'specify polarizations.')
+    with pytest.raises(ValueError) as cm:
+        uv_object.select(bls=(6, 0, 8))
+    assert str(cm.value).startswith('The third element in each bl must be a '
+                                    'polarization string')
+    with pytest.raises(ValueError) as cm:
+        uv_object.select(bls=[])
+    assert str(cm.value).startswith('bls must be a list of tuples of antenna numbers')
 
 
 def test_select_times():

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1963,7 +1963,7 @@ class UVData(UVBase):
         if bls is not None:
             if isinstance(bls, tuple) and (len(bls) == 2 or len(bls) == 3):
                 bls = [bls]
-            if not all(isinstance(item, tuple) for item in bls):
+            if len(bls) == 0 or not all(isinstance(item, tuple) for item in bls):
                 raise ValueError(
                     'bls must be a list of tuples of antenna numbers (optionally with polarization).')
             if not all([isinstance(item[0], six.integer_types + (np.integer,)) for item in bls]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Give a better error message if a user provides an empty list to the `bls` parameter in `select`.

I don't think this needs a changelog update, but I can be convinced otherwise.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #662 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
