### PR TITLE
Uvbeam freq interp real interp bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - `UVFlag` objects can now be initialized without inputs
 
 ### Fixed
+- A bug in UVBeam._interp_freq where kind parameter was not passed for real-only beams
 - A bug in get_antenna_redundancies for nearly N-S baselines.
 - A bug where `conj_pol` could not handle cardinal direction polarizations.
 - A bug that gave the wrong error message when calling `UVData.phase_to_time` without an Astropy Time object.

--- a/pyuvdata/uvbeam.py
+++ b/pyuvdata/uvbeam.py
@@ -796,7 +796,7 @@ class UVBeam(UVBase):
                     imag_lut = interpolate.interp1d(self.freq_array[0, :], data.imag, kind=kind, axis=ax)
                     lut = get_lambda(real_lut, imag_lut)
                 else:
-                    lut = interpolate.interp1d(self.freq_array[0, :], data, axis=ax)
+                    lut = interpolate.interp1d(self.freq_array[0, :], data, kind=kind, axis=ax)
                     lut = get_lambda(lut)
 
                 interp_arrays.append(lut(freq_array))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Appropriately passes `freq_interp_kind` kwarg when beam is purely real.

## Description
<!--- Describe your changes in detail -->
The `freq_interp_kind`  wasn't passed to `scipy.interpolate.interp1d` when the beam was purely real, and would therefore default to simply linear: just a simple oversight, probably on my part. Anyways this fixes that and adds a test to make sure real and complex interpolation match when using the same beam for higher-than-linear interpolation.

This fixes the high delay interpolation artifacts we were seeing before. @aelanman @zacharymartinot @AaronParsons @bhazelton @nithyanandan 

![beam_interp](https://user-images.githubusercontent.com/4307358/66538250-6c296b00-ead8-11e9-8d46-cc6dd99fff8e.png)
^Frequency FT of beam averaged across the sky with uniform and beam weighting. As suspected, the beam-weighted average has less structure, meaning that not surprisingly the large zenith angles have more spectral structure. The beam is inherently sampled at 1 MHz meaning it achieves a maximum delay of 500 ns.

![beam_linear_interp](https://user-images.githubusercontent.com/4307358/66538360-d80bd380-ead8-11e9-9835-6476913680e1.png)
^This is with linear interpolation onto a full 1024 channelization between 100-200 MHz, which is what @aelanman was showing before b/c the interpolation code was defaulting to linear by mistake.

![beam_quad_interp](https://user-images.githubusercontent.com/4307358/66538386-feca0a00-ead8-11e9-81b4-41cd64be8ddd.png)
^This is with quadratic interpolation, which has lower sub-nyquist sidelobes, as suspected

![beam_cubic_interp](https://user-images.githubusercontent.com/4307358/66538406-143f3400-ead9-11e9-9980-62b9fb957d96.png)
^This is with cubic interpolation, which has even lower.

@aelanman I haven't tried with the GPR yet, but I think that the cubic interpolation does a good enough job, getting you 60-70 dB worth of suppression at sub-nyquist scales that it should be okay given what you want to do I think.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass in both python 2 and python 3.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Breaking change checklist:  
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass in both python 2 and python 3.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
