### PR TITLE
Make calls to jstr2num inside a UVCal object use self.x_orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - A bug in UVFlag where polarization array states were not updated when using `force_pol` keyword in `to_antenna` and `to_baseline`
 - A bug in UVFlag.to_baseline() where force_pol kwarg did not work for UVData Npols > 1
 - `UVData.read_uvfits` no longer breaks if there are non-ascii bytes in antenna names (which CASA sometimes writes).
+- A bug in `UVCal` objects that prevented them from properly getting data with `ee`/`nn`-style polarizations.
 
 ## [1.4.2] - 2019-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ All notable changes to this project will be documented in this file.
 - `utils.apply_uvflag` for applying UVFlag objects to UVData objects
 
 ### Fixed
+- A bug in `UVCal` objects that prevented them from properly getting data with `ee`/`nn`-style polarizations.
 - a bug in `UVFlag` where `x_orientation` was not set during initialization.
 - A bug in `UVCal.read_fhd_cal` that caused calibration solutions to be approximately doubled.
 - A bug in UVFlag where polarization array states were not updated when using `force_pol` keyword in `to_antenna` and `to_baseline`
 - A bug in UVFlag.to_baseline() where force_pol kwarg did not work for UVData Npols > 1
 - `UVData.read_uvfits` no longer breaks if there are non-ascii bytes in antenna names (which CASA sometimes writes).
-- A bug in `UVCal` objects that prevented them from properly getting data with `ee`/`nn`-style polarizations.
 
 ## [1.4.2] - 2019-10-15
 

--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -1443,7 +1443,7 @@ def test_uvcal_get_methods():
     uvc.read_calfits(os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits'))
 
     # test get methods: add in a known value and make sure it is returned
-    key = (10, 'Jxx')
+    key = (10, 'Jee')
     uvc.gain_array[1] = 0.0
     d, f, q = uvc.get_gains(key), uvc.get_flags(key), uvc.get_quality(key)
 
@@ -1470,14 +1470,14 @@ def test_uvcal_get_methods():
 
     # check has_key
     assert uvc._has_key(antnum=10)
-    assert uvc._has_key(jpol='Jxx')
-    assert uvc._has_key(antnum=10, jpol='Jxx')
-    assert not uvc._has_key(antnum=10, jpol='Jyy')
-    assert not uvc._has_key(antnum=101, jpol='Jxx')
+    assert uvc._has_key(jpol='Jee')
+    assert uvc._has_key(antnum=10, jpol='Jee')
+    assert not uvc._has_key(antnum=10, jpol='Jnn')
+    assert not uvc._has_key(antnum=101, jpol='Jee')
 
     # test exceptions
     pytest.raises(ValueError, uvc.get_gains, 1)
-    pytest.raises(ValueError, uvc.get_gains, (10, 'Jyy'))
+    pytest.raises(ValueError, uvc.get_gains, (10, 'Jnn'))
     uvc.cal_type = 'delay'
     pytest.raises(ValueError, uvc.get_gains, 10)
 

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -761,7 +761,7 @@ class UVCal(UVBase):
             Index in data arrays
         """
         if isinstance(jpol, (str, np.str)):
-            jpol = uvutils.jstr2num(jpol)
+            jpol = uvutils.jstr2num(jpol, x_orientation=self.x_orientation)
 
         if not self._has_key(jpol=jpol):
             raise ValueError("{} not found in jones_array".format(jpol))
@@ -777,7 +777,7 @@ class UVCal(UVBase):
                 return False
         if jpol is not None:
             if isinstance(jpol, (str, np.str)):
-                jpol = uvutils.jstr2num(jpol)
+                jpol = uvutils.jstr2num(jpol, x_orientation=self.x_orientation)
             if jpol not in self.jones_array:
                 return False
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes a bug that prevents UVCal objects from using the `'Jee'`/`'Jnn'` format for `get_data()`, etc. See #723 for more detail.

## Description
<!--- Describe your changes in detail -->
The relevant functions now use UVCal's `self.x_orientation` explicitly. Added a test to expose the issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

This closes #723.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass in both python 2 and python 3.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Breaking change checklist:  
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass in both python 2 and python 3.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
