### PR TITLE
explicitly add pip in linting ci

### DIFF
--- a/ci/pyuvdata_linting.yml
+++ b/ci/pyuvdata_linting.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - flake8
+  - pip
   - pip:
     - flake8-docstrings
     - flake8-pytest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
adds `pip` explicitly to the linting ci to get rid of this warning:

>Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
