### PR TITLE
Miriad testing update

### DIFF
--- a/pyuvdata/src/miriad_wrap.cpp
+++ b/pyuvdata/src/miriad_wrap.cpp
@@ -112,6 +112,8 @@ PyObject * UVObject_read(UVObject *self, PyObject *args) {
                      (float *)PyArray_DATA(data), (int *)PyArray_DATA(flags), n2read, &nread);
         } catch (MiriadError &e) {
             PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
+            Py_DECREF(data);
+            Py_DECREF(flags);
             return NULL;
         }
         if (preamble[3] != self->curtime) {

--- a/pyuvdata/src/uvio.c
+++ b/pyuvdata/src/uvio.c
@@ -1127,7 +1127,7 @@ private void uv_vartable_out(UV *uv)
   for(i=0, v = uv->variable; i < uv->nvar; i++,v++){
     Sprintf(line,"%c %s",VARTYPE(v),v->name);
     hwritea_c(item,line,strlen(line)+1,&iostat);
-    CHECK(iostat,(message,"Error writing to vartable (var # %d %s), in UVCLOSE(vartable_out)", i, v->name));
+    CHECK(iostat,(message,"Error writing to vartable, in UVCLOSE(vartable_out)"));
   }
   hdaccess_c(item,&iostat);
   CHECK(iostat,(message,"Error closing vartable, in UVCLOSE(vartable_out)"));

--- a/pyuvdata/src/uvio.c
+++ b/pyuvdata/src/uvio.c
@@ -1127,7 +1127,7 @@ private void uv_vartable_out(UV *uv)
   for(i=0, v = uv->variable; i < uv->nvar; i++,v++){
     Sprintf(line,"%c %s",VARTYPE(v),v->name);
     hwritea_c(item,line,strlen(line)+1,&iostat);
-    CHECK(iostat,(message,"Error writing to vartable, in UVCLOSE(vartable_out)"));
+    CHECK(iostat,(message,"Error writing to vartable (var # %d %s), in UVCLOSE(vartable_out)", i, v->name));
   }
   hdaccess_c(item,&iostat);
   CHECK(iostat,(message,"Error closing vartable, in UVCLOSE(vartable_out)"));

--- a/pyuvdata/tests/conftest.py
+++ b/pyuvdata/tests/conftest.py
@@ -35,6 +35,7 @@ def setup_and_teardown_package():
         t1.ut1
     except(urllib.error.URLError):
         if six.PY3:
+            # python 3 offers a mirror for the download url.
             try:
                 iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL_MIRROR)
                 t1 = Time.now()

--- a/pyuvdata/tests/conftest.py
+++ b/pyuvdata/tests/conftest.py
@@ -28,7 +28,6 @@ def setup_and_teardown_package():
     # tests. If it fails, turn off auto downloading for the tests and turn it
     # back on once all tests are completed (done by extending auto_max_age).
     # Also, the checkWarnings function will ignore IERS-related warnings.
-    iers.auto_download = False
     try:
         iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL)
         t1 = Time.now()
@@ -48,4 +47,3 @@ def setup_and_teardown_package():
     yield
 
     iers.conf.auto_max_age = 30
-    iers.auto_download = True

--- a/pyuvdata/tests/conftest.py
+++ b/pyuvdata/tests/conftest.py
@@ -27,6 +27,7 @@ def setup_and_teardown_package():
     # tests. If it fails, turn off auto downloading for the tests and turn it
     # back on once all tests are completed (done by extending auto_max_age).
     # Also, the checkWarnings function will ignore IERS-related warnings.
+    iers.auto_download = False
     try:
         iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL)
         t1 = Time.now()
@@ -42,3 +43,4 @@ def setup_and_teardown_package():
     yield
 
     iers.conf.auto_max_age = 30
+    iers.auto_download = True

--- a/pyuvdata/tests/conftest.py
+++ b/pyuvdata/tests/conftest.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import pytest
+import six
 import six.moves.urllib as urllib
 from astropy.utils import iers
 from astropy.time import Time
@@ -33,11 +34,14 @@ def setup_and_teardown_package():
         t1 = Time.now()
         t1.ut1
     except(urllib.error.URLError):
-        try:
-            iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL_MIRROR)
-            t1 = Time.now()
-            t1.ut1
-        except(urllib.error.URLError):
+        if six.PY3:
+            try:
+                iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL_MIRROR)
+                t1 = Time.now()
+                t1.ut1
+            except(urllib.error.URLError):
+                iers.conf.auto_max_age = None
+        else:
             iers.conf.auto_max_age = None
 
     yield

--- a/pyuvdata/tests/conftest.py
+++ b/pyuvdata/tests/conftest.py
@@ -27,7 +27,6 @@ def setup_and_teardown_package():
     # tests. If it fails, turn off auto downloading for the tests and turn it
     # back on once all tests are completed (done by extending auto_max_age).
     # Also, the checkWarnings function will ignore IERS-related warnings.
-    iers.conf.auto_download = False
     try:
         iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL)
         t1 = Time.now()

--- a/pyuvdata/tests/conftest.py
+++ b/pyuvdata/tests/conftest.py
@@ -27,12 +27,18 @@ def setup_and_teardown_package():
     # tests. If it fails, turn off auto downloading for the tests and turn it
     # back on once all tests are completed (done by extending auto_max_age).
     # Also, the checkWarnings function will ignore IERS-related warnings.
+    iers.conf.auto_download = False
     try:
-        iers_a = iers.IERS_A.open(iers.IERS_A_URL)
+        iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL)
         t1 = Time.now()
         t1.ut1
     except(urllib.error.URLError):
-        iers.conf.auto_max_age = None
+        try:
+            iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL_MIRROR)
+            t1 = Time.now()
+            t1.ut1
+        except(urllib.error.URLError):
+            iers.conf.auto_max_age = None
 
     yield
 

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -25,6 +25,10 @@ from pyuvdata.data import DATA_PATH
 
 from .. import aipy_extracts
 
+# always ignore the Altitude not present warning
+# This does NOT break uvutils.checkWarnings tests for this warning
+pytestmark = pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad")
+
 
 @pytest.mark.filterwarnings("ignore:Telescope ATCA is not")
 def test_ReadWriteReadATCA():
@@ -64,7 +68,6 @@ def test_ReadNRAOWriteMiriadReadMiriad():
     assert uvfits_uv == miriad_uv
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_ReadMiriadWriteUVFits():
     """
     Miriad to uvfits loopback test.
@@ -183,7 +186,6 @@ def test_miriad_location_handling():
     uv_in = UVData()
     uv_out = UVData()
     miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    testdir = os.path.join(DATA_PATH, 'test/')
     testfile = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
     aipy_uv = aipy_extracts.UV(miriad_file)
 
@@ -367,7 +369,6 @@ def test_miriad_location_handling():
                                   'Telescope foo is not in known_telescopes.'])
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_singletimeselect_drift():
     """
     Check behavior with writing & reading after selecting a single time from a drift file.
@@ -406,7 +407,6 @@ def test_singletimeselect_drift():
     assert uv_in == uv_out
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_poltoind():
     miriad_uv = UVData()
     miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
@@ -425,7 +425,6 @@ def test_poltoind():
     assert str(cm.value).startswith('multiple matches for pol=-7 in polarization_array')
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_miriad_extra_keywords():
     uv_in = UVData()
     uv_out = UVData()
@@ -545,7 +544,6 @@ def test_miriad_extra_keywords():
         assert str(cm.value).startswith("Extra keyword complex2 is of <class 'complex'>")
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_roundtrip_optional_params():
     uv_in = UVData()
     uv_out = UVData()
@@ -570,7 +568,6 @@ def test_roundtrip_optional_params():
     assert uv_in == uv_out
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_breakReadMiriad():
     """Test Miriad file checking."""
     uv_in = UVData()
@@ -601,7 +598,6 @@ def test_breakReadMiriad():
                          message=['Ntimes does not match the number of unique times in the data'])
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_readWriteReadMiriad():
     """
     PAPER file Miriad loopback test.
@@ -710,7 +706,6 @@ def test_readWriteReadMiriad():
                                            {"bls": [(4, 4, 'xy')]}
                                            ]
                          )
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_readWriteReadMiriad_partial_bls(select_kwargs):
     testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
     write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
@@ -735,7 +730,6 @@ def test_readWriteReadMiriad_partial_bls(select_kwargs):
     del(full)
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_readWriteReadMiriad_partial_antenna_nums():
     testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
     write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
@@ -763,7 +757,6 @@ def test_readWriteReadMiriad_partial_antenna_nums():
                                            {"time_range": [2456865.607, 2456865.609], "polarizations": [-7]}
                                            ]
                          )
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_readWriteReadMiriad_partial_times(select_kwargs):
     testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
     write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
@@ -791,7 +784,6 @@ def test_readWriteReadMiriad_partial_times(select_kwargs):
 
 
 @pytest.mark.parametrize("pols", [['xy'], [-7]])
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_readWriteReadMiriad_partial_pols(pols):
     testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
     write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
@@ -814,7 +806,6 @@ def test_readWriteReadMiriad_partial_pols(pols):
     del(uv_in)
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_readWriteReadMiriad_partial_ant_str():
     testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
     write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
@@ -859,7 +850,6 @@ def test_readWriteReadMiriad_partial_ant_str():
     del(uv_in)
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 @pytest.mark.parametrize("err_type,select_kwargs,err_msg",
                          [(AssertionError, {"ant_str": 'auto', "antenna_nums": [0, 1]}, "ant_str must be None if antenna_nums or bls is not None"),
                           (ValueError, {"bls": 'foo'}, "bls must be a list of tuples of antenna numbers"),
@@ -897,7 +887,6 @@ def test_readWriteReadMiriad_partial_errors(err_type, select_kwargs, err_msg):
     shutil.rmtree(write_file)
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_readWriteReadMiriad_partial_error_special_cases():
     testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
     write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
@@ -920,7 +909,6 @@ def test_readWriteReadMiriad_partial_error_special_cases():
     shutil.rmtree(write_file)
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_readWriteReadMiriad_partial_with_warnings():
     testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
     write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
@@ -961,7 +949,6 @@ def test_readWriteReadMiriad_partial_with_warnings():
     del(uv_in)
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_readWriteReadMiriad_partial_metadata_only():
     testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
     write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
@@ -1029,7 +1016,6 @@ def test_readMSWriteMiriad_CASAHistory():
     assert miriad_uv == ms_uv
 
 
-@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
 def test_rwrMiriad_antpos_issues():
     """
     test warnings and errors associated with antenna position issues in Miriad files

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -977,7 +977,7 @@ def test_miriad_integration_time_precision():
     [
         {"bls": [(0, 0), (0, 1), (4, 2)]},
         {"bls": [(0, 0), (2, 4)], "antenna_nums": [0, 2, 4]},
-        {"bls": [(2, 4, "xy")]},
+        {"bls": (2, 4, "xy")},
         {"bls": [(4, 2, "yx")]},
         {"polarizations": [-7], "bls": [(4, 4)]},
         {"bls": [(4, 4, "xy")]},
@@ -997,8 +997,11 @@ def test_readWriteReadMiriad_partial_bls(select_kwargs):
     uv_in.read(write_file, **select_kwargs)
     antpairs = uv_in.get_antpairs()
     # indexing here is to ignore polarization if present, maybe there is a better way
+    bls = select_kwargs["bls"]
+    if isinstance(bls, tuple):
+        bls = [bls]
     assert np.all(
-        [bl[:2] in antpairs or bl[:2][::-1] in antpairs for bl in select_kwargs["bls"]]
+        [bl[:2] in antpairs or bl[:2][::-1] in antpairs for bl in bls]
     )
     exp_uv = full.select(inplace=False, **select_kwargs)
     assert uv_in == exp_uv

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -949,8 +949,9 @@ def test_readWriteReadMiriad_partial_errors(err_type, select_kwargs, err_msg):
         uv_in.read(write_file, **select_kwargs)
     assert str(cm.value).startswith(err_msg)
 
-    del(uv_in)
-    shutil.rmtree(write_file)
+    del(uv_in, full)
+    if os.path.exists(write_file):
+        shutil.rmtree(write_file)
 
 
 def test_readWriteReadMiriad_partial_error_special_cases():

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -727,7 +727,7 @@ def test_readWriteReadMiriad_partial_bls(select_kwargs):
     # indexing here is to ignore polarization if present, maybe there is a better way
     assert np.all([bl[:2] in antpairs or bl[:2][::-1] in antpairs
                    for bl in select_kwargs["bls"]])
-    exp_uv = full.select(**select_kwargs, inplace=False)
+    exp_uv = full.select(inplace=False, **select_kwargs)
     assert uv_in == exp_uv
 
     shutil.rmtree(write_file)
@@ -782,7 +782,7 @@ def test_readWriteReadMiriad_partial_times(select_kwargs):
     # The exact time are calculated above, pop out the time range to compare time range with
     # selecting on exact times
     select_kwargs.pop("time_range", None)
-    exp_uv = full.select(times=full_times, **select_kwargs, inplace=False)
+    exp_uv = full.select(times=full_times, inplace=False, **select_kwargs)
     assert uv_in == exp_uv
 
     shutil.rmtree(write_file)

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -2,7 +2,19 @@
 # Copyright (c) 2018 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
 
-"""Tests for Miriad object."""
+"""Tests for Miriad object.
+
+Note that because of the way that file handling is done in the C++ API, a miriad
+file is not closed until the destructor function (tp_dealloc) is called. Due to
+implementation details of CPython, it is sometimes not enough to `del` the
+object--a manual garbage collection may be required. When adding new tests,
+proper cleanup consists of: (1) deleting any Miriad objects or UVData objects,
+(2) performing garbage collection (with `gc.collect()`), and (3) removing the
+directory corresponding to the miriad file. Each test should do this, to avoid
+open file handles interfering with other tests. The exception to this is if a
+test uses the `uv_in_paper` or `uv_in_uvfits` fixture, as these handle cleanup
+on their own.
+"""
 from __future__ import absolute_import, division, print_function
 
 import os
@@ -32,61 +44,70 @@ pytestmark = pytest.mark.filterwarnings("ignore:Altitude is not present in Miria
 @pytest.fixture
 def uv_in_paper():
     uv_in = UVData()
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
     uv_in.read(testfile)
     uv_in.write_miriad(write_file, clobber=True)
     uv_out = UVData()
 
     yield uv_in, uv_out, write_file
 
-    del(uv_in, uv_out)
+    # cleanup
+    del uv_in, uv_out
+    gc.collect()
     if os.path.exists(write_file):
         shutil.rmtree(write_file)
-    gc.collect()
 
 
 @pytest.fixture
 def uv_in_uvfits():
     uv_in = UVData()
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uvfits')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uvfits")
 
     uv_in.read(testfile)
     uv_out = UVData()
 
     yield uv_in, uv_out, write_file
 
-    del(uv_in, uv_out)
+    # cleanup
+    del uv_in, uv_out
+    gc.collect()
     if os.path.exists(write_file):
         os.remove(write_file)
-    gc.collect()
 
 
 @pytest.mark.filterwarnings("ignore:Telescope ATCA is not")
 def test_ReadWriteReadATCA():
     uv_in = UVData()
     uv_out = UVData()
-    atca_file = os.path.join(DATA_PATH, 'atca_miriad')
-    testfile = os.path.join(DATA_PATH, 'test/outtest_atca_miriad.uv')
-    uvtest.checkWarnings(uv_in.read, [atca_file],
-                         nwarnings=4, category=[UserWarning, UserWarning, UserWarning, UserWarning],
-                         message=['Altitude is not present in Miriad file, and '
-                                  'telescope ATCA is not in known_telescopes. ',
-                                  'Altitude is not present',
-                                  'Telescope location is set at sealevel at the file lat/lon '
-                                  'coordinates. Antenna positions are present, but the mean antenna '
-                                  'position does not give a telescope_location on the surface of the '
-                                  'earth. Antenna positions do not appear to be on the surface of the '
-                                  'earth and will be treated as relative.',
-                                  'Telescope ATCA is not in known_telescopes.'])
+    atca_file = os.path.join(DATA_PATH, "atca_miriad")
+    testfile = os.path.join(DATA_PATH, "test/outtest_atca_miriad.uv")
+    uvtest.checkWarnings(
+        uv_in.read,
+        [atca_file],
+        nwarnings=4,
+        category=[UserWarning, UserWarning, UserWarning, UserWarning],
+        message=[
+            "Altitude is not present in Miriad file, and "
+            "telescope ATCA is not in known_telescopes. ",
+            "Altitude is not present",
+            "Telescope location is set at sealevel at the file lat/lon "
+            "coordinates. Antenna positions are present, but the mean antenna "
+            "position does not give a telescope_location on the surface of the "
+            "earth. Antenna positions do not appear to be on the surface of the "
+            "earth and will be treated as relative.",
+            "Telescope ATCA is not in known_telescopes.",
+        ],
+    )
     uv_in.write_miriad(testfile, clobber=True)
-    uvtest.checkWarnings(uv_out.read, [testfile],
-                         message=['Telescope ATCA is not in known_telescopes']
-                         )
-    # uv_out.read(testfile)
+    uv_out.read(testfile)
     assert uv_in == uv_out
+
+    # cleanup
+    del uv_in, uv_out
     gc.collect()
+    shutil.rmtree(testfile)
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
@@ -94,19 +115,28 @@ def test_ReadNRAOWriteMiriadReadMiriad():
     """Test reading in a CASA tutorial uvfits file, writing and reading as miriad"""
     uvfits_uv = UVData()
     miriad_uv = UVData()
-    testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    writefile = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
-    expected_extra_keywords = ['OBSERVER', 'SORTORD', 'SPECSYS',
-                               'RESTFREQ', 'ORIGIN']
-    uvtest.checkWarnings(uvfits_uv.read_uvfits, [testfile],
-                         message=['Telescope EVLA is not in known_telescopes'])
+    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
+    writefile = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
+    expected_extra_keywords = ["OBSERVER", "SORTORD", "SPECSYS", "RESTFREQ", "ORIGIN"]
+    uvtest.checkWarnings(
+        uvfits_uv.read_uvfits,
+        [testfile],
+        message=["Telescope EVLA is not in known_telescopes"],
+    )
     # uvfits_uv.read_uvfits(testfile)
     uvfits_uv.write_miriad(writefile, clobber=True)
-    uvtest.checkWarnings(miriad_uv.read_uvfits, [testfile],
-                         message=['Telescope EVLA is not in known_telescopes'])
+    uvtest.checkWarnings(
+        miriad_uv.read_uvfits,
+        [testfile],
+        message=["Telescope EVLA is not in known_telescopes"],
+    )
     # miriad_uv.read(writefile)
     assert uvfits_uv == miriad_uv
+
+    # cleanup
+    del uvfits_uv, miriad_uv
     gc.collect()
+    shutil.rmtree(writefile)
 
 
 def test_ReadMiriadWriteUVFits(uv_in_uvfits):
@@ -125,22 +155,39 @@ def test_ReadMiriadWriteUVFits(uv_in_uvfits):
 
 def test_miriad_read_warning_lat_lon_corrected():
     miriad_uv = UVData()
-    miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
+    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
     # check warning when correct_lat_lon is set to False
-    uvtest.checkWarnings(miriad_uv.read, [miriad_file],
-                         {'correct_lat_lon': False}, nwarnings=1,
-                         message=['Altitude is not present in Miriad file, '
-                                  'using known location altitude value for '
-                                  'PAPER and lat/lon from file.']
-                         )
+    uvtest.checkWarnings(
+        miriad_uv.read,
+        [miriad_file],
+        {"correct_lat_lon": False},
+        nwarnings=1,
+        message=[
+            "Altitude is not present in Miriad file, "
+            "using known location altitude value for "
+            "PAPER and lat/lon from file."
+        ],
+    )
+
+    # cleanup
+    del miriad_uv
     gc.collect()
 
 
-@pytest.mark.parametrize("err_type,write_kwargs,err_msg", [(ValueError, {"spoof_nonessential": True}, 'The data are in drift mode. Set force_phase'),
-                                                           (ValueError, {"force_phase": True}, 'Required attribute'),
-                                                           ]
-                         )
-def test_ReadMiriadWriteUVFits_phasing_errors(uv_in_uvfits, err_type, write_kwargs, err_msg):
+@pytest.mark.parametrize(
+    "err_type,write_kwargs,err_msg",
+    [
+        (
+            ValueError,
+            {"spoof_nonessential": True},
+            "The data are in drift mode. Set force_phase",
+        ),
+        (ValueError, {"force_phase": True}, "Required attribute"),
+    ],
+)
+def test_ReadMiriadWriteUVFits_phasing_errors(
+    uv_in_uvfits, err_type, write_kwargs, err_msg
+):
     miriad_uv, uvfits_uv, testfile = uv_in_uvfits
 
     # check error if phase_type is wrong and force_phase not set
@@ -149,17 +196,27 @@ def test_ReadMiriadWriteUVFits_phasing_errors(uv_in_uvfits, err_type, write_kwar
     assert str(cm.value).startswith(err_msg)
 
 
-@pytest.mark.parametrize("err_type,read_kwargs,err_msg", [(ValueError, {"phase_type": "phased"}, 'phase_type is "phased" but the RA values are varying'),
-                                                          (ValueError, {"phase_type": "foo"}, 'The phase_type was not recognized.'),
-                                                          ]
-                         )
+@pytest.mark.parametrize(
+    "err_type,read_kwargs,err_msg",
+    [
+        (
+            ValueError,
+            {"phase_type": "phased"},
+            'phase_type is "phased" but the RA values are varying',
+        ),
+        (ValueError, {"phase_type": "foo"}, "The phase_type was not recognized."),
+    ],
+)
 def test_ReadMiriad_phasing_errors(err_type, read_kwargs, err_msg):
     miriad_uv = UVData()
-    miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
+    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
     # check that setting the phase_type to something wrong errors
     with pytest.raises(err_type) as cm:
         miriad_uv.read(miriad_file, **read_kwargs)
     assert str(cm.value).startswith(err_msg)
+
+    # cleanup
+    del miriad_uv
     gc.collect()
 
 
@@ -169,7 +226,7 @@ def test_read_miriad_write_uvfits_phasing_error(uv_in_uvfits):
     miriad_uv.set_unknown_phase_type()
     with pytest.raises(ValueError) as cm:
         miriad_uv.write_uvfits(testfile, spoof_nonessential=True)
-    assert str(cm.value).startswith('The phasing type of the data is unknown')
+    assert str(cm.value).startswith("The phasing type of the data is unknown")
 
 
 def test_wronglatlon():
@@ -210,40 +267,62 @@ def test_wronglatlon():
     uv_out.read(telescopefile, run_check=False)
     """
     uv_in = UVData()
-    latfile = os.path.join(DATA_PATH, 'zen.2456865.60537_wronglat.xy.uvcRREAA')
-    lonfile = os.path.join(DATA_PATH, 'zen.2456865.60537_wronglon.xy.uvcRREAA')
-    telescopefile = os.path.join(DATA_PATH, 'zen.2456865.60537_wrongtelecope.xy.uvcRREAA')
+    latfile = os.path.join(DATA_PATH, "zen.2456865.60537_wronglat.xy.uvcRREAA")
+    lonfile = os.path.join(DATA_PATH, "zen.2456865.60537_wronglon.xy.uvcRREAA")
+    telescopefile = os.path.join(
+        DATA_PATH, "zen.2456865.60537_wrongtelecope.xy.uvcRREAA"
+    )
 
-    uvtest.checkWarnings(uv_in.read, [latfile], nwarnings=3,
-                         message=['Altitude is not present in file and latitude value does not match',
-                                  'This file was written with an old version of pyuvdata',
-                                  'This file was written with an old version of pyuvdata'],
-                         category=[UserWarning, DeprecationWarning, DeprecationWarning])
-    uvtest.checkWarnings(uv_in.read, [lonfile], nwarnings=3,
-                         message=['Altitude is not present in file and longitude value does not match',
-                                  'This file was written with an old version of pyuvdata',
-                                  'This file was written with an old version of pyuvdata'],
-                         category=[UserWarning, DeprecationWarning, DeprecationWarning])
-    uvtest.checkWarnings(uv_in.read, [telescopefile], {'run_check': False},
-                         nwarnings=6,
-                         message=['Altitude is not present in Miriad file, and telescope',
-                                  'Altitude is not present in Miriad file, and telescope',
-                                  'Telescope location is set at sealevel at the '
-                                  'file lat/lon coordinates. Antenna positions '
-                                  'are present, but the mean antenna position',
-                                  'This file was written with an old version of pyuvdata',
-                                  'This file was written with an old version of pyuvdata',
-                                  'Telescope foo is not in known_telescopes.'],
-                         category=(3 * [UserWarning] + 2 * [DeprecationWarning]
-                                   + [UserWarning]))
+    uvtest.checkWarnings(
+        uv_in.read,
+        [latfile],
+        nwarnings=3,
+        message=[
+            "Altitude is not present in file and latitude value does not match",
+            "This file was written with an old version of pyuvdata",
+            "This file was written with an old version of pyuvdata",
+        ],
+        category=[UserWarning, DeprecationWarning, DeprecationWarning],
+    )
+    uvtest.checkWarnings(
+        uv_in.read,
+        [lonfile],
+        nwarnings=3,
+        message=[
+            "Altitude is not present in file and longitude value does not match",
+            "This file was written with an old version of pyuvdata",
+            "This file was written with an old version of pyuvdata",
+        ],
+        category=[UserWarning, DeprecationWarning, DeprecationWarning],
+    )
+    uvtest.checkWarnings(
+        uv_in.read,
+        [telescopefile],
+        {"run_check": False},
+        nwarnings=6,
+        message=[
+            "Altitude is not present in Miriad file, and telescope",
+            "Altitude is not present in Miriad file, and telescope",
+            "Telescope location is set at sealevel at the "
+            "file lat/lon coordinates. Antenna positions "
+            "are present, but the mean antenna position",
+            "This file was written with an old version of pyuvdata",
+            "This file was written with an old version of pyuvdata",
+            "Telescope foo is not in known_telescopes.",
+        ],
+        category=(3 * [UserWarning] + 2 * [DeprecationWarning] + [UserWarning]),
+    )
+
+    # cleanup
+    del uv_in
     gc.collect()
 
 
 def test_miriad_location_handling():
     uv_in = UVData()
     uv_out = UVData()
-    miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    testfile = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    testfile = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
     aipy_uv = aipy_extracts.UV(miriad_file)
 
     if os.path.exists(testfile):
@@ -252,13 +331,13 @@ def test_miriad_location_handling():
     # Test for using antenna positions to get telescope position
     uv_in.read(miriad_file)
     # extract antenna positions and rotate them for miriad
-    nants = aipy_uv['nants']
+    nants = aipy_uv["nants"]
     rel_ecef_antpos = np.zeros((nants, 3), dtype=uv_in.antenna_positions.dtype)
     for ai, num in enumerate(uv_in.antenna_numbers):
         rel_ecef_antpos[num, :] = uv_in.antenna_positions[ai, :]
 
     # find zeros so antpos can be zeroed there too
-    antpos_length = np.sqrt(np.sum(np.abs(rel_ecef_antpos)**2, axis=1))
+    antpos_length = np.sqrt(np.sum(np.abs(rel_ecef_antpos) ** 2, axis=1))
 
     ecef_antpos = rel_ecef_antpos + uv_in.telescope_location
     longitude = uv_in.telescope_location_lat_lon_alt[1]
@@ -266,61 +345,76 @@ def test_miriad_location_handling():
 
     # zero out bad locations (these are checked on read)
     antpos[np.where(antpos_length == 0), :] = [0, 0, 0]
-    antpos = antpos.T.flatten() / const.c.to('m/ns').value
+    antpos = antpos.T.flatten() / const.c.to("m/ns").value
 
     # make new file
-    aipy_uv2 = aipy_extracts.UV(testfile, status='new')
+    aipy_uv2 = aipy_extracts.UV(testfile, status="new")
     # initialize headers from old file
     # change telescope name (so the position isn't set from known_telescopes)
     # and use absolute antenna positions
-    aipy_uv2.init_from_uv(aipy_uv, override={'telescop': 'foo', 'antpos': antpos})
+    aipy_uv2.init_from_uv(aipy_uv, override={"telescop": "foo", "antpos": antpos})
     # copy data from old file
     aipy_uv2.pipe(aipy_uv)
     # close file properly
-    del(aipy_uv2)
+    del aipy_uv2
+    gc.collect()
 
-    uvtest.checkWarnings(uv_out.read, [testfile], nwarnings=4,
-                         message=['Altitude is not present in Miriad file, and '
-                                  'telescope foo is not in known_telescopes. '
-                                  'Telescope location will be set using antenna positions.',
-                                  'Altitude is not present ',
-                                  'Telescope location is not set, but antenna '
-                                  'positions are present. Mean antenna latitude '
-                                  'and longitude values match file values, so '
-                                  'telescope_position will be set using the mean '
-                                  'of the antenna altitudes',
-                                  'Telescope foo is not in known_telescopes.'])
+    uvtest.checkWarnings(
+        uv_out.read,
+        [testfile],
+        nwarnings=4,
+        message=[
+            "Altitude is not present in Miriad file, and "
+            "telescope foo is not in known_telescopes. "
+            "Telescope location will be set using antenna positions.",
+            "Altitude is not present ",
+            "Telescope location is not set, but antenna "
+            "positions are present. Mean antenna latitude "
+            "and longitude values match file values, so "
+            "telescope_position will be set using the mean "
+            "of the antenna altitudes",
+            "Telescope foo is not in known_telescopes.",
+        ],
+    )
 
     # Test for handling when antenna positions have a different mean latitude than the file latitude
     # make new file
     if os.path.exists(testfile):
         shutil.rmtree(testfile)
     aipy_uv = aipy_extracts.UV(miriad_file)
-    aipy_uv2 = aipy_extracts.UV(testfile, status='new')
+    aipy_uv2 = aipy_extracts.UV(testfile, status="new")
     # initialize headers from old file
     # change telescope name (so the position isn't set from known_telescopes)
     # and use absolute antenna positions, change file latitude
-    new_lat = aipy_uv['latitud'] * 1.5
-    aipy_uv2.init_from_uv(aipy_uv, override={'telescop': 'foo', 'antpos': antpos,
-                                             'latitud': new_lat})
+    new_lat = aipy_uv["latitud"] * 1.5
+    aipy_uv2.init_from_uv(
+        aipy_uv, override={"telescop": "foo", "antpos": antpos, "latitud": new_lat}
+    )
     # copy data from old file
     aipy_uv2.pipe(aipy_uv)
     # close file properly
-    del(aipy_uv2)
+    del aipy_uv2
+    gc.collect()
 
-    uvtest.checkWarnings(uv_out.read, [testfile], nwarnings=5,
-                         message=['Altitude is not present in Miriad file, and '
-                                  'telescope foo is not in known_telescopes. '
-                                  'Telescope location will be set using antenna positions.',
-                                  'Altitude is not present in Miriad file, and '
-                                  'telescope foo is not in known_telescopes. '
-                                  'Telescope location will be set using antenna positions.',
-                                  'Telescope location is set at sealevel at the '
-                                  'file lat/lon coordinates. Antenna positions '
-                                  'are present, but the mean antenna latitude '
-                                  'value does not match',
-                                  'drift RA, Dec is off from lst, latitude by more than 1.0 deg',
-                                  'Telescope foo is not in known_telescopes.'])
+    uvtest.checkWarnings(
+        uv_out.read,
+        [testfile],
+        nwarnings=5,
+        message=[
+            "Altitude is not present in Miriad file, and "
+            "telescope foo is not in known_telescopes. "
+            "Telescope location will be set using antenna positions.",
+            "Altitude is not present in Miriad file, and "
+            "telescope foo is not in known_telescopes. "
+            "Telescope location will be set using antenna positions.",
+            "Telescope location is set at sealevel at the "
+            "file lat/lon coordinates. Antenna positions "
+            "are present, but the mean antenna latitude "
+            "value does not match",
+            "drift RA, Dec is off from lst, latitude by more than 1.0 deg",
+            "Telescope foo is not in known_telescopes.",
+        ],
+    )
 
     # Test for handling when antenna positions have a different mean longitude than the file longitude
     # this is harder because of the rotation that's done on the antenna positions
@@ -328,31 +422,39 @@ def test_miriad_location_handling():
     if os.path.exists(testfile):
         shutil.rmtree(testfile)
     aipy_uv = aipy_extracts.UV(miriad_file)
-    aipy_uv2 = aipy_extracts.UV(testfile, status='new')
+    aipy_uv2 = aipy_extracts.UV(testfile, status="new")
     # initialize headers from old file
     # change telescope name (so the position isn't set from known_telescopes)
     # and use absolute antenna positions, change file longitude
-    new_lon = aipy_uv['longitu'] + np.pi
-    aipy_uv2.init_from_uv(aipy_uv, override={'telescop': 'foo', 'antpos': antpos,
-                                             'longitu': new_lon})
+    new_lon = aipy_uv["longitu"] + np.pi
+    aipy_uv2.init_from_uv(
+        aipy_uv, override={"telescop": "foo", "antpos": antpos, "longitu": new_lon}
+    )
     # copy data from old file
     aipy_uv2.pipe(aipy_uv)
     # close file properly
-    del(aipy_uv2)
+    del aipy_uv2
+    gc.collect()
 
-    uvtest.checkWarnings(uv_out.read, [testfile], nwarnings=5,
-                         message=['Altitude is not present in Miriad file, and '
-                                  'telescope foo is not in known_telescopes. '
-                                  'Telescope location will be set using antenna positions.',
-                                  'Altitude is not present in Miriad file, and '
-                                  'telescope foo is not in known_telescopes. '
-                                  'Telescope location will be set using antenna positions.',
-                                  'Telescope location is set at sealevel at the '
-                                  'file lat/lon coordinates. Antenna positions '
-                                  'are present, but the mean antenna longitude '
-                                  'value does not match',
-                                  'drift RA, Dec is off from lst, latitude by more than 1.0 deg',
-                                  'Telescope foo is not in known_telescopes.'])
+    uvtest.checkWarnings(
+        uv_out.read,
+        [testfile],
+        nwarnings=5,
+        message=[
+            "Altitude is not present in Miriad file, and "
+            "telescope foo is not in known_telescopes. "
+            "Telescope location will be set using antenna positions.",
+            "Altitude is not present in Miriad file, and "
+            "telescope foo is not in known_telescopes. "
+            "Telescope location will be set using antenna positions.",
+            "Telescope location is set at sealevel at the "
+            "file lat/lon coordinates. Antenna positions "
+            "are present, but the mean antenna longitude "
+            "value does not match",
+            "drift RA, Dec is off from lst, latitude by more than 1.0 deg",
+            "Telescope foo is not in known_telescopes.",
+        ],
+    )
 
     # Test for handling when antenna positions have a different mean longitude &
     # latitude than the file longitude
@@ -360,69 +462,96 @@ def test_miriad_location_handling():
     if os.path.exists(testfile):
         shutil.rmtree(testfile)
     aipy_uv = aipy_extracts.UV(miriad_file)
-    aipy_uv2 = aipy_extracts.UV(testfile, status='new')
+    aipy_uv2 = aipy_extracts.UV(testfile, status="new")
     # initialize headers from old file
     # change telescope name (so the position isn't set from known_telescopes)
     # and use absolute antenna positions, change file latitude and longitude
-    aipy_uv2.init_from_uv(aipy_uv, override={'telescop': 'foo', 'antpos': antpos,
-                                             'latitud': new_lat, 'longitu': new_lon})
+    aipy_uv2.init_from_uv(
+        aipy_uv,
+        override={
+            "telescop": "foo",
+            "antpos": antpos,
+            "latitud": new_lat,
+            "longitu": new_lon,
+        },
+    )
     # copy data from old file
     aipy_uv2.pipe(aipy_uv)
     # close file properly
-    del(aipy_uv2)
+    del aipy_uv2
+    gc.collect()
 
-    uvtest.checkWarnings(uv_out.read, [testfile], nwarnings=5,
-                         message=['Altitude is not present in Miriad file, and '
-                                  'telescope foo is not in known_telescopes. '
-                                  'Telescope location will be set using antenna positions.',
-                                  'Altitude is not present in Miriad file, and '
-                                  'telescope foo is not in known_telescopes. '
-                                  'Telescope location will be set using antenna positions.',
-                                  'Telescope location is set at sealevel at the '
-                                  'file lat/lon coordinates. Antenna positions '
-                                  'are present, but the mean antenna latitude and '
-                                  'longitude values do not match',
-                                  'drift RA, Dec is off from lst, latitude by more than 1.0 deg',
-                                  'Telescope foo is not in known_telescopes.'])
+    uvtest.checkWarnings(
+        uv_out.read,
+        [testfile],
+        nwarnings=5,
+        message=[
+            "Altitude is not present in Miriad file, and "
+            "telescope foo is not in known_telescopes. "
+            "Telescope location will be set using antenna positions.",
+            "Altitude is not present in Miriad file, and "
+            "telescope foo is not in known_telescopes. "
+            "Telescope location will be set using antenna positions.",
+            "Telescope location is set at sealevel at the "
+            "file lat/lon coordinates. Antenna positions "
+            "are present, but the mean antenna latitude and "
+            "longitude values do not match",
+            "drift RA, Dec is off from lst, latitude by more than 1.0 deg",
+            "Telescope foo is not in known_telescopes.",
+        ],
+    )
 
     # Test for handling when antenna positions are far enough apart to make the
     # mean position inside the earth
 
     good_antpos = np.where(antpos_length > 0)[0]
-    rot_ants = good_antpos[:len(good_antpos) // 2]
+    rot_ants = good_antpos[: len(good_antpos) // 2]
     rot_antpos = uvutils.rotECEF_from_ECEF(ecef_antpos[rot_ants, :], longitude + np.pi)
     modified_antpos = uvutils.rotECEF_from_ECEF(ecef_antpos, longitude)
     modified_antpos[rot_ants, :] = rot_antpos
     # zero out bad locations (these are checked on read)
     modified_antpos[np.where(antpos_length == 0), :] = [0, 0, 0]
-    modified_antpos = modified_antpos.T.flatten() / const.c.to('m/ns').value
+    modified_antpos = modified_antpos.T.flatten() / const.c.to("m/ns").value
 
     # make new file
     if os.path.exists(testfile):
         shutil.rmtree(testfile)
     aipy_uv = aipy_extracts.UV(miriad_file)
-    aipy_uv2 = aipy_extracts.UV(testfile, status='new')
+    aipy_uv2 = aipy_extracts.UV(testfile, status="new")
     # initialize headers from old file
     # change telescope name (so the position isn't set from known_telescopes)
     # and use modified absolute antenna positions
-    aipy_uv2.init_from_uv(aipy_uv, override={'telescop': 'foo', 'antpos': modified_antpos})
+    aipy_uv2.init_from_uv(
+        aipy_uv, override={"telescop": "foo", "antpos": modified_antpos}
+    )
     # copy data from old file
     aipy_uv2.pipe(aipy_uv)
     # close file properly
-    del(aipy_uv2)
-
-    uvtest.checkWarnings(uv_out.read, [testfile], nwarnings=4,
-                         message=['Altitude is not present in Miriad file, and '
-                                  'telescope foo is not in known_telescopes. '
-                                  'Telescope location will be set using antenna positions.',
-                                  'Altitude is not present ',
-                                  'Telescope location is set at sealevel at the '
-                                  'file lat/lon coordinates. Antenna positions '
-                                  'are present, but the mean antenna position '
-                                  'does not give a telescope_location on the '
-                                  'surface of the earth.',
-                                  'Telescope foo is not in known_telescopes.'])
+    del aipy_uv2
     gc.collect()
+
+    uvtest.checkWarnings(
+        uv_out.read,
+        [testfile],
+        nwarnings=4,
+        message=[
+            "Altitude is not present in Miriad file, and "
+            "telescope foo is not in known_telescopes. "
+            "Telescope location will be set using antenna positions.",
+            "Altitude is not present ",
+            "Telescope location is set at sealevel at the "
+            "file lat/lon coordinates. Antenna positions "
+            "are present, but the mean antenna position "
+            "does not give a telescope_location on the "
+            "surface of the earth.",
+            "Telescope foo is not in known_telescopes.",
+        ],
+    )
+
+    # cleanup
+    del aipy_uv, uv_in, uv_out
+    gc.collect()
+    shutil.rmtree(testfile)
 
 
 def test_singletimeselect_drift():
@@ -432,8 +561,8 @@ def test_singletimeselect_drift():
     """
     uv_in = UVData()
     uv_out = UVData()
-    miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    testfile = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    testfile = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
     uv_in.read(miriad_file)
 
     uv_in.select(times=uv_in.time_array[0])
@@ -442,7 +571,7 @@ def test_singletimeselect_drift():
     assert uv_in == uv_out
 
     # check that setting the phase_type works
-    uv_out.read(testfile, phase_type='drift')
+    uv_out.read(testfile, phase_type="drift")
     assert uv_in == uv_out
 
     # check again with more than one time but only 1 unflagged time
@@ -452,49 +581,58 @@ def test_singletimeselect_drift():
 
     # get unflagged blts
     blt_good = np.where(~np.all(uv_in.flag_array, axis=(1, 2, 3)))
-    assert np.isclose(np.mean(np.diff(uv_in.time_array[blt_good])), 0.)
+    assert np.isclose(np.mean(np.diff(uv_in.time_array[blt_good])), 0.0)
 
     uv_in.write_miriad(testfile, clobber=True)
     uv_out.read(testfile)
     assert uv_in == uv_out
 
     # check that setting the phase_type works
-    uv_out.read(testfile, phase_type='drift')
+    uv_out.read(testfile, phase_type="drift")
     assert uv_in == uv_out
+
+    # cleanup
+    del uv_in, uv_out
     gc.collect()
+    shutil.rmtree(testfile)
 
 
 def test_poltoind():
     miriad_uv = UVData()
-    miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
+    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
     miriad_uv.read(miriad_file)
     pol_arr = miriad_uv.polarization_array
 
-    miriad = miriad_uv._convert_to_filetype('miriad')
+    miriad = miriad_uv._convert_to_filetype("miriad")
     miriad.polarization_array = None
     with pytest.raises(ValueError) as cm:
         miriad._pol_to_ind(pol_arr[0])
-    assert str(cm.value).startswith("Can't index polarization -7 because polarization_array is not set")
+    assert str(cm.value).startswith(
+        "Can't index polarization -7 because polarization_array is not set"
+    )
 
     miriad.polarization_array = [pol_arr[0], pol_arr[0]]
     with pytest.raises(ValueError) as cm:
         miriad._pol_to_ind(pol_arr[0])
-    assert str(cm.value).startswith('multiple matches for pol=-7 in polarization_array')
+    assert str(cm.value).startswith("multiple matches for pol=-7 in polarization_array")
+
+    # cleanup
+    del miriad_uv
     gc.collect()
 
 
-@pytest.mark.skip(reason="This test is associated with segfaults. Skipping until resolution is found.")
 def test_miriad_extra_keywords():
     uv_in = UVData()
     uv_out = UVData()
-    miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    testfile = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    testfile = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
     uv_in.read(miriad_file)
 
     # check for warnings & errors with extra_keywords that are dicts, lists or arrays
-    uv_in.extra_keywords['testdict'] = {'testkey': 23}
-    uvtest.checkWarnings(uv_in.check, message=['testdict in extra_keywords is a '
-                                               'list, array or dict'])
+    uv_in.extra_keywords["testdict"] = {"testkey": 23}
+    uvtest.checkWarnings(
+        uv_in.check, message=["testdict in extra_keywords is a " "list, array or dict"]
+    )
 
     if six.PY2:
         with pytest.raises(TypeError) as cm:
@@ -505,11 +643,12 @@ def test_miriad_extra_keywords():
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
         assert str(cm.value).startswith("Extra keyword testdict is of <class 'dict'>")
 
-    uv_in.extra_keywords.pop('testdict')
+    uv_in.extra_keywords.pop("testdict")
 
-    uv_in.extra_keywords['testlist'] = [12, 14, 90]
-    uvtest.checkWarnings(uv_in.check, message=['testlist in extra_keywords is a '
-                                               'list, array or dict'])
+    uv_in.extra_keywords["testlist"] = [12, 14, 90]
+    uvtest.checkWarnings(
+        uv_in.check, message=["testlist in extra_keywords is a " "list, array or dict"]
+    )
     if six.PY2:
         with pytest.raises(TypeError) as cm:
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
@@ -518,81 +657,96 @@ def test_miriad_extra_keywords():
         with pytest.raises(TypeError) as cm:
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
         assert str(cm.value).startswith("Extra keyword testlist is of <class 'list'>")
-    uv_in.extra_keywords.pop('testlist')
+    uv_in.extra_keywords.pop("testlist")
 
-    uv_in.extra_keywords['testarr'] = np.array([12, 14, 90])
-    uvtest.checkWarnings(uv_in.check, message=['testarr in extra_keywords is a '
-                                               'list, array or dict'])
+    uv_in.extra_keywords["testarr"] = np.array([12, 14, 90])
+    uvtest.checkWarnings(
+        uv_in.check, message=["testarr in extra_keywords is a " "list, array or dict"]
+    )
     if six.PY2:
         with pytest.raises(TypeError) as cm:
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
-        assert str(cm.value).startswith("Extra keyword testarr is of <type 'numpy.ndarray'>")
+        assert str(cm.value).startswith(
+            "Extra keyword testarr is of <type 'numpy.ndarray'>"
+        )
     else:
         with pytest.raises(TypeError) as cm:
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
-        assert str(cm.value).startswith("Extra keyword testarr is of <class 'numpy.ndarray'>")
-    uv_in.extra_keywords.pop('testarr')
+        assert str(cm.value).startswith(
+            "Extra keyword testarr is of <class 'numpy.ndarray'>"
+        )
+    uv_in.extra_keywords.pop("testarr")
 
     # check for warnings with extra_keywords keys that are too long
-    uv_in.extra_keywords['test_long_key'] = True
-    uvtest.checkWarnings(uv_in.check, message=['key test_long_key in extra_keywords '
-                                               'is longer than 8 characters'])
-    uvtest.checkWarnings(uv_in.write_miriad, [testfile], {'clobber': True, 'run_check': False},
-                         message=['key test_long_key in extra_keywords is longer than 8 characters'])
-    uv_in.extra_keywords.pop('test_long_key')
+    uv_in.extra_keywords["test_long_key"] = True
+    uvtest.checkWarnings(
+        uv_in.check,
+        message=["key test_long_key in extra_keywords " "is longer than 8 characters"],
+    )
+    uvtest.checkWarnings(
+        uv_in.write_miriad,
+        [testfile],
+        {"clobber": True, "run_check": False},
+        message=["key test_long_key in extra_keywords is longer than 8 characters"],
+    )
+    uv_in.extra_keywords.pop("test_long_key")
 
     # check handling of boolean keywords
-    uv_in.extra_keywords['bool'] = True
-    uv_in.extra_keywords['bool2'] = False
+    uv_in.extra_keywords["bool"] = True
+    uv_in.extra_keywords["bool2"] = False
     uv_in.write_miriad(testfile, clobber=True)
     uv_out.read(testfile)
 
     assert uv_in == uv_out
-    uv_in.extra_keywords.pop('bool')
-    uv_in.extra_keywords.pop('bool2')
+    uv_in.extra_keywords.pop("bool")
+    uv_in.extra_keywords.pop("bool2")
 
     # check handling of int-like keywords
-    uv_in.extra_keywords['int1'] = np.int(5)
-    uv_in.extra_keywords['int2'] = 7
+    uv_in.extra_keywords["int1"] = np.int(5)
+    uv_in.extra_keywords["int2"] = 7
     uv_in.write_miriad(testfile, clobber=True)
     uv_out.read(testfile)
 
     assert uv_in == uv_out
-    uv_in.extra_keywords.pop('int1')
-    uv_in.extra_keywords.pop('int2')
+    uv_in.extra_keywords.pop("int1")
+    uv_in.extra_keywords.pop("int2")
 
     # check handling of float-like keywords
-    uv_in.extra_keywords['float1'] = np.int64(5.3)
-    uv_in.extra_keywords['float2'] = 6.9
+    uv_in.extra_keywords["float1"] = np.int64(5.3)
+    uv_in.extra_keywords["float2"] = 6.9
     uv_in.write_miriad(testfile, clobber=True)
     uv_out.read(testfile)
 
     assert uv_in == uv_out
-    uv_in.extra_keywords.pop('float1')
-    uv_in.extra_keywords.pop('float2')
+    uv_in.extra_keywords.pop("float1")
+    uv_in.extra_keywords.pop("float2")
 
     # check handling of very long strings
-    long_string = 'this is a very long string ' * 1000
-    uv_in.extra_keywords['longstr'] = long_string
+    long_string = "this is a very long string " * 1000
+    uv_in.extra_keywords["longstr"] = long_string
     uv_in.write_miriad(testfile, clobber=True)
     uv_out.read(testfile)
     assert uv_in == uv_out
-    uv_in.extra_keywords.pop('longstr')
+    uv_in.extra_keywords.pop("longstr")
 
     # check handling of complex-like keywords
     # currently they are NOT supported
-    uv_in.extra_keywords['complex1'] = np.complex64(5.3 + 1.2j)
+    uv_in.extra_keywords["complex1"] = np.complex64(5.3 + 1.2j)
     if six.PY2:
         with pytest.raises(TypeError) as cm:
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
-        assert str(cm.value).startswith("Extra keyword complex1 is of <type 'numpy.complex64'>")
+        assert str(cm.value).startswith(
+            "Extra keyword complex1 is of <type 'numpy.complex64'>"
+        )
     else:
         with pytest.raises(TypeError) as cm:
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
-        assert str(cm.value).startswith("Extra keyword complex1 is of <class 'numpy.complex64'>")
-    uv_in.extra_keywords.pop('complex1')
+        assert str(cm.value).startswith(
+            "Extra keyword complex1 is of <class 'numpy.complex64'>"
+        )
+    uv_in.extra_keywords.pop("complex1")
 
-    uv_in.extra_keywords['complex2'] = 6.9 + 4.6j
+    uv_in.extra_keywords["complex2"] = 6.9 + 4.6j
     if six.PY2:
         with pytest.raises(TypeError) as cm:
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
@@ -600,18 +754,24 @@ def test_miriad_extra_keywords():
     else:
         with pytest.raises(TypeError) as cm:
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
-        assert str(cm.value).startswith("Extra keyword complex2 is of <class 'complex'>")
+        assert str(cm.value).startswith(
+            "Extra keyword complex2 is of <class 'complex'>"
+        )
+
+    # cleanup
+    del uv_in, uv_out
     gc.collect()
+    shutil.rmtree(testfile)
 
 
 def test_roundtrip_optional_params():
     uv_in = UVData()
     uv_out = UVData()
-    miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    testfile = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    testfile = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
     uv_in.read(miriad_file)
 
-    uv_in.x_orientation = 'east'
+    uv_in.x_orientation = "east"
     uv_in.reorder_blts()
 
     uv_in.write_miriad(testfile, clobber=True)
@@ -620,7 +780,7 @@ def test_roundtrip_optional_params():
     assert uv_in == uv_out
 
     # test with bda as well (single entry in tuple)
-    uv_in.reorder_blts(order='bda')
+    uv_in.reorder_blts(order="bda")
 
     uv_in.write_miriad(testfile, clobber=True)
     uv_out.read(testfile)
@@ -628,9 +788,9 @@ def test_roundtrip_optional_params():
     assert uv_in == uv_out
 
     # cleanup
-    del(uv_in, uv_out)
-    shutil.rmtree(testfile)
+    del uv_in, uv_out
     gc.collect()
+    shutil.rmtree(testfile)
 
 
 def test_breakReadMiriad():
@@ -638,29 +798,46 @@ def test_breakReadMiriad():
     uv_in = UVData()
     uv_out = UVData()
     with pytest.raises(IOError) as cm:
-        uv_in.read('foo', file_type='miriad')
+        uv_in.read("foo", file_type="miriad")
     assert str(cm.value).startswith("foo not found")
 
-    miriad_file = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    testfile = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    testfile = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
     uv_in.read(miriad_file)
 
     uv_in.Nblts += 10
     uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    uvtest.checkWarnings(uv_out.read, [testfile], {'run_check': False},
-                         message=['Nblts does not match the number of unique blts in the data'])
+    uvtest.checkWarnings(
+        uv_out.read,
+        [testfile],
+        {"run_check": False},
+        message=["Nblts does not match the number of unique blts in the data"],
+    )
 
     uv_in.read(miriad_file)
     uv_in.Nbls += 10
     uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    uvtest.checkWarnings(uv_out.read, [testfile], {'run_check': False},
-                         message=['Nbls does not match the number of unique baselines in the data'])
+    uvtest.checkWarnings(
+        uv_out.read,
+        [testfile],
+        {"run_check": False},
+        message=["Nbls does not match the number of unique baselines in the data"],
+    )
 
     uv_in.read(miriad_file)
     uv_in.Ntimes += 10
     uv_in.write_miriad(testfile, clobber=True, run_check=False)
-    uvtest.checkWarnings(uv_out.read, [testfile], {'run_check': False},
-                         message=['Ntimes does not match the number of unique times in the data'])
+    uvtest.checkWarnings(
+        uv_out.read,
+        [testfile],
+        {"run_check": False},
+        message=["Ntimes does not match the number of unique times in the data"],
+    )
+
+    # cleanup
+    del uv_in, uv_out
+    gc.collect()
+    shutil.rmtree(testfile)
 
 
 def test_readWriteReadMiriad(uv_in_paper):
@@ -677,12 +854,12 @@ def test_readWriteReadMiriad(uv_in_paper):
 
     # check that we can read & write phased data
     uv_in2 = copy.deepcopy(uv_in)
-    uv_in2.phase_to_time(Time(np.mean(uv_in2.time_array), format='jd'))
+    uv_in2.phase_to_time(Time(np.mean(uv_in2.time_array), format="jd"))
     uv_in2.write_miriad(write_file, clobber=True)
     uv_out.read(write_file)
 
     assert uv_in2 == uv_out
-    del(uv_in2)
+    del uv_in2
 
     # check that trying to overwrite without clobber raises an error
     if six.PY2:
@@ -695,7 +872,7 @@ def test_readWriteReadMiriad(uv_in_paper):
         assert str(cm.value).startswith("File exists: skipping")
 
     # check that if x_orientation is set, it's read back out properly
-    uv_in.x_orientation = 'east'
+    uv_in.x_orientation = "east"
     uv_in.write_miriad(write_file, clobber=True)
     uv_out.read(write_file)
     assert uv_in == uv_out
@@ -711,13 +888,14 @@ def test_miriad_antenna_diameters(uv_in_paper):
     assert uv_in == uv_out
 
     # check that antenna diameters get written if not exactly float
-    uv_in.antenna_diameters = np.zeros((uv_in.Nants_telescope,), dtype=np.float32) + 14.0
+    uv_in.antenna_diameters = (
+        np.zeros((uv_in.Nants_telescope,), dtype=np.float32) + 14.0
+    )
     uv_in.write_miriad(write_file, clobber=True)
     uv_out.read(write_file)
     assert uv_in == uv_out
 
 
-@pytest.mark.skip(reason='This test occasionally causes segfaults. Skipping until resolution is found.')
 def test_miriad_write_miriad_unkonwn_phase_error(uv_in_paper):
     uv_in, uv_out, write_file = uv_in_paper
     # check that trying to write a file with unknown phasing raises an error
@@ -730,7 +908,7 @@ def test_miriad_write_miriad_unkonwn_phase_error(uv_in_paper):
 def test_miriad_write_read_diameters(uv_in_paper):
     uv_in, uv_out, write_file = uv_in_paper
     # check for backwards compatibility with old keyword 'diameter' for antenna diameters
-    testfile_diameters = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcA')
+    testfile_diameters = os.path.join(DATA_PATH, "zen.2457698.40355.xx.HH.uvcA")
     uv_in.read(testfile_diameters)
     uv_in.write_miriad(write_file, clobber=True)
     uv_out.read(write_file)
@@ -742,17 +920,22 @@ def test_miriad_and_aipy_reads(uv_in_paper):
     # check that variables 'ischan' and 'nschan' were written to new file
     # need to use aipy, since pyuvdata is not currently capturing these variables
     uv_in.read(write_file)
-    uv_aipy = aipy_extracts.UV(write_file)  # on enterprise, this line makes it so you cant delete the file
+    uv_aipy = aipy_extracts.UV(
+        write_file
+    )  # on enterprise, this line makes it so you cant delete the file
     nfreqs = uv_in.Nfreqs
-    nschan = uv_aipy['nschan']
-    ischan = uv_aipy['ischan']
+    nschan = uv_aipy["nschan"]
+    ischan = uv_aipy["ischan"]
     assert nschan == nfreqs
     assert ischan == 1
-    del(uv_aipy)  # close the file so it can be used later
+
+    # cleanup
+    del uv_aipy
+    gc.collect()
 
 
 def test_miriad_telescope_locations():
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
     # test load_telescope_coords w/ blank Miriad
     uv_in = Miriad()
     uv = aipy_extracts.UV(testfile)
@@ -764,10 +947,14 @@ def test_miriad_telescope_locations():
     uv_in._load_antpos(uv)
     assert uv_in.antenna_positions is not None
 
+    # cleanup
+    del uv, uv_in
+    gc.collect()
+
 
 def test_miriad_integration_time_precision():
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
 
     # test that changing precision of integraiton_time is okay
     # tolerance of integration_time (1e-3) is larger than floating point type conversions
@@ -779,21 +966,26 @@ def test_miriad_integration_time_precision():
     new_uv.read(write_file)
     assert uv_in == new_uv
 
+    # cleanup
+    del new_uv, uv_in
+    gc.collect()
     shutil.rmtree(write_file)
-    del(new_uv, uv_in)
 
 
-@pytest.mark.parametrize("select_kwargs", [{"bls": [(0, 0), (0, 1), (4, 2)]},
-                                           {"bls": [(0, 0), (2, 4)], "antenna_nums": [0, 2, 4]},
-                                           {"bls": [(2, 4, 'xy')]},
-                                           {"bls": [(4, 2, 'yx')]},
-                                           {"polarizations": [-7], "bls": [(4, 4)]},
-                                           {"bls": [(4, 4, 'xy')]}
-                                           ]
-                         )
+@pytest.mark.parametrize(
+    "select_kwargs",
+    [
+        {"bls": [(0, 0), (0, 1), (4, 2)]},
+        {"bls": [(0, 0), (2, 4)], "antenna_nums": [0, 2, 4]},
+        {"bls": [(2, 4, "xy")]},
+        {"bls": [(4, 2, "yx")]},
+        {"polarizations": [-7], "bls": [(4, 4)]},
+        {"bls": [(4, 4, "xy")]},
+    ],
+)
 def test_readWriteReadMiriad_partial_bls(select_kwargs):
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
 
     # check partial read selections
     full = UVData()
@@ -805,19 +997,21 @@ def test_readWriteReadMiriad_partial_bls(select_kwargs):
     uv_in.read(write_file, **select_kwargs)
     antpairs = uv_in.get_antpairs()
     # indexing here is to ignore polarization if present, maybe there is a better way
-    assert np.all([bl[:2] in antpairs or bl[:2][::-1] in antpairs
-                   for bl in select_kwargs["bls"]])
+    assert np.all(
+        [bl[:2] in antpairs or bl[:2][::-1] in antpairs for bl in select_kwargs["bls"]]
+    )
     exp_uv = full.select(inplace=False, **select_kwargs)
     assert uv_in == exp_uv
 
+    # cleanup
+    del uv_in, full
+    gc.collect()
     shutil.rmtree(write_file)
-    del(uv_in)
-    del(full)
 
 
 def test_readWriteReadMiriad_partial_antenna_nums():
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
 
     # check partial read selections
     full = UVData()
@@ -833,18 +1027,23 @@ def test_readWriteReadMiriad_partial_antenna_nums():
     assert np.max(exp_uv.ant_2_array) == 0
     assert uv_in == exp_uv
 
+    # cleanup
+    del uv_in, exp_uv, full
+    gc.collect()
     shutil.rmtree(write_file)
-    del(uv_in)
 
 
-@pytest.mark.parametrize("select_kwargs", [{"time_range": [2456865.607, 2456865.609]},
-                                           {"time_range": [2456865.607, 2456865.609], "antenna_nums": [0]},
-                                           {"time_range": [2456865.607, 2456865.609], "polarizations": [-7]}
-                                           ]
-                         )
+@pytest.mark.parametrize(
+    "select_kwargs",
+    [
+        {"time_range": [2456865.607, 2456865.609]},
+        {"time_range": [2456865.607, 2456865.609], "antenna_nums": [0]},
+        {"time_range": [2456865.607, 2456865.609], "polarizations": [-7]},
+    ],
+)
 def test_readWriteReadMiriad_partial_times(select_kwargs):
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
 
     # check partial read selections
     full = UVData()
@@ -854,8 +1053,12 @@ def test_readWriteReadMiriad_partial_times(select_kwargs):
     # test time loading
     uv_in = UVData()
     uv_in.read(write_file, **select_kwargs)
-    full_times = np.unique(full.time_array[(full.time_array > select_kwargs["time_range"][0])
-                                           & (full.time_array < select_kwargs["time_range"][1])])
+    full_times = np.unique(
+        full.time_array[
+            (full.time_array > select_kwargs["time_range"][0])
+            & (full.time_array < select_kwargs["time_range"][1])
+        ]
+    )
     assert np.isclose(np.unique(uv_in.time_array), full_times).all()
     # The exact time are calculated above, pop out the time range to compare time range with
     # selecting on exact times
@@ -863,15 +1066,16 @@ def test_readWriteReadMiriad_partial_times(select_kwargs):
     exp_uv = full.select(times=full_times, inplace=False, **select_kwargs)
     assert uv_in == exp_uv
 
+    # cleanup
+    del uv_in, full, exp_uv
+    gc.collect()
     shutil.rmtree(write_file)
-    del(uv_in)
-    del(full)
 
 
-@pytest.mark.parametrize("pols", [['xy'], [-7]])
+@pytest.mark.parametrize("pols", [["xy"], [-7]])
 def test_readWriteReadMiriad_partial_pols(pols):
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
 
     # check partial read selections
     full = UVData()
@@ -885,13 +1089,15 @@ def test_readWriteReadMiriad_partial_pols(pols):
     exp_uv = full.select(polarizations=pols, inplace=False)
     assert uv_in == exp_uv
 
+    # cleanup
+    del uv_in, full
+    gc.collect()
     shutil.rmtree(write_file)
-    del(uv_in)
 
 
 def test_readWriteReadMiriad_partial_ant_str():
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
 
     # check partial read selections
     full = UVData()
@@ -899,14 +1105,15 @@ def test_readWriteReadMiriad_partial_ant_str():
     full.write_miriad(write_file, clobber=True)
     uv_in = UVData()
     # test ant_str
-    del(uv_in)
+    del uv_in
     uv_in = UVData()
-    uv_in.read(write_file, ant_str='auto')
+    uv_in.read(write_file, ant_str="auto")
     assert np.array([blp[0] == blp[1] for blp in uv_in.get_antpairs()]).all()
-    exp_uv = full.select(ant_str='auto', inplace=False)
+    exp_uv = full.select(ant_str="auto", inplace=False)
     assert uv_in == exp_uv
 
-    del(uv_in)
+    del uv_in
+    gc.collect()
     shutil.rmtree(write_file)
 
     full = UVData()
@@ -914,12 +1121,13 @@ def test_readWriteReadMiriad_partial_ant_str():
     full.write_miriad(write_file, clobber=True)
 
     uv_in = UVData()
-    uv_in.read(write_file, ant_str='cross')
+    uv_in.read(write_file, ant_str="cross")
     assert np.array([blp[0] != blp[1] for blp in uv_in.get_antpairs()]).all()
-    exp_uv = full.select(ant_str='cross', inplace=False)
+    exp_uv = full.select(ant_str="cross", inplace=False)
     assert uv_in == exp_uv
 
-    del(uv_in)
+    del uv_in
+    gc.collect()
     shutil.rmtree(write_file)
 
     full = UVData()
@@ -927,34 +1135,95 @@ def test_readWriteReadMiriad_partial_ant_str():
     full.write_miriad(write_file, clobber=True)
 
     uv_in = UVData()
-    uv_in.read(write_file, ant_str='all')
+    uv_in.read(write_file, ant_str="all")
     assert uv_in == full
 
-    del(uv_in)
+    # cleanup
+    del uv_in, full, exp_uv
+    gc.collect()
+    shutil.rmtree(write_file)
 
 
-@pytest.mark.parametrize("err_type,select_kwargs,err_msg",
-                         [(AssertionError, {"ant_str": 'auto', "antenna_nums": [0, 1]}, "ant_str must be None if antenna_nums or bls is not None"),
-                          (ValueError, {"bls": 'foo'}, "bls must be a list of tuples of antenna numbers"),
-                          (ValueError, {"bls": [[0, 1]]}, "bls must be a list of tuples of antenna numbers"),
-                          (ValueError, {"bls": [('foo', 'bar')]}, "bls must be a list of tuples of antenna numbers"),
-                          (ValueError, {"bls": [('foo', )]}, "bls tuples must be all length-2 or all length-3"),
-                          (ValueError, {"bls": [(1, 2), (2, 3, 'xx')]}, "bls tuples must be all length-2 or all length-3"),
-                          (ValueError, {"bls": [(2, 4, 0)]}, "The third element in each bl must be a polarization string"),
-                          (ValueError, {"bls": [(2, 4, 'xy')], "polarizations": ['xy']}, "Cannot provide length-3 tuples and also specify polarizations."),
-                          (AssertionError, {"antenna_nums": np.array([(0, 10)])}, "antenna_nums must be fed as a list of antenna number integers"),
-                          (AssertionError, {"polarizations": 'xx'}, "pols must be a list of polarization strings or ints"),
-                          (ValueError, {"polarizations": ['yy']}, "No data is present, probably as a result of select on read"),
-                          (AssertionError, {"time_range": 'foo'}, "time_range must be a len-2 list of Julian Date floats"),
-                          (AssertionError, {"time_range": [1, 2, 3]}, "time_range must be a len-2 list of Julian Date floats"),
-                          (AssertionError, {"time_range": ['foo', 'bar']}, "time_range must be a len-2 list of Julian Date floats"),
-                          (ValueError, {"time_range": [10.1, 10.2]}, "No data is present, probably as a result of select on read"),
-                          (AssertionError, {"ant_str": 0}, "ant_str must be fed as a string")
-                          ]
-                         )
+@pytest.mark.parametrize(
+    "err_type,select_kwargs,err_msg",
+    [
+        (
+            AssertionError,
+            {"ant_str": "auto", "antenna_nums": [0, 1]},
+            "ant_str must be None if antenna_nums or bls is not None",
+        ),
+        (ValueError, {"bls": "foo"}, "bls must be a list of tuples of antenna numbers"),
+        (
+            ValueError,
+            {"bls": [[0, 1]]},
+            "bls must be a list of tuples of antenna numbers",
+        ),
+        (
+            ValueError,
+            {"bls": [("foo", "bar")]},
+            "bls must be a list of tuples of antenna numbers",
+        ),
+        (
+            ValueError,
+            {"bls": [("foo",)]},
+            "bls tuples must be all length-2 or all length-3",
+        ),
+        (
+            ValueError,
+            {"bls": [(1, 2), (2, 3, "xx")]},
+            "bls tuples must be all length-2 or all length-3",
+        ),
+        (
+            ValueError,
+            {"bls": [(2, 4, 0)]},
+            "The third element in each bl must be a polarization string",
+        ),
+        (
+            ValueError,
+            {"bls": [(2, 4, "xy")], "polarizations": ["xy"]},
+            "Cannot provide length-3 tuples and also specify polarizations.",
+        ),
+        (
+            AssertionError,
+            {"antenna_nums": np.array([(0, 10)])},
+            "antenna_nums must be fed as a list of antenna number integers",
+        ),
+        (
+            AssertionError,
+            {"polarizations": "xx"},
+            "pols must be a list of polarization strings or ints",
+        ),
+        (
+            ValueError,
+            {"polarizations": ["yy"]},
+            "No data is present, probably as a result of select on read",
+        ),
+        (
+            AssertionError,
+            {"time_range": "foo"},
+            "time_range must be a len-2 list of Julian Date floats",
+        ),
+        (
+            AssertionError,
+            {"time_range": [1, 2, 3]},
+            "time_range must be a len-2 list of Julian Date floats",
+        ),
+        (
+            AssertionError,
+            {"time_range": ["foo", "bar"]},
+            "time_range must be a len-2 list of Julian Date floats",
+        ),
+        (
+            ValueError,
+            {"time_range": [10.1, 10.2]},
+            "No data is present, probably as a result of select on read",
+        ),
+        (AssertionError, {"ant_str": 0}, "ant_str must be fed as a string"),
+    ],
+)
 def test_readWriteReadMiriad_partial_errors(err_type, select_kwargs, err_msg):
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
 
     # check partial read selections
     full = UVData()
@@ -966,14 +1235,15 @@ def test_readWriteReadMiriad_partial_errors(err_type, select_kwargs, err_msg):
         uv_in.read(write_file, **select_kwargs)
     assert str(cm.value).startswith(err_msg)
 
-    del(uv_in, full)
+    del uv_in, full
+    gc.collect()
     if os.path.exists(write_file):
         shutil.rmtree(write_file)
 
 
 def test_readWriteReadMiriad_partial_error_special_cases():
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
 
     # check partial read selections
     full = UVData()
@@ -984,18 +1254,25 @@ def test_readWriteReadMiriad_partial_error_special_cases():
     if six.PY2:
         with pytest.raises(AssertionError) as cm:
             uv_in.read(write_file, polarizations=[1.0])
-        assert str(cm.value).startswith("pols must be a list of polarization strings or ints")
+        assert str(cm.value).startswith(
+            "pols must be a list of polarization strings or ints"
+        )
     else:
         with pytest.raises(ValueError) as cm:
             uv_in.read(write_file, polarizations=[1.0])
-        assert str(cm.value).startswith("Polarization 1.0 cannot be converted to a polarization number")
+        assert str(cm.value).startswith(
+            "Polarization 1.0 cannot be converted to a polarization number"
+        )
 
+    # cleanup
+    del uv_in, full
+    gc.collect()
     shutil.rmtree(write_file)
 
 
 def test_readWriteReadMiriad_partial_with_warnings():
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
 
     # check partial read selections
     full = UVData()
@@ -1005,14 +1282,20 @@ def test_readWriteReadMiriad_partial_with_warnings():
     uv_in = UVData()
     # check handling for generic read selections unsupported by read_miriad
     unique_times = np.unique(full.time_array)
-    times_to_keep = unique_times[((unique_times > 2456865.607)
-                                 & (unique_times < 2456865.609))]
-    uvtest.checkWarnings(uv_in.read, [write_file], {'times': times_to_keep},
-                         message=['Warning: a select on read keyword is set'])
+    times_to_keep = unique_times[
+        ((unique_times > 2456865.607) & (unique_times < 2456865.609))
+    ]
+    uvtest.checkWarnings(
+        uv_in.read,
+        [write_file],
+        {"times": times_to_keep},
+        message=["Warning: a select on read keyword is set"],
+    )
     exp_uv = full.select(times=times_to_keep, inplace=False)
     assert uv_in == exp_uv
 
-    del(uv_in)
+    del uv_in
+    gc.collect()
     shutil.rmtree(write_file)
 
     full = UVData()
@@ -1023,22 +1306,26 @@ def test_readWriteReadMiriad_partial_with_warnings():
     # check handling for generic read selections unsupported by read_miriad
     blts_select = np.where(full.time_array == unique_times[0])[0]
     ants_keep = [0, 2, 4]
-    uvtest.checkWarnings(uv_in.read, [write_file],
-                         {'blt_inds': blts_select, 'antenna_nums': ants_keep},
-                         nwarnings=1,
-                         message=['Warning: blt_inds is set along with select on read'],
-                         )
+    uvtest.checkWarnings(
+        uv_in.read,
+        [write_file],
+        {"blt_inds": blts_select, "antenna_nums": ants_keep},
+        nwarnings=1,
+        message=["Warning: blt_inds is set along with select on read"],
+    )
     exp_uv = full.select(blt_inds=blts_select, antenna_nums=ants_keep, inplace=False)
     assert uv_in != exp_uv
 
+    # cleanup
+    del uv_in, full
+    gc.collect()
     shutil.rmtree(write_file)
-    del(uv_in)
 
 
 def test_readWriteReadMiriad_partial_metadata_only():
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
-    write_file2 = os.path.join(DATA_PATH, 'test/outtest_miriad2.uv')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
+    write_file2 = os.path.join(DATA_PATH, "test/outtest_miriad2.uv")
 
     # try metadata only read
     uv_in = UVData()
@@ -1046,13 +1333,20 @@ def test_readWriteReadMiriad_partial_metadata_only():
     assert uv_in.time_array is None
     assert uv_in.data_array is None
     assert uv_in.integration_time is None
-    metadata = ['antenna_positions', 'antenna_names', 'antenna_positions', 'channel_width',
-                'history', 'vis_units', 'telescope_location']
+    metadata = [
+        "antenna_positions",
+        "antenna_names",
+        "antenna_positions",
+        "channel_width",
+        "history",
+        "vis_units",
+        "telescope_location",
+    ]
     for m in metadata:
         assert getattr(uv_in, m) is not None
 
     # metadata only multiple file read-in
-    del(uv_in)
+    del uv_in
 
     uv_in = UVData()
     uv_in.read(testfile)
@@ -1072,7 +1366,8 @@ def test_readWriteReadMiriad_partial_metadata_only():
 
     # test exceptions
     # read-in when data already exists
-    del(uv_in)
+    del uv_in, new_uv
+    gc.collect()
     shutil.rmtree(write_file)
     shutil.rmtree(write_file2)
 
@@ -1080,7 +1375,13 @@ def test_readWriteReadMiriad_partial_metadata_only():
     uv_in.read(testfile)
     with pytest.raises(ValueError) as cm:
         uv_in.read(testfile, read_data=False)
-    assert str(cm.value).startswith("data_array is already defined, cannot read metadata")
+    assert str(cm.value).startswith(
+        "data_array is already defined, cannot read metadata"
+    )
+
+    # cleanup
+    del uv_in, uv_in2
+    gc.collect()
 
 
 @uvtest.skipIf_no_casa
@@ -1091,16 +1392,20 @@ def test_readMSWriteMiriad_CASAHistory():
     """
     ms_uv = UVData()
     miriad_uv = UVData()
-    ms_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.ms')
-    testfile = os.path.join(DATA_PATH, 'test/outtest_miriad')
-    uvtest.checkWarnings(ms_uv.read_ms, [ms_file],
-                         message='Telescope EVLA is not',
-                         nwarnings=0)
+    ms_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.ms")
+    testfile = os.path.join(DATA_PATH, "test/outtest_miriad")
+    uvtest.checkWarnings(
+        ms_uv.read_ms, [ms_file], message="Telescope EVLA is not", nwarnings=0
+    )
     ms_uv.write_miriad(testfile, clobber=True)
-    uvtest.checkWarnings(miriad_uv.read, [testfile],
-                         message='Telescope EVLA is not')
+    uvtest.checkWarnings(miriad_uv.read, [testfile], message="Telescope EVLA is not")
 
     assert miriad_uv == ms_uv
+
+    # cleanup
+    del ms_uv, miriad_uv
+    gc.collect()
+    shutil.rmtree(testfile)
 
 
 def test_rwrMiriad_antpos_issues():
@@ -1112,19 +1417,28 @@ def test_rwrMiriad_antpos_issues():
     """
     uv_in = UVData()
     uv_out = UVData()
-    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
-    write_file = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
+    testfile = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
+    write_file = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
     uv_in.read(testfile)
     uv_in.antenna_positions = None
-    uvtest.checkWarnings(uv_in.write_miriad, [write_file], {'clobber': True},
-                         message=['antenna_positions are not defined.'],
-                         category=DeprecationWarning)
-    uvtest.checkWarnings(uv_out.read, [write_file], nwarnings=3,
-                         message=['Antenna positions are not present in the file.',
-                                  'Antenna positions are not present in the file.',
-                                  'antenna_positions are not defined.'],
-                         category=[UserWarning, UserWarning, DeprecationWarning],
-                         )
+    uvtest.checkWarnings(
+        uv_in.write_miriad,
+        [write_file],
+        {"clobber": True},
+        message=["antenna_positions are not defined."],
+        category=DeprecationWarning,
+    )
+    uvtest.checkWarnings(
+        uv_out.read,
+        [write_file],
+        nwarnings=3,
+        message=[
+            "Antenna positions are not present in the file.",
+            "Antenna positions are not present in the file.",
+            "antenna_positions are not defined.",
+        ],
+        category=[UserWarning, UserWarning, DeprecationWarning],
+    )
 
     assert uv_in == uv_out
     uv_in.read(testfile)
@@ -1132,7 +1446,7 @@ def test_rwrMiriad_antpos_issues():
     ant_ind = np.where(uv_in.antenna_numbers == ants_with_data[0])[0]
     uv_in.antenna_positions[ant_ind, :] = [0, 0, 0]
     uv_in.write_miriad(write_file, clobber=True, no_antnums=True)
-    uvtest.checkWarnings(uv_out.read, [write_file], message=['antenna number'])
+    uvtest.checkWarnings(uv_out.read, [write_file], message=["antenna number"])
 
     assert uv_in == uv_out
 
@@ -1148,16 +1462,31 @@ def test_rwrMiriad_antpos_issues():
     uv_in.antenna_numbers = np.array(new_nums)
     uv_in.antenna_names = new_names
     uv_in.Nants_telescope = len(uv_in.antenna_numbers)
-    uvtest.checkWarnings(uv_in.write_miriad, [write_file], {'clobber': True, 'no_antnums': True},
-                         message=['antenna_positions are not defined.'],
-                         category=DeprecationWarning)
-    uvtest.checkWarnings(uv_out.read, [write_file], nwarnings=3,
-                         message=['Antenna positions are not present in the file.',
-                                  'Antenna positions are not present in the file.',
-                                  'antenna_positions are not defined.'],
-                         category=[UserWarning, UserWarning, DeprecationWarning])
+    uvtest.checkWarnings(
+        uv_in.write_miriad,
+        [write_file],
+        {"clobber": True, "no_antnums": True},
+        message=["antenna_positions are not defined."],
+        category=DeprecationWarning,
+    )
+    uvtest.checkWarnings(
+        uv_out.read,
+        [write_file],
+        nwarnings=3,
+        message=[
+            "Antenna positions are not present in the file.",
+            "Antenna positions are not present in the file.",
+            "antenna_positions are not defined.",
+        ],
+        category=[UserWarning, UserWarning, DeprecationWarning],
+    )
 
     assert uv_in == uv_out
+
+    # cleanup
+    del uv_in, uv_out
+    gc.collect()
+    shutil.rmtree(write_file)
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
@@ -1166,14 +1495,16 @@ def test_multi_files():
     Reading multiple files at once.
     """
     uv_full = UVData()
-    uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    testfile1 = os.path.join(DATA_PATH, 'test/uv1')
-    testfile2 = os.path.join(DATA_PATH, 'test/uv2')
+    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
+    testfile1 = os.path.join(DATA_PATH, "test/uv1")
+    testfile2 = os.path.join(DATA_PATH, "test/uv2")
     uv_full.read_uvfits(uvfits_file)
-    uvtest.checkWarnings(uv_full.unphase_to_drift, category=DeprecationWarning,
-                         message='The xyz array in ENU_from_ECEF is being '
-                                 'interpreted as (Npts, 3)')
-    uv_full.conjugate_bls('ant1<ant2')
+    uvtest.checkWarnings(
+        uv_full.unphase_to_drift,
+        category=DeprecationWarning,
+        message="The xyz array in ENU_from_ECEF is being " "interpreted as (Npts, 3)",
+    )
+    uv_full.conjugate_bls("ant1<ant2")
 
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)
@@ -1181,28 +1512,40 @@ def test_multi_files():
     uv2.select(freq_chans=np.arange(32, 64))
     uv1.write_miriad(testfile1, clobber=True)
     uv2.write_miriad(testfile2, clobber=True)
-    del(uv1)
+    del uv1
     uv1 = UVData()
     uv1.read([testfile1, testfile2])
     # Check history is correct, before replacing and doing a full object check
-    assert uvutils._check_histories(uv_full.history + '  Downselected to '
-                                    'specific frequencies using pyuvdata. '
-                                    'Combined data along frequency axis using'
-                                    ' pyuvdata.', uv1.history)
+    assert uvutils._check_histories(
+        uv_full.history + "  Downselected to "
+        "specific frequencies using pyuvdata. "
+        "Combined data along frequency axis using"
+        " pyuvdata.",
+        uv1.history,
+    )
     uv1.history = uv_full.history
     assert uv1 == uv_full
 
     # again, setting axis
-    del(uv1)
+    del uv1
     uv1 = UVData()
-    uv1.read([testfile1, testfile2], axis='freq')
+    uv1.read([testfile1, testfile2], axis="freq")
     # Check history is correct, before replacing and doing a full object check
-    assert uvutils._check_histories(uv_full.history + '  Downselected to '
-                                    'specific frequencies using pyuvdata. '
-                                    'Combined data along frequency axis using'
-                                    ' pyuvdata.', uv1.history)
+    assert uvutils._check_histories(
+        uv_full.history + "  Downselected to "
+        "specific frequencies using pyuvdata. "
+        "Combined data along frequency axis using"
+        " pyuvdata.",
+        uv1.history,
+    )
     uv1.history = uv_full.history
     assert uv1 == uv_full
+
+    # cleanup
+    del uv1, uv2, uv_full
+    gc.collect()
+    shutil.rmtree(testfile1)
+    shutil.rmtree(testfile2)
 
 
 def test_antpos_units():
@@ -1210,16 +1553,23 @@ def test_antpos_units():
     Read uvfits, write miriad. Check written antpos are in ns.
     """
     uv = UVData()
-    uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    testfile = os.path.join(DATA_PATH, 'test/uv_antpos_units')
-    uvtest.checkWarnings(uv.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
+    uvfits_file = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
+    testfile = os.path.join(DATA_PATH, "test/uv_antpos_units")
+    uvtest.checkWarnings(uv.read_uvfits, [uvfits_file], message="Telescope EVLA is not")
     uv.write_miriad(testfile, clobber=True)
     auv = aipy_extracts.UV(testfile)
-    aantpos = auv['antpos'].reshape(3, -1).T * const.c.to('m/ns').value
+    aantpos = auv["antpos"].reshape(3, -1).T * const.c.to("m/ns").value
     aantpos = aantpos[uv.antenna_numbers, :]
-    aantpos = (uvutils.ECEF_from_rotECEF(aantpos, uv.telescope_location_lat_lon_alt[1])
-               - uv.telescope_location)
+    aantpos = (
+        uvutils.ECEF_from_rotECEF(aantpos, uv.telescope_location_lat_lon_alt[1])
+        - uv.telescope_location
+    )
     assert np.allclose(aantpos, uv.antenna_positions)
+
+    # cleanup
+    del uv, auv
+    gc.collect()
+    shutil.rmtree(testfile)
 
 
 def test_readMiriadwriteMiriad_check_time_format():
@@ -1227,21 +1577,21 @@ def test_readMiriadwriteMiriad_check_time_format():
     test time_array is converted properly from Miriad format
     """
     # test read-in
-    fname = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcA')
+    fname = os.path.join(DATA_PATH, "zen.2457698.40355.xx.HH.uvcA")
     uvd = UVData()
     uvd.read(fname)
     uvd_t = uvd.time_array.min()
     uvd_l = uvd.lst_array.min()
     uv = aipy_extracts.UV(fname)
-    uv_t = uv['time'] + uv['inttime'] / (24 * 3600.) / 2
+    uv_t = uv["time"] + uv["inttime"] / (24 * 3600.0) / 2
 
     lat, lon, alt = uvd.telescope_location_lat_lon_alt
-    t1 = Time(uv['time'], format='jd', location=(lon, lat))
-    dt = TimeDelta(uv['inttime'] / 2, format='sec')
+    t1 = Time(uv["time"], format="jd", location=(lon, lat))
+    dt = TimeDelta(uv["inttime"] / 2, format="sec")
     t2 = t1 + dt
     lsts = uvutils.get_lst_for_time(np.array([t1.jd, t2.jd]), lat, lon, alt)
     delta_lst = lsts[1] - lsts[0]
-    uv_l = uv['lst'] + delta_lst
+    uv_l = uv["lst"] + delta_lst
 
     # assert starting time array and lst array are shifted by half integration
     assert np.isclose(uvd_t, uv_t)
@@ -1253,40 +1603,55 @@ def test_readMiriadwriteMiriad_check_time_format():
         tolerance = 1e-8
     assert np.allclose(uvd_l, uv_l, atol=tolerance)
     # test write-out
-    fout = os.path.join(DATA_PATH, 'ex_miriad')
+    fout = os.path.join(DATA_PATH, "ex_miriad")
     uvd.write_miriad(fout, clobber=True)
     # assert equal to original miriad time
     uv2 = aipy_extracts.UV(fout)
-    assert np.isclose(uv['time'], uv2['time'])
-    assert np.isclose(uv['lst'], uv2['lst'], atol=tolerance)
+    assert np.isclose(uv["time"], uv2["time"])
+    assert np.isclose(uv["lst"], uv2["lst"], atol=tolerance)
+
+    # cleanup
+    del uv, uv2, uvd
+    gc.collect()
     if os.path.exists(fout):
         shutil.rmtree(fout)
 
 
 def test_file_with_bad_extra_words():
     """Test file with bad extra words is iterated and popped correctly."""
-    fname = os.path.join(DATA_PATH, 'test_miriad_changing_extra.uv')
+    fname = os.path.join(DATA_PATH, "test_miriad_changing_extra.uv")
     uv = UVData()
-    warn_message = ['Altitude is not present in Miriad file, '
-                    'using known location values for PAPER.',
-                    'Mean of empty slice.',
-                    'invalid value encountered in double_scalars',
-                    'npols=4 but found 1 pols in data file',
-                    'Mean of empty slice.',
-                    'invalid value encountered in double_scalars',
-                    'antenna number 0 has visibilities associated with it, '
-                    'but it has a position of (0,0,0)',
-                    'antenna number 26 has visibilities associated with it, '
-                    'but it has a position of (0,0,0)',
-                    ]
-    warn_category = ([UserWarning] + [RuntimeWarning] * 2
-                     + [UserWarning] + [RuntimeWarning] * 2
-                     + [UserWarning] * 2)
+    warn_message = [
+        "Altitude is not present in Miriad file, "
+        "using known location values for PAPER.",
+        "Mean of empty slice.",
+        "invalid value encountered in double_scalars",
+        "npols=4 but found 1 pols in data file",
+        "Mean of empty slice.",
+        "invalid value encountered in double_scalars",
+        "antenna number 0 has visibilities associated with it, "
+        "but it has a position of (0,0,0)",
+        "antenna number 26 has visibilities associated with it, "
+        "but it has a position of (0,0,0)",
+    ]
+    warn_category = (
+        [UserWarning]
+        + [RuntimeWarning] * 2
+        + [UserWarning]
+        + [RuntimeWarning] * 2
+        + [UserWarning] * 2
+    )
     # This is an old PAPER file, run_check must be set to false
     # The antenna positions is (0, 0, 0) vector
-    uv = uvtest.checkWarnings(uv.read_miriad, func_args=[fname],
-                              func_kwargs={'run_check': False},
-                              category=warn_category,
-                              nwarnings=len(warn_message),
-                              message=warn_message
-                              )
+    uv = uvtest.checkWarnings(
+        uv.read_miriad,
+        func_args=[fname],
+        func_kwargs={"run_check": False},
+        category=warn_category,
+        nwarnings=len(warn_message),
+        message=warn_message,
+    )
+
+    # cleanup
+    del uv
+    gc.collect()

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -2,9 +2,7 @@
 # Copyright (c) 2018 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
 
-"""Tests for Miriad object.
-
-"""
+"""Tests for Miriad object."""
 from __future__ import absolute_import, division, print_function
 
 import os
@@ -63,6 +61,7 @@ def uv_in_uvfits():
     if os.path.exists(write_file):
         os.remove(write_file)
     gc.collect()
+
 
 @pytest.mark.filterwarnings("ignore:Telescope ATCA is not")
 def test_ReadWriteReadATCA():

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -118,19 +118,9 @@ def test_ReadNRAOWriteMiriadReadMiriad():
     testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
     writefile = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
     expected_extra_keywords = ["OBSERVER", "SORTORD", "SPECSYS", "RESTFREQ", "ORIGIN"]
-    uvtest.checkWarnings(
-        uvfits_uv.read_uvfits,
-        [testfile],
-        message=["Telescope EVLA is not in known_telescopes"],
-    )
-    # uvfits_uv.read_uvfits(testfile)
+    uvfits_uv.read_uvfits(testfile)
     uvfits_uv.write_miriad(writefile, clobber=True)
-    uvtest.checkWarnings(
-        miriad_uv.read_uvfits,
-        [testfile],
-        message=["Telescope EVLA is not in known_telescopes"],
-    )
-    # miriad_uv.read(writefile)
+    miriad_uv.read(writefile)
     assert uvfits_uv == miriad_uv
 
     # cleanup
@@ -881,7 +871,6 @@ def test_readWriteReadMiriad(uv_in_paper):
 def test_miriad_antenna_diameters(uv_in_paper):
     # check that if antenna_diameters is set, it's read back out properly
     uv_in, uv_out, write_file = uv_in_paper
-    # uv_in.read(testfile)
     uv_in.antenna_diameters = np.zeros((uv_in.Nants_telescope,), dtype=np.float) + 14.0
     uv_in.write_miriad(write_file, clobber=True)
     uv_out.read(write_file)
@@ -922,7 +911,7 @@ def test_miriad_and_aipy_reads(uv_in_paper):
     uv_in.read(write_file)
     uv_aipy = aipy_extracts.UV(
         write_file
-    )  # on enterprise, this line makes it so you cant delete the file
+    )
     nfreqs = uv_in.Nfreqs
     nschan = uv_aipy["nschan"]
     ischan = uv_aipy["ischan"]


### PR DESCRIPTION
## Description
The tests for miriad file handling were producing seemingly random errors, which were stalling CI builds of other development efforts. This PR (hopefully) resolves this issue.

## Motivation and Context
After debugging, it seems that the test failures stemmed from the fact that miriad objects do not close underlying files until the object destructor function is called, which cannot be dictated by the user. The workaround here deletes the objects, and invokes a garbage collection, which seems to properly close the file handles. A more robust solution would be for the miriad objects to close file handles when they are no longer needed, or expose this functionality to the user. However, this would likely require modifying the C/C++ API, which may have unintended consequences.

In addition to cleaning up test files, this PR also breaks several of the larger miriad tests into atomic units, and builds fixtures for commonly used input files. Breaking up tests allows for finer-grained understanding of specific issues going forward.

Closes #692.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).