### PR TITLE
Try a change to iers handling

### DIFF
--- a/pyuvdata/tests/conftest.py
+++ b/pyuvdata/tests/conftest.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import pytest
-import six
-import six.moves.urllib as urllib
 from astropy.utils import iers
 from astropy.time import Time
 
@@ -29,20 +27,10 @@ def setup_and_teardown_package():
     # back on once all tests are completed (done by extending auto_max_age).
     # Also, the checkWarnings function will ignore IERS-related warnings.
     try:
-        iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL)
         t1 = Time.now()
         t1.ut1
-    except(urllib.error.URLError):
-        if six.PY3:
-            # python 3 offers a mirror for the download url.
-            try:
-                iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL_MIRROR)
-                t1 = Time.now()
-                t1.ut1
-            except(urllib.error.URLError):
-                iers.conf.auto_max_age = None
-        else:
-            iers.conf.auto_max_age = None
+    except(Exception):
+        iers.conf.auto_max_age = None
 
     yield
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Prevent constant re-downloading of iers tables on machines where a recent file is already present.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Constant file downloading at the start of any test significantly slows testing on users' machines (as opposed to CI runs). This PR alters the IERS check to just try to run an IERS related operation. This should cause auto-downloading of the IERS file, including using the mirror (@mkolopanis reports). @mkolopanis has agreed to test this in his setup that mimics the IERS server being down.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
