### PR TITLE
Warning cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: |
             source activate ${ENV_NAME}
             mkdir test-reports
-            python -m pytest pyuvdata -v --cov=pyuvdata --cov-config=.coveragerc --cov-report xml:./coverage.xml --junitxml=test-reports/xunit.xml
+            python -m pytest pyuvdata --cov=pyuvdata --cov-config=.coveragerc --cov-report xml:./coverage.xml --junitxml=test-reports/xunit.xml
       - save_cache:
           key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_tests.yml" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - image: continuumio/miniconda:latest
     environment:
       PYTHON: << parameters.python_version >>
-      ENV_NAME: pyuvdata_linting
+      ENV_NAME: << parameters.env_name >>
     steps:
       - checkout
       - restore_cache:
@@ -36,7 +36,7 @@ jobs:
       - image: continuumio/miniconda:latest
     environment:
       PYTHON: << parameters.python_version >>
-      ENV_NAME: pyuvdata_tests
+      ENV_NAME: << parameters.env_name >>
     steps:
       - checkout
       - restore_cache:
@@ -66,44 +66,6 @@ jobs:
       - codecov/upload:
           file: ./coverage.xml
 
-  pyuvdata_min_deps:
-    parameters:
-      python_version:
-        type: string
-    docker:
-      - image: continuumio/miniconda:latest
-    environment:
-      PYTHON: << parameters.python_version >>
-      ENV_NAME: pyuvdata_min_deps_tests
-    steps:
-      - checkout
-      - restore_cache:
-          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_min_deps_tests.yml" }}
-      - run:
-          name: configure conda environment
-          command: ./ci/install-circle.sh
-      - run:
-          name: install
-          command: |
-            source activate ${ENV_NAME}
-            python setup.py build_ext --force --inplace
-      - run:
-          name: run pyuvdata tests
-          command: |
-            source activate ${ENV_NAME}
-            mkdir test-reports
-            python -m pytest pyuvdata -v --cov=pyuvdata --cov-config=.coveragerc --cov-report xml:./coverage.xml --junitxml=test-reports/xunit.xml
-      - save_cache:
-          key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_min_deps_tests.yml" }}
-          paths:
-            - "/opt/conda/envs/${ENV_NAME}/"
-      - store_test_results:
-          path: test-reports
-      - store_artifacts:
-          path: test-reports
-      - codecov/upload:
-          file: ./coverage.xml
-
   doctest:
     parameters:
       python_version:
@@ -112,7 +74,7 @@ jobs:
       - image: continuumio/miniconda:latest
     environment:
       PYTHON: << parameters.python_version >>
-      ENV_NAME: pyuvdata_tests
+      ENV_NAME: << parameters.env_name >>
     steps:
       - checkout
       - restore_cache:
@@ -141,16 +103,23 @@ workflows:
     jobs:
       - linter:
           python_version: "3.6"
+          env_name: "pyuvdata_linting"
       - pyuvdata:
           name: pyuvdata_2.7
           python_version: "2.7"
+          env_name: "pyuvdata_tests"
       - pyuvdata:
           name: pyuvdata_3.6
           python_version: "3.6"
+          env_name: "pyuvdata_tests"
       - pyuvdata:
           name: pyuvdata_3.7
           python_version: "3.7"
-      - pyuvdata_min_deps:
+          env_name: "pyuvdata_tests"
+      - pyuvdata:
+          name: pyuvdata_min_deps
           python_version: "3.6"
+          env_name: "pyuvdata_min_deps_tests"
       - doctest:
           python_version: "3.6"
+          env_name: "pyuvdata_tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ jobs:
     parameters:
       python_version:
         type: string
+      env_name:
+        type: string
     docker:
       - image: continuumio/miniconda:latest
     environment:
@@ -31,6 +33,8 @@ jobs:
   pyuvdata:
     parameters:
       python_version:
+        type: string
+      env_name:
         type: string
     docker:
       - image: continuumio/miniconda:latest
@@ -69,6 +73,8 @@ jobs:
   doctest:
     parameters:
       python_version:
+        type: string
+      env_name:
         type: string
     docker:
       - image: continuumio/miniconda:latest

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -719,6 +719,8 @@ def test_readWriteReadMiriad_partial():
     exp_uv = full.select(bls=[(0, 0), (0, 1), (4, 2)], inplace=False)
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     # test all bls w/ 0 are loaded
     uv_in.read(write_file, antenna_nums=[0])
     diff = set(full.get_antpairs()) - set(uv_in.get_antpairs())
@@ -728,27 +730,37 @@ def test_readWriteReadMiriad_partial():
     assert np.max(exp_uv.ant_2_array) == 0
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     uv_in.read(write_file, antenna_nums=[0, 2, 4], bls=[(0, 0), (2, 4)])
     assert np.array([bl in uv_in.get_antpairs() for bl in [(0, 0), (2, 4)]]).all()
     exp_uv = full.select(antenna_nums=[0, 2, 4], bls=[(0, 0), (2, 4)], inplace=False)
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     uv_in.read(write_file, bls=[(2, 4, 'xy')])
     assert np.array([bl in uv_in.get_antpairs() for bl in [(2, 4)]]).all()
     exp_uv = full.select(bls=[(2, 4, 'xy')], inplace=False)
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     uv_in.read(write_file, bls=[(4, 2, 'yx')])
     assert np.array([bl in uv_in.get_antpairs() for bl in [(2, 4)]]).all()
     exp_uv = full.select(bls=[(4, 2, 'yx')], inplace=False)
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     uv_in.read(write_file, bls=(4, 2, 'yx'))
     assert np.array([bl in uv_in.get_antpairs() for bl in [(2, 4)]]).all()
     exp_uv = full.select(bls=[(4, 2, 'yx')], inplace=False)
     assert uv_in == exp_uv
 
     # test time loading
+    del(uv_in)
+    uv_in = UVData()
     uv_in.read(write_file, time_range=[2456865.607, 2456865.609])
     full_times = np.unique(full.time_array[(full.time_array > 2456865.607) & (full.time_array < 2456865.609)])
     assert np.isclose(np.unique(uv_in.time_array), full_times).all()
@@ -756,30 +768,42 @@ def test_readWriteReadMiriad_partial():
     assert uv_in == exp_uv
 
     # test polarization loading
+    del(uv_in)
+    uv_in = UVData()
     uv_in.read(write_file, polarizations=['xy'])
     assert full.polarization_array == uv_in.polarization_array
     exp_uv = full.select(polarizations=['xy'], inplace=False)
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     uv_in.read(write_file, polarizations=[-7])
     assert full.polarization_array == uv_in.polarization_array
     exp_uv = full.select(polarizations=[-7], inplace=False)
     uv_in == exp_uv
 
     # test ant_str
+    del(uv_in)
+    uv_in = UVData()
     uv_in.read(write_file, ant_str='auto')
     assert np.array([blp[0] == blp[1] for blp in uv_in.get_antpairs()]).all()
     exp_uv = full.select(ant_str='auto', inplace=False)
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     uv_in.read(write_file, ant_str='cross')
     assert np.array([blp[0] != blp[1] for blp in uv_in.get_antpairs()]).all()
     exp_uv = full.select(ant_str='cross', inplace=False)
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     uv_in.read(write_file, ant_str='all')
     assert uv_in == full
 
+    del(uv_in)
+    uv_in = UVData()
     # assert exceptions
     with pytest.raises(AssertionError) as cm:
         uv_in.read(write_file, ant_str='auto', antenna_nums=[0, 1])
@@ -854,16 +878,22 @@ def test_readWriteReadMiriad_partial():
         uv_in.read(write_file, ant_str=0)
     assert str(cm.value).startswith("ant_str must be fed as a string")
 
+    del(uv_in)
+    uv_in = UVData()
     # assert partial-read and select are same
     uv_in.read(write_file, polarizations=[-7], bls=[(4, 4)])
     exp_uv = full.select(polarizations=[-7], bls=[(4, 4)], inplace=False)
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     # assert partial-read and select are same
     uv_in.read(write_file, bls=[(4, 4, 'xy')])
     exp_uv = full.select(bls=[(4, 4, 'xy')], inplace=False)
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     # assert partial-read and select are same
     unique_times = np.unique(full.time_array)
     time_range = [2456865.607, 2456865.609]
@@ -873,21 +903,28 @@ def test_readWriteReadMiriad_partial():
     exp_uv = full.select(antenna_nums=[0], times=times_to_keep, inplace=False)
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     # assert partial-read and select are same
     uv_in.read(write_file, polarizations=[-7], time_range=time_range)
     exp_uv = full.select(polarizations=[-7], times=times_to_keep, inplace=False)
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     # check handling for generic read selections unsupported by read_miriad
     uvtest.checkWarnings(uv_in.read, [write_file], {'times': times_to_keep},
                          message=['Warning: a select on read keyword is set'])
     exp_uv = full.select(times=times_to_keep, inplace=False)
     assert uv_in == exp_uv
 
+    del(uv_in)
+    uv_in = UVData()
     # check handling for generic read selections unsupported by read_miriad
     blts_select = np.where(full.time_array == unique_times[0])[0]
     ants_keep = [0, 2, 4]
-    uvtest.checkWarnings(uv_in.read, [write_file], {'blt_inds': blts_select, 'antenna_nums': ants_keep},
+    uvtest.checkWarnings(uv_in.read, [write_file],
+                         {'blt_inds': blts_select, 'antenna_nums': ants_keep},
                          message=['Warning: blt_inds is set along with select on read'])
     exp_uv = full.select(blt_inds=blts_select, antenna_nums=ants_keep, inplace=False)
     assert uv_in != exp_uv

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -26,6 +26,7 @@ from pyuvdata.data import DATA_PATH
 from .. import aipy_extracts
 
 
+@pytest.mark.filterwarnings("ignore:Telescope ATCA is not")
 def test_ReadWriteReadATCA():
     uv_in = UVData()
     uv_out = UVData()
@@ -44,8 +45,7 @@ def test_ReadWriteReadATCA():
                                   'Telescope ATCA is not in known_telescopes.'])
 
     uv_in.write_miriad(testfile, clobber=True)
-    uvtest.checkWarnings(uv_out.read, [testfile],
-                         message='Telescope ATCA is not in known_telescopes.')
+    uv_out.read(testfile)
     assert uv_in == uv_out
 
 
@@ -911,6 +911,7 @@ def test_readWriteReadMiriad_partial_metadata_only():
         assert getattr(uv_in, m) is not None
 
     # metadata only multiple file read-in
+    del(uv_in)
     uv_in = UVData()
     uv_in.read(testfile)
     new_uv = uv_in.select(freq_chans=np.arange(5), inplace=False)
@@ -928,6 +929,7 @@ def test_readWriteReadMiriad_partial_metadata_only():
 
     # test exceptions
     # read-in when data already exists
+    del(uv_in)
     uv_in = UVData()
     uv_in.read(testfile)
     with pytest.raises(ValueError) as cm:
@@ -1013,6 +1015,7 @@ def test_rwrMiriad_antpos_issues():
     assert uv_in == uv_out
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_multi_files():
     """
     Reading multiple files at once.
@@ -1021,7 +1024,7 @@ def test_multi_files():
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     testfile1 = os.path.join(DATA_PATH, 'test/uv1')
     testfile2 = os.path.join(DATA_PATH, 'test/uv2')
-    uvtest.checkWarnings(uv_full.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
+    uv_full.read_uvfits(uvfits_file)
     uvtest.checkWarnings(uv_full.unphase_to_drift, category=DeprecationWarning,
                          message='The xyz array in ENU_from_ECEF is being '
                                  'interpreted as (Npts, 3)')
@@ -1033,8 +1036,9 @@ def test_multi_files():
     uv2.select(freq_chans=np.arange(32, 64))
     uv1.write_miriad(testfile1, clobber=True)
     uv2.write_miriad(testfile2, clobber=True)
-    uvtest.checkWarnings(uv1.read, [[testfile1, testfile2]], nwarnings=2,
-                         message=['Telescope EVLA is not', 'Telescope EVLA is not'])
+    del(uv1)
+    uv1 = UVData()
+    uv1.read([testfile1, testfile2])
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(uv_full.history + '  Downselected to '
                                     'specific frequencies using pyuvdata. '
@@ -1044,8 +1048,9 @@ def test_multi_files():
     assert uv1 == uv_full
 
     # again, setting axis
-    uvtest.checkWarnings(uv1.read, [[testfile1, testfile2]], {'axis': 'freq'},
-                         nwarnings=2, message=['Telescope EVLA is not'])
+    del(uv1)
+    uv1 = UVData()
+    uv1.read([testfile1, testfile2])
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(uv_full.history + '  Downselected to '
                                     'specific frequencies using pyuvdata. '

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -452,17 +452,27 @@ def test_miriad_extra_keywords():
     uv_in.extra_keywords['testlist'] = [12, 14, 90]
     uvtest.checkWarnings(uv_in.check, message=['testlist in extra_keywords is a '
                                                'list, array or dict'])
-    with pytest.raises(TypeError) as cm:
-        uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    assert str(cm.value).startswith("Extra keyword testlist is of <class 'list'>")
+    if six.PY2:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_miriad(testfile, clobber=True, run_check=False)
+        assert str(cm.value).startswith("Extra keyword testlist is of <type 'list'>")
+    else:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_miriad(testfile, clobber=True, run_check=False)
+        assert str(cm.value).startswith("Extra keyword testlist is of <class 'list'>")
     uv_in.extra_keywords.pop('testlist')
 
     uv_in.extra_keywords['testarr'] = np.array([12, 14, 90])
     uvtest.checkWarnings(uv_in.check, message=['testarr in extra_keywords is a '
                                                'list, array or dict'])
-    with pytest.raises(TypeError) as cm:
-        uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    assert str(cm.value).startswith("Extra keyword testarr is of <class 'numpy.ndarray'>")
+    if six.PY2:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_miriad(testfile, clobber=True, run_check=False)
+        assert str(cm.value).startswith("Extra keyword testarr is of <type 'numpy.ndarray'>")
+    else:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_miriad(testfile, clobber=True, run_check=False)
+        assert str(cm.value).startswith("Extra keyword testarr is of <class 'numpy.ndarray'>")
     uv_in.extra_keywords.pop('testarr')
 
     # check for warnings with extra_keywords keys that are too long
@@ -514,15 +524,25 @@ def test_miriad_extra_keywords():
     # check handling of complex-like keywords
     # currently they are NOT supported
     uv_in.extra_keywords['complex1'] = np.complex64(5.3 + 1.2j)
-    with pytest.raises(TypeError) as cm:
-        uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    assert str(cm.value).startswith("Extra keyword complex1 is of <class 'numpy.complex64'>")
+    if six.PY2:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_miriad(testfile, clobber=True, run_check=False)
+        assert str(cm.value).startswith("Extra keyword complex1 is of <type 'numpy.complex64'>")
+    else:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_miriad(testfile, clobber=True, run_check=False)
+        assert str(cm.value).startswith("Extra keyword complex1 is of <class 'numpy.complex64'>")
     uv_in.extra_keywords.pop('complex1')
 
     uv_in.extra_keywords['complex2'] = 6.9 + 4.6j
-    with pytest.raises(TypeError) as cm:
-        uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    assert str(cm.value).startswith("Extra keyword complex2 is of <class 'complex'>")
+    if six.PY2:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_miriad(testfile, clobber=True, run_check=False)
+        assert str(cm.value).startswith("Extra keyword complex2 is of <type 'complex'>")
+    else:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_miriad(testfile, clobber=True, run_check=False)
+        assert str(cm.value).startswith("Extra keyword complex2 is of <class 'complex'>")
 
 
 @pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -1050,7 +1050,7 @@ def test_multi_files():
     # again, setting axis
     del(uv1)
     uv1 = UVData()
-    uv1.read([testfile1, testfile2])
+    uv1.read([testfile1, testfile2], axis='freq')
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(uv_full.history + '  Downselected to '
                                     'specific frequencies using pyuvdata. '

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -437,9 +437,15 @@ def test_miriad_extra_keywords():
     uv_in.extra_keywords['testdict'] = {'testkey': 23}
     uvtest.checkWarnings(uv_in.check, message=['testdict in extra_keywords is a '
                                                'list, array or dict'])
-    with pytest.raises(TypeError) as cm:
-        uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    assert str(cm.value).startswith("Extra keyword testdict is of <class 'dict'>")
+
+    if six.PY2:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_miriad(testfile, clobber=True, run_check=False)
+        assert str(cm.value).startswith("Extra keyword testdict is of <type 'dict'>")
+    else:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_miriad(testfile, clobber=True, run_check=False)
+        assert str(cm.value).startswith("Extra keyword testdict is of <class 'dict'>")
 
     uv_in.extra_keywords.pop('testdict')
 
@@ -602,9 +608,14 @@ def test_readWriteReadMiriad():
     assert uv_in2 == uv_out
 
     # check that trying to overwrite without clobber raises an error
-    with pytest.raises(OSError) as cm:
-        uv_in.write_miriad(write_file, clobber=False)
-    assert str(cm.value).startswith("File exists: skipping")
+    if six.PY2:
+        with pytest.raises(IOError) as cm:
+            uv_in.write_miriad(write_file, clobber=False)
+        assert str(cm.value).startswith("File exists: skipping")
+    else:
+        with pytest.raises(OSError) as cm:
+            uv_in.write_miriad(write_file, clobber=False)
+        assert str(cm.value).startswith("File exists: skipping")
 
     # check that if x_orientation is set, it's read back out properly
     uv_in.x_orientation = 'east'
@@ -790,9 +801,14 @@ def test_readWriteReadMiriad_partial():
         uv_in.read(write_file, polarizations='xx')
     assert str(cm.value).startswith("pols must be a list of polarization strings or ints")
 
-    with pytest.raises(ValueError) as cm:
-        uv_in.read(write_file, polarizations=[1.0])
-    assert str(cm.value).startswith("Polarization 1.0 cannot be converted to a polarization number")
+    if six.PY2:
+        with pytest.raises(AssertionError) as cm:
+            uv_in.read(write_file, polarizations=[1.0])
+        assert str(cm.value).startswith("pols must be a list of polarization strings or ints")
+    else:
+        with pytest.raises(ValueError) as cm:
+            uv_in.read(write_file, polarizations=[1.0])
+        assert str(cm.value).startswith("Polarization 1.0 cannot be converted to a polarization number")
 
     with pytest.raises(ValueError) as cm:
         uv_in.read(write_file, polarizations=['yy'])

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1744,6 +1744,14 @@ def test_add():
 
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)
+    uv1.select(freq_chans=[0])
+    uv2.select(freq_chans=[1])
+    uv2.freq_array += uv2._channel_width.tols[1] / 2.
+    uvtest.checkWarnings(uv1.__iadd__, [uv2],
+                         nwarnings=0)
+
+    uv1 = copy.deepcopy(uv_full)
+    uv2 = copy.deepcopy(uv_full)
     uv1.select(polarizations=uv1.polarization_array[0:2])
     uv2.select(polarizations=uv2.polarization_array[3])
     uvtest.checkWarnings(uv1.__iadd__, [uv2],
@@ -2211,6 +2219,14 @@ def test_fast_concat():
     uv2.select(freq_chans=[3])
     uvtest.checkWarnings(uv1.fast_concat, [uv2, 'freq'],
                          message='Combined frequencies are not contiguous')
+
+    uv1 = copy.deepcopy(uv_full)
+    uv2 = copy.deepcopy(uv_full)
+    uv1.select(freq_chans=[0])
+    uv2.select(freq_chans=[1])
+    uv2.freq_array += uv2._channel_width.tols[1] / 2.
+    uvtest.checkWarnings(uv1.fast_concat, [uv2, 'freq'],
+                         nwarnings=0)
 
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -207,6 +207,7 @@ def test_equality(uvdata_data):
     assert uvdata_data.uv_object == uvdata_data.uv_object
 
 
+@pytest.mark.filterwarnings("ignore:Telescope location derived from obs")
 def test_check(uvdata_data):
     """Test simple check function."""
     assert uvdata_data.uv_object.check()
@@ -230,7 +231,7 @@ def test_check(uvdata_data):
                  testdir + '1061316296_layout.sav',
                  testdir + '1061316296_settings.txt']
 
-    uvtest.checkWarnings(uvdata_data.uv_object.read_fhd, [file_list], known_warning='fhd')
+    uvdata_data.uv_object.read_fhd(file_list)
 
     uvdata_data.uv_object.select(blt_inds=np.where(uvdata_data.uv_object.ant_1_array
                                                    == uvdata_data.uv_object.ant_2_array)[0])
@@ -380,11 +381,11 @@ def test_known_telescopes():
     assert np.sort(known_telescopes).tolist() == np.sort(uv_object.known_telescopes()).tolist()
 
 
+@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_HERA_diameters():
     miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
     uv_in = UVData()
-    uvtest.checkWarnings(uv_in.read_miriad, [miriad_file],
-                         known_warning='miriad')
+    uv_in.read_miriad(miriad_file)
 
     uv_in.telescope_name = 'HERA'
     uvtest.checkWarnings(uv_in.set_telescope_params, message='antenna_diameters '
@@ -396,11 +397,11 @@ def test_HERA_diameters():
     uv_in.check()
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_generic_read():
     uv_in = UVData()
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_in.read, [uvfits_file], {'read_data': False},
-                         message='Telescope EVLA is not')
+    uv_in.read(uvfits_file, read_data=False)
     unique_times = np.unique(uv_in.time_array)
 
     pytest.raises(ValueError, uv_in.read, uvfits_file, times=unique_times[0:2],
@@ -590,12 +591,12 @@ def test_phasing():
     assert np.allclose(uvd2.uvw_array, uvd2_drift_antpos.uvw_array, atol=2e-2)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_set_phase_unknown():
     uv_object = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_object.read_uvfits, [
-                         testfile], message='Telescope EVLA is not')
+    uv_object.read_uvfits(testfile)
 
     uv_object.set_unknown_phase_type()
     assert uv_object.phase_type == 'unknown'
@@ -605,11 +606,11 @@ def test_set_phase_unknown():
     assert uv_object.check()
 
 
+@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_select_blts():
     uv_object = UVData()
     testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    uvtest.checkWarnings(uv_object.read_miriad, [testfile],
-                         known_warning='miriad')
+    uv_object.read_miriad(testfile)
     old_history = uv_object.history
     blt_inds = np.array([172, 182, 132, 227, 144, 44, 16, 104, 385, 134, 326, 140, 116,
                          218, 178, 391, 111, 276, 274, 308, 38, 64, 317, 76, 239, 246,
@@ -686,12 +687,12 @@ def test_select_blts():
                   blt_inds=np.arange(uv_object.Nblts + 1, uv_object.Nblts + 10))
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_select_antennas():
     uv_object = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_object.read_uvfits(testfile)
     old_history = uv_object.history
     unique_ants = np.unique(
         uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist())
@@ -789,12 +790,12 @@ def sort_bl(p):
     return (p[1], p[0]) + p[2:]
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_select_bls():
     uv_object = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_object.read_uvfits(testfile)
     old_history = uv_object.history
     first_ants = [6, 2, 7, 2, 21, 27, 8]
     second_ants = [0, 20, 8, 1, 2, 3, 22]
@@ -927,12 +928,12 @@ def test_select_bls():
     assert str(cm.value).startswith('bls must be a list of tuples of antenna numbers')
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_select_times():
     uv_object = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_object.read_uvfits(testfile)
     old_history = uv_object.history
     unique_times = np.unique(uv_object.time_array)
     times_to_keep = unique_times[[0, 3, 5, 6, 7, 10, 14]]
@@ -971,12 +972,12 @@ def test_select_times():
     pytest.raises(ValueError, uv_object.select, times=[np.min(unique_times) - uv_object.integration_time[0]])
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_select_frequencies():
     uv_object = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_object.read_uvfits(testfile)
     old_history = uv_object.history
     freqs_to_keep = uv_object.freq_array[0, np.arange(12, 22)]
 
@@ -1039,12 +1040,12 @@ def test_select_frequencies():
     pytest.raises(ValueError, uv_object2.write_miriad, write_file_miriad)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_select_freq_chans():
     uv_object = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_object.read_uvfits(testfile)
     old_history = uv_object.history
     chans_to_keep = np.arange(12, 22)
 
@@ -1089,12 +1090,12 @@ def test_select_freq_chans():
         assert f in uv_object.freq_array[0, all_chans_to_keep]
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_select_polarizations():
     uv_object = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_object.read_uvfits(testfile)
     old_history = uv_object.history
     pols_to_keep = [-1, -2]
 
@@ -1135,13 +1136,13 @@ def test_select_polarizations():
     pytest.raises(ValueError, uv_object.write_uvfits, write_file_uvfits)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_select():
     # now test selecting along all axes at once
     uv_object = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_object.read_uvfits(testfile)
     old_history = uv_object.history
 
     blt_inds = np.array([1057, 461, 1090, 354, 528, 654, 882, 775, 369, 906, 748,
@@ -1218,13 +1219,13 @@ def test_select():
                   times=unique_times[0], antenna_nums=1)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_select_not_inplace():
     # Test non-inplace select
     uv_object = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_object.read_uvfits(testfile)
     old_history = uv_object.history
     uv1 = uv_object.select(freq_chans=np.arange(32), inplace=False)
     uv1 += uv_object.select(freq_chans=np.arange(32, 64), inplace=False)
@@ -1237,10 +1238,12 @@ def test_select_not_inplace():
     assert uv1 == uv_object
 
 
+@pytest.mark.filterwarnings("ignore:The default for the `center` keyword")
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_conjugate_bls():
     uv1 = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv1.read_uvfits, [testfile], message='Telescope EVLA is not')
+    uv1.read_uvfits(testfile)
 
     # file comes in with ant1<ant2
     assert(np.min(uv1.ant_2_array - uv1.ant_1_array) >= 0)
@@ -1355,11 +1358,12 @@ def test_conjugate_bls():
     assert str(cm.value).startswith('If convention is an index array')
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_reorder_pols():
     # Test function to fix polarization order
     uv1 = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv1.read_uvfits, [testfile], message='Telescope EVLA is not')
+    uv1.read_uvfits(testfile)
     uv2 = copy.deepcopy(uv1)
     # reorder uv2 manually
     order = [1, 3, 2, 0]
@@ -1371,7 +1375,7 @@ def test_reorder_pols():
     assert uv1 == uv2
 
     # Restore original order
-    uvtest.checkWarnings(uv1.read_uvfits, [testfile], message='Telescope EVLA is not')
+    uv1.read_uvfits(testfile)
     uv2.reorder_pols()
     assert uv1 == uv2
 
@@ -1408,10 +1412,11 @@ def test_reorder_pols():
                          category=DeprecationWarning)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_reorder_blts():
     uv1 = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv1.read_uvfits, [testfile], message='Telescope EVLA is not')
+    uv1.read_uvfits(testfile)
 
     # test default reordering in detail
     uv2 = copy.deepcopy(uv1)
@@ -1533,11 +1538,11 @@ def test_reorder_blts():
     assert str(cm.value).startswith('minor_order can only be one of')
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_add():
     uv_full = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_full.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_full.read_uvfits(testfile)
 
     # Add frequencies
     uv1 = copy.deepcopy(uv_full)
@@ -1773,12 +1778,12 @@ def test_add():
     assert uv2.Nbls == uv_auto.Nbls + uv_cross.Nbls
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_add_drift():
     uv_full = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_full.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_full.read_uvfits(testfile)
 
     uvtest.checkWarnings(uv_full.unphase_to_drift, category=DeprecationWarning,
                          message='The xyz array in ENU_from_ECEF is being '
@@ -1949,13 +1954,13 @@ def test_add_drift():
     assert uv1 == uv_full
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_break_add():
     # Test failure modes of add function
     uv_full = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_full.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_full.read_uvfits(testfile)
 
     # Wrong class
     uv1 = copy.deepcopy(uv_full)
@@ -1986,11 +1991,11 @@ def test_break_add():
     pytest.raises(ValueError, uv1.__iadd__, uv2)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_fast_concat():
     uv_full = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_full.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_full.read_uvfits(testfile)
 
     # Add frequencies
     uv1 = copy.deepcopy(uv_full)
@@ -2243,11 +2248,11 @@ def test_fast_concat():
     assert uv2.Nbls == uv_auto.Nbls + uv_cross.Nbls
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_fast_concat_errors():
     uv_full = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_full.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv_full.read_uvfits(testfile)
 
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)
@@ -2259,13 +2264,13 @@ def test_fast_concat_errors():
     pytest.raises(ValueError, uv1.fast_concat, cal, 'freq', inplace=True)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_key2inds():
     # Test function to interpret key as antpair, pol
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     # Get an antpair/pol combo
     ant1 = uv.ant_1_array[0]
@@ -2355,12 +2360,12 @@ def test_key2inds():
     assert np.array_equal(ind2, [])
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_key2inds_conj_all_pols():
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     ant1 = uv.ant_1_array[0]
     ant2 = uv.ant_2_array[0]
@@ -2375,12 +2380,12 @@ def test_key2inds_conj_all_pols():
     assert np.array_equal([0, 1, 3, 2], indp[1])
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_key2inds_conj_all_pols_fringe():
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     uv.select(polarizations=['rl'])
     ant1 = uv.ant_1_array[0]
@@ -2397,12 +2402,12 @@ def test_key2inds_conj_all_pols_fringe():
     assert np.array_equal(np.array([]), indp[1])
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_key2inds_conj_all_pols_bl_fringe():
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     uv.select(polarizations=['rl'])
     ant1 = uv.ant_1_array[0]
@@ -2421,12 +2426,12 @@ def test_key2inds_conj_all_pols_bl_fringe():
     assert np.array_equal(np.array([]), indp[1])
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_key2inds_conj_all_pols_missing_data():
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
     uv.select(polarizations=['rl'])
     ant1 = uv.ant_1_array[0]
     ant2 = uv.ant_2_array[0]
@@ -2434,12 +2439,12 @@ def test_key2inds_conj_all_pols_missing_data():
     pytest.raises(KeyError, uv._key2inds, (ant2, ant1))
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_key2inds_conj_all_pols_bls():
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     ant1 = uv.ant_1_array[0]
     ant2 = uv.ant_2_array[0]
@@ -2455,12 +2460,12 @@ def test_key2inds_conj_all_pols_bls():
     assert np.array_equal([0, 1, 3, 2], indp[1])
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_key2inds_conj_all_pols_missing_data_bls():
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
     uv.select(polarizations=['rl'])
     ant1 = uv.ant_1_array[0]
     ant2 = uv.ant_2_array[0]
@@ -2469,13 +2474,13 @@ def test_key2inds_conj_all_pols_missing_data_bls():
     pytest.raises(KeyError, uv._key2inds, bl)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_smart_slicing():
     # Test function to slice data
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     # ind1 reg, ind2 empty, pol reg
     ind1 = 10 * np.arange(9)
@@ -2626,13 +2631,13 @@ def test_smart_slicing():
                   (indp, []), squeeze='notasqueeze')
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_get_data():
     # Test get_data function for easy access to data
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     # Get an antpair/pol combo
     ant1 = uv.ant_1_array[0]
@@ -2673,13 +2678,13 @@ def test_get_data():
     assert np.all(dcheck == d)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_get_flags():
     # Test function for easy access to flags
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     # Get an antpair/pol combo
     ant1 = uv.ant_1_array[0]
@@ -2716,13 +2721,13 @@ def test_get_flags():
     assert np.all(dcheck == d)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_get_nsamples():
     # Test function for easy access to nsample array
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     # Get an antpair/pol combo
     ant1 = uv.ant_1_array[0]
@@ -2758,13 +2763,13 @@ def test_get_nsamples():
     assert np.all(dcheck == d)
 
 
+@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_antpair2ind():
     # Test for baseline-time axis indexer
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    uvtest.checkWarnings(uv.read_miriad, [testfile],
-                         message='Altitude is not present in Miriad file')
+    uv.read_miriad(testfile)
 
     # get indices
     inds = uv.antpair2ind(0, 1, ordered=False)
@@ -2792,13 +2797,13 @@ def test_antpair2ind():
     pytest.raises(ValueError, uv.antpair2ind, 0, 1, 'foo')
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_get_times():
     # Test function for easy access to times, to work in conjunction with get_data
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     # Get an antpair/pol combo (pol shouldn't actually effect result)
     ant1 = uv.ant_1_array[0]
@@ -2832,13 +2837,13 @@ def test_get_times():
     assert np.all(d == uv.time_array)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_antpairpol_iter():
     # Test generator
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     pol_dict = {uvutils.polnum2str(uv.polarization_array[i]): i for i in range(uv.Npols)}
     keys = []
@@ -2856,13 +2861,14 @@ def test_antpairpol_iter():
     assert len(pols) == uv.Npols
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_get_ants():
     # Test function to get unique antennas in data
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
+
     ants = uv.get_ants()
     for ant in ants:
         assert (ant in uv.ant_1_array) or (ant in uv.ant_2_array)
@@ -2894,22 +2900,23 @@ def test_get_ENU_antpos():
     assert np.isclose(antpos[0, 0], -0.0026981323386223721)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_get_pols():
     # Test function to get unique polarizations in string format
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
     pols = uv.get_pols()
     pols_data = ['rr', 'll', 'lr', 'rl']
     assert sorted(pols) == sorted(pols_data)
 
 
+@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_get_pols_x_orientation():
     miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
     uv_in = UVData()
-    uvtest.checkWarnings(uv_in.read, [miriad_file], known_warning='miriad')
+    uv_in.read(miriad_file)
 
     uv_in.x_orientation = 'east'
 
@@ -2924,10 +2931,11 @@ def test_get_pols_x_orientation():
     assert pols == pols_data
 
 
+@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_deprecated_x_orientation():
     miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
     uv_in = UVData()
-    uvtest.checkWarnings(uv_in.read, [miriad_file], known_warning='miriad')
+    uv_in.read(miriad_file)
 
     uv_in.x_orientation = 'e'
 
@@ -2947,13 +2955,13 @@ def test_deprecated_x_orientation():
                            'cannot be converted.'])
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_get_feedpols():
     # Test function to get unique antenna feed polarizations in data. String format.
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
     pols = uv.get_feedpols()
     pols_data = ['r', 'l']
     assert sorted(pols) == sorted(pols_data)
@@ -2963,12 +2971,13 @@ def test_get_feedpols():
     pytest.raises(ValueError, uv.get_feedpols)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_parse_ants():
     # Test function to get correct antenna pairs and polarizations
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile], message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     # All baselines
     ant_str = 'all'
@@ -3214,12 +3223,13 @@ def test_parse_ants():
     assert isinstance(polarizations, type(None))
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_select_with_ant_str():
     # Test select function with ant_str argument
     uv = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile], message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
     inplace = False
 
     # Check error thrown if ant_str passed with antenna_nums,
@@ -3489,20 +3499,21 @@ def test_set_uvws_from_antenna_pos():
 def test_deprecated_redundancy_funcs():
     uv0 = UVData()
     uv0.read_uvfits(os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'))
-    redant_gps, centers, lengths = uvtest.checkWarnings(uv0.get_antenna_redundancies,
-                                                        func_kwargs={'include_autos': False, 'conjugate_bls': True},
-                                                        category=DeprecationWarning,
-                                                        nwarnings=2,
-                                                        message=['UVData.get_antenna_redundancies has been replaced',
-                                                                 'The default for the `center` keyword'])
-    redbl_gps, centers, lengths, _ = uvtest.checkWarnings(uv0.get_baseline_redundancies,
-                                                          category=DeprecationWarning,
-                                                          message='UVData.get_baseline_redundancies has been replaced')
+    redant_gps, centers, lengths = uvtest.checkWarnings(
+        uv0.get_antenna_redundancies,
+        func_kwargs={'include_autos': False, 'conjugate_bls': True},
+        category=DeprecationWarning, nwarnings=2,
+        message=['UVData.get_antenna_redundancies has been replaced',
+                 'The default for the `center` keyword'])
+    redbl_gps, centers, lengths, _ = uvtest.checkWarnings(
+        uv0.get_baseline_redundancies, category=DeprecationWarning,
+        message='UVData.get_baseline_redundancies has been replaced')
 
     red_gps_new, _, _, = uv0.get_redundancies(include_autos=False, use_antpos=True)
     assert red_gps_new == redant_gps
 
 
+@pytest.mark.filterwarnings("ignore:The default for the `center` keyword")
 def test_get_antenna_redundancies():
     uv0 = UVData()
     uv0.read_uvfits(os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'))
@@ -3535,6 +3546,7 @@ def test_get_antenna_redundancies():
     assert np.allclose(lengths, new_lengths)
 
 
+@pytest.mark.filterwarnings("ignore:The default for the `center` keyword")
 def test_redundancy_contract_expand():
     # Test that a UVData object can be reduced to one baseline from each redundant group
     # and restored to its original form.
@@ -3593,10 +3605,12 @@ def test_redundancy_contract_expand():
     assert uv2 == uv3
 
 
+@pytest.mark.filterwarnings("ignore:The default for the `center` keyword")
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_redundancy_contract_expand_nblts_not_nbls_times_ntimes():
     uv0 = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv0.read_uvfits, [testfile], message='Telescope EVLA is not')
+    uv0.read_uvfits(testfile)
 
     # check that Nblts != Nbls * Ntimes
     assert uv0.Nblts != uv0.Nbls * uv0.Ntimes
@@ -3647,6 +3661,7 @@ def test_redundancy_contract_expand_nblts_not_nbls_times_ntimes():
     assert uv3 == uv1
 
 
+@pytest.mark.filterwarnings("ignore:The default for the `center` keyword")
 def test_compress_redundancy_metadata_only():
     uv0 = UVData()
     uv0.read_uvfits(os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'))
@@ -3759,12 +3774,13 @@ def test_quick_redundant_vs_redundant_test_array():
     assert groups == redundant_groups
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_redundancy_finder_when_nblts_not_nbls_times_ntimes():
     """Test the redundancy finder functions when Nblts != Nbls * Ntimes."""
     tol = 1  # meter
     uv = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile], message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
     uvtest.checkWarnings(uv.conjugate_bls, func_kwargs={'convention': 'u>0', 'use_enu': True},
                          message=['The default for the `center`'],
                          nwarnings=1, category=DeprecationWarning)
@@ -3800,11 +3816,12 @@ def test_redundancy_finder_when_nblts_not_nbls_times_ntimes():
     assert groups == redundant_groups
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_overlapping_data_add():
     # read in test data
     uv = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv.read_uvfits, [testfile], message='Telescope EVLA is not')
+    uv.read_uvfits(testfile)
 
     # slice into four objects
     blts1 = np.arange(500)
@@ -3850,8 +3867,7 @@ def test_overlapping_data_add():
     uv4.write_uvfits(uv4_out)
 
     uvfull = UVData()
-    uvtest.checkWarnings(uvfull.read, [[uv1_out, uv2_out, uv3_out, uv4_out]],
-                         nwarnings=4, message='Telescope EVLA is not')
+    uvfull.read([uv1_out, uv2_out, uv3_out, uv4_out])
     assert uvutils._check_histories(uvfull.history, uv.history + extra_history)
     uvfull.history = uv.history  # make histories match
     assert uvfull == uv
@@ -3865,12 +3881,12 @@ def test_overlapping_data_add():
     return
 
 
+@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_lsts_from_time_with_only_unique():
     """Test `set_lsts_from_time_array` with only unique values is identical to full array."""
     miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
     uv = UVData()
-    uvtest.checkWarnings(uv.read_miriad, [miriad_file],
-                         known_warning='miriad')
+    uv.read_miriad(miriad_file)
     lat, lon, alt = uv.telescope_location_lat_lon_alt_degrees
     # calculate the lsts for all elements in time array
     full_lsts = uvutils.get_lst_for_time(uv.time_array, lat, lon, alt)

--- a/pyuvdata/tests/test_uvfits.py
+++ b/pyuvdata/tests/test_uvfits.py
@@ -331,9 +331,14 @@ def test_extra_keywords():
     uv_in.extra_keywords['testdict'] = {'testkey': 23}
     uvtest.checkWarnings(uv_in.check, message=['testdict in extra_keywords is a '
                                                'list, array or dict'])
-    with pytest.raises(TypeError) as cm:
-        uv_in.write_uvfits(testfile, run_check=False)
-    assert str(cm.value).startswith("Extra keyword testdict is of <class 'dict'>")
+    if six.PY2:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_uvfits(testfile, run_check=False)
+        assert str(cm.value).startswith("Extra keyword testdict is of <type 'dict'>")
+    else:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_uvfits(testfile, run_check=False)
+        assert str(cm.value).startswith("Extra keyword testdict is of <class 'dict'>")
     uv_in.extra_keywords.pop('testdict')
 
     uv_in.extra_keywords['testlist'] = [12, 14, 90]

--- a/pyuvdata/tests/test_uvfits.py
+++ b/pyuvdata/tests/test_uvfits.py
@@ -10,6 +10,8 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 import copy
 import os
+
+import six
 import pytest
 import astropy
 from astropy.io import fits

--- a/pyuvdata/tests/test_uvfits.py
+++ b/pyuvdata/tests/test_uvfits.py
@@ -34,7 +34,9 @@ def test_ReadNRAO():
     uvtest.checkWarnings(UV2.read, [testfile], {'read_data': False, 'read_metadata': False},
                          message='Telescope EVLA is not')
     assert expected_extra_keywords.sort() == list(UV2.extra_keywords.keys()).sort()
-    pytest.raises(ValueError, UV2.check)
+    with pytest.raises(ValueError) as cm:
+        UV2.check()
+    assert str(cm.value).startswith('Required UVParameter')
 
     UV2.read(testfile, read_data=False)
     assert UV2.check()
@@ -50,35 +52,38 @@ def test_ReadNRAO():
     assert UV == UV2
 
     # check error trying to read metadata after data is already present
-    pytest.raises(ValueError, uvtest.checkWarnings, UV2.read, [testfile],
-                  {'read_data': False}, message='Telescope EVLA is not')
-    del(UV)
+    with pytest.raises(ValueError) as cm:
+        UV2.read(testfile, read_data=False)
+    assert str(cm.value).startswith('data_array is already defined, cannot read metadata')
 
 
+@pytest.mark.filterwarnings("ignore:Required Antenna frame keyword")
+@pytest.mark.filterwarnings("ignore:telescope_location is not set")
 def test_noSPW():
     """Test reading in a PAPER uvfits file with no spw axis."""
     UV = UVData()
     testfile_no_spw = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAAM.uvfits')
-    uvtest.checkWarnings(UV.read, [testfile_no_spw], known_warning='paper_uvfits')
+    UV.read(testfile_no_spw)
     del(UV)
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_breakReadUVFits():
     """Test errors on reading in a uvfits file with subarrays and other problems."""
     UV = UVData()
     multi_subarray_file = os.path.join(DATA_PATH, 'multi_subarray.uvfits')
-    uvtest.checkWarnings(pytest.raises, [ValueError, UV.read, multi_subarray_file],
-                         message='Telescope EVLA is not')
+    with pytest.raises(ValueError) as cm:
+        UV.read(multi_subarray_file)
+    assert str(cm.value).startswith('This file appears to have multiple subarray')
 
-    del(UV)
 
-
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_source_group_params():
     # make a file with a single source to test that it works
     uv_in = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     write_file = os.path.join(DATA_PATH, 'test/outtest_casa.uvfits')
-    uvtest.checkWarnings(uv_in.read, [testfile], message='Telescope EVLA is not')
+    uv_in.read(testfile)
     uv_in.write_uvfits(write_file)
 
     with fits.open(write_file, memmap=True) as hdu_list:
@@ -121,16 +126,17 @@ def test_source_group_params():
         hdulist.writeto(write_file, overwrite=True)
 
     uv_out = UVData()
-    uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
+    uv_out.read(write_file)
     assert uv_in == uv_out
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_multisource_error():
     # make a file with multiple sources to test error condition
     uv_in = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     write_file = os.path.join(DATA_PATH, 'test/outtest_casa.uvfits')
-    uvtest.checkWarnings(uv_in.read, [testfile], message='Telescope EVLA is not')
+    uv_in.read(testfile)
     uv_in.write_uvfits(write_file)
 
     with fits.open(write_file, memmap=True) as hdu_list:
@@ -174,18 +180,22 @@ def test_multisource_error():
         hdulist = fits.HDUList(hdus=[vis_hdu, ant_hdu])
         hdulist.writeto(write_file, overwrite=True)
 
-    uvtest.checkWarnings(pytest.raises, [ValueError, uv_in.read, write_file],
-                         message='Telescope EVLA is not')
+    with pytest.raises(ValueError) as cm:
+        uv_in.read(write_file)
+    assert str(cm.value).startswith('This file has multiple sources')
 
 
 def test_spwnotsupported():
     """Test errors on reading in a uvfits file with multiple spws."""
     UV = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1scan.uvfits')
-    pytest.raises(ValueError, UV.read, testfile)
-    del(UV)
+    with pytest.raises(ValueError) as cm:
+        UV.read(testfile)
+    assert str(cm.value).startswith('Sorry.  Files with more than one spectral'
+                                    'window (spw) are not yet supported')
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_readwriteread():
     """
     CASA tutorial uvfits loopback test.
@@ -197,38 +207,38 @@ def test_readwriteread():
     uv_out = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     write_file = os.path.join(DATA_PATH, 'test/outtest_casa.uvfits')
-    uvtest.checkWarnings(uv_in.read, [testfile], message='Telescope EVLA is not')
+    uv_in.read(testfile)
     uv_in.write_uvfits(write_file)
-    uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
+    uv_out.read(write_file)
     assert uv_in == uv_out
 
     # test that it works with write_lst = False
     uv_in.write_uvfits(write_file, write_lst=False)
-    uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
+    uv_out.read(write_file)
     assert uv_in == uv_out
 
     # check that if x_orientation is set, it's read back out properly
     uv_in.x_orientation = 'east'
     uv_in.write_uvfits(write_file)
-    uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
+    uv_out.read(write_file)
     assert uv_in == uv_out
 
     # check that if antenna_diameters is set, it's read back out properly
-    uvtest.checkWarnings(uv_in.read, [testfile], message='Telescope EVLA is not')
+    uv_in.read(testfile)
     uv_in.antenna_diameters = np.zeros((uv_in.Nants_telescope,), dtype=np.float) + 14.0
     uv_in.write_uvfits(write_file)
-    uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
+    uv_out.read(write_file)
     assert uv_in == uv_out
 
     # check that if antenna_numbers are > 256 everything works
-    uvtest.checkWarnings(uv_in.read, [testfile], message='Telescope EVLA is not')
+    uv_in.read(testfile)
     uv_in.antenna_numbers = uv_in.antenna_numbers + 256
     uv_in.ant_1_array = uv_in.ant_1_array + 256
     uv_in.ant_2_array = uv_in.ant_2_array + 256
     uv_in.baseline_array = uv_in.antnums_to_baseline(uv_in.ant_1_array, uv_in.ant_2_array)
     uvtest.checkWarnings(uv_in.write_uvfits, [write_file],
                          message='antnums_to_baseline: found > 256 antennas, using 2048 baseline')
-    uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
+    uv_out.read(write_file)
     assert uv_in == uv_out
 
     # check missing telescope_name, timesys vs timsys spelling, xyz_telescope_frame=????
@@ -253,14 +263,17 @@ def test_readwriteread():
         hdulist = fits.HDUList(hdus=[vis_hdu, ant_hdu])
         hdulist.writeto(write_file, overwrite=True)
 
-    uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
+    uv_out.read(write_file)
     assert uv_out.telescope_name == 'EVLA'
     assert uv_out.timesys == time_sys
 
     # check error if timesys is 'IAT'
-    uvtest.checkWarnings(uv_in.read, [testfile], message='Telescope EVLA is not')
+    uv_in.read(testfile)
     uv_in.timesys = 'IAT'
-    pytest.raises(ValueError, uv_in.write_uvfits, write_file)
+    with pytest.raises(ValueError) as cm:
+        uv_in.write_uvfits(write_file)
+    assert str(cm.value).startswith('This file has a time system IAT. '
+                                    'Only "UTC" time system files are supported')
     uv_in.timesys = 'UTC'
 
     # check error if one time & no inttime specified
@@ -289,48 +302,54 @@ def test_readwriteread():
         hdulist = fits.HDUList(hdus=[vis_hdu, ant_hdu])
         hdulist.writeto(write_file, overwrite=True)
 
-    uvtest.checkWarnings(pytest.raises, [ValueError, uv_out.read, write_file],
-                         message=['Telescope EVLA is not',
-                                  'ERFA function "utcut1" yielded 1 of "dubious year (Note 3)"',
-                                  'ERFA function "utctai" yielded 1 of "dubious year (Note 3)"',
-                                  'LST values stored in this file are not self-consistent'],
-                         nwarnings=4,
-                         category=[UserWarning, astropy._erfa.core.ErfaWarning,
-                                   astropy._erfa.core.ErfaWarning, UserWarning])
+    with pytest.raises(ValueError) as cm:
+        uvtest.checkWarnings(uv_out.read, func_args=[write_file],
+                             message=['Telescope EVLA is not',
+                                      'ERFA function "utcut1" yielded 1 of "dubious year (Note 3)"',
+                                      'ERFA function "utctai" yielded 1 of "dubious year (Note 3)"',
+                                      'LST values stored in this file are not self-consistent'],
+                             nwarnings=4,
+                             category=[UserWarning, astropy._erfa.core.ErfaWarning,
+                             astropy._erfa.core.ErfaWarning, UserWarning])
+    assert str(cm.value).startswith('integration time not specified and only one time present')
 
     # check that unflagged data with nsample = 0 will cause warnings
     uv_in.nsample_array[list(range(11, 22))] = 0
     uv_in.flag_array[list(range(11, 22))] = False
     uvtest.checkWarnings(uv_in.write_uvfits, [write_file], message='Some unflagged data has nsample = 0')
 
-    del(uv_in)
-    del(uv_out)
 
-
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_extra_keywords():
     uv_in = UVData()
     uv_out = UVData()
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     testfile = os.path.join(DATA_PATH, 'test/outtest_casa.uvfits')
-    uvtest.checkWarnings(uv_in.read, [uvfits_file], message='Telescope EVLA is not')
+    uv_in.read(uvfits_file)
 
     # check for warnings & errors with extra_keywords that are dicts, lists or arrays
     uv_in.extra_keywords['testdict'] = {'testkey': 23}
     uvtest.checkWarnings(uv_in.check, message=['testdict in extra_keywords is a '
                                                'list, array or dict'])
-    pytest.raises(TypeError, uv_in.write_uvfits, testfile, run_check=False)
+    with pytest.raises(TypeError) as cm:
+        uv_in.write_uvfits(testfile, run_check=False)
+    assert str(cm.value).startswith("Extra keyword testdict is of <class 'dict'>")
     uv_in.extra_keywords.pop('testdict')
 
     uv_in.extra_keywords['testlist'] = [12, 14, 90]
     uvtest.checkWarnings(uv_in.check, message=['testlist in extra_keywords is a '
                                                'list, array or dict'])
-    pytest.raises(TypeError, uv_in.write_uvfits, testfile, run_check=False)
+    with pytest.raises(TypeError) as cm:
+        uv_in.write_uvfits(testfile, run_check=False)
+    assert str(cm.value).startswith("Extra keyword testlist is of <class 'list'>")
     uv_in.extra_keywords.pop('testlist')
 
     uv_in.extra_keywords['testarr'] = np.array([12, 14, 90])
     uvtest.checkWarnings(uv_in.check, message=['testarr in extra_keywords is a '
                                                'list, array or dict'])
-    pytest.raises(TypeError, uv_in.write_uvfits, testfile, run_check=False)
+    with pytest.raises(TypeError) as cm:
+        uv_in.write_uvfits(testfile, run_check=False)
+    assert str(cm.value).startswith("Extra keyword testarr is of <class 'numpy.ndarray'>")
     uv_in.extra_keywords.pop('testarr')
 
     # check for warnings with extra_keywords keys that are too long
@@ -345,7 +364,7 @@ def test_extra_keywords():
     uv_in.extra_keywords['bool'] = True
     uv_in.extra_keywords['bool2'] = False
     uv_in.write_uvfits(testfile)
-    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
+    uv_out.read(testfile)
 
     assert uv_in == uv_out
     uv_in.extra_keywords.pop('bool')
@@ -355,7 +374,7 @@ def test_extra_keywords():
     uv_in.extra_keywords['int1'] = np.int(5)
     uv_in.extra_keywords['int2'] = 7
     uv_in.write_uvfits(testfile)
-    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
+    uv_out.read(testfile)
 
     assert uv_in == uv_out
     uv_in.extra_keywords.pop('int1')
@@ -365,7 +384,7 @@ def test_extra_keywords():
     uv_in.extra_keywords['float1'] = np.int64(5.3)
     uv_in.extra_keywords['float2'] = 6.9
     uv_in.write_uvfits(testfile)
-    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
+    uv_out.read(testfile)
 
     assert uv_in == uv_out
     uv_in.extra_keywords.pop('float1')
@@ -375,7 +394,7 @@ def test_extra_keywords():
     uv_in.extra_keywords['complex1'] = np.complex64(5.3 + 1.2j)
     uv_in.extra_keywords['complex2'] = 6.9 + 4.6j
     uv_in.write_uvfits(testfile)
-    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
+    uv_out.read(testfile)
 
     assert uv_in == uv_out
     uv_in.extra_keywords.pop('complex1')
@@ -386,32 +405,36 @@ def test_extra_keywords():
                                        'be broken into several lines\nif '
                                        'everything works properly.')
     uv_in.write_uvfits(testfile)
-    uvtest.checkWarnings(uv_out.read, [testfile], message='Telescope EVLA is not')
+    uv_out.read(testfile)
 
     assert uv_in == uv_out
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_roundtrip_blt_order():
     uv_in = UVData()
     uv_out = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     write_file = os.path.join(DATA_PATH, 'test/outtest_casa.uvfits')
-    uvtest.checkWarnings(uv_in.read, [testfile], message='Telescope EVLA is not')
+    uv_in.read(testfile)
 
     uv_in.reorder_blts()
 
     uv_in.write_uvfits(write_file)
-    uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
+    uv_out.read(write_file)
     assert uv_in == uv_out
 
     # test with bda as well (single entry in tuple)
     uv_in.reorder_blts(order='bda')
 
     uv_in.write_uvfits(write_file)
-    uvtest.checkWarnings(uv_out.read, [write_file], message='Telescope EVLA is not')
+    uv_out.read(write_file)
     assert uv_in == uv_out
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:Required Antenna frame keyword")
+@pytest.mark.filterwarnings("ignore:telescope_location is not set")
 def test_select_read():
     uvfits_uv = UVData()
     uvfits_uv2 = UVData()
@@ -419,21 +442,15 @@ def test_select_read():
 
     # select on antennas
     ants_to_keep = np.array([0, 19, 11, 24, 3, 23, 1, 20, 21])
-    uvtest.checkWarnings(uvfits_uv.read, [uvfits_file],
-                         {'antenna_nums': ants_to_keep},
-                         message='Telescope EVLA is not')
-    uvtest.checkWarnings(uvfits_uv2.read, [uvfits_file],
-                         message='Telescope EVLA is not')
+    uvfits_uv.read(uvfits_file, antenna_nums=ants_to_keep)
+    uvfits_uv2.read(uvfits_file)
     uvfits_uv2.select(antenna_nums=ants_to_keep)
     assert uvfits_uv == uvfits_uv2
 
     # select on frequency channels
     chans_to_keep = np.arange(12, 22)
-    uvtest.checkWarnings(uvfits_uv.read, [uvfits_file],
-                         {'freq_chans': chans_to_keep},
-                         message='Telescope EVLA is not')
-    uvtest.checkWarnings(uvfits_uv2.read, [uvfits_file],
-                         message='Telescope EVLA is not')
+    uvfits_uv.read(uvfits_file, freq_chans=chans_to_keep)
+    uvfits_uv2.read(uvfits_file)
     uvfits_uv2.select(freq_chans=chans_to_keep)
     assert uvfits_uv == uvfits_uv2
 
@@ -441,17 +458,13 @@ def test_select_read():
     uvfits_uv.select(freq_chans=[0])
     testfile = os.path.join(DATA_PATH, 'test/outtest_casa.uvfits')
     uvfits_uv.write_uvfits(testfile)
-    uvtest.checkWarnings(uvfits_uv2.read, [testfile],
-                         message='Telescope EVLA is not')
+    uvfits_uv2.read(testfile)
     assert uvfits_uv == uvfits_uv2
 
     # select on pols
     pols_to_keep = [-1, -2]
-    uvtest.checkWarnings(uvfits_uv.read, [uvfits_file],
-                         {'polarizations': pols_to_keep},
-                         message='Telescope EVLA is not')
-    uvtest.checkWarnings(uvfits_uv2.read, [uvfits_file],
-                         message='Telescope EVLA is not')
+    uvfits_uv.read(uvfits_file, polarizations=pols_to_keep)
+    uvfits_uv2.read(uvfits_file)
     uvfits_uv2.select(polarizations=pols_to_keep)
     assert uvfits_uv == uvfits_uv2
 
@@ -462,33 +475,24 @@ def test_select_read():
                          nwarnings=2,
                          message=['Warning: "time_range" keyword is set',
                                   'Telescope EVLA is not'])
-    uvtest.checkWarnings(uvfits_uv2.read, [uvfits_file],
-                         message='Telescope EVLA is not')
+    uvfits_uv2.read(uvfits_file)
     uvfits_uv2.select(times=unique_times[0:2])
     assert uvfits_uv == uvfits_uv2
 
     # now test selecting on multiple axes
     # frequencies first
-    uvtest.checkWarnings(uvfits_uv.read, [uvfits_file],
-                         {'antenna_nums': ants_to_keep,
-                          'freq_chans': chans_to_keep,
-                          'polarizations': pols_to_keep},
-                         message='Telescope EVLA is not')
-    uvtest.checkWarnings(uvfits_uv2.read, [uvfits_file],
-                         message='Telescope EVLA is not')
+    uvfits_uv.read(uvfits_file, antenna_nums=ants_to_keep,
+                   freq_chans=chans_to_keep, polarizations=pols_to_keep)
+    uvfits_uv2.read(uvfits_file)
     uvfits_uv2.select(antenna_nums=ants_to_keep, freq_chans=chans_to_keep,
                       polarizations=pols_to_keep)
     assert uvfits_uv == uvfits_uv2
 
     # baselines first
     ants_to_keep = np.array([0, 1])
-    uvtest.checkWarnings(uvfits_uv.read, [uvfits_file],
-                         {'antenna_nums': ants_to_keep,
-                          'freq_chans': chans_to_keep,
-                          'polarizations': pols_to_keep},
-                         message='Telescope EVLA is not')
-    uvtest.checkWarnings(uvfits_uv2.read, [uvfits_file],
-                         message='Telescope EVLA is not')
+    uvfits_uv.read(uvfits_file, antenna_nums=ants_to_keep,
+                   freq_chans=chans_to_keep, polarizations=pols_to_keep)
+    uvfits_uv2.read(uvfits_file)
     uvfits_uv2.select(antenna_nums=ants_to_keep, freq_chans=chans_to_keep,
                       polarizations=pols_to_keep)
     assert uvfits_uv == uvfits_uv2
@@ -496,13 +500,9 @@ def test_select_read():
     # polarizations first
     ants_to_keep = np.array([0, 1, 2, 3, 6, 7, 8, 11, 14, 18, 19, 20, 21, 22])
     chans_to_keep = np.arange(12, 64)
-    uvtest.checkWarnings(uvfits_uv.read, [uvfits_file],
-                         {'antenna_nums': ants_to_keep,
-                          'freq_chans': chans_to_keep,
-                          'polarizations': pols_to_keep},
-                         message='Telescope EVLA is not')
-    uvtest.checkWarnings(uvfits_uv2.read, [uvfits_file],
-                         message='Telescope EVLA is not')
+    uvfits_uv.read(uvfits_file, antenna_nums=ants_to_keep,
+                   freq_chans=chans_to_keep, polarizations=pols_to_keep)
+    uvfits_uv2.read(uvfits_file)
     uvfits_uv2.select(antenna_nums=ants_to_keep, freq_chans=chans_to_keep,
                       polarizations=pols_to_keep)
     assert uvfits_uv == uvfits_uv2
@@ -512,21 +512,15 @@ def test_select_read():
 
     # select on antennas
     ants_to_keep = np.array([2, 4, 5])
-    uvtest.checkWarnings(uvfits_uv.read, [uvfitsfile_no_spw],
-                         {'antenna_nums': ants_to_keep},
-                         known_warning='paper_uvfits')
-    uvtest.checkWarnings(uvfits_uv2.read, [uvfitsfile_no_spw],
-                         known_warning='paper_uvfits')
+    uvfits_uv.read(uvfitsfile_no_spw, antenna_nums=ants_to_keep)
+    uvfits_uv2.read(uvfitsfile_no_spw)
     uvfits_uv2.select(antenna_nums=ants_to_keep)
     assert uvfits_uv == uvfits_uv2
 
     # select on frequency channels
     chans_to_keep = np.arange(4, 8)
-    uvtest.checkWarnings(uvfits_uv.read, [uvfitsfile_no_spw],
-                         {'freq_chans': chans_to_keep},
-                         known_warning='paper_uvfits')
-    uvtest.checkWarnings(uvfits_uv2.read, [uvfitsfile_no_spw],
-                         known_warning='paper_uvfits')
+    uvfits_uv.read(uvfitsfile_no_spw, freq_chans=chans_to_keep)
+    uvfits_uv2.read(uvfitsfile_no_spw)
     uvfits_uv2.select(freq_chans=chans_to_keep)
     assert uvfits_uv == uvfits_uv2
 
@@ -579,15 +573,13 @@ def test_select_read():
         hdulist.writeto(write_file, overwrite=True)
 
     pols_to_keep = [-1, -2]
-    uvtest.checkWarnings(uvfits_uv.read, [write_file],
-                         {'polarizations': pols_to_keep},
-                         message='Telescope EVLA is not')
-    uvtest.checkWarnings(uvfits_uv2.read, [write_file],
-                         message='Telescope EVLA is not')
+    uvfits_uv.read(write_file, polarizations=pols_to_keep)
+    uvfits_uv2.read(uvfits_file)
     uvfits_uv2.select(polarizations=pols_to_keep)
     assert uvfits_uv == uvfits_uv2
 
 
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_ReadUVFitsWriteMiriad():
     """
     read uvfits, write miriad test.
@@ -598,31 +590,29 @@ def test_ReadUVFitsWriteMiriad():
     miriad_uv = UVData()
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     testfile = os.path.join(DATA_PATH, 'test/outtest_miriad')
-    uvtest.checkWarnings(uvfits_uv.read, [uvfits_file], message='Telescope EVLA is not')
+    uvfits_uv.read(uvfits_file)
     uvfits_uv.write_miriad(testfile, clobber=True)
-    uvtest.checkWarnings(miriad_uv.read_miriad, [testfile], message='Telescope EVLA is not')
+    miriad_uv.read_miriad(testfile)
 
     assert miriad_uv == uvfits_uv
 
     # check that setting the phase_type keyword also works
-    uvtest.checkWarnings(miriad_uv.read_miriad, [testfile], {'phase_type': 'phased'},
-                         message='Telescope EVLA is not')
+    miriad_uv.read_miriad(testfile, phase_type='phased')
 
     # check that setting the phase_type to drift raises an error
-    pytest.raises(ValueError, miriad_uv.read_miriad, testfile, phase_type='drift'),
+    with pytest.raises(ValueError) as cm:
+        miriad_uv.read_miriad(testfile, phase_type='drift')
+    assert str(cm.value).startswith('phase_type is "drift" but the RA values are constant.')
 
     # check that setting it works after selecting a single time
     uvfits_uv.select(times=uvfits_uv.time_array[0])
     uvfits_uv.write_miriad(testfile, clobber=True)
-    uvtest.checkWarnings(miriad_uv.read_miriad, [testfile],
-                         message='Telescope EVLA is not')
+    miriad_uv.read_miriad(testfile)
 
     assert miriad_uv == uvfits_uv
 
-    del(uvfits_uv)
-    del(miriad_uv)
 
-
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_multi_files():
     """
     Reading multiple files at once.
@@ -631,15 +621,14 @@ def test_multi_files():
     uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     testfile1 = os.path.join(DATA_PATH, 'test/uv1.uvfits')
     testfile2 = os.path.join(DATA_PATH, 'test/uv2.uvfits')
-    uvtest.checkWarnings(uv_full.read, [uvfits_file], message='Telescope EVLA is not')
+    uv_full.read(uvfits_file)
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)
     uv1.select(freq_chans=np.arange(0, 32))
     uv2.select(freq_chans=np.arange(32, 64))
     uv1.write_uvfits(testfile1)
     uv2.write_uvfits(testfile2)
-    uvtest.checkWarnings(uv1.read, [[testfile1, testfile2]], nwarnings=2,
-                         message=['Telescope EVLA is not'])
+    uv1.read([testfile1, testfile2])
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(uv_full.history + '  Downselected to '
                                     'specific frequencies using pyuvdata. '
@@ -650,8 +639,7 @@ def test_multi_files():
     assert uv1 == uv_full
 
     # again, setting axis
-    uvtest.checkWarnings(uv1.read, [[testfile1, testfile2]], {'axis': 'freq'},
-                         nwarnings=2, message=['Telescope EVLA is not'])
+    uv1.read([testfile1, testfile2], axis='freq')
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(uv_full.history + '  Downselected to '
                                     'specific frequencies using pyuvdata. '
@@ -663,8 +651,7 @@ def test_multi_files():
 
     # check with metadata_only
     uv_full = UVData()
-    uvtest.checkWarnings(uv_full.read, [uvfits_file], {'read_data': False},
-                         message='Telescope EVLA is not')
+    uv_full.read(uvfits_file, read_data=False)
     uv1 = UVData()
     uv1.read([testfile1, testfile2], read_data=False)
 
@@ -685,8 +672,7 @@ def test_multi_files():
 
     # check raises error if only reading data on a list of files (metadata already read)
     uv1 = UVData()
-    uvtest.checkWarnings(uv1.read, [uvfits_file], {'read_data': False},
-                         message=['Telescope EVLA is not'])
+    uv1.read(uvfits_file, read_data=False)
     with pytest.raises(ValueError) as cm:
         uv1.read([testfile1, testfile2])
     assert str(cm.value).startswith('A list of files cannot be used when just '
@@ -694,6 +680,7 @@ def test_multi_files():
 
 
 @uvtest.skipIf_no_casa
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_readMSWriteUVFits_CASAHistory():
     """
     read in .ms file.
@@ -705,8 +692,5 @@ def test_readMSWriteUVFits_CASAHistory():
     testfile = os.path.join(DATA_PATH, 'test/outtest.uvfits')
     ms_uv.read_ms(ms_file)
     ms_uv.write_uvfits(testfile, spoof_nonessential=True)
-    uvtest.checkWarnings(uvfits_uv.read, [testfile],
-                         message='Telescope EVLA is not')
+    uvfits_uv.read(testfile)
     assert ms_uv == uvfits_uv
-    del(uvfits_uv)
-    del(ms_uv)

--- a/pyuvdata/tests/test_uvfits.py
+++ b/pyuvdata/tests/test_uvfits.py
@@ -346,17 +346,27 @@ def test_extra_keywords():
     uv_in.extra_keywords['testlist'] = [12, 14, 90]
     uvtest.checkWarnings(uv_in.check, message=['testlist in extra_keywords is a '
                                                'list, array or dict'])
-    with pytest.raises(TypeError) as cm:
-        uv_in.write_uvfits(testfile, run_check=False)
-    assert str(cm.value).startswith("Extra keyword testlist is of <class 'list'>")
+    if six.PY2:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_uvfits(testfile, run_check=False)
+        assert str(cm.value).startswith("Extra keyword testlist is of <type 'list'>")
+    else:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_uvfits(testfile, run_check=False)
+        assert str(cm.value).startswith("Extra keyword testlist is of <class 'list'>")
     uv_in.extra_keywords.pop('testlist')
 
     uv_in.extra_keywords['testarr'] = np.array([12, 14, 90])
     uvtest.checkWarnings(uv_in.check, message=['testarr in extra_keywords is a '
                                                'list, array or dict'])
-    with pytest.raises(TypeError) as cm:
-        uv_in.write_uvfits(testfile, run_check=False)
-    assert str(cm.value).startswith("Extra keyword testarr is of <class 'numpy.ndarray'>")
+    if six.PY2:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_uvfits(testfile, run_check=False)
+        assert str(cm.value).startswith("Extra keyword testarr is of <type 'numpy.ndarray'>")
+    else:
+        with pytest.raises(TypeError) as cm:
+            uv_in.write_uvfits(testfile, run_check=False)
+        assert str(cm.value).startswith("Extra keyword testarr is of <class 'numpy.ndarray'>")
     uv_in.extra_keywords.pop('testarr')
 
     # check for warnings with extra_keywords keys that are too long

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1781,7 +1781,7 @@ class UVData(UVBase):
                               rtol=this._freq_array.tols[0], atol=this._freq_array.tols[1]):
                 warnings.warn('Combined frequencies are not evenly spaced. This will '
                               'make it impossible to write this data out to some file types.')
-            elif np.max(freq_separation) > this.channel_width:
+            elif np.max(freq_separation) > this.channel_width + this._channel_width.tols[1]:
                 warnings.warn('Combined frequencies are not contiguous. This will make '
                               'it impossible to write this data out to some file types.')
             if not self.metadata_only:

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1640,7 +1640,7 @@ class UVData(UVBase):
                               rtol=this._freq_array.tols[0], atol=this._freq_array.tols[1]):
                 warnings.warn('Combined frequencies are not evenly spaced. This will '
                               'make it impossible to write this data out to some file types.')
-            elif np.max(freq_separation) > this.channel_width:
+            elif np.max(freq_separation) > this.channel_width + this._channel_width.tols[1]:
                 warnings.warn('Combined frequencies are not contiguous. This will make '
                               'it impossible to write this data out to some file types.')
 


### PR DESCRIPTION
## Description
Catch warnings in tests that weren't being caught. Move towards better warning & error handling in some tests:
- Use pytest's warning filtering mechanism for warnings unrelated to tests  (as opposed to checkWarning that really should be used for warnings that are related to the tests).
- Check that error messages are as expected (not just that errors are raised).

## Motivation and Context
Several uncaught warnings had crept into the tests. The logs shown on CircleCI were cut off before the warning section, so it was hard to tell from them that warnings weren't being caught. I removed the `-v` argument to pytest on CircleCI to shorten the logs.

While tackling the uncaught warnings, I went ahead and improved the warning and error handling in `test_miriad`, `test_uvfits` and some of the tests in `test_uvdata`. And I fixed one small bug that was exposed in this process (a warning was raised inappropriately). I don't really thing it merits a line in the changelog.

I also streamlined the circleci config to make sure there weren't differences in how the minimum dependencies tests were run because we were having weird errors with them.

## Types of changes
None of these types really apply. I guess bug fix is closest.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
