### PR TITLE
Error if baselines appear in multiple redundant groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - `utils.apply_uvflag` for applying UVFlag objects to UVData objects
 
 ### Fixed
+- Redundancy finder will now error if any baselines appear in multiple groups.
 - A bug in `UVCal` objects that prevented them from properly getting data with `ee`/`nn`-style polarizations.
 - a bug in `UVFlag` where `x_orientation` was not set during initialization.
 - A bug in `UVCal.read_fhd_cal` that caused calibration solutions to be approximately doubled.

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -570,7 +570,7 @@ def test_redundancy_finder():
                               lens[gi], atol=tol)
 
 
-def test_hitol_redundancy():
+def test_high_tolerance_redundancy_error():
     """
     Confirm that an error is raised if the redundancy tolerance is set too high,
     such that baselines end up in multiple

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -588,7 +588,7 @@ def test_high_tolerance_redundancy_error():
     with pytest.raises(ValueError) as cm:
         baseline_groups, vec_bin_centers, lens, conjugates = uvutils.get_baseline_redundancies(
             uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True)
-    assert "Tolerance is too high." in str(cm.value)
+    assert "Some baselines are falling into" in str(cm.value)
 
 
 def test_redundancy_conjugates():

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -570,6 +570,27 @@ def test_redundancy_finder():
                               lens[gi], atol=tol)
 
 
+def test_hitol_redundancy():
+    """
+    Confirm that an error is raised if the redundancy tolerance is set too high,
+    such that baselines end up in multiple
+    """
+    uvd = pyuvdata.UVData()
+    uvd.read_uvfits(os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'))
+
+    uvd.select(times=uvd.time_array[0])
+    uvd.unphase_to_drift(use_ant_pos=True)   # uvw_array is now equivalent to baseline positions
+    uvd.conjugate_bls(convention='ant1<ant2', use_enu=True)
+    bl_positions = uvd.uvw_array
+
+    tol = 20.05  # meters
+
+    with pytest.raises(ValueError) as cm:
+        baseline_groups, vec_bin_centers, lens, conjugates = uvutils.get_baseline_redundancies(
+            uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True)
+    assert "Tolerance is too high." in str(cm.value)
+
+
 def test_redundancy_conjugates():
     # Check that the correct baselines are flipped when returning redundancies with conjugates.
 

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -3858,7 +3858,7 @@ def test_redundancy_contract_expand_nblts_not_nbls_times_ntimes():
 def test_compress_redundancy_metadata_only():
     uv0 = UVData()
     uv0.read_uvfits(os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'))
-    tol = 0.01
+    tol = 0.05
 
     # Assign identical data to each redundant group:
     red_gps, centers, lengths = uv0.get_redundancies(tol=tol, use_antpos=True, conjugate_bls=True)

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1390,6 +1390,10 @@ def get_baseline_redundancies(baselines, baseline_vecs, tol=1.0, with_conjugates
 
     lens = np.sqrt(np.sum(vec_bin_centers**2, axis=1))
 
+    if np.sum([len(bg) for bg in bl_gps]) > Nbls:
+        raise ValueError("Tolerance is too high. Some baselines are falling into multiple"
+                         " redundant groups.")
+
     return bl_gps, vec_bin_centers, lens
 
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1389,10 +1389,9 @@ def get_baseline_redundancies(baselines, baseline_vecs, tol=1.0, with_conjugates
         vec_bin_centers[gi] = np.mean(baseline_vecs[inds, :], axis=0)
 
     lens = np.sqrt(np.sum(vec_bin_centers**2, axis=1))
-
     if np.sum([len(bg) for bg in bl_gps]) > Nbls:
-        raise ValueError("Tolerance is too high. Some baselines are falling into multiple"
-                         " redundant groups.")
+        raise ValueError("Some baselines are falling into multiple"
+                         " redundant groups. Redundancy tolerance is causing ambiguity.")
 
     return bl_gps, vec_bin_centers, lens
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1391,7 +1391,7 @@ def get_baseline_redundancies(baselines, baseline_vecs, tol=1.0, with_conjugates
     lens = np.sqrt(np.sum(vec_bin_centers**2, axis=1))
     if np.sum([len(bg) for bg in bl_gps]) > Nbls:
         raise ValueError("Some baselines are falling into multiple"
-                         " redundant groups. Redundancy tolerance is causing ambiguity.")
+                         " redundant groups. Lower the tolerance to resolve ambiguity.")
 
     return bl_gps, vec_bin_centers, lens
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Checks that the total number of baselines in redundant groups does not exceed the total number of baselines given to the finder. This ensures that baselines are only assigned to one group each.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Redundancy is defined to within a tolerance. If this tolerance is too high, baselines can appear in multiple "redundant" groups, but this is physically meaningless. The redundancy finder should error instead.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #615 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).