### PR TITLE
Make h5py a required package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - `UVFlag` information on Read The Docs
 
 ### Changed
+- `h5py` is now a required package instead of an optional one.
 - Phasing now supports metadata only `UVData` objects
 - utils.get_baseline_redundancies uses scipy pdist functions instead of for loops (faster)
 - UVData.get_antenna_redundancies will no longer automatically conjugate baselines.

--- a/README.md
+++ b/README.md
@@ -146,10 +146,11 @@ Required:
 * numpy >= 1.15
 * scipy
 * astropy >= 2.0
+* h5py
+* six
 
 Optional:
 
-* h5py (for reading and writing uvh5 format and uvflag save files)
 * python-casacore (for working with CASA measurement sets)
 * healpy (for working with beams in HEALPix formats)
 * pyyaml (for working with settings files for CST beam files)

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -7,6 +7,7 @@ dependencies:
   - numpy
   - scipy
   - six
+  - h5py
   - coverage
   - pytest-cov
   - setuptools_scm

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -142,7 +142,6 @@ g) miriad -> uvh5
   >>> UV.read(miriad_file)
 
   # Write out the uvh5 file
-  # note that writing uvh5 files requires h5py to be installed
   >>> UV.write_uvh5('tutorial.uvh5')
 
 h) uvfits -> uvh5
@@ -156,7 +155,6 @@ h) uvfits -> uvh5
    >>> UV.read(uvfits_file)
 
    # Write out the uvh5 file
-   # note that writing uvh5 files requires h5py to be installed
    >>> write_file = 'tutorial.uvh5'
    >>> if os.path.exists(write_file):
    ...    os.remove(write_file)

--- a/pyuvdata/tests/__init__.py
+++ b/pyuvdata/tests/__init__.py
@@ -52,17 +52,6 @@ reason = 'healpy is not installed, skipping tests that require it.'
 skipIf_no_healpy = pytest.mark.skipif(not healpy_installed, reason=reason)
 
 
-# defines a decorator to skip tests that require h5py.
-try:
-    import h5py
-
-    h5py_installed = True
-except(ImportError):
-    h5py_installed = False
-reason = 'h5py is not installed, skipping tests that require it.'
-skipIf_no_h5py = pytest.mark.skipif(not h5py_installed, reason=reason)
-
-
 # defines a decorator to skip tests that require yaml.
 try:
     import yaml

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -5181,6 +5181,11 @@ def test_upsample_downsample_in_time_odd_resample(resample_in_time_file):
 
     uv_object.downsample_in_time(np.amin(uv_object2.integration_time), blt_order="baseline")
 
+    # increase tolerance on LST if iers.conf.auto_max_age is set to None, as we
+    # do in testing if the iers url is down. See conftest.py for more info.
+    if iers.conf.auto_max_age is None:
+        uv_object._lst_array.tols = (0, 1e-4)
+
     # make sure that history is correct
     assert "Upsampled data to 0.626349 second integration time using pyuvdata." in uv_object.history
     assert "Downsampled data to 1.879048 second integration time using pyuvdata." in uv_object.history

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1,4 +1,4 @@
-# -*- mode: python; coding: utf-8 -*
+# -*- mode: python; coding: utf-8 -*-
 # Copyright (c) 2018 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
 
@@ -446,7 +446,6 @@ def test_generic_read():
     pytest.raises(ValueError, uv_in.read, 'foo')
 
 
-@uvtest.skipIf_no_h5py
 def test_phase_unphaseHERA():
     """
     Read in drift data, phase to an RA/DEC, unphase and check for object equality.
@@ -3979,7 +3978,6 @@ def test_copy():
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_upsample_in_time(resample_in_time_file):
@@ -4015,7 +4013,6 @@ def test_upsample_in_time(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_upsample_in_time_with_flags(resample_in_time_file):
@@ -4052,7 +4049,6 @@ def test_upsample_in_time_with_flags(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_upsample_in_time_noninteger_resampling(resample_in_time_file):
@@ -4088,7 +4084,6 @@ def test_upsample_in_time_noninteger_resampling(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_upsample_in_time_errors(resample_in_time_file):
     """Test errors and warnings raised by upsample_in_time"""
     uv_object = resample_in_time_file
@@ -4110,7 +4105,6 @@ def test_upsample_in_time_errors(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_upsample_in_time_summing_correlator_mode(resample_in_time_file):
@@ -4147,7 +4141,6 @@ def test_upsample_in_time_summing_correlator_mode(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_upsample_in_time_summing_correlator_mode_with_flags(resample_in_time_file):
@@ -4183,7 +4176,6 @@ def test_upsample_in_time_summing_correlator_mode_with_flags(resample_in_time_fi
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_upsample_in_time_summing_correlator_mode_nonint_resampling(resample_in_time_file):
@@ -4223,7 +4215,6 @@ def test_upsample_in_time_summing_correlator_mode_nonint_resampling(resample_in_
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_partial_upsample_in_time(resample_in_time_file):
@@ -4268,7 +4259,6 @@ def test_partial_upsample_in_time(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_upsample_in_time_drift(resample_in_time_file):
@@ -4307,7 +4297,6 @@ def test_upsample_in_time_drift(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_upsample_in_time_drift_no_phasing(resample_in_time_file):
@@ -4347,7 +4336,6 @@ def test_upsample_in_time_drift_no_phasing(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_downsample_in_time(resample_in_time_file):
@@ -4386,7 +4374,6 @@ def test_downsample_in_time(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_downsample_in_time_partial_flags(resample_in_time_file):
@@ -4427,7 +4414,6 @@ def test_downsample_in_time_partial_flags(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_downsample_in_time_totally_flagged(resample_in_time_file):
@@ -4469,7 +4455,6 @@ def test_downsample_in_time_totally_flagged(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_downsample_in_time_uneven_samples(resample_in_time_file):
@@ -4509,7 +4494,6 @@ def test_downsample_in_time_uneven_samples(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_downsample_in_time_uneven_samples_discard_ragged(resample_in_time_file):
@@ -4547,7 +4531,6 @@ def test_downsample_in_time_uneven_samples_discard_ragged(resample_in_time_file)
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_downsample_in_time_summing_correlator_mode(resample_in_time_file):
@@ -4586,7 +4569,6 @@ def test_downsample_in_time_summing_correlator_mode(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_downsample_in_time_summing_correlator_mode_partial_flags(
@@ -4631,7 +4613,6 @@ def test_downsample_in_time_summing_correlator_mode_partial_flags(
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_downsample_in_time_summing_correlator_mode_totally_flagged(
@@ -4677,7 +4658,6 @@ def test_downsample_in_time_summing_correlator_mode_totally_flagged(
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_downsample_in_time_summing_correlator_mode_uneven_samples(
@@ -4730,7 +4710,6 @@ def test_downsample_in_time_summing_correlator_mode_uneven_samples(
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_downsample_in_time_summing_correlator_mode_uneven_samples_drop_ragged(
@@ -4777,7 +4756,6 @@ def test_downsample_in_time_summing_correlator_mode_uneven_samples_drop_ragged(
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_partial_downsample_in_time(resample_in_time_file):
@@ -4826,7 +4804,6 @@ def test_partial_downsample_in_time(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_downsample_in_time_drift(resample_in_time_file):
@@ -4868,7 +4845,6 @@ def test_downsample_in_time_drift(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_downsample_in_time_drift_no_phasing(resample_in_time_file):
@@ -4916,7 +4892,6 @@ def test_downsample_in_time_drift_no_phasing(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_downsample_in_time_errors(resample_in_time_file):
     """Test various errors and warnings are raised"""
     uv_object = resample_in_time_file
@@ -4973,7 +4948,6 @@ def test_downsample_in_time_errors(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_downsample_in_time_int_time_mismatch_warning(resample_in_time_file):
     """Test warning in downsample_in_time about mismatch between integration
     times and the time between integrations.
@@ -5016,7 +4990,6 @@ def test_downsample_in_time_int_time_mismatch_warning(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_downsample_in_time_varying_integration_time(resample_in_time_file):
     """Test downsample_in_time handling of file with integration time changing
     within a baseline
@@ -5062,7 +5035,6 @@ def test_downsample_in_time_varying_integration_time(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_downsample_in_time_varying_integration_time_warning(resample_in_time_file):
     """Test downsample_in_time handling of file with integration time changing
     within a baseline, but without adjusting the time_array so there is a mismatch.
@@ -5104,7 +5076,6 @@ def test_downsample_in_time_varying_integration_time_warning(resample_in_time_fi
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 @pytest.mark.filterwarnings("ignore:Data will be unphased and rephased")
@@ -5182,7 +5153,6 @@ def test_upsample_downsample_in_time(resample_in_time_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 @pytest.mark.filterwarnings("ignore:Data will be unphased and rephased")
@@ -5220,7 +5190,6 @@ def test_upsample_downsample_in_time_odd_resample(resample_in_time_file):
     assert uv_object == uv_object2
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:The xyz array in ENU_from_ECEF")
 @pytest.mark.filterwarnings("ignore:The enu array in ECEF_from_ENU")
 def test_upsample_downsample_in_time_metadata_only(resample_in_time_file):
@@ -5264,7 +5233,6 @@ def test_upsample_downsample_in_time_metadata_only(resample_in_time_file):
     assert uv_object == uv_object2
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:Telescope mock-HERA is not in known_telescopes")
 @pytest.mark.filterwarnings("ignore:There is a gap in the times of baseline")
 def test_resample_in_time(bda_test_file):
@@ -5314,7 +5282,6 @@ def test_resample_in_time(bda_test_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:Telescope mock-HERA is not in known_telescopes")
 @pytest.mark.filterwarnings("ignore:There is a gap in the times of baseline")
 def test_resample_in_time_downsample_only(bda_test_file):
@@ -5370,7 +5337,6 @@ def test_resample_in_time_downsample_only(bda_test_file):
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.filterwarnings("ignore:Telescope mock-HERA is not in known_telescopes")
 @pytest.mark.filterwarnings("ignore:There is a gap in the times of baseline")
 def test_resample_in_time_only_upsample(bda_test_file):

--- a/pyuvdata/tests/test_uvflag.py
+++ b/pyuvdata/tests/test_uvflag.py
@@ -21,6 +21,7 @@ import shutil
 import copy
 import warnings
 import six
+import h5py
 
 
 # The following three fixtures are used regularly
@@ -267,7 +268,6 @@ def test_init_invalid_input():
     assert str(cm.value).startswith('input to UVFlag.__init__ must be one of:')
 
 
-@uvtest.skipIf_no_h5py
 def test_init_list_files_weights(tmpdir):
     # Test that weights are preserved when reading list of files
     tmp_path = tmpdir.strpath
@@ -295,7 +295,6 @@ def test_data_like_property_mode_tamper():
     assert str(cm.value).startswith('Invalid mode. Mode must be one of')
 
 
-@uvtest.skipIf_no_h5py
 def test_read_write_loop():
     uv = UVData()
     uv.read_miriad(test_d_file)
@@ -305,7 +304,6 @@ def test_read_write_loop():
     assert uvf.__eq__(uvf2, check_history=True)
 
 
-@uvtest.skipIf_no_h5py
 def test_read_write_loop_with_optional_x_orientation():
     uv = UVData()
     uv.read_miriad(test_d_file)
@@ -316,7 +314,6 @@ def test_read_write_loop_with_optional_x_orientation():
     assert uvf.__eq__(uvf2, check_history=True)
 
 
-@uvtest.skipIf_no_h5py
 def test_read_write_loop_waterfal():
     uv = UVData()
     uv.read_miriad(test_d_file)
@@ -327,10 +324,7 @@ def test_read_write_loop_waterfal():
     assert uvf.__eq__(uvf2, check_history=True)
 
 
-@uvtest.skipIf_no_h5py
 def test_bad_mode_savefile():
-    # redundant skip definition but a good example
-    h5py = pytest.importorskip('h5py')
     uv = UVData()
     uv.read_miriad(test_d_file)
     uvf = UVFlag(uv, label='test')
@@ -345,10 +339,7 @@ def test_bad_mode_savefile():
     assert str(cm.value).startswith('File cannot be read. Received mode')
 
 
-@uvtest.skipIf_no_h5py
 def test_bad_type_savefile():
-    # redundant skip definition but a good example
-    h5py = pytest.importorskip('h5py')
     uv = UVData()
     uv.read_miriad(test_d_file)
     uvf = UVFlag(uv, label='test')
@@ -363,9 +354,7 @@ def test_bad_type_savefile():
     assert str(cm.value).startswith('File cannot be read. Received type')
 
 
-@uvtest.skipIf_no_h5py
 def test_write_add_version_str():
-    h5py = pytest.importorskip('h5py')
     uv = UVData()
     uv.read_miriad(test_d_file)
     uvf = UVFlag(uv, label='test')
@@ -379,9 +368,7 @@ def test_write_add_version_str():
     assert pyuvdata_version_str in hist
 
 
-@uvtest.skipIf_no_h5py
 def test_read_add_version_str():
-    h5py = pytest.importorskip('h5py')
     uv = UVData()
     uv.read_miriad(test_d_file)
     uvf = UVFlag(uv, label='test')
@@ -398,7 +385,6 @@ def test_read_add_version_str():
     assert uvf == uvf2
 
 
-@uvtest.skipIf_no_h5py
 def test_read_write_ant():
     uv = UVCal()
     uv.read_calfits(test_c_file)
@@ -408,10 +394,7 @@ def test_read_write_ant():
     assert uvf.__eq__(uvf2, check_history=True)
 
 
-@uvtest.skipIf_no_h5py
 def test_read_missing_nants_data():
-    # redundant skip definition but a good example
-    h5py = pytest.importorskip('h5py')
     uv = UVCal()
     uv.read_calfits(test_c_file)
     uvf = UVFlag(uv, mode='flag', label='test')
@@ -432,10 +415,7 @@ def test_read_missing_nants_data():
     assert uvf.__eq__(uvf2, check_history=True)
 
 
-@uvtest.skipIf_no_h5py
 def test_read_missing_nspws():
-    # redundant skip definition but a good example
-    h5py = pytest.importorskip('h5py')
     uv = UVCal()
     uv.read_calfits(test_c_file)
     uvf = UVFlag(uv, mode='flag', label='test')
@@ -452,7 +432,6 @@ def test_read_missing_nspws():
     assert uvf.__eq__(uvf2, check_history=True)
 
 
-@uvtest.skipIf_no_h5py
 def test_read_write_nocompress():
     uv = UVData()
     uv.read_miriad(test_d_file)
@@ -462,7 +441,6 @@ def test_read_write_nocompress():
     assert uvf.__eq__(uvf2, check_history=True)
 
 
-@uvtest.skipIf_no_h5py
 def test_read_write_nocompress_flag():
     uv = UVData()
     uv.read_miriad(test_d_file)
@@ -472,7 +450,6 @@ def test_read_write_nocompress_flag():
     assert uvf.__eq__(uvf2, check_history=True)
 
 
-@uvtest.skipIf_no_h5py
 def test_init_list():
     uv = UVData()
     uv.read_miriad(test_d_file)
@@ -497,7 +474,6 @@ def test_init_list():
     assert np.all(uvf.polarization_array == uv.polarization_array)
 
 
-@uvtest.skipIf_no_h5py
 def test_read_list():
     uv = UVData()
     uv.read_miriad(test_d_file)
@@ -524,14 +500,12 @@ def test_read_list():
     assert np.all(uvf.polarization_array == uv.polarization_array)
 
 
-@uvtest.skipIf_no_h5py
 def test_read_error():
     with pytest.raises(IOError) as cm:
         UVFlag('foo')
     assert str(cm.value).startswith('foo not found')
 
 
-@uvtest.skipIf_no_h5py
 def test_read_change_type():
     uv = UVData()
     uv.read_miriad(test_d_file)
@@ -558,7 +532,6 @@ def test_read_change_type():
     assert uvf.ant_2_array is None
 
 
-@uvtest.skipIf_no_h5py
 def test_read_change_mode():
     uv = UVData()
     uv.read_miriad(test_d_file)
@@ -577,7 +550,6 @@ def test_read_change_mode():
     assert uvf.metric_array is None
 
 
-@uvtest.skipIf_no_h5py
 def test_write_no_clobber():
     uvf = UVFlag(test_f_file)
     with pytest.raises(ValueError) as cm:
@@ -598,7 +570,6 @@ def test_lst_from_uv_error():
     assert str(cm.value).startswith('Function lst_from_uv can only operate on')
 
 
-@uvtest.skipIf_no_h5py
 def test_add():
     uv1 = UVFlag(test_f_file)
     uv2 = copy.deepcopy(uv1)
@@ -625,7 +596,6 @@ def test_add():
     assert 'Data combined along time axis. ' in uv3.history
 
 
-@uvtest.skipIf_no_h5py
 def test_add_collapsed_pols():
     uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -640,7 +610,6 @@ def test_add_collapsed_pols():
     assert uvf4.check()
 
 
-@uvtest.skipIf_no_h5py
 def test_add_add_version_str():
     uv1 = UVFlag(test_f_file)
     uv1.history = uv1.history.replace(pyuvdata_version_str, '')
@@ -653,7 +622,6 @@ def test_add_add_version_str():
     assert pyuvdata_version_str in uv3.history
 
 
-@uvtest.skipIf_no_h5py
 def test_add_baseline():
     uv1 = UVFlag(test_f_file)
     uv2 = copy.deepcopy(uv1)
@@ -702,7 +670,6 @@ def test_add_antenna():
     assert 'Data combined along antenna axis. ' in uv3.history
 
 
-@uvtest.skipIf_no_h5py
 def test_add_frequency():
     uv1 = UVFlag(test_f_file)
     uv2 = copy.deepcopy(uv1)
@@ -725,7 +692,6 @@ def test_add_frequency():
     assert 'Data combined along frequency axis. ' in uv3.history
 
 
-@uvtest.skipIf_no_h5py
 def test_add_pol():
     uv1 = UVFlag(test_f_file)
     uv2 = copy.deepcopy(uv1)
@@ -809,7 +775,6 @@ def test_add_errors():
     assert str(cm.value).endswith('concatenated along baseline axis.')
 
 
-@uvtest.skipIf_no_h5py
 def test_inplace_add():
     uv1a = UVFlag(test_f_file)
     uv1b = copy.deepcopy(uv1a)
@@ -819,7 +784,6 @@ def test_inplace_add():
     assert uv1a.__eq__(uv1b + uv2)
 
 
-@uvtest.skipIf_no_h5py
 def test_clear_unused_attributes():
     uv = UVFlag(test_f_file)
     assert hasattr(uv, 'baseline_array')
@@ -856,7 +820,6 @@ def test_clear_unused_attributes():
     assert uv.flag_array is None
 
 
-@uvtest.skipIf_no_h5py
 def test_not_equal():
     uvf1 = UVFlag(test_f_file)
     # different class
@@ -879,7 +842,6 @@ def test_not_equal():
     assert not uvf1.__eq__(uvf2, check_history=True)
 
 
-@uvtest.skipIf_no_h5py
 def test_to_waterfall_bl():
     uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -890,7 +852,6 @@ def test_to_waterfall_bl():
     assert uvf.weights_array.shape == uvf.metric_array.shape
 
 
-@uvtest.skipIf_no_h5py
 def test_to_waterfall_add_version_str():
     uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -901,7 +862,6 @@ def test_to_waterfall_add_version_str():
     assert pyuvdata_version_str in uvf.history
 
 
-@uvtest.skipIf_no_h5py
 def test_to_waterfall_bl_multi_pol():
     uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -924,7 +884,6 @@ def test_to_waterfall_bl_multi_pol():
     assert uvf2.polarization_array[0] == np.str_(','.join(map(str, uvf.polarization_array)))
 
 
-@uvtest.skipIf_no_h5py
 def test_collapse_pol():
     uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -952,7 +911,6 @@ def test_collapse_pol():
     os.remove(test_outfile)
 
 
-@uvtest.skipIf_no_h5py
 def test_collapse_pol_add_pol_axis():
     uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -966,7 +924,6 @@ def test_collapse_pol_add_pol_axis():
     assert str(cm.value).startswith("Two UVFlag objects with their")
 
 
-@uvtest.skipIf_no_h5py
 def test_collapse_pol_or():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -984,7 +941,6 @@ def test_collapse_pol_or():
     assert uvf2.metric_array is None
 
 
-@uvtest.skipIf_no_h5py
 def test_collapse_pol_add_version_str():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -1003,7 +959,6 @@ def test_collapse_pol_add_version_str():
     assert pyuvdata_version_str in uvf2.history
 
 
-@uvtest.skipIf_no_h5py
 def test_collapse_single_pol():
     uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -1013,7 +968,6 @@ def test_collapse_single_pol():
     assert uvf == uvf2
 
 
-@uvtest.skipIf_no_h5py
 def test_collapse_pol_flag():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -1031,7 +985,6 @@ def test_collapse_pol_flag():
     assert uvf2.flag_array is None
 
 
-@uvtest.skipIf_no_h5py
 def test_to_waterfall_bl_flags():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -1045,7 +998,6 @@ def test_to_waterfall_bl_flags():
     assert len(uvf.lst_array) == len(uvf.time_array)
 
 
-@uvtest.skipIf_no_h5py
 def test_to_waterfall_bl_flags_or():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -1084,7 +1036,6 @@ def test_to_waterfall_ant():
     assert len(uvf.lst_array) == len(uvf.time_array)
 
 
-@uvtest.skipIf_no_h5py
 def test_to_waterfall_waterfall():
     uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -1161,7 +1112,6 @@ def test_baseline_to_baseline():
     assert uvf == uvf2
 
 
-@uvtest.skipIf_no_h5py
 def test_to_baseline_errors():
     uvc = UVCal()
     uvc.read_calfits(test_c_file)
@@ -1313,7 +1263,6 @@ def test_antenna_to_antenna():
     assert uvf == uvf2
 
 
-@uvtest.skipIf_no_h5py
 def test_to_antenna_errors():
     uvc = UVCal()
     uvc.read_calfits(test_c_file)
@@ -1382,7 +1331,6 @@ def test_to_antenna_metric_force_pol():
                       (3.2 + 2.1) * uvc.Nants_data / uvf.metric_array.size)
 
 
-@uvtest.skipIf_no_h5py
 def test_copy():
     uvf = UVFlag(test_f_file)
     uvf2 = uvf.copy()
@@ -1392,7 +1340,6 @@ def test_copy():
     assert uvf != uvf2
 
 
-@uvtest.skipIf_no_h5py
 def test_or():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -1407,7 +1354,6 @@ def test_or():
     assert np.all(uvf3.flag_array[2:])
 
 
-@uvtest.skipIf_no_h5py
 def test_or_add_version_str():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -1424,7 +1370,6 @@ def test_or_add_version_str():
     assert pyuvdata_version_str in uvf3.history
 
 
-@uvtest.skipIf_no_h5py
 def test_or_error():
     uvf = UVFlag(test_f_file)
     uvf2 = uvf.copy()
@@ -1434,7 +1379,6 @@ def test_or_error():
     assert str(cm.value).startswith('UVFlag object must be in "flag" mode')
 
 
-@uvtest.skipIf_no_h5py
 def test_or_add_history():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -1446,7 +1390,6 @@ def test_or_add_history():
     assert "Flags OR'd with:" in uvf3.history
 
 
-@uvtest.skipIf_no_h5py
 def test_ior():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -1461,7 +1404,6 @@ def test_ior():
     assert np.all(uvf.flag_array[2:])
 
 
-@uvtest.skipIf_no_h5py
 def test_to_flag():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -1472,7 +1414,6 @@ def test_to_flag():
     assert 'Converted to mode "flag"' in uvf.history
 
 
-@uvtest.skipIf_no_h5py
 def test_to_flag_add_version_str():
     uvf = UVFlag(test_f_file)
     uvf.history = uvf.history.replace(pyuvdata_version_str, '')
@@ -1482,7 +1423,6 @@ def test_to_flag_add_version_str():
     assert pyuvdata_version_str in uvf.history
 
 
-@uvtest.skipIf_no_h5py
 def test_to_flag_threshold():
     uvf = UVFlag(test_f_file)
     uvf.metric_array = np.zeros_like(uvf.metric_array)
@@ -1497,7 +1437,6 @@ def test_to_flag_threshold():
     assert 'Converted to mode "flag"' in uvf.history
 
 
-@uvtest.skipIf_no_h5py
 def test_flag_to_flag():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -1506,7 +1445,6 @@ def test_flag_to_flag():
     assert uvf == uvf2
 
 
-@uvtest.skipIf_no_h5py
 def test_to_flag_unknown_mode():
     uvf = UVFlag(test_f_file)
     uvf.mode = 'foo'
@@ -1515,7 +1453,6 @@ def test_to_flag_unknown_mode():
     assert str(cm.value).startswith('Unknown UVFlag mode: foo')
 
 
-@uvtest.skipIf_no_h5py
 def test_to_metric_baseline():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -1535,7 +1472,6 @@ def test_to_metric_baseline():
     assert np.isclose(uvf.weights_array[:, :, 10], 0.0).all()
 
 
-@uvtest.skipIf_no_h5py
 def test_to_metric_add_version_str():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()
@@ -1553,7 +1489,6 @@ def test_to_metric_add_version_str():
     assert pyuvdata_version_str in uvf.history
 
 
-@uvtest.skipIf_no_h5py
 def test_to_metric_waterfall():
     uvf = UVFlag(test_f_file)
     uvf.to_waterfall()
@@ -1576,7 +1511,6 @@ def test_to_metric_antenna():
     assert np.isclose(uvf.weights_array[15, :, 3, :, :], 0.0).all()
 
 
-@uvtest.skipIf_no_h5py
 def test_metric_to_metric():
     uvf = UVFlag(test_f_file)
     uvf2 = uvf.copy()
@@ -1584,7 +1518,6 @@ def test_metric_to_metric():
     assert uvf == uvf2
 
 
-@uvtest.skipIf_no_h5py
 def test_to_metric_unknown_mode():
     uvf = UVFlag(test_f_file)
     uvf.mode = 'foo'
@@ -1593,7 +1526,6 @@ def test_to_metric_unknown_mode():
     assert str(cm.value).startswith('Unknown UVFlag mode: foo')
 
 
-@uvtest.skipIf_no_h5py
 def test_antpair2ind():
     uvf = UVFlag(test_f_file)
     ind = uvf.antpair2ind(uvf.ant_1_array[0], uvf.ant_2_array[0])
@@ -1601,7 +1533,6 @@ def test_antpair2ind():
     assert np.all(uvf.ant_2_array[ind] == uvf.ant_2_array[0])
 
 
-@uvtest.skipIf_no_h5py
 def test_antpair2ind_nonbaseline():
     uvf = UVFlag(test_f_file)
     uvf.to_waterfall()
@@ -1612,7 +1543,6 @@ def test_antpair2ind_nonbaseline():
                                     + 'pairs to index.')
 
 
-@uvtest.skipIf_no_h5py
 def test_baseline_to_antnums():
     uvf = UVFlag(test_f_file)
     a1, a2 = uvf.baseline_to_antnums(uvf.baseline_array[0])
@@ -1620,14 +1550,12 @@ def test_baseline_to_antnums():
     assert a2 == uvf.ant_2_array[0]
 
 
-@uvtest.skipIf_no_h5py
 def test_get_baseline_nums():
     uvf = UVFlag(test_f_file)
     bls = uvf.get_baseline_nums()
     assert np.array_equal(bls, np.unique(uvf.baseline_array))
 
 
-@uvtest.skipIf_no_h5py
 def test_get_antpairs():
     uvf = UVFlag(test_f_file)
     antpairs = uvf.get_antpairs()
@@ -1638,10 +1566,7 @@ def test_get_antpairs():
         assert (a1, a2) in antpairs
 
 
-@uvtest.skipIf_no_h5py
 def test_missing_Nants_telescope():
-    import h5py
-
     testfile = os.path.join(DATA_PATH, 'test_missing_Nants.h5')
     shutil.copyfile(test_f_file, testfile)
 

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -13,21 +13,15 @@ import copy
 import numpy as np
 import pytest
 from astropy.time import Time
+import h5py
 
-from pyuvdata import UVData
+from pyuvdata import UVData, uvh5
 import pyuvdata.utils as uvutils
 from pyuvdata.data import DATA_PATH
 import pyuvdata.tests as uvtest
-
-try:
-    import h5py
-    from pyuvdata import uvh5
-    from pyuvdata.uvh5 import _hera_corr_dtype
-except(ImportError):
-    pass
+from pyuvdata.uvh5 import _hera_corr_dtype
 
 
-@uvtest.skipIf_no_h5py
 def test_ReadMiriadWriteUVH5ReadUVH5():
     """
     Miriad round trip test
@@ -56,7 +50,6 @@ def test_ReadMiriadWriteUVH5ReadUVH5():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_ReadUVFITSWriteUVH5ReadUVH5():
     """
     UVFITS round trip test
@@ -82,7 +75,6 @@ def test_ReadUVFITSWriteUVH5ReadUVH5():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_ReadUVH5Errors():
     """
     Test raising errors in read function
@@ -94,7 +86,6 @@ def test_ReadUVH5Errors():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_WriteUVH5Errors():
     """
     Test raising errors in write_uvh5 function
@@ -121,7 +112,6 @@ def test_WriteUVH5Errors():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5OptionalParameters():
     """
     Test reading and writing optional parameters not in sample files
@@ -158,7 +148,6 @@ def test_UVH5OptionalParameters():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5CompressionOptions():
     """
     Test writing data with compression filters
@@ -181,7 +170,6 @@ def test_UVH5CompressionOptions():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5ReadMultiple_files():
     """
     Test reading multiple uvh5 files
@@ -214,7 +202,6 @@ def test_UVH5ReadMultiple_files():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5ReadMultiple_files_metadata_only():
     """
     Test reading multiple uvh5 files with metadata only
@@ -251,7 +238,6 @@ def test_UVH5ReadMultiple_files_metadata_only():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5ReadMultiple_files_axis():
     """
     Test reading multiple uvh5 files with setting axis
@@ -284,7 +270,6 @@ def test_UVH5ReadMultiple_files_axis():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5PartialRead():
     """
     Test reading in only part of a dataset from disk
@@ -361,7 +346,6 @@ def test_UVH5PartialRead():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5PartialWrite():
     """
     Test writing an entire UVH5 file in pieces
@@ -500,7 +484,6 @@ def test_UVH5PartialWrite():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5PartialWriteIrregular():
     """
     Test writing a uvh5 file using irregular intervals
@@ -867,7 +850,6 @@ def test_UVH5PartialWriteIrregular():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5PartialWriteErrors():
     """
     Test errors in uvh5_write_part method
@@ -926,7 +908,6 @@ def test_UVH5PartialWriteErrors():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5InitializeFile():
     """
     Test initializing a UVH5 file on disk
@@ -968,7 +949,6 @@ def test_UVH5InitializeFile():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5SingleIntegrationTime():
     """
     Check backwards compatibility warning for files with a single integration time
@@ -997,7 +977,6 @@ def test_UVH5SingleIntegrationTime():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5LstArray():
     """
     Test different cases of the lst_array
@@ -1033,7 +1012,6 @@ def test_UVH5LstArray():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5StringBackCompat():
     """
     Test backwards compatibility handling of strings
@@ -1061,7 +1039,6 @@ def test_UVH5StringBackCompat():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5ReadHeaderSpecialCases():
     """
     Test special cases values when reading files
@@ -1103,7 +1080,6 @@ def test_UVH5ReadHeaderSpecialCases():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5ReadInts():
     """
     Test reading visibility data saved as integers
@@ -1133,7 +1109,6 @@ def test_UVH5ReadInts():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5WriteInts():
     """
     Test writing visibility data as integers
@@ -1163,7 +1138,6 @@ def test_UVH5WriteInts():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5PartialReadInts():
     """
     Test reading in only part of a dataset from disk
@@ -1233,7 +1207,6 @@ def test_UVH5PartialReadInts():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5PartialWriteInts():
     """
     Test writing an entire UVH5 file in pieces with integer outputs
@@ -1357,7 +1330,6 @@ def test_UVH5PartialWriteInts():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_read_complex_astype():
     # make a testfile with a test dataset
     test_file = os.path.join(DATA_PATH, 'test', 'test_file.h5')
@@ -1393,7 +1365,6 @@ def test_read_complex_astype():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_write_complex_astype():
     # make sure we can write data out
     test_file = os.path.join(DATA_PATH, 'test', 'test_file.h5')
@@ -1421,7 +1392,6 @@ def test_write_complex_astype():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_check_uvh5_dtype_errors():
     # test passing in something that's not a dtype
     pytest.raises(ValueError, uvh5._check_uvh5_dtype, 'hi')
@@ -1437,7 +1407,6 @@ def test_check_uvh5_dtype_errors():
     return
 
 
-@uvtest.skipIf_no_h5py
 def test_UVH5PartialWriteIntsIrregular():
     """
     Test writing a uvh5 file using irregular intervals
@@ -1801,7 +1770,6 @@ def test_UVH5PartialWriteIntsIrregular():
     return
 
 
-@uvtest.skipIf_no_h5py
 @pytest.mark.skipif(not six.PY3, reason="Skipping. This test is only relevant in python3.")
 def test_antenna_names_not_list():
     """Test if antenna_names is cast to an array, dimensions are preserved in np.string_ call during uvh5 write."""

--- a/pyuvdata/uvflag.py
+++ b/pyuvdata/uvflag.py
@@ -10,6 +10,7 @@ import warnings
 import copy
 import six
 from six.moves import map
+import h5py
 
 from .uvbase import UVBase
 from . import parameter as uvp
@@ -1090,8 +1091,6 @@ class UVFlag(UVBase):
             reading data.
 
         """
-        import h5py
-
         if isinstance(filename, (tuple, list)):
             self.read(filename[0])
             if len(filename) > 1:
@@ -1266,8 +1265,6 @@ class UVFlag(UVBase):
             If no compression is wanted, set to None.
 
         """
-        import h5py
-
         if os.path.exists(filename):
             if clobber:
                 print('File ' + filename + ' exists; clobbering')

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -11,15 +11,11 @@ import numpy as np
 import os
 import warnings
 import six
+import h5py
 
 from . import UVData
 from . import utils as uvutils
 
-try:
-    import h5py
-except ImportError:  # pragma: no cover
-    uvutils._reraise_context('h5py is not installed but is required for '
-                             'uvh5 functionality')
 
 # define HDF5 type for interpreting HERA correlator outputs (integers) as complex numbers
 _hera_corr_dtype = np.dtype([('r', '<i4'), ('i', '<i4')])

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup_args = {
     'version': version.version,
     'include_package_data': True,
     'setup_requires': ['pytest-runner', 'numpy>=1.15'],
-    'install_requires': ['numpy>=1.15', 'six>=1.10', 'scipy', 'astropy>=2.0'],
+    'install_requires': ['numpy>=1.15', 'six>=1.10', 'scipy', 'astropy>=2.0', 'h5py'],
     'tests_require': ['pytest'],
     'classifiers': ['Development Status :: 5 - Production/Stable',
                     'Intended Audience :: Science/Research',


### PR DESCRIPTION
## Description
This PR moves `h5py` from an optional dependency to a required one. Tests and package installation have been updated accordingly.

## Motivation and Context
Due to how integral `h5py` has become to multiple components of the repo (uvh5 files, UVFlag files, and the MWA beam), we have decided to move `h5py` to a required package. This change makes the test files simpler, and ensures that the user can access this functionality without additional installation requirements.

Closes #687.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
