### PR TITLE
Use flake8 for linting in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
           name: configure conda environment
           command: ./ci/install-circle.sh
       - run:
-          name: linting for PEP8 compliance
+          name: linting for PEP8 and PEP257 (with numpy style) compliance
           command: |
             source activate ${ENV_NAME}
-            pycodestyle --ignore=E501,W503
+            flake8
       - save_cache:
           key: deps-{{ .Branch }}-{{ checksum "ci/pyuvdata_linting.yml" }}
           paths:

--- a/ci/pyuvdata_linting.yml
+++ b/ci/pyuvdata_linting.yml
@@ -3,4 +3,6 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - pycodestyle
+  - flake8
+  - pip:
+     - flake8-docstrings

--- a/ci/pyuvdata_linting.yml
+++ b/ci/pyuvdata_linting.yml
@@ -5,4 +5,5 @@ channels:
 dependencies:
   - flake8
   - pip:
-     - flake8-docstrings
+    - flake8-docstrings
+    - flake8-pytest

--- a/docs/make_beam_parameters.py
+++ b/docs/make_beam_parameters.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, division, print_function
 import os
 import inspect
 from pyuvdata import UVBeam
-import numpy as np
 from astropy.time import Time
 
 

--- a/docs/make_cal_parameters.py
+++ b/docs/make_cal_parameters.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, division, print_function
 import os
 import inspect
 from pyuvdata import UVCal
-import numpy as np
 from astropy.time import Time
 
 

--- a/docs/make_index.py
+++ b/docs/make_index.py
@@ -25,8 +25,6 @@ def write_index_rst(readme_file=None, write_file=None):
         main_path = os.path.dirname(os.path.dirname(os.path.abspath(inspect.stack()[0][1])))
         readme_file = os.path.join(main_path, 'README.md')
 
-    readme_md = pypandoc.convert_file(readme_file, 'md')
-
     readme_text = pypandoc.convert_file(readme_file, 'rst')
 
     title_badge_text = (
@@ -48,8 +46,6 @@ def write_index_rst(readme_file=None, write_file=None):
     # convert relative links in readme to explicit links
     version_info = construct_version_info()
     branch = version_info['git_branch']
-
-    first_docs_loc = readme_text.find('docs/')
 
     readme_text = readme_text.replace(
         '<docs/', '<https://github.com/RadioAstronomySoftwareGroup/pyuvdata/tree/'

--- a/docs/make_parameters.py
+++ b/docs/make_parameters.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, division, print_function
 import os
 import inspect
 from pyuvdata import UVData
-import numpy as np
 from astropy.time import Time
 
 

--- a/pyuvdata/aipy_extracts.py
+++ b/pyuvdata/aipy_extracts.py
@@ -419,7 +419,7 @@ class UV(_miriad.UV):
             assert t == 'b'
 
             for t in itype:
-                v, o = _miread.hread(h, offset, t)
+                v, o = _miriad.hread(h, offset, t)
                 rv.append(v)
                 offset += o
 
@@ -500,14 +500,14 @@ class UV(_miriad.UV):
         """
         if name == 'freqs':
             h = self.haccess(name, 'write')
-            o = _miriad.hwrite(h, 0, val[0], 'i')
+            _miriad.hwrite(h, 0, val[0], 'i')
             offset = 8
 
             for i, v in enumerate(val[1:]):
                 if i % 3 == 0:
-                    o = _miriad.hwrite(h, offset, v, 'i')
+                    _miriad.hwrite(h, offset, v, 'i')
                 else:
-                    o = _miriad.hwrite(h, offset, v, 'd')
+                    _miriad.hwrite(h, offset, v, 'd')
                 offset += 8
 
             _miriad.hdaccess(h)

--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -496,7 +496,6 @@ class CALFITS(UVCal):
                     self.quality_array = data[:, :, :, :, :, 1]
                 sechdu = F[hdunames['FLAGS']]
                 flag_data = sechdu.data
-                flag_hdr = sechdu.header
                 if sechdu.header['NAXIS1'] == 2:
                     self.flag_array = flag_data[:, :, :, :, :, 0].astype('bool')
                     self.input_flag_array = flag_data[:, :, :, :, :, 1].astype('bool')

--- a/pyuvdata/cst_beam.py
+++ b/pyuvdata/cst_beam.py
@@ -4,8 +4,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import os
-import sys
 import re
 import numpy as np
 import warnings
@@ -212,7 +210,6 @@ class CSTBeam(UVBeam):
                 raise ValueError('Rotating by pi/2 failed')
 
             # theta is not affected by the rotation
-            rot_theta = theta_data
 
         # get beam
         if self.beam_type == 'power':

--- a/pyuvdata/data/__init__.py
+++ b/pyuvdata/data/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""Init file for data directory.
-
-"""
+"""Init file for data directory."""
 from __future__ import absolute_import, division, print_function
 
 DATA_PATH = __path__[0]

--- a/pyuvdata/fhd.py
+++ b/pyuvdata/fhd.py
@@ -7,7 +7,6 @@
 """
 from __future__ import absolute_import, division, print_function
 
-from itertools import islice
 import numpy as np
 import warnings
 from scipy.io.idl import readsav
@@ -187,7 +186,6 @@ class FHD(UVData):
 
         obs = this_obs
         bl_info = obs['BASELINE_INFO'][0]
-        meta_data = obs['META_DATA'][0]
         astrometry = obs['ASTR'][0]
         fhd_pol_list = []
         for pol in obs['POL_NAMES'][0]:
@@ -317,7 +315,7 @@ class FHD(UVData):
         if self.telescope_name.lower() == 'mwa':
             if np.isclose(obs['ORIG_PHASERA'][0], 0) and \
                     np.isclose(obs['ORIG_PHASEDEC'][0], -27):
-                object_name = 'EoR 0 Field'
+                self.object_name = 'EoR 0 Field'
 
         self.instrument = self.telescope_name
         latitude = np.deg2rad(float(obs['LAT'][0]))

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, division, print_function
 import os
 import shutil
 import numpy as np
-import copy
 import itertools
 import six
 import warnings
@@ -240,7 +239,10 @@ class Miriad(UVData):
                 cnt = np.ones(d.shape, dtype=np.float)
             ra = uv['ra']
             dec = uv['dec']
-            lst = uv['lst']
+            # NOTE: Using our lst calculator, which uses astropy,
+            # instead of _miriad values which come from pyephem.
+            # The differences are of order 5 seconds.
+            # lst = uv['lst']
             inttime = uv['inttime']
             source = uv['source']
             if source != _source:
@@ -462,9 +464,9 @@ class Miriad(UVData):
 
         # first check to see if the phase_type was specified.
         if phase_type is not None:
-            if phase_type is 'phased':
+            if phase_type == 'phased':
                 self.set_phased()
-            elif phase_type is 'drift':
+            elif phase_type == 'drift':
                 self.set_drift()
             else:
                 raise ValueError('The phase_type was not recognized. '

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -242,7 +242,7 @@ class Miriad(UVData):
             # NOTE: Using our lst calculator, which uses astropy,
             # instead of _miriad values which come from pyephem.
             # The differences are of order 5 seconds.
-            # lst = uv['lst']
+            # To use the values from the file you'd want: lst = uv['lst']
             inttime = uv['inttime']
             source = uv['source']
             if source != _source:

--- a/pyuvdata/ms.py
+++ b/pyuvdata/ms.py
@@ -10,14 +10,10 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import os
-import re
 import warnings
-from astropy import constants as const
 import astropy.time as time
 
 from . import UVData
-from . import parameter as uvp
-from . import telescopes
 from . import utils as uvutils
 
 try:
@@ -277,7 +273,6 @@ class MS(UVData):
             # importuvfits measurement sets store antenna names in the STATION column.
             self.antenna_names = tbAnt.getcol('NAME')
         self.antenna_numbers = np.arange(len(self.antenna_names)).astype(int)
-        nAntOrig = len(self.antenna_names)
         ant_names = []
         for antNum in range(len(self.antenna_names)):
             if not(antFlags[antNum]):

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -23,38 +23,43 @@ class UVParameter(object):
     """
     Data and metadata objects for interferometric data sets.
 
-    Attributes:
-        name: A string giving the name of the attribute. Used as the associated
-            property name in classes based on UVBase.
+    Attributes
+    ----------
+    name : str
+        The name of the attribute. Used as the associated property name in
+        classes based on UVBase.
+    required : bool
+        Flag indicating whether this is required metadata for
+        the class with this UVParameter as an attribute. Default is True.
+    value
+        The value of the data or metadata.
+    spoof_val
+        A fake value that can be assigned to a non-required UVParameter if the
+        metadata is required for a particular file-type.
+        This is not an attribute of required UVParameters.
+    form : 'str' or tuple
+        Either 'str' or a tuple giving information about the expected
+        shape of the value. Elements of the tuple may be the name of other
+        UVParameters that indicate data shapes.
 
-        required: A boolean indicating whether this is required metadata for
-            the class with this UVParameter as an attribute. Default is True.
+        Form examples:
+            - 'str': a string value
+            - ('Nblts', 3): the value should be an array of shape:
+            Nblts (another UVParameter name), 3
+    description : str
+        Description of the data or metadata in the object.
+    expected_type
+        The type that the data or metadata should be.
+        Default is np.int or str if form is 'str'
+    acceptable_vals : list, optional
+        List giving allowed values for elements of value.
+    acceptable_range: 2-tuple, optional
+        Tuple giving a range of allowed magnitudes for elements of value.
+    tols : float or 2-tuple of float
+        Tolerances for testing the equality of UVParameters. Either a
+        single absolute value or a tuple of relative and absolute values to
+        be used by np.isclose()
 
-        value: The value of the data or metadata.
-
-        spoof_val: A fake value that can be assigned to a non-required
-            UVParameter if the metadata is required for a particular file-type.
-            This is not an attribute of required UVParameters.
-
-        form: Either 'str' or a tuple giving information about the expected
-            shape of the value. Elements of the tuple may be the name of other
-            UVParameters that indicate data shapes. \n
-            Examples:\n
-                'str': a string value\n
-                ('Nblts', 3): the value should be an array of shape: Nblts (another UVParameter name), 3
-
-        description: A string description of the data or metadata in the object.
-
-        expected_type: The type that the data or metadata should be.
-            Default is np.int or str if form is 'str'
-
-        acceptable_vals: Optional. List giving allowed values for elements of value.
-
-        acceptable_range: Optional. Tuple giving a range of allowed magnitudes for elements of value.
-
-        tols: Tolerances for testing the equality of UVParameters. Either a
-            single absolute value or a tuple of relative and absolute values to
-            be used by np.isclose()
     """
 
     def __init__(self, name, required=True, value=None, spoof_val=None,
@@ -188,11 +193,15 @@ class UVParameter(object):
         """
         Get the expected shape of the value based on the form.
 
-        Args:
-            uvbase: object with this UVParameter as an attribute. Needed
-                because the form can refer to other UVParameters on this object.
+        Parameters
+        ----------
+        uvbase : object
+            Object with this UVParameter as an attribute. Needed
+            because the form can refer to other UVParameters on this object.
 
-        Returns:
+        Returns
+        -------
+        tuple
             The expected shape of the value.
         """
         if self.form == 'str':
@@ -265,11 +274,14 @@ class AntPositionParameter(UVParameter):
         """
         Set value to zeroed array of shape: number of antennas, 3.
 
-        Args:
-            uvbase: object with this UVParameter as an attribute. Needed
-                to get the number of antennas.
-            antnum_name: A string giving the name of the UVParameter containing
-                the number of antennas.
+        Parameters
+        ----------
+        uvbase : object
+            object with this UVParameter as an attribute. Needed
+            to get the number of antennas.
+        antnum_name : str
+            A string giving the name of the UVParameter containing
+            the number of antennas.
         """
         self.value = np.zeros((getattr(uvbase, antnum_name), 3))
 
@@ -293,8 +305,10 @@ class AngleParameter(UVParameter):
         """
         Set value in degrees.
 
-        Args:
-            degree_val: value in degrees to use to set the value attribute.
+        Parameters
+        ----------
+        degree_val : float
+            Value in degrees to use to set the value attribute.
         """
         if degree_val is None:
             self.value = None
@@ -309,7 +323,9 @@ class LocationParameter(UVParameter):
     Adds extra methods for conversion to & from lat/lon/alt in radians or
     degrees (used by UVBase objects for _lat_lon_alt and _lat_lon_alt_degrees
     properties associated with these parameters).
+
     """
+
     def __init__(self, name, required=True, value=None, spoof_val=None, description='',
                  acceptable_range=(6.35e6, 6.39e6), tols=1e-3):
         super(LocationParameter, self).__init__(name, required=required, value=value,
@@ -330,9 +346,11 @@ class LocationParameter(UVParameter):
         """
         Set value from (latitude, longitude, altitude) tuple in radians.
 
-        Args:
-            lat_lon_alt: tuple giving the latitude (radians), longitude (radians)
-                and altitude to use to set the value attribute.
+        Parameters
+        ----------
+        lat_lon_alt : 3-tuple of float
+            Tuple with the latitude (radians), longitude (radians)
+            and altitude (meters) to use to set the value attribute.
         """
         if lat_lon_alt is None:
             self.value = None
@@ -352,9 +370,12 @@ class LocationParameter(UVParameter):
         """
         Set value from (latitude, longitude, altitude) tuple in degrees.
 
-        Args:
-            lat_lon_alt: tuple giving the latitude (degrees), longitude (degrees)
-                and altitude to use to set the value attribute.
+        Parameters
+        ----------
+        lat_lon_alt : 3-tuple of float
+            Tuple with the latitude (degrees), longitude (degrees)
+            and altitude (meters) to use to set the value attribute.
+
         """
         if lat_lon_alt_degree is None:
             self.value = None
@@ -365,9 +386,7 @@ class LocationParameter(UVParameter):
                                                   altitude)
 
     def check_acceptability(self):
-        """Check that values are acceptable. Special case for location, where
-            we want to check the vector magnitude
-        """
+        """Check that vector magnitudes are in range."""
         if self.acceptable_range is None:
             return True, 'No acceptability check'
         else:

--- a/pyuvdata/telescopes.py
+++ b/pyuvdata/telescopes.py
@@ -2,9 +2,7 @@
 # Copyright (c) 2018 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
 
-"""Telescope information and known telescope list.
-
-"""
+"""Telescope information and known telescope list."""
 from __future__ import absolute_import, division, print_function
 
 import numpy as np

--- a/pyuvdata/tests/__init__.py
+++ b/pyuvdata/tests/__init__.py
@@ -22,7 +22,7 @@ import pyuvdata.utils as uvutils
 
 # define a pytest marker for skipping pytest-cases
 try:
-    import pytest_cases
+    import pytest_cases # noqa
 
     cases_installed = True
 except ImportError:
@@ -32,7 +32,7 @@ skipIf_no_pytest_cases = pytest.mark.skipif(not cases_installed, reason=reason)
 
 # define a pytest marker for skipping casacore tests
 try:
-    import casacore
+    import casacore # noqa
 
     casa_installed = True
 except ImportError:
@@ -43,7 +43,7 @@ skipIf_no_casa = pytest.mark.skipif(not casa_installed, reason=reason)
 
 # define a pytest marker to skip astropy_healpix tests
 try:
-    import astropy_healpix
+    import astropy_healpix  # noqa
 
     healpix_installed = True
 except(ImportError):
@@ -54,7 +54,7 @@ skipIf_no_healpix = pytest.mark.skipif(not healpix_installed, reason=reason)
 
 # defines a decorator to skip tests that require yaml.
 try:
-    import yaml
+    import yaml  # noqa
 
     yaml_installed = True
 except(ImportError):

--- a/pyuvdata/tests/conftest.py
+++ b/pyuvdata/tests/conftest.py
@@ -21,10 +21,12 @@ def setup_and_teardown_package():
         print('making test directory')
         os.mkdir(testdir)
 
-    # Try to download the latest IERS table. If the download succeeds, run a
-    # computation that requires the values, so they are cached for all future
-    # tests. If it fails, turn off auto downloading for the tests and turn it
-    # back on once all tests are completed (done by extending auto_max_age).
+    # Do a calculation that requires a current IERS table. This will trigger
+    # automatic downloading of the IERS table if needed, including trying the
+    # mirror site in python 3 (but won't redownload if a current one exists).
+    # If there's not a current IERS table and it can't be downloaded, turn off
+    # auto downloading for the tests and turn it back on once all tests are
+    # completed (done by extending auto_max_age).
     # Also, the checkWarnings function will ignore IERS-related warnings.
     try:
         t1 = Time.now()

--- a/pyuvdata/tests/test_calfits.py
+++ b/pyuvdata/tests/test_calfits.py
@@ -528,7 +528,6 @@ def test_total_quality_array_size():
     """
 
     cal_in = UVCal()
-    cal_out = UVCal()
     testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
     cal_in.read_calfits(testfile)
 

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -117,7 +117,6 @@ def test_ReadNRAOWriteMiriadReadMiriad():
     miriad_uv = UVData()
     testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
     writefile = os.path.join(DATA_PATH, "test/outtest_miriad.uv")
-    expected_extra_keywords = ["OBSERVER", "SORTORD", "SPECSYS", "RESTFREQ", "ORIGIN"]
     uvfits_uv.read_uvfits(testfile)
     uvfits_uv.write_miriad(writefile, clobber=True)
     miriad_uv.read(writefile)

--- a/pyuvdata/tests/test_ms.py
+++ b/pyuvdata/tests/test_ms.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import os
 import shutil
-import copy
 import numpy as np
 
 from pyuvdata import UVData

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -221,8 +221,6 @@ def test_phasing_funcs():
     ants_enu = np.array([-101.94, 0156.41, 0001.24])
 
     ant_xyz_abs = uvutils.ECEF_from_ENU(ants_enu, lat_lon_alt[0], lat_lon_alt[1], lat_lon_alt[2])
-    ant_xyz_rel_itrs = ant_xyz_abs - array_center_xyz
-    ant_xyz_rel_rot = uvutils.rotECEF_from_ECEF(ant_xyz_rel_itrs, lat_lon_alt[1])
 
     array_center_coord = SkyCoord(x=array_center_xyz[0] * units.m,
                                   y=array_center_xyz[1] * units.m,
@@ -987,9 +985,6 @@ def test_uvcalibrate_flag_propagation():
     # downselect to match each other
     uvd.select(frequencies=uvd.freq_array[0, :10])
     uvc.select(times=uvc.time_array[:3])
-    key = (43, 72, 'xx')
-    ant1 = (43, 'Jxx')
-    ant2 = (72, 'Jxx')
 
     # test flag propagation
     uvc.flag_array[0] = True

--- a/pyuvdata/tests/test_uvbeam.py
+++ b/pyuvdata/tests/test_uvbeam.py
@@ -155,7 +155,7 @@ def test_unexpected_attributes(uvbeam_data):
 
 
 def test_properties(uvbeam_data):
-    "Test that properties can be get and set properly."
+    """Test that properties can be get and set properly."""
     prop_dict = dict(list(zip(uvbeam_data.required_properties + uvbeam_data.extra_properties,
                               uvbeam_data.required_parameters + uvbeam_data.extra_parameters)))
     for k, v in prop_dict.items():

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -915,9 +915,6 @@ def test_select_bls():
     ant_pairs_to_keep = list(zip(first_ants, second_ants))
     sorted_pairs_to_keep = [sort_bl(p) for p in ant_pairs_to_keep]
 
-    sorted_pairs_object = [sort_bl(p) for p in zip(
-        uv_object.ant_1_array, uv_object.ant_2_array)]
-
     blts_select = [sort_bl((a1, a2)) in sorted_pairs_to_keep for (a1, a2) in
                    zip(uv_object.ant_1_array, uv_object.ant_2_array)]
     Nblts_selected = np.sum(blts_select)
@@ -949,9 +946,6 @@ def test_select_bls():
     new_unique_ants = np.unique(first_ants + second_ants)
     bls_to_keep = list(zip(first_ants, second_ants, pols))
     sorted_bls_to_keep = [sort_bl(p) for p in bls_to_keep]
-
-    sorted_pairs_object = [sort_bl(p) for p in zip(
-        uv_object.ant_1_array, uv_object.ant_2_array)]
 
     blts_select = [sort_bl((a1, a2, 'RR')) in sorted_bls_to_keep for (a1, a2) in
                    zip(uv_object.ant_1_array, uv_object.ant_2_array)]
@@ -1271,8 +1265,6 @@ def test_select():
                          1242, 702, 567, 557, 1032, 1352, 504, 545, 422, 179, 780,
                          280, 890, 774, 884])
 
-    unique_ants = np.unique(
-        uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist())
     ants_to_keep = np.array([11, 6, 20, 26, 2, 27, 7, 14])
 
     ant_pairs_to_keep = [(2, 11), (20, 26), (6, 7), (3, 27), (14, 6)]
@@ -2286,7 +2278,6 @@ def test_fast_concat():
     # Add multiple axes
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)
-    uv_ref = copy.deepcopy(uv_full)
     times = np.unique(uv_full.time_array)
     uv1.select(times=times[0:len(times) // 2],
                polarizations=uv1.polarization_array[0:2])
@@ -2297,7 +2288,6 @@ def test_fast_concat():
     # Another combo
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)
-    uv_ref = copy.deepcopy(uv_full)
     times = np.unique(uv_full.time_array)
     uv1.select(times=times[0:len(times) // 2], freq_chans=np.arange(0, 32))
     uv2.select(times=times[len(times) // 2:], freq_chans=np.arange(32, 64))
@@ -2912,7 +2902,9 @@ def test_antpair2ind():
 
     # test ordered
     inds3 = uv.antpair2ind(1, 0, ordered=True)
-    np.testing.assert_array_equal(inds, inds2)
+    assert inds3.size == 0
+    inds3 = uv.antpair2ind(0, 1, ordered=True)
+    np.testing.assert_array_equal(inds, inds3)
 
     # test autos w/ and w/o ordered
     inds4 = uv.antpair2ind(0, 0, ordered=True)
@@ -3806,7 +3798,6 @@ def test_redundancy_contract_expand_nblts_not_nbls_times_ntimes():
     blt_inds = []
     missing_inds = []
     for bl, t in zip(uv0.baseline_array, uv0.time_array):
-        antpair = uv2.baseline_to_antnums(bl)
         if (bl, t) in zip(uv2.baseline_array, uv2.time_array):
             this_ind = np.where((uv2.baseline_array == bl) & (uv2.time_array == t))[0]
             blt_inds.append(this_ind[0])
@@ -4127,7 +4118,6 @@ def test_upsample_in_time_with_flags(resample_in_time_file):
     uv_object.reorder_blts(order="baseline")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
     # check that there are no flags
     assert np.nonzero(uv_object.flag_array)[0].size == 0
@@ -4255,7 +4245,6 @@ def test_upsample_in_time_summing_correlator_mode_with_flags(resample_in_time_fi
     uv_object.reorder_blts(order="baseline")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
     # check that there are no flags
     assert np.nonzero(uv_object.flag_array)[0].size == 0
@@ -4333,7 +4322,6 @@ def test_partial_upsample_in_time(resample_in_time_file):
     uv_object.reorder_blts(order="baseline")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf_01 = uv_object.get_data(0, 1)
     init_wf_02 = uv_object.get_data(0, 2)
     # check that there are no flags
@@ -4487,7 +4475,6 @@ def test_downsample_in_time_partial_flags(resample_in_time_file):
     uv_object.reorder_blts(order="baseline", minor_order="time")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
     original_int_time = np.amax(uv_object.integration_time)
     # check that there are no flags
@@ -4527,7 +4514,6 @@ def test_downsample_in_time_totally_flagged(resample_in_time_file):
     uv_object.reorder_blts(order="baseline", minor_order="time")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
     original_int_time = np.amax(uv_object.integration_time)
     # check that there are no flags
@@ -4568,12 +4554,10 @@ def test_downsample_in_time_uneven_samples(resample_in_time_file):
     uv_object.reorder_blts(order="baseline", minor_order="time")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
     original_int_time = np.amax(uv_object.integration_time)
     # check that there are no flags
     assert np.nonzero(uv_object.flag_array)[0].size == 0
-    init_ns = uv_object.get_nsamples(0, 1)
 
     # test again with a downsample factor that doesn't go evenly into the number of samples
     min_integration_time = original_int_time * 3.0
@@ -4609,12 +4593,10 @@ def test_downsample_in_time_uneven_samples_discard_ragged(resample_in_time_file)
     uv_object.reorder_blts(order="baseline", minor_order="time")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
     original_int_time = np.amax(uv_object.integration_time)
     # check that there are no flags
     assert np.nonzero(uv_object.flag_array)[0].size == 0
-    init_ns = uv_object.get_nsamples(0, 1)
 
     # test again with a downsample factor that doesn't go evenly into the number of samples
     min_integration_time = original_int_time * 3.0
@@ -4686,7 +4668,6 @@ def test_downsample_in_time_summing_correlator_mode_partial_flags(
     uv_object.reorder_blts(order="baseline", minor_order="time")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
     original_int_time = np.amax(uv_object.integration_time)
     # check that there are no flags
@@ -4730,7 +4711,6 @@ def test_downsample_in_time_summing_correlator_mode_totally_flagged(
     uv_object.reorder_blts(order="baseline", minor_order="time")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
     original_int_time = np.amax(uv_object.integration_time)
     # check that there are no flags
@@ -4775,7 +4755,6 @@ def test_downsample_in_time_summing_correlator_mode_uneven_samples(
     uv_object.reorder_blts(order="baseline", minor_order="time")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
     original_int_time = np.amax(uv_object.integration_time)
     # check that there are no flags
@@ -4827,7 +4806,6 @@ def test_downsample_in_time_summing_correlator_mode_uneven_samples_drop_ragged(
     uv_object.reorder_blts(order="baseline", minor_order="time")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
     original_int_time = np.amax(uv_object.integration_time)
     # check that there are no flags
@@ -4874,7 +4852,6 @@ def test_partial_downsample_in_time(resample_in_time_file):
     uv_object.reorder_blts(order="baseline")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf_01 = uv_object.get_data(0, 1)
     init_wf_02 = uv_object.get_data(0, 2)
     # check that there are no flags
@@ -5020,7 +4997,6 @@ def test_downsample_in_time_errors(resample_in_time_file):
     # save some values for later
     init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
-    original_int_time = np.amax(uv_object.integration_time)
     # check that there are no flags
     assert np.nonzero(uv_object.flag_array)[0].size == 0
     init_ns = uv_object.get_nsamples(0, 1)
@@ -5063,7 +5039,6 @@ def test_downsample_in_time_int_time_mismatch_warning(resample_in_time_file):
     # save some values for later
     init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
-    original_int_time = np.amax(uv_object.integration_time)
     # check that there are no flags
     assert np.nonzero(uv_object.flag_array)[0].size == 0
     init_ns = uv_object.get_nsamples(0, 1)
@@ -5103,9 +5078,7 @@ def test_downsample_in_time_varying_integration_time(resample_in_time_file):
     uv_object.reorder_blts(order="baseline", minor_order="time")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
-    original_int_time = np.amax(uv_object.integration_time)
     # check that there are no flags
     assert np.nonzero(uv_object.flag_array)[0].size == 0
     init_ns = uv_object.get_nsamples(0, 1)
@@ -5148,9 +5121,7 @@ def test_downsample_in_time_varying_integration_time_warning(resample_in_time_fi
     uv_object.reorder_blts(order="baseline", minor_order="time")
 
     # save some values for later
-    init_data_size = uv_object.data_array.size
     init_wf = uv_object.get_data(0, 1)
-    original_int_time = np.amax(uv_object.integration_time)
     # check that there are no flags
     assert np.nonzero(uv_object.flag_array)[0].size == 0
     init_ns = uv_object.get_nsamples(0, 1)
@@ -5280,8 +5251,6 @@ def test_upsample_downsample_in_time_odd_resample(resample_in_time_file):
     uv_object.upsample_in_time(max_integration_time, blt_order="baseline")
     assert np.amax(uv_object.integration_time) <= max_integration_time
 
-    new_Nblts = uv_object.Nblts
-
     uv_object.downsample_in_time(np.amin(uv_object2.integration_time), blt_order="baseline")
 
     # increase tolerance on LST if iers.conf.auto_max_age is set to None, as we
@@ -5323,7 +5292,6 @@ def test_upsample_downsample_in_time_metadata_only(resample_in_time_file):
     max_integration_time = np.amin(uv_object.integration_time) / 2.0
     uv_object.upsample_in_time(max_integration_time, blt_order="baseline")
     assert np.amax(uv_object.integration_time) <= max_integration_time
-    new_Nblts = uv_object.Nblts
 
     uv_object.downsample_in_time(np.amin(uv_object2.integration_time), blt_order="baseline")
 
@@ -5349,8 +5317,6 @@ def test_resample_in_time(bda_test_file):
     # that causes our gap test to issue a warning, but the variations are small
     # We aren't worried about them, so we filter those warnings
     uv_object = bda_test_file
-
-    ant_pairs = uv_object.get_antpairs()
 
     # save some initial info
     # 2s integration time
@@ -5398,8 +5364,6 @@ def test_resample_in_time_downsample_only(bda_test_file):
     # that causes our gap test to issue a warning, but the variations are small
     # We aren't worried about them, so we filter those warnings
     uv_object = bda_test_file
-
-    ant_pairs = uv_object.get_antpairs()
 
     # save some initial info
     # 2s integration time
@@ -5453,8 +5417,6 @@ def test_resample_in_time_only_upsample(bda_test_file):
     # that causes our gap test to issue a warning, but the variations are small
     # We aren't worried about them, so we filter those warnings
     uv_object = bda_test_file
-
-    ant_pairs = uv_object.get_antpairs()
 
     # save some initial info
     # 2s integration time

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -111,9 +111,9 @@ def initialize_with_zeros(uvd, filename):
         data_dset = dgrp['visdata']
         flags_dset = dgrp['flags']
         nsample_dset = dgrp['nsamples']
-        data_dset = data
-        flags_dset = flags
-        nsample_dset = nsamples
+        data_dset = data  # noqa
+        flags_dset = flags  # noqa
+        nsample_dset = nsamples  # noqa
     return
 
 
@@ -139,8 +139,8 @@ def initialize_with_zeros_ints(uvd, filename):
         with data_dset.astype(_hera_corr_dtype):
             data_dset[:, :, :, :, 'r'] = data.real
             data_dset[:, :, :, :, 'i'] = data.imag
-        flags_dset = flags
-        nsample_dset = nsamples
+        flags_dset = flags  # noqa
+        nsample_dset = nsamples  # noqa
     return
 
 

--- a/pyuvdata/tests/test_version.py
+++ b/pyuvdata/tests/test_version.py
@@ -90,7 +90,6 @@ def test_construct_version_info():
         git_hash = get_git_output(['rev-parse', 'HEAD'], capture_stderr=True)
         git_description = get_git_output(['describe', '--dirty', '--tag', '--always'])
         git_branch = get_git_output(['rev-parse', '--abbrev-ref', 'HEAD'], capture_stderr=True)
-        git_version = get_git_output(['describe', '--tags', '--abbrev=0'])
     except (subprocess.CalledProcessError, ValueError):
         try:
             # Check if a GIT_INFO file was created when installing package

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -2,9 +2,7 @@
 # Copyright (c) 2018 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
 
-"""Commonly used utility functions.
-
-"""
+"""Commonly used utility functions."""
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
@@ -73,13 +71,22 @@ def LatLonAlt_from_XYZ(xyz, check_acceptability=True):
     """
     Calculate lat/lon/alt from ECEF x,y,z.
 
-    Args:
-        xyz: numpy array, shape (Npts, 3), with ECEF x,y,z coordinates
-        check_acceptability: bool, check XYZ coordinates are reasonable.
+    Parameters
+    ----------
+    xyz : ndarray of float
+        numpy array, shape (Npts, 3), with ECEF x,y,z coordinates.
+    check_acceptability : bool
+        Flag to check XYZ coordinates are reasonable.
 
-    Returns:
-        tuple of latitude, longitude, altitude numpy arrays (if Npts > 1) or
-            values (if Npts = 1) in radians & meters
+    Returns
+    -------
+    latitude :  ndarray or float
+        latitude, numpy array (if Npts > 1) or value (if Npts = 1) in radians
+    longitude :  ndarray or float
+        longitude, numpy array (if Npts > 1) or value (if Npts = 1) in radians
+    altitude :  ndarray or float
+        altitude, numpy array (if Npts > 1) or value (if Npts = 1) in meters
+
     """
     # convert to a numpy array
     xyz = np.array(xyz)
@@ -135,13 +142,20 @@ def XYZ_from_LatLonAlt(latitude, longitude, altitude):
     """
     Calculate ECEF x,y,z from lat/lon/alt values.
 
-    Args:
-        latitude: latitude in radians, can be a single value or a vector of length Npts
-        longitude: longitude in radians, can be a single value or a vector of length Npts
-        altitude: altitude in meters, can be a single value or a vector of length Npts
+    Parameters
+    ----------
+    latitude :  ndarray or float
+        latitude, numpy array (if Npts > 1) or value (if Npts = 1) in radians
+    longitude :  ndarray or float
+        longitude, numpy array (if Npts > 1) or value (if Npts = 1) in radians
+    altitude :  ndarray or float
+        altitude, numpy array (if Npts > 1) or value (if Npts = 1) in meters
 
-    Returns:
-        numpy array, shape (Npts, 3) (if Npts > 1) or (3,) (if Npts = 1), with ECEF x,y,z coordinates
+    Returns
+    -------
+    xyz : ndarray of float
+        numpy array, shape (Npts, 3), with ECEF x,y,z coordinates.
+
     """
     latitude = np.array(latitude)
     longitude = np.array(longitude)
@@ -168,17 +182,24 @@ def XYZ_from_LatLonAlt(latitude, longitude, altitude):
 
 def rotECEF_from_ECEF(xyz, longitude):
     """
-    Calculate a rotated ECEF from ECEF such that the x-axis goes through the
-    specified longitude.
+    Get rotated ECEF positions such that the x-axis goes through the longitude.
 
-    Miriad (and maybe uvfits) expect antenna positions in this frame
+    Miriad and uvfits expect antenna positions in this frame
     (with longitude of the array center/telescope location)
 
-    Args:
-        xyz: numpy array, shape (Npts, 3), with ECEF x,y,z coordinates
-        longitude: longitude in radians to rotate coordinates to (usually the array center/telescope location)
-    Returns:
-        numpy array, shape (Npts, 3), with rotated ECEF coordinates
+    Parameters
+    ----------
+    xyz : ndarray of float
+        numpy array, shape (Npts, 3), with ECEF x,y,z coordinates.
+    longitude : float
+        longitude in radians to rotate coordinates to
+        (usually the array center/telescope location).
+
+    Returns
+    -------
+    ndarray of float
+        Rotated ECEF coordinates, shape (Npts, 3).
+
     """
     angle = -1 * longitude
     rot_matrix = np.array([[np.cos(angle), -1 * np.sin(angle), 0],
@@ -189,14 +210,21 @@ def rotECEF_from_ECEF(xyz, longitude):
 
 def ECEF_from_rotECEF(xyz, longitude):
     """
-    Calculate ECEF from a rotated ECEF such that the x-axis goes through the
-    specified longitude. (Inverse of rotECEF_from_ECEF)
+    Calculate ECEF from a rotated ECEF (Inverse of rotECEF_from_ECEF).
 
-    Args:
-        xyz: numpy array, shape (Npts, 3), with rotated ECEF x,y,z coordinates
-        longitude: longitude in radians to rotate coordinates to (usually the array center/telescope location)
-    Returns:
-        numpy array, shape (Npts, 3), with ECEF coordinates
+    Parameters
+    ----------
+    xyz : ndarray of float
+        numpy array, shape (Npts, 3), with rotated ECEF x,y,z coordinates.
+    longitude : float
+        longitude in radians giving the x direction of the rotated coordinates
+        (usually the array center/telescope location).
+
+    Returns
+    -------
+    ndarray of float
+        ECEF coordinates, shape (Npts, 3).
+
     """
     angle = longitude
     rot_matrix = np.array([[np.cos(angle), -1 * np.sin(angle), 0],
@@ -209,14 +237,22 @@ def ENU_from_ECEF(xyz, latitude, longitude, altitude):
     """
     Calculate local ENU (east, north, up) coordinates from ECEF coordinates.
 
-    Args:
-        xyz: numpy array, shape (Npts, 3), with ECEF x,y,z coordinates
-        latitude: latitude of center of ENU coordinates in radians
-        longitude: longitude of center of ENU coordinates in radians
-        altitude: altitude of center of ENU coordinates in radians
+    Parameters
+    ----------
+    xyz : ndarray of float
+        numpy array, shape (Npts, 3), with ECEF x,y,z coordinates.
+    latitude : float
+        Latitude of center of ENU coordinates in radians.
+    longitude : float
+        Longitude of center of ENU coordinates in radians.
+    altitude : float
+        Altitude of center of ENU coordinates in radians.
 
-    Returns:
+    Returns
+    -------
+    ndarray of float
         numpy array, shape (Npts, 3), with local ENU coordinates
+
     """
     xyz = np.array(xyz)
     if xyz.ndim > 1 and xyz.shape[1] != 3:
@@ -279,13 +315,23 @@ def ECEF_from_ENU(enu, latitude, longitude, altitude):
     """
     Calculate ECEF coordinates from local ENU (east, north, up) coordinates.
 
-    Args:
-        enu: numpy array, shape (Npts, 3), with local ENU coordinates
-        latitude: latitude of center of ENU coordinates in radians
-        longitude: longitude of center of ENU coordinates in radians
+    Parameters
+    ----------
+    enu : ndarray of float
+        numpy array, shape (Npts, 3), with local ENU coordinates.
+    latitude : float
+        Latitude of center of ENU coordinates in radians.
+    longitude : float
+        Longitude of center of ENU coordinates in radians.
+    altitude : float
+        Altitude of center of ENU coordinates in radians.
 
-    Returns:
-        numpy array, shape (Npts, 3), with ECEF x,y,z coordinates
+
+    Returns
+    -------
+    xyz : ndarray of float
+        numpy array, shape (Npts, 3), with ECEF x,y,z coordinates.
+
     """
     enu = np.array(enu)
     if enu.ndim > 1 and enu.shape[1] != 3:
@@ -333,67 +379,88 @@ def ECEF_from_ENU(enu, latitude, longitude, altitude):
     return xyz
 
 
-def phase_uvw(ra, dec, xyz):
+def phase_uvw(ra, dec, initial_uvw):
     """
-    This code expects xyz locations relative to the telescope location in the
-    same frame that ra/dec are in (e.g. icrs or gcrs) and returns uvws in the
-    same frame.
+    Calculate phased uvws/positions from unphased ones in an icrs or gcrs frame.
 
-    Note that this code is nearly identical to ENU_from_ECEF, except that it uses
-    an arbitrary phasing center rather than a coordinate center.
+    This code expects input uvws or positions relative to the telescope
+    location in the same frame that ra/dec are in (e.g. icrs or gcrs) and
+    returns phased ones in the same frame.
 
-    Args:
-        ra: right ascension to phase to in desired frame
-        dec: declination to phase to in desired frame
-        xyz: locations relative to the array center in desired frame, shape (Nlocs, 3)
+    Note that this code is nearly identical to ENU_from_ECEF, except that it
+    uses an arbitrary phasing center rather than a coordinate center.
 
-    Returns:
-        uvw array in the same frame as xyz, ra and dec
+    Parameters
+    ----------
+    ra : float
+        Right ascension of phase center.
+    dec : float
+        Declination of phase center.
+    initial_uvw : ndarray of float
+        Unphased uvws or positions relative to the array center,
+        shape (Nlocs, 3).
+
+    Returns
+    -------
+    uvw : ndarray of float
+        uvw array in the same frame as initial_uvws, ra and dec.
+
     """
-    if xyz.ndim == 1:
-        xyz = xyz[np.newaxis, :]
+    if initial_uvw.ndim == 1:
+        initial_uvw = initial_uvw[np.newaxis, :]
 
-    uvw = np.zeros_like(xyz)
-    uvw[:, 0] = (-np.sin(ra) * xyz[:, 0]
-                 + np.cos(ra) * xyz[:, 1])
-    uvw[:, 1] = (-np.sin(dec) * np.cos(ra) * xyz[:, 0]
-                 - np.sin(dec) * np.sin(ra) * xyz[:, 1]
-                 + np.cos(dec) * xyz[:, 2])
-    uvw[:, 2] = (np.cos(dec) * np.cos(ra) * xyz[:, 0]
-                 + np.cos(dec) * np.sin(ra) * xyz[:, 1]
-                 + np.sin(dec) * xyz[:, 2])
+    uvw = np.zeros_like(initial_uvw)
+    uvw[:, 0] = (-np.sin(ra) * initial_uvw[:, 0]
+                 + np.cos(ra) * initial_uvw[:, 1])
+    uvw[:, 1] = (-np.sin(dec) * np.cos(ra) * initial_uvw[:, 0]
+                 - np.sin(dec) * np.sin(ra) * initial_uvw[:, 1]
+                 + np.cos(dec) * initial_uvw[:, 2])
+    uvw[:, 2] = (np.cos(dec) * np.cos(ra) * initial_uvw[:, 0]
+                 + np.cos(dec) * np.sin(ra) * initial_uvw[:, 1]
+                 + np.sin(dec) * initial_uvw[:, 2])
     return(uvw)
 
 
 def unphase_uvw(ra, dec, uvw):
     """
-    This code expects uvw locations in the same frame that ra/dec are in
-    (e.g. icrs or gcrs) and returns relative xyz values in the same frame.
+    Calculate unphased uvws/positions from phased ones in an icrs or gcrs frame.
 
-    Args:
-        ra: right ascension data are phased to
-        dec: declination data are phased to
-        uvw: phased uvw values
+    This code expects phased uvws or positions in the same frame that ra/dec
+    are in (e.g. icrs or gcrs) and returns unphased ones in the same frame.
 
-    Returns:
-        xyz locations relative to the array center in the phased frame
+    Parameters
+    ----------
+    ra : float
+        Right ascension of phase center.
+    dec : float
+        Declination of phase center.
+    uvw : ndarray of float
+        Phased uvws or positions relative to the array center,
+        shape (Nlocs, 3).
+
+    Returns
+    -------
+    unphased_uvws : ndarray of float
+        Unphased uvws or positions relative to the array center,
+        shape (Nlocs, 3).
+
     """
     if uvw.ndim == 1:
         uvw = uvw[np.newaxis, :]
 
-    xyz = np.zeros_like(uvw)
-    xyz[:, 0] = (-np.sin(ra) * uvw[:, 0]
-                 - np.sin(dec) * np.cos(ra) * uvw[:, 1]
-                 + np.cos(dec) * np.cos(ra) * uvw[:, 2])
+    unphased_uvws = np.zeros_like(uvw)
+    unphased_uvws[:, 0] = (-np.sin(ra) * uvw[:, 0]
+                           - np.sin(dec) * np.cos(ra) * uvw[:, 1]
+                           + np.cos(dec) * np.cos(ra) * uvw[:, 2])
 
-    xyz[:, 1] = (np.cos(ra) * uvw[:, 0]
-                 - np.sin(dec) * np.sin(ra) * uvw[:, 1]
-                 + np.cos(dec) * np.sin(ra) * uvw[:, 2])
+    unphased_uvws[:, 1] = (np.cos(ra) * uvw[:, 0]
+                           - np.sin(dec) * np.sin(ra) * uvw[:, 1]
+                           + np.cos(dec) * np.sin(ra) * uvw[:, 2])
 
-    xyz[:, 2] = (np.cos(dec) * uvw[:, 1]
-                 + np.sin(dec) * uvw[:, 2])
+    unphased_uvws[:, 2] = (np.cos(dec) * uvw[:, 1]
+                           + np.sin(dec) * uvw[:, 2])
 
-    return(xyz)
+    return(unphased_uvws)
 
 
 def uvcalibrate(uvdata, uvcal, inplace=True, prop_flags=True, flag_missing=True,
@@ -495,8 +562,10 @@ def uvcalibrate(uvdata, uvcal, inplace=True, prop_flags=True, flag_missing=True,
 def apply_uvflag(uvd, uvf, inplace=True, unflag_first=False,
                  flag_missing=True, force_pol=True):
     """
-    Apply flags from a UVFlag to a UVData instantiation. This edits inplace by default.
-    Note: if uvf.Nfreqs or uvf.Ntimes is 1, will broadcast flags across that axis.
+    Apply flags from a UVFlag to a UVData instantiation.
+
+    Note that if uvf.Nfreqs or uvf.Ntimes is 1, it will broadcast flags across
+    that axis.
 
     Parameters
     ----------
@@ -520,6 +589,7 @@ def apply_uvflag(uvd, uvf, inplace=True, unflag_first=False,
     -------
     UVData
         If not inplace, returns new UVData object with flags applied
+
     """
     # assertions
     if uvf.mode != 'flag':
@@ -596,6 +666,7 @@ def apply_uvflag(uvd, uvf, inplace=True, unflag_first=False,
 
 
 def get_iterable(x):
+    """Deprecated: return iterable version of input."""
     warnings.warn('The get_iterable function is deprecated in favor of '
                   '_get_iterable because it is not API level code. This '
                   'function will be removed in version 1.5', DeprecationWarning)
@@ -603,7 +674,7 @@ def get_iterable(x):
 
 
 def _get_iterable(x):
-    """Helper function to ensure iterability."""
+    """Return iterable version of input."""
     if isinstance(x, Iterable):
         return x
     else:
@@ -611,6 +682,7 @@ def _get_iterable(x):
 
 
 def fits_gethduaxis(HDU, axis, strict_fits=True):
+    """Deprecated: make axis arrays for fits files."""
     warnings.warn('The fits_gethduaxis function is deprecated in favor of '
                   '_fits_gethduaxis because it is not API level code. This '
                   'function will be removed in version 1.5', DeprecationWarning)
@@ -619,20 +691,25 @@ def fits_gethduaxis(HDU, axis, strict_fits=True):
 
 def _fits_gethduaxis(HDU, axis, strict_fits=True):
     """
-    Helper function for making axis arrays for fits files.
+    Make axis arrays for fits files.
 
-    Args:
-        HDU: a fits HDU
-        axis: the axis number of interest
-        strict_fits: boolean
-            If True, require that the axis has cooresponding NAXIS, CRVAL,
-            CDELT and CRPIX keywords. If False, allow CRPIX to be missing and
-            set it equal to zero (as a way of supporting old calfits files).
-            Default is False.
-    Returns:
-        numpy array of values for that axis
+    Parameters
+    ----------
+    HDU : astropy.io.fits HDU object
+        The HDU to make an axis array for.
+    axis : int
+        The axis number of interest (1-based).
+    strict_fits: bool
+        If True, require that the axis has cooresponding NAXIS, CRVAL,
+        CDELT and CRPIX keywords. If False, allow CRPIX to be missing and
+        set it equal to zero (as a way of supporting old calfits files).
+
+    Returns
+    -------
+    ndarray of float
+        Array of values for the specified axis.
+
     """
-
     ax = str(axis)
     N = HDU.header['NAXIS' + ax]
     X0 = HDU.header['CRVAL' + ax]
@@ -654,14 +731,22 @@ def get_lst_for_time(jd_array, latitude, longitude, altitude):
     """
     Get the lsts for a set of jd times at an earth location.
 
-    Args:
-        jd_array: an array of JD times to get lst for
-        latitude: latitude of location to get lst for in degrees
-        longitude: longitude of location to get lst for in degrees
-        altitude: altitude of location to get lst for in meters
+    Parameters
+    ----------
+    jd_array : ndarray of float
+        JD times to get lsts for.
+    latitude : float
+        Latitude of location to get lst for in degrees.
+    longitude : float
+        Longitude of location to get lst for in degrees.
+    altitude : float
+        Altitude of location to get lst for in meters.
 
-    Returns:
-        an array of lst times corresponding to the jd_array
+    Returns
+    -------
+    ndarray of float
+        LSTs in radians corresponding to the jd_array.
+
     """
     lst_array = np.zeros_like(jd_array)
     for ind, jd in enumerate(np.unique(jd_array)):
@@ -682,6 +767,7 @@ def get_lst_for_time(jd_array, latitude, longitude, altitude):
 
 
 def fits_indexhdus(hdulist):
+    """Deprecated: get a dict of tablenames from a FITS HDU list."""
     warnings.warn('The fits_indexhdus function is deprecated in favor of '
                   '_fits_indexhdus because it is not API level code. This '
                   'function will be removed in version 1.5', DeprecationWarning)
@@ -690,13 +776,18 @@ def fits_indexhdus(hdulist):
 
 def _fits_indexhdus(hdulist):
     """
-    Helper function for fits I/O.
+    Get a dict of table names and HDU numbers from a FITS HDU list.
 
-    Args:
-        hdulist: a list of hdus
+    Parameters
+    ----------
+    hdulist : list of astropy.io.fits HDU objects
+        List of HDUs to get names for
 
-    Returns:
-        dictionary of table names
+    Returns
+    -------
+    dict
+        dictionary with table names as keys and HDU number as values.
+
     """
     tablenames = {}
     for i in range(len(hdulist)):
@@ -708,7 +799,7 @@ def _fits_indexhdus(hdulist):
 
 
 def _x_orientation_rep_dict(x_orientation):
-    """"Helper function to create replacement dict based on x_orientation"""
+    """Create replacement dict based on x_orientation."""
     if x_orientation.lower() == 'east' or x_orientation.lower() == 'e':
         return {'x': 'e', 'y': 'n'}
     elif x_orientation.lower() == 'north' or x_orientation.lower() == 'n':
@@ -735,7 +826,7 @@ def polstr2num(pol, x_orientation=None):
         for more details.
 
     Returns
-    ----------
+    -------
     int
         Number corresponding to string
 
@@ -745,9 +836,10 @@ def polstr2num(pol, x_orientation=None):
         If the pol string cannot be converted to a polarization number.
 
     Warns
-    ------
+    -----
     UserWarning
         If the x_orientation not recognized.
+
     """
     dict_use = copy.deepcopy(POL_STR2NUM_DICT)
     if x_orientation is not None:
@@ -786,7 +878,7 @@ def polnum2str(num, x_orientation=None):
         E/N strings. See corresonding parameter on UVData for more details.
 
     Returns
-    ----------
+    -------
     str
         String corresponding to polarization number
 
@@ -796,9 +888,10 @@ def polnum2str(num, x_orientation=None):
         If the polarization number cannot be converted to a polarization string.
 
     Warns
-    ------
+    -----
     UserWarning
         If the x_orientation not recognized.
+
     """
     dict_use = copy.deepcopy(POL_NUM2STR_DICT)
     if x_orientation is not None:
@@ -834,7 +927,7 @@ def jstr2num(jstr, x_orientation=None):
         for more details.
 
     Returns
-    ----------
+    -------
     int
         antenna (jones) polarization number corresponding to string
 
@@ -844,9 +937,10 @@ def jstr2num(jstr, x_orientation=None):
         If the jones string cannot be converted to a polarization number.
 
     Warns
-    ------
+    -----
     UserWarning
         If the x_orientation not recognized.
+
     """
     dict_use = copy.deepcopy(JONES_STR2NUM_DICT)
     if x_orientation is not None:
@@ -882,7 +976,7 @@ def jnum2str(jnum, x_orientation=None):
         E/N strings. See corresonding parameter on UVData for more details.
 
     Returns
-    ----------
+    -------
     str
         antenna (jones) polarization string corresponding to number
 
@@ -892,9 +986,10 @@ def jnum2str(jnum, x_orientation=None):
         If the jones polarization number cannot be converted to a jones polarization string.
 
     Warns
-    ------
+    -----
     UserWarning
         If the x_orientation not recognized.
+
     """
     dict_use = copy.deepcopy(JONES_NUM2STR_DICT)
     if x_orientation is not None:
@@ -932,7 +1027,7 @@ def parse_polstr(polstr, x_orientation=None):
         for more details.
 
     Returns
-    ----------
+    -------
     str
         AIPS Memo 117 standard string
 
@@ -942,9 +1037,10 @@ def parse_polstr(polstr, x_orientation=None):
         If the pol string cannot be converted to a polarization number.
 
     Warns
-    ------
+    -----
     UserWarning
         If the x_orientation not recognized.
+
     """
     return polnum2str(polstr2num(polstr, x_orientation=x_orientation),
                       x_orientation=x_orientation)
@@ -962,7 +1058,7 @@ def parse_jpolstr(jpolstr, x_orientation=None):
         Jones polarization string
 
     Returns
-    ----------
+    -------
     str
         calfits memo standard string
 
@@ -972,9 +1068,10 @@ def parse_jpolstr(jpolstr, x_orientation=None):
         If the jones string cannot be converted to a polarization number.
 
     Warns
-    ------
+    -----
     UserWarning
         If the x_orientation not recognized.
+
     """
     return jnum2str(jstr2num(jpolstr, x_orientation=x_orientation),
                     x_orientation=x_orientation)
@@ -982,20 +1079,26 @@ def parse_jpolstr(jpolstr, x_orientation=None):
 
 def conj_pol(pol):
     """
-    Returns the polarization for the conjugate baseline.
+    Return the polarization for the conjugate baseline.
+
     For example, (1, 2, 'xy') = conj(2, 1, 'yx').
-    The returned polarization is determined by assuming the antenna pair is reversed
-    in the data, and finding the correct polarization correlation which will yield
-    the requested baseline when conjugated. Note this means changing the polarization
-    for linear cross-pols, but keeping auto-pol (e.g. xx) and Stokes the same.
+    The returned polarization is determined by assuming the antenna pair is
+    reversed in the data, and finding the correct polarization correlation
+    which will yield the requested baseline when conjugated. Note this means
+    changing the polarization for linear cross-pols, but keeping auto-pol
+    (e.g. xx) and Stokes the same.
 
-    Args:
-        pol: Polarization (str or int)
+    Parameters
+    ----------
+    pol : str or int
+        Polarization string or integer.
 
-    Returns:
-        cpol: Polarization as if antennas are swapped (type matches input)
+    Returns
+    -------
+    cpol : str or int
+        Polarization as if antennas are swapped (type matches input)
+
     """
-
     deprecated_jones_dict = {'jxx': 'Jxx', 'jyy': 'Jyy', 'jxy': 'Jyx', 'jyx': 'Jxy',
                              'jrr': 'Jrr', 'jll': 'Jll', 'jrl': 'Jlr', 'jlr': 'Jrl'}
 
@@ -1020,21 +1123,26 @@ def conj_pol(pol):
 
 def reorder_conj_pols(pols):
     """
-    Reorders a list of pols, swapping pols that are conjugates of one another.
+    Reorder multiple pols, swapping pols that are conjugates of one another.
+
     For example ('xx', 'xy', 'yx', 'yy') -> ('xx', 'yx', 'xy', 'yy')
     This is useful for the _key2inds function in the case where an antenna
     pair is specified but the conjugate pair exists in the data. The conjugated
-    data should be returned in the order of the polarization axis, so after conjugating
-    the data, the pols need to be reordered.
+    data should be returned in the order of the polarization axis, so after
+    conjugating the data, the pols need to be reordered.
     For example, if a file contains antpair (0, 1) and pols 'xy' and 'yx', but
     the user requests antpair (1, 0), they should get:
     [(1x, 0y), (1y, 0x)] = [conj(0y, 1x), conj(0x, 1y)]
 
-    Args:
-        pols: Polarization array (strings or ints)
+    Parameters
+    ----------
+    pols : array_like of str or int
+        Polarization array (strings or ints).
 
-    Returns:
-        conj_order: Indices to reorder polarization axis
+    Returns
+    -------
+    conj_order : ndarray of int
+        Indices to reorder polarization array.
     """
     if not isinstance(pols, Iterable):
         raise ValueError('reorder_conj_pols must be given an array of polarizations.')
@@ -1046,6 +1154,7 @@ def reorder_conj_pols(pols):
 
 
 def check_history_version(history, version_string):
+    """Deprecated: check if version_string is present in history string."""
     warnings.warn('The check_history_version function is deprecated in favor of '
                   '_check_history_version because it is not API level code. This '
                   'function will be removed in version 1.5', DeprecationWarning)
@@ -1053,6 +1162,7 @@ def check_history_version(history, version_string):
 
 
 def _check_history_version(history, version_string):
+    """Check if version_string is present in history string."""
     if (version_string.replace(' ', '') in history.replace('\n', '').replace(' ', '')):
         return True
     else:
@@ -1060,6 +1170,7 @@ def _check_history_version(history, version_string):
 
 
 def check_histories(history1, history2):
+    """Deprecated: check if two histories are the same."""
     warnings.warn('The check_histories function is deprecated in favor of '
                   '_check_histories because it is not API level code. This '
                   'function will be removed in version 1.5', DeprecationWarning)
@@ -1067,6 +1178,7 @@ def check_histories(history1, history2):
 
 
 def _check_histories(history1, history2):
+    """Check if two histories are the same."""
     if (history1.replace('\n', '').replace(' ', '') == history2.replace('\n', '').replace(' ', '')):
         return True
     else:
@@ -1074,6 +1186,7 @@ def _check_histories(history1, history2):
 
 
 def combine_histories(history1, history2):
+    """Deprecated: combine histories with minimal repeats."""
     warnings.warn('The combine_histories function is deprecated in favor of '
                   '_combine_histories because it is not API level code. This '
                   'function will be removed in version 1.5', DeprecationWarning)
@@ -1081,6 +1194,7 @@ def combine_histories(history1, history2):
 
 
 def _combine_histories(history1, history2):
+    """Combine histories with minimal repeats."""
     hist2_words = history2.split(' ')
     add_hist = ''
     test_hist1 = ' ' + history1 + ' '
@@ -1117,6 +1231,7 @@ def baseline_to_antnums(baseline, Nants_telescope):
         first antenna number(s)
     int or array_like of int
         second antenna number(s)
+
     """
     if Nants_telescope > 2048:
         raise Exception('error Nants={Nants}>2048 not '
@@ -1153,6 +1268,7 @@ def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False):
     -------
     int or array of int
         baseline number corresponding to the two antenna numbers.
+
     """
     ant1, ant2 = np.int64((ant1, ant2))
     if Nants_telescope is not None and Nants_telescope > 2048:
@@ -1179,16 +1295,14 @@ def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False):
 
 
 def baseline_index_flip(baseline, Nants_telescope):
-    """
-    Change baseline number to reverse antenna order.
-    """
+    """Change baseline number to reverse antenna order."""
     ant1, ant2 = baseline_to_antnums(baseline, Nants_telescope)
     return antnums_to_baseline(ant2, ant1, Nants_telescope)
 
 
 def get_baseline_redundancies(baselines, baseline_vecs, tol=1.0, with_conjugates=False):
     """
-    Find redundant baseline groups
+    Find redundant baseline groups.
 
     Parameters
     ----------
@@ -1212,6 +1326,7 @@ def get_baseline_redundancies(baselines, baseline_vecs, tol=1.0, with_conjugates
     baseline_ind_conj : list of int
         List of baselines that are redundant when reversed. Only returned if
         with_conjugates is True
+
     """
     Nbls = baselines.shape[0]
 
@@ -1304,7 +1419,6 @@ def get_antenna_redundancies(antenna_numbers, antenna_positions, tol=1.0, includ
 
     Notes
     -----
-
     The baseline numbers refer to antenna pairs (a1, a2) such that
     the baseline vector formed from ENU antenna positions,
         blvec = enu[a1] - enu[a2]
@@ -1317,6 +1431,7 @@ def get_antenna_redundancies(antenna_numbers, antenna_positions, tol=1.0, includ
     To guarantee that the same baseline numbers are present in a UVData
     object, ``UVData.conjugate_bls('u>0', uvw_tol=tol)``, where `tol` is
     the tolerance used here.
+
     """
     Nants = antenna_numbers.size
 
@@ -1346,7 +1461,8 @@ def get_antenna_redundancies(antenna_numbers, antenna_positions, tol=1.0, includ
 
 
 def _reraise_context(fmt, *args):
-    """Reraise an exception with its message modified to specify additional context.
+    r"""
+    Reraise an exception with its message modified to specify additional context.
 
     This function tries to help provide context when a piece of code
     encounters an exception while trying to get something done, and it wishes
@@ -1360,7 +1476,8 @@ def _reraise_context(fmt, *args):
     the first argument is treated as an old-fashioned ``printf``-type
     (``%``-based) format string, and the remaining arguments are the formatted
     values.
-    Borrowed from pwkit (https://github.com/pkgw/pwkit/blob/master/pwkit/__init__.py)
+    Borrowed from `pwkit <https://github.com/pkgw/pwkit/blob/master/pwkit/__init__.py>`_
+
     Example usage::
       from pyuvdata.utils import reraise_context
       filename = 'my-filename.txt'
@@ -1396,21 +1513,32 @@ def _reraise_context(fmt, *args):
 
 
 def collapse(arr, alg, weights=None, axis=None, return_weights=False):
-    ''' Parent function to collapse an array with a given algorithm.
-    Args:
-        arr (array): Input array to process.
-        alg (str): Algorithm to use. Must be defined in this function with
-            corresponding subfunction below.
-        weights (array, optional): weights for collapse operation (e.g. weighted mean).
-            NOTE: Some subfunctions do not use the weights. See corresponding doc strings.
-        axis (int, tuple, optional): Axis or axes to collapse. Default is all.
-        return_weights (Bool): Whether to return sum of weights. Default is False.
-    '''
+    """
+    Parent function to collapse an array with a given algorithm.
+
+    Parameters
+    ----------
+    arr : array
+        Input array to process.
+    alg : str
+        Algorithm to use. Must be defined in this function with
+        corresponding subfunction below.
+    weights: ndarray, optional
+        weights for collapse operation (e.g. weighted mean).
+        NOTE: Some subfunctions do not use the weights. See corresponding
+        doc strings.
+    axis : int or tuple, optional
+        Axis or axes to collapse. Default is all.
+    return_weights : bool
+        Whether to return sum of weights.
+
+    """
     collapse_dict = {'mean': mean_collapse, 'absmean': absmean_collapse,
                      'quadmean': quadmean_collapse, 'or': or_collapse,
                      'and': and_collapse}
     try:
-        out = collapse_dict[alg](arr, weights=weights, axis=axis, return_weights=return_weights)
+        out = collapse_dict[alg](arr, weights=weights, axis=axis,
+                                 return_weights=return_weights)
     except KeyError:
         raise ValueError('Collapse algorithm must be one of: '
                          + ', '.join(collapse_dict.keys()) + '.')
@@ -1418,16 +1546,26 @@ def collapse(arr, alg, weights=None, axis=None, return_weights=False):
 
 
 def mean_collapse(arr, weights=None, axis=None, return_weights=False):
-    ''' Function to average data. This is similar to np.average, except it
-    handles infs (by giving them zero weight) and zero weight axes (by forcing
-    result to be inf with zero output weight).
-    Args:
-        arr - array to process
-        weights - weights for average. If none, will default to equal weight for
-                  all non-infinite data.
-        axis - axis keyword to pass to np.sum
-        return_weights - whether to return sum of weights. Default is False.
-    '''
+    """
+    Collapse by averaging data.
+
+    This is similar to np.average, except it handles infs (by giving them
+    zero weight) and zero weight axes (by forcing result to be inf with zero
+    output weight).
+
+    Parameters
+    ----------
+    arr : array
+        Input array to process.
+    weights: ndarray, optional
+        weights for average. If none, will default to equal weight for all
+        non-infinite data.
+    axis : int or tuple, optional
+        Axis or axes to collapse (passed to np.sum). Default is all.
+    return_weights : bool
+        Whether to return sum of weights.
+
+    """
     arr = copy.deepcopy(arr)  # avoid changing outside
     if weights is None:
         weights = np.ones_like(arr)
@@ -1447,24 +1585,43 @@ def mean_collapse(arr, weights=None, axis=None, return_weights=False):
 
 
 def absmean_collapse(arr, weights=None, axis=None, return_weights=False):
-    ''' Function to average absolute value
-    Args:
-        arr - array to process
-        weights - weights for average
-        axis - axis keyword to pass to np.mean
-        return_weights - whether to return sum of weights. Default is False.
-    '''
-    return mean_collapse(np.abs(arr), weights=weights, axis=axis, return_weights=return_weights)
+    """
+    Collapse by averaging absolute value of data.
+
+    Parameters
+    ----------
+    arr : array
+        Input array to process.
+    weights: ndarray, optional
+        weights for average. If none, will default to equal weight for all
+        non-infinite data.
+    axis : int or tuple, optional
+        Axis or axes to collapse (passed to np.sum). Default is all.
+    return_weights : bool
+        Whether to return sum of weights.
+
+    """
+    return mean_collapse(np.abs(arr), weights=weights, axis=axis,
+                         return_weights=return_weights)
 
 
 def quadmean_collapse(arr, weights=None, axis=None, return_weights=False):
-    ''' Function to average in quadrature
-    Args:
-        arr - array to process
-        weights - weights for average
-        axis - axis keyword to pass to np.mean
-        return_weights - whether to return sum of weights. Default is False.
-    '''
+    """
+    Collapse by averaging in quadrature.
+
+    Parameters
+    ----------
+    arr : array
+        Input array to process.
+    weights: ndarray, optional
+        weights for average. If none, will default to equal weight for all
+        non-infinite data.
+    axis : int or tuple, optional
+        Axis or axes to collapse (passed to np.sum). Default is all.
+    return_weights : bool
+        Whether to return sum of weights.
+
+    """
     out = mean_collapse(np.abs(arr)**2, weights=weights, axis=axis, return_weights=return_weights)
     if return_weights:
         return np.sqrt(out[0]), out[1]
@@ -1473,14 +1630,22 @@ def quadmean_collapse(arr, weights=None, axis=None, return_weights=False):
 
 
 def or_collapse(arr, weights=None, axis=None, return_weights=False):
-    ''' Function to collapse axes using OR operation
-    Args:
-        arr - boolean array to process
-        weights - NOT USED, but kept for symmetry with other averaging functions
-        axis - axis or axes over which to OR
-        return_weights - whether to return dummy weights array. NOTE: the dummy weights
-            will simply be an array of ones. Default is False.
-    '''
+    """
+    Collapse using OR operation.
+
+    Parameters
+    ----------
+    arr : array
+        Input array to process.
+    weights: ndarray, optional
+        NOT USED, but kept for symmetry with other collapsing functions.
+    axis : int or tuple, optional
+        Axis or axes to collapse (take OR over). Default is all.
+    return_weights : bool
+        Whether to return dummy weights array.
+        NOTE: the dummy weights will simply be an array of ones
+
+    """
     if arr.dtype != np.bool:
         raise ValueError('Input to or_collapse function must be boolean array')
     out = np.any(arr, axis=axis)
@@ -1493,14 +1658,22 @@ def or_collapse(arr, weights=None, axis=None, return_weights=False):
 
 
 def and_collapse(arr, weights=None, axis=None, return_weights=False):
-    ''' Function to collapse axes using AND operation
-    Args:
-        arr - boolean array to process
-        weights - NOT USED, but kept for symmetry with other averaging functions
-        axis - axis or axes over which to AND
-        return_weights - whether to return dummy weights array. NOTE: the dummy weights
-            will simply be an array of ones. Default is False.
-    '''
+    """
+    Collapse using AND operation.
+
+    Parameters
+    ----------
+    arr : array
+        Input array to process.
+    weights: ndarray, optional
+        NOT USED, but kept for symmetry with other collapsing functions.
+    axis : int or tuple, optional
+        Axis or axes to collapse (take AND over). Default is all.
+    return_weights : bool
+        Whether to return dummy weights array.
+        NOTE: the dummy weights will simply be an array of ones
+
+    """
     if arr.dtype != np.bool:
         raise ValueError('Input to and_collapse function must be boolean array')
     out = np.all(arr, axis=axis)

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -663,7 +663,6 @@ def get_lst_for_time(jd_array, latitude, longitude, altitude):
     Returns:
         an array of lst times corresponding to the jd_array
     """
-    lsts = []
     lst_array = np.zeros_like(jd_array)
     for ind, jd in enumerate(np.unique(jd_array)):
         t = Time(jd, format='jd', location=(Angle(longitude, unit='deg'),
@@ -1090,7 +1089,7 @@ def _combine_histories(history1, history2):
             add_hist += ' ' + word
             keep_going = (i + 1 < len(hist2_words))
             while keep_going:
-                if ((hist2_words[i + 1] is ' ')
+                if ((hist2_words[i + 1] == ' ')
                         or (' ' + hist2_words[i + 1] + ' ' not in test_hist1)):
                     add_hist += ' ' + hist2_words[i + 1]
                     del(hist2_words[i + 1])

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -63,7 +63,7 @@ class UVBase(object):
         # String to add to history of any files written with this version of pyuvdata
         self.pyuvdata_version_str = ('  Read/written with pyuvdata version: '
                                      + uvversion.version + '.')
-        if uvversion.git_hash is not '':
+        if uvversion.git_hash != '':
             self.pyuvdata_version_str += ('  Git origin: ' + uvversion.git_origin
                                           + '.  Git hash: ' + uvversion.git_hash
                                           + '.  Git branch: ' + uvversion.git_branch

--- a/pyuvdata/uvbeam.py
+++ b/pyuvdata/uvbeam.py
@@ -1536,7 +1536,7 @@ class UVBeam(UVBase):
                 history_update_string += 'healpix pixel'
                 n_axes += 1
             else:
-                pix_new_inds, _ = ([], [])
+                pix_new_inds = []
         else:
             temp = np.nonzero(~np.in1d(other.axis1_array, this.axis1_array))[0]
             if len(temp) > 0:
@@ -1544,7 +1544,7 @@ class UVBeam(UVBase):
                 history_update_string += 'first image'
                 n_axes += 1
             else:
-                ax1_new_inds, _ = ([], [])
+                ax1_new_inds = []
 
             temp = np.nonzero(~np.in1d(other.axis2_array, this.axis2_array))[0]
             if len(temp) > 0:
@@ -1555,7 +1555,7 @@ class UVBeam(UVBase):
                     history_update_string += 'second image'
                 n_axes += 1
             else:
-                ax2_new_inds, _ = ([], [])
+                ax2_new_inds = []
 
         temp = np.nonzero(~np.in1d(other.freq_array[0, :],
                                    this.freq_array[0, :]))[0]
@@ -1567,7 +1567,7 @@ class UVBeam(UVBase):
                 history_update_string += 'frequency'
             n_axes += 1
         else:
-            fnew_inds, _ = ([], [])
+            fnew_inds = []
 
         if this.beam_type == 'power':
             temp = np.nonzero(~np.in1d(other.polarization_array,
@@ -1580,7 +1580,7 @@ class UVBeam(UVBase):
                     history_update_string += 'polarization'
                 n_axes += 1
             else:
-                pnew_inds, _ = ([], [])
+                pnew_inds = []
         else:
             temp = np.nonzero(~np.in1d(other.feed_array,
                                        this.feed_array))[0]
@@ -1592,7 +1592,7 @@ class UVBeam(UVBase):
                     history_update_string += 'feed'
                 n_axes += 1
             else:
-                pnew_inds, _ = ([], [])
+                pnew_inds = []
 
         # Pad out self to accommodate new data
         if this.pixel_coordinate_system == 'healpix':

--- a/pyuvdata/uvbeam.py
+++ b/pyuvdata/uvbeam.py
@@ -763,8 +763,6 @@ class UVBeam(UVBase):
         assert(isinstance(freq_array, np.ndarray))
         assert(freq_array.ndim == 1)
 
-        nfreqs = freq_array.size
-
         # use the beam at nearest neighbors if not kind is 'nearest'
         if kind == 'nearest':
             freq_dists = np.abs(self.freq_array - freq_array.reshape(-1, 1))
@@ -931,7 +929,6 @@ class UVBeam(UVBase):
                 Npol_feeds = self.Npols
                 pol_inds = np.arange(Npol_feeds)
             else:
-                Npol_feeds_total = self.Npols
                 pols = [uvutils.polstr2num(p, x_orientation=self.x_orientation) for p in polarizations]
                 pol_inds = []
                 for pol in pols:
@@ -943,7 +940,6 @@ class UVBeam(UVBase):
                 Npol_feeds = len(pol_inds)
 
         else:
-            Npol_feeds_total = self.Nfeeds
             Npol_feeds = self.Nfeeds
             pol_inds = np.arange(Npol_feeds)
 
@@ -1118,7 +1114,6 @@ class UVBeam(UVBase):
         lon_array = Angle(az_array, units.radian)
         for index1 in range(self.Nspws):
             for index3 in range(input_nfreqs):
-                freq = freq_array[index3]
                 for index0 in range(self.Naxes_vec):
                     for index2 in range(Npol_feeds):
                         if np.iscomplexobj(input_data_array):
@@ -1416,10 +1411,6 @@ class UVBeam(UVBase):
         else:
             hp_obj = HEALPix(nside=nside)
 
-        if np.iscomplexobj(self.data_array):
-            data_type = np.complex
-        else:
-            data_type = np.float
         pixels = np.arange(hp_obj.npix)
         hpx_lon, hpx_lat = hp_obj.healpix_to_lonlat(pixels)
 
@@ -1542,72 +1533,66 @@ class UVBeam(UVBase):
             temp = np.nonzero(~np.in1d(other.pixel_array, this.pixel_array))[0]
             if len(temp) > 0:
                 pix_new_inds = temp
-                new_pixels = other.pixel_array[temp]
                 history_update_string += 'healpix pixel'
                 n_axes += 1
             else:
-                pix_new_inds, new_pixels = ([], [])
+                pix_new_inds, _ = ([], [])
         else:
             temp = np.nonzero(~np.in1d(other.axis1_array, this.axis1_array))[0]
             if len(temp) > 0:
                 ax1_new_inds = temp
-                new_ax1 = other.axis1_array[temp]
                 history_update_string += 'first image'
                 n_axes += 1
             else:
-                ax1_new_inds, new_ax1 = ([], [])
+                ax1_new_inds, _ = ([], [])
 
             temp = np.nonzero(~np.in1d(other.axis2_array, this.axis2_array))[0]
             if len(temp) > 0:
                 ax2_new_inds = temp
-                new_ax2 = other.axis2_array[temp]
                 if n_axes > 0:
                     history_update_string += ', second image'
                 else:
                     history_update_string += 'second image'
                 n_axes += 1
             else:
-                ax2_new_inds, new_ax2 = ([], [])
+                ax2_new_inds, _ = ([], [])
 
         temp = np.nonzero(~np.in1d(other.freq_array[0, :],
                                    this.freq_array[0, :]))[0]
         if len(temp) > 0:
             fnew_inds = temp
-            new_freqs = other.freq_array[0, temp]
             if n_axes > 0:
                 history_update_string += ', frequency'
             else:
                 history_update_string += 'frequency'
             n_axes += 1
         else:
-            fnew_inds, new_freqs = ([], [])
+            fnew_inds, _ = ([], [])
 
         if this.beam_type == 'power':
             temp = np.nonzero(~np.in1d(other.polarization_array,
                                        this.polarization_array))[0]
             if len(temp) > 0:
                 pnew_inds = temp
-                new_pols = other.polarization_array[temp]
                 if n_axes > 0:
                     history_update_string += ', polarization'
                 else:
                     history_update_string += 'polarization'
                 n_axes += 1
             else:
-                pnew_inds, new_pols = ([], [])
+                pnew_inds, _ = ([], [])
         else:
             temp = np.nonzero(~np.in1d(other.feed_array,
                                        this.feed_array))[0]
             if len(temp) > 0:
                 pnew_inds = temp
-                new_pols = other.feed_array[temp]
                 if n_axes > 0:
                     history_update_string += ', feed'
                 else:
                     history_update_string += 'feed'
                 n_axes += 1
             else:
-                pnew_inds, new_pols = ([], [])
+                pnew_inds, _ = ([], [])
 
         # Pad out self to accommodate new data
         if this.pixel_coordinate_system == 'healpix':
@@ -2174,7 +2159,7 @@ class UVBeam(UVBase):
             setattr(self, p, param)
 
     def _convert_to_filetype(self, filetype):
-        if filetype is 'beamfits':
+        if filetype == 'beamfits':
             from . import beamfits
             other_obj = beamfits.BeamFITS()
         else:

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -1049,7 +1049,7 @@ class UVCal(UVBase):
             history_update_string += 'antenna'
             n_axes += 1
         else:
-            anew_inds, _ = ([], [])
+            anew_inds = []
 
         temp = np.nonzero(~np.in1d(other.time_array, this.time_array))[0]
         if len(temp) > 0:
@@ -1060,7 +1060,7 @@ class UVCal(UVBase):
                 history_update_string += 'time'
             n_axes += 1
         else:
-            tnew_inds, _ = ([], [])
+            tnew_inds = []
 
         # adding along frequency axis is not supported for delay-type cal files
         if this.cal_type == 'gain':
@@ -1074,9 +1074,9 @@ class UVCal(UVBase):
                     history_update_string += 'frequency'
                 n_axes += 1
             else:
-                fnew_inds, _ = ([], [])
+                fnew_inds = []
         else:
-            fnew_inds, _ = ([], [])
+            fnew_inds = []
 
         temp = np.nonzero(~np.in1d(other.jones_array,
                                    this.jones_array))[0]
@@ -1088,7 +1088,7 @@ class UVCal(UVBase):
                 history_update_string += 'jones'
             n_axes += 1
         else:
-            jnew_inds, _ = ([], [])
+            jnew_inds = []
 
         # Initialize tqa variables
         can_combine_tqa = True

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -23,9 +23,9 @@ class UVCal(UVBase):
                 (http://pyuvdata.readthedocs.io/en/latest/uvcal.html).
                 Some are always required, some are required for certain cal_types
                 and others are always optional.
+
     """
     def __init__(self):
-        radian_tol = 10 * 2 * np.pi * 1e-3 / (60.0 * 60.0 * 360.0)
         self._Nfreqs = uvp.UVParameter('Nfreqs',
                                        description='Number of frequency channels',
                                        expected_type=int)
@@ -820,7 +820,7 @@ class UVCal(UVBase):
             setattr(self, p, param)
 
     def _convert_to_filetype(self, filetype):
-        if filetype is 'calfits':
+        if filetype == 'calfits':
             from . import calfits
             other_obj = calfits.CALFITS()
         else:
@@ -1046,23 +1046,21 @@ class UVCal(UVBase):
         temp = np.nonzero(~np.in1d(other.ant_array, this.ant_array))[0]
         if len(temp) > 0:
             anew_inds = temp
-            new_ants = other.ant_array[temp]
             history_update_string += 'antenna'
             n_axes += 1
         else:
-            anew_inds, new_ants = ([], [])
+            anew_inds, _ = ([], [])
 
         temp = np.nonzero(~np.in1d(other.time_array, this.time_array))[0]
         if len(temp) > 0:
             tnew_inds = temp
-            new_times = other.time_array[temp]
             if n_axes > 0:
                 history_update_string += ', time'
             else:
                 history_update_string += 'time'
             n_axes += 1
         else:
-            tnew_inds, new_times = ([], [])
+            tnew_inds, _ = ([], [])
 
         # adding along frequency axis is not supported for delay-type cal files
         if this.cal_type == 'gain':
@@ -1070,29 +1068,27 @@ class UVCal(UVBase):
                 ~np.in1d(other.freq_array[0, :], this.freq_array[0, :]))[0]
             if len(temp) > 0:
                 fnew_inds = temp
-                new_freqs = other.freq_array[0, temp]
                 if n_axes > 0:
                     history_update_string += ', frequency'
                 else:
                     history_update_string += 'frequency'
                 n_axes += 1
             else:
-                fnew_inds, new_freqs = ([], [])
+                fnew_inds, _ = ([], [])
         else:
-            fnew_inds, new_freqs = ([], [])
+            fnew_inds, _ = ([], [])
 
         temp = np.nonzero(~np.in1d(other.jones_array,
                                    this.jones_array))[0]
         if len(temp) > 0:
             jnew_inds = temp
-            new_jones = other.jones_array[temp]
             if n_axes > 0:
                 history_update_string += ', jones'
             else:
                 history_update_string += 'jones'
             n_axes += 1
         else:
-            jnew_inds, new_jones = ([], [])
+            jnew_inds, _ = ([], [])
 
         # Initialize tqa variables
         can_combine_tqa = True

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1544,7 +1544,7 @@ class UVData(UVBase):
                 history_update_string += 'frequency'
             n_axes += 1
         else:
-            fnew_inds, _ = ([], [])
+            fnew_inds = []
 
         # find the pol indices in "other" but not in "this"
         temp = np.nonzero(~np.in1d(other.polarization_array,
@@ -1557,7 +1557,7 @@ class UVData(UVBase):
                 history_update_string += 'polarization'
             n_axes += 1
         else:
-            pnew_inds, _ = ([], [])
+            pnew_inds = []
 
         # Actually check compatibility parameters
         for a in compatibility_params:

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1538,28 +1538,26 @@ class UVData(UVBase):
             ~np.in1d(other.freq_array[0, :], this.freq_array[0, :]))[0]
         if len(temp) > 0:
             fnew_inds = temp
-            new_freqs = other.freq_array[0, temp]
             if n_axes > 0:
                 history_update_string += ', frequency'
             else:
                 history_update_string += 'frequency'
             n_axes += 1
         else:
-            fnew_inds, new_freqs = ([], [])
+            fnew_inds, _ = ([], [])
 
         # find the pol indices in "other" but not in "this"
         temp = np.nonzero(~np.in1d(other.polarization_array,
                                    this.polarization_array))[0]
         if len(temp) > 0:
             pnew_inds = temp
-            new_pols = other.polarization_array[temp]
             if n_axes > 0:
                 history_update_string += ', polarization'
             else:
                 history_update_string += 'polarization'
             n_axes += 1
         else:
-            pnew_inds, new_pols = ([], [])
+            pnew_inds, _ = ([], [])
 
         # Actually check compatibility parameters
         for a in compatibility_params:
@@ -2430,16 +2428,16 @@ class UVData(UVBase):
         ValueError
             if filetype is not a known type
         """
-        if filetype is 'uvfits':
+        if filetype == 'uvfits':
             from . import uvfits
             other_obj = uvfits.UVFITS()
-        elif filetype is 'fhd':
+        elif filetype == 'fhd':
             from . import fhd
             other_obj = fhd.FHD()
-        elif filetype is 'miriad':
+        elif filetype == 'miriad':
             from . import miriad
             other_obj = miriad.Miriad()
-        elif filetype is 'uvh5':
+        elif filetype == 'uvh5':
             from . import uvh5
             other_obj = uvh5.UVH5()
         else:
@@ -3686,7 +3684,6 @@ class UVData(UVBase):
         list of tuples of int
             list of unique antpair + pol tuples (ant1, ant2, pol) with data associated with them.
         """
-        bli = 0
         pols = self.get_pols()
         bls = self.get_antpairs()
         return [(bl) + (pol,) for bl in bls for pol in pols]
@@ -4003,10 +4000,10 @@ class UVData(UVBase):
         if squeeze == 'full':
             out = np.squeeze(out)
         elif squeeze == 'default':
-            if out.shape[3] is 1:
+            if out.shape[3] == 1:
                 # one polarization dimension
                 out = np.squeeze(out, axis=3)
-            if out.shape[1] is 1:
+            if out.shape[1] == 1:
                 # one spw dimension
                 out = np.squeeze(out, axis=1)
         elif squeeze != 'none':
@@ -5007,7 +5004,6 @@ class UVData(UVBase):
         # make temporary arrays
         temp_baseline = np.zeros((temp_Nblts,), dtype=np.int)
         temp_time = np.zeros((temp_Nblts,))
-        temp_uvw = np.zeros((temp_Nblts, 3))
         temp_int_time = np.zeros((temp_Nblts,))
         if self.metadata_only:
             temp_data = None

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -5,7 +5,6 @@
 """Class for reading and writing uvfits files."""
 from __future__ import absolute_import, division, print_function
 
-import re
 import warnings
 
 import numpy as np

--- a/pyuvdata/uvflag.py
+++ b/pyuvdata/uvflag.py
@@ -1217,16 +1217,16 @@ class UVFlag(UVBase):
 
             dgrp = f.create_group("Data")
             if self.mode == 'metric':
-                data = dgrp.create_dataset('metric_array', chunks=True,
-                                           data=self.metric_array,
-                                           compression=data_compression)
-                wtsdata = dgrp.create_dataset('weights_array', chunks=True,
-                                              data=self.weights_array,
-                                              compression=data_compression)
+                dgrp.create_dataset('metric_array', chunks=True,
+                                    data=self.metric_array,
+                                    compression=data_compression)
+                dgrp.create_dataset('weights_array', chunks=True,
+                                    data=self.weights_array,
+                                    compression=data_compression)
             elif self.mode == 'flag':
-                data = dgrp.create_dataset('flag_array', chunks=True,
-                                           data=self.flag_array,
-                                           compression=data_compression)
+                dgrp.create_dataset('flag_array', chunks=True,
+                                    data=self.flag_array,
+                                    compression=data_compression)
 
     def __add__(self, other, inplace=False, axis='time',
                 run_check=True, check_extra=True, run_check_acceptability=True):

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -686,12 +686,12 @@ class UVH5(UVData):
                                               data=self.data_array,
                                               compression=data_compression,
                                               dtype=data_write_dtype)
-            flags = dgrp.create_dataset("flags", chunks=True,
-                                        data=self.flag_array,
-                                        compression=flags_compression)
-            nsample_array = dgrp.create_dataset("nsamples", chunks=True,
-                                                data=self.nsample_array.astype(np.float32),
-                                                compression=nsample_compression)
+            dgrp.create_dataset("flags", chunks=True,
+                                data=self.flag_array,
+                                compression=flags_compression)
+            dgrp.create_dataset("nsamples", chunks=True,
+                                data=self.nsample_array.astype(np.float32),
+                                compression=nsample_compression)
 
         return
 
@@ -758,12 +758,12 @@ class UVH5(UVData):
             if data_write_dtype not in ('c8', 'c16'):
                 # make sure the data type is correct
                 _check_uvh5_dtype(data_write_dtype)
-            visdata = dgrp.create_dataset("visdata", data_size, chunks=True,
-                                          dtype=data_write_dtype, compression=data_compression)
-            flags = dgrp.create_dataset("flags", data_size, chunks=True,
-                                        dtype='b1', compression=flags_compression)
-            nsample_array = dgrp.create_dataset("nsamples", data_size, chunks=True,
-                                                dtype='f4', compression=nsample_compression)
+            dgrp.create_dataset("visdata", data_size, chunks=True,
+                                dtype=data_write_dtype, compression=data_compression)
+            dgrp.create_dataset("flags", data_size, chunks=True,
+                                dtype='b1', compression=flags_compression)
+            dgrp.create_dataset("nsamples", data_size, chunks=True,
+                                dtype='f4', compression=nsample_compression)
 
         return
 

--- a/pyuvdata/version.py
+++ b/pyuvdata/version.py
@@ -70,11 +70,6 @@ def construct_version_info():
     with open(version_file) as f:
         version = f.read().strip()
 
-    git_origin = ''
-    git_hash = ''
-    git_description = ''
-    git_branch = ''
-
     version_info = {'version': version, 'git_origin': '', 'git_hash': '',
                     'git_description': '', 'git_branch': ''}
 

--- a/scripts/convert_to_uvfits.py
+++ b/scripts/convert_to_uvfits.py
@@ -3,10 +3,7 @@
 # Copyright (c) 2018 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
 
-"""
-A command-line script for converting
-any pyuvdata compatible file to UVFITS format
-"""
+"""Convert any pyuvdata compatible file to UVFITS format."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/scripts/fhd_batch_convert.py
+++ b/scripts/fhd_batch_convert.py
@@ -16,8 +16,9 @@ from pyuvdata import UVData
 def parse_range(string):
     m = re.match(r'(\d+)(?:-(\d+))?$', string)
     if not m:
-        raise ArgumentTypeError("'" + string + "' is not a range of numbers."
-                                " Expected forms like '0-5' or '2'.")
+        raise argparse.ArgumentTypeError(
+            "'" + string + "' is not a range of numbers. Expected forms "
+            "like '0-5' or '2'.")
     start = int(m.group(1))
     end = int(m.group(2)) or start
 

--- a/scripts/fhd_batch_convert.py
+++ b/scripts/fhd_batch_convert.py
@@ -2,6 +2,7 @@
 # -*- mode: python; coding: utf-8 -*
 # Copyright (c) 2018 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
+"""Convert multiple FHD datasets to UVFITS format."""
 
 
 from __future__ import absolute_import, division, print_function
@@ -14,6 +15,7 @@ from pyuvdata import UVData
 
 
 def parse_range(string):
+    """Parse numbers from a range string."""
     m = re.match(r'(\d+)(?:-(\d+))?$', string)
     if not m:
         raise argparse.ArgumentTypeError(

--- a/scripts/fhd_batch_convert.py
+++ b/scripts/fhd_batch_convert.py
@@ -19,7 +19,8 @@ def parse_range(string):
     m = re.match(r'(\d+)(?:-(\d+))?$', string)
     if not m:
         raise argparse.ArgumentTypeError(
-            "'{}' is not a range of numbers. Expected forms ".format(string))
+            "'{}' is not a range of numbers. Expected forms like '0-5' or '2'."
+            .format(string))
     start = int(m.group(1))
     end = int(m.group(2)) or start
 

--- a/scripts/fhd_batch_convert.py
+++ b/scripts/fhd_batch_convert.py
@@ -17,8 +17,7 @@ def parse_range(string):
     m = re.match(r'(\d+)(?:-(\d+))?$', string)
     if not m:
         raise argparse.ArgumentTypeError(
-            "'" + string + "' is not a range of numbers. Expected forms "
-            "like '0-5' or '2'.")
+            "'{}' is not a range of numbers. Expected forms ".format(string))
     start = int(m.group(1))
     end = int(m.group(2)) or start
 

--- a/scripts/pyuvdata_inspect.py
+++ b/scripts/pyuvdata_inspect.py
@@ -2,6 +2,7 @@
 # -*- mode: python; coding: utf-8 -*
 # Copyright (c) 2018 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
+"""Inspect attributes of pyuvdata objects."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/scripts/readwrite_uvfits.py
+++ b/scripts/readwrite_uvfits.py
@@ -2,6 +2,7 @@
 # -*- mode: python; coding: utf-8 -*
 # Copyright (c) 2018 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
+"""Read in a uvfits file and write a new one out."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/scripts/renumber_ants.py
+++ b/scripts/renumber_ants.py
@@ -47,7 +47,7 @@ if args.filetype == 'uvfits':
 elif args.filetype == 'miriad':
     uv_obj.read_miriad(args.file_in)
 else:
-    raise IOError("didn't recognize filetype {}".format(arge.filetype))
+    raise IOError("didn't recognize filetype {}".format(args.filetype))
 
 large_ant_nums = sorted(list(uv_obj.antenna_numbers[np.where(uv_obj.antenna_numbers > 254)[0]]))
 

--- a/scripts/test_uvfits_equal.py
+++ b/scripts/test_uvfits_equal.py
@@ -2,6 +2,7 @@
 # -*- mode: python; coding: utf-8 -*
 # Copyright (c) 2018 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
+"""Test if two UVData compatible files are equal."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/scripts/uvfits_memtest.py
+++ b/scripts/uvfits_memtest.py
@@ -2,6 +2,7 @@
 # -*- mode: python; coding: utf-8 -*
 # Copyright (c) 2018 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
+"""Test memory usage of read_uvfits."""
 
 from __future__ import absolute_import, division, print_function
 
@@ -14,6 +15,7 @@ from pyuvdata import UVData
 
 @profile
 def read_uvfits():
+    """Test memory usage of read_uvfits."""
     filename = '/Volumes/Data1/mwa_uvfits/1066571272.uvfits'
 
     # first test uvdata.read_uvfits. First read metadata then full data

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,13 @@ test=pytest
 
 [tool:pytest]
 addopts = --ignore=scripts
+
+[flake8]
+ignore = E501, W503
+# maybe we should move to a max line length rather than ignoring E501
+# max-line-length = 100
+# it's recommended to have max-complexity ~ 18
+# we're not there yet
+# max-complexity = 18
+select = B,C,E,W,T4,B9,F
+docstring-convention = numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,22 @@ addopts = --ignore=scripts
 
 [flake8]
 ignore = E501, W503
-# maybe we should move to a max line length rather than ignoring E501
-# max-line-length = 100
-# it's recommended to have max-complexity ~ 18
-# we're not there yet
-# max-complexity = 18
 select = B,C,E,W,T4,B9,F
 docstring-convention = numpy
+# List of other checks to consider adding:
+# move to a max line length rather than ignoring E501
+# max-line-length = 88
+# it's recommended to have max-complexity ~ 18
+# max-complexity = 18
+# flake8-quotes
+# flake8-comprehensions
+# flake8-black
+# flake8-builtins
+# flake8-eradicate
+# pep8-naming
+# flake8-isort
+# flake8-rst-docstrings
+# flake8-rst
+# darglint
+# flake8-copyright
+# flake8-ownership

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ addopts = --ignore=scripts
 
 [flake8]
 ignore = E501, W503
-select = B,C,E,W,T4,B9,F
+select = B,C,E,W,T4,B9,F,D
 docstring-convention = numpy
 # List of other checks to consider adding:
 # move to a max line length rather than ignoring E501

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,13 @@ addopts = --ignore=scripts
 
 [flake8]
 ignore = E501, W503
-select = B,C,E,W,T4,B9,F,D
+# per-file-ignores =
+#     pyuvdata/tests/*.py: D
+#     docs/*.py: D
 docstring-convention = numpy
+select = B,C,E,W,T4,B9,F
+# should add `D` to the above list when we've fully
+# moved to numpy style docstrings.
 # List of other checks to consider adding:
 # move to a max line length rather than ignoring E501
 # max-line-length = 88


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use flake8 for linting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Flake8 catches more things that pycodestyle and helped me find one bug (see #712).
It checks for pep8 plus docstrings, unused imports, variables that are defined but not used and maybe some others. We might want to turn on other things later (e.g. line length limits, max complexity).


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
