### PR TITLE
Adjacency list calculation speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - `UVFlag` information on Read The Docs
 
 ### Changed
+- utils.get_baseline_redundancies uses scipy pdist functions instead of for loops (faster)
 - UVData.get_antenna_redundancies will no longer automatically conjugate baselines.
 - UVData.get_baseline_redundancies and UVData.get_antenna_redundancies have been combined.
 - `UVFlag` inherits from `UVBase` object.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The redundancy finder was significantly slowed down by two nested for loops over the baselines, calculating distances between baselines for each pair. This changes to use the function `scipy.spatial.distance.pdist` to compute pairwise distances and build the adjacency list.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is much faster. Previously, trying to solve for the redundant baselines of HERA 350 took over five hours and still didn't finish. With this change, the calculation ran in minutes.

However -- this does increase the memory usage. The `pdist` function returns an array of size `Nbls * (Nbls - 1)/ 2`. This is then expanded to an `Nbls x Nbls` boolean array. For HERA350, this ultimately required around 15G of memory to handle. There may be a way to reduce this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
   (The existing redundancy tests are sufficient to check this).
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).