### PR TITLE
Uvflag x orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - `utils.apply_uvflag` for applying UVFlag objects to UVData objects
 
 ### Fixed
-- a but in `UVFlag` where `x_orientation` was not set during initialization.
+- a bug in `UVFlag` where `x_orientation` was not set during initialization.
 - A bug in `UVCal.read_fhd_cal` that caused calibration solutions to be approximately doubled.
 - A bug in UVFlag where polarization array states were not updated when using `force_pol` keyword in `to_antenna` and `to_baseline`
 - A bug in UVFlag.to_baseline() where force_pol kwarg did not work for UVData Npols > 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - `utils.apply_uvflag` for applying UVFlag objects to UVData objects
 
 ### Fixed
+- a but in `UVFlag` where `x_orientation` was not set during initialization.
 - A bug in `UVCal.read_fhd_cal` that caused calibration solutions to be approximately doubled.
 - A bug in UVFlag where polarization array states were not updated when using `force_pol` keyword in `to_antenna` and `to_baseline`
 - A bug in UVFlag.to_baseline() where force_pol kwarg did not work for UVData Npols > 1

--- a/pyuvdata/tests/test_uvflag.py
+++ b/pyuvdata/tests/test_uvflag.py
@@ -149,6 +149,14 @@ def test_init_UVData():
     assert uvf.label == 'test'
 
 
+def test_init_UVData_x_orientation():
+    uv = UVData()
+    uv.read_miriad(test_d_file)
+    uv.x_orientation = 'east'
+    uvf = UVFlag(uv, history='I made a UVFlag object', label='test')
+    assert uvf.x_orientation == uv.x_orientation
+
+
 def test_init_UVData_copy_flags():
     uv = UVData()
     uv.read_miriad(test_d_file)
@@ -206,6 +214,7 @@ def test_init_UVCal():
     assert uvf.type == 'antenna'
     assert uvf.mode == 'metric'
     assert np.all(uvf.time_array == uvc.time_array)
+    assert uvf.x_orientation == uvc.x_orientation
     lst = lst_from_uv(uvc)
     assert np.all(uvf.lst_array == lst)
     assert np.all(uvf.freq_array == uvc.freq_array[0])

--- a/pyuvdata/uvflag.py
+++ b/pyuvdata/uvflag.py
@@ -1579,6 +1579,9 @@ class UVFlag(UVBase):
                     self.metric_array = (np.zeros_like(input.flag_array)
                                          .astype(np.float))
 
+        if input.x_orientation is not None:
+            self.x_orientation = input.x_orientation
+
         if self.mode == "metric":
             self.weights_array = np.ones(self.metric_array.shape)
 
@@ -1707,6 +1710,9 @@ class UVFlag(UVBase):
                                          .astype(np.float))
         if self.mode == "metric":
             self.weights_array = np.ones(self.metric_array.shape)
+
+        if input.x_orientation is not None:
+            self.x_orientation = input.x_orientation
 
         if history not in self.history:
             self.history += history


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Has uvflag set x_orientation when initialized from uvdata or uvcal
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Currently does not check `x_orientation` of input objects in `from_uvcal` and `from_uvdata` but has support for `x_orientation` elsewhere.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
