### PR TITLE
Bug fix to conjugate cardinal direction polarizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - `UVFlag` inherits from `UVBase` object.
 
 ### Fixed
+- A bug where `conj_pol` could not handle cardinal direction polarizations.
 - A bug that gave the wrong error message when calling `UVData.phase_to_time` without an Astropy Time object.
 
 ## [1.4.1] - 2019-08-2

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -416,8 +416,10 @@ def test_conj_pol():
     cpol_nums = [-7, -8, -6, -5, -3, -4, -2, -1, 1, 2, 3, 4]
     assert pol_nums == uvutils.conj_pol(cpol_nums)
     assert uvutils.conj_pol(pol_nums) == cpol_nums
-    pol_str = ['yx', 'xy', 'yy', 'xx', 'lr', 'rl', 'll', 'rr', 'pI', 'pQ', 'pU', 'pV']
-    cpol_str = ['xy', 'yx', 'yy', 'xx', 'rl', 'lr', 'll', 'rr', 'pI', 'pQ', 'pU', 'pV']
+    pol_str = ['yx', 'xy', 'yy', 'xx', 'ee', 'nn', 'en', 'ne', 'lr', 'rl', 'll',
+               'rr', 'pI', 'pQ', 'pU', 'pV']
+    cpol_str = ['xy', 'yx', 'yy', 'xx', 'ee', 'nn', 'ne', 'en', 'rl', 'lr', 'll',
+                'rr', 'pI', 'pQ', 'pU', 'pV']
     assert pol_str == uvutils.conj_pol(cpol_str)
     assert uvutils.conj_pol(pol_str) == cpol_str
     assert [pol_str, pol_nums] == uvutils.conj_pol([cpol_str, cpol_nums])

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -53,6 +53,7 @@ POL_NUM2STR_DICT = {1: 'pI', 2: 'pQ', 3: 'pU', 4: 'pV',
 
 # maps how polarizations change when antennas are swapped
 CONJ_POL_DICT = {'xx': 'xx', 'yy': 'yy', 'xy': 'yx', 'yx': 'xy',
+                 'ee': 'ee', 'nn': 'nn', 'en': 'ne', 'ne': 'en',
                  'rr': 'rr', 'll': 'll', 'rl': 'lr', 'lr': 'rl',
                  'I': 'I', 'Q': 'Q', 'U': 'U', 'V': 'V',
                  'pI': 'pI', 'pQ': 'pQ', 'pU': 'pU', 'pV': 'pV'}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix bug so `conj_pol` can handle cardinal direction polarizations.

## Description
<!--- Describe your changes in detail -->
The `CONJ_POL_DICT` in `utils.py` had no concept of `'ee', 'nn', 'ne', 'en'` polarizations, so it couldn't conjugate them. This manifested in errors when calling `get_antpairpols`, then `get_data`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #665.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
