### PR TITLE
Fix uvflag npol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ All notable changes to this project will be documented in this file.
 - `utils.apply_uvflag` for applying UVFlag objects to UVData objects
 
 ### Fixed
+- A bug in UVFlag where polarization array states were not updated when using `force_pol` keyword in `to_antenna` and `to_baseline`
 - A bug in UVFlag.to_baseline() where force_pol kwarg did not work for UVData Npols > 1
 - `UVData.read_uvfits` no longer breaks if there are non-ascii bytes in antenna names (which CASA sometimes writes).
-- A bug in UVFlag where polarization array states were not updated when using `force_pol` keyword in `to_antenna` and `to_baseline`
 
 ## [1.4.2] - 2019-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - A bug in UVFlag.to_baseline() where force_pol kwarg did not work for UVData Npols > 1
 - `UVData.read_uvfits` no longer breaks if there are non-ascii bytes in antenna names (which CASA sometimes writes).
+- A bug in UVFlag where polarization array states were not updated when using `force_pol` keyword in `to_antenna` and `to_baseline`
 
 ## [1.4.2] - 2019-10-15
 

--- a/pyuvdata/tests/test_uvflag.py
+++ b/pyuvdata/tests/test_uvflag.py
@@ -2573,8 +2573,7 @@ def test_to_antenna_collapsed_pols(uvf_from_uvcal):
     assert uvf.pol_collapsed
     assert uvf.check()
 
+    uvf.to_waterfall()
     uvf.to_antenna(uvc, force_pol=True)
-    print(uvc.jones_array)
-
     assert not uvf.pol_collapsed
     assert uvf.check()

--- a/pyuvdata/tests/test_uvflag.py
+++ b/pyuvdata/tests/test_uvflag.py
@@ -2560,3 +2560,21 @@ def test_inequality_different_classes(uvf_from_miriad):
     other_class = test_class()
 
     assert uvf.__ne__(other_class, check_history=False)
+
+
+def test_to_antenna_collapsed_pols(uvf_from_uvcal):
+    uvf = uvf_from_uvcal
+
+    assert not uvf.pol_collapsed
+    uvc = UVCal()
+    uvc.read_calfits(test_c_file)
+
+    uvf.collapse_pol()
+    assert uvf.pol_collapsed
+    assert uvf.check()
+
+    uvf.to_antenna(uvc, force_pol=True)
+    print(uvc.jones_array)
+
+    assert not uvf.pol_collapsed
+    assert uvf.check()

--- a/pyuvdata/uvflag.py
+++ b/pyuvdata/uvflag.py
@@ -2111,6 +2111,7 @@ class UVFlag(UVBase):
             else:
                 self.metric_array = self.metric_array.repeat(self.polarization_array.size, axis=-1)
                 self.weights_array = self.weights_array.repeat(self.polarization_array.size, axis=-1)
+            self.Npols = len(self.polarization_array)
         # Now the pol axes should match regardless of force_pol.
         if not np.array_equal(polarr, self.polarization_array):
             if self.polarization_array.size == 1:

--- a/pyuvdata/uvflag.py
+++ b/pyuvdata/uvflag.py
@@ -1967,6 +1967,7 @@ class UVFlag(UVBase):
                 self.metric_array = self.metric_array.repeat(self.polarization_array.size, axis=-1)
                 self.weights_array = self.weights_array.repeat(self.polarization_array.size, axis=-1)
             self.Npols = len(self.polarization_array)
+            self._check_pol_state()
 
         # Now the pol axes should match regardless of force_pol.
         if not np.array_equal(uv.polarization_array, self.polarization_array):
@@ -2112,6 +2113,8 @@ class UVFlag(UVBase):
                 self.metric_array = self.metric_array.repeat(self.polarization_array.size, axis=-1)
                 self.weights_array = self.weights_array.repeat(self.polarization_array.size, axis=-1)
             self.Npols = len(self.polarization_array)
+            self._check_pol_state()
+
         # Now the pol axes should match regardless of force_pol.
         if not np.array_equal(polarr, self.polarization_array):
             if self.polarization_array.size == 1:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
designed to fix HERA-Team/hera_qm#309
## Description
<!--- Describe your changes in detail -->
set Npols in `to_antenna`, add a check_pol_state call after `force_pol` is used
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes a bug where the UVFlag polarization array was not handled typed properly after a call with `force pol`
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
