### PR TITLE
Add routine mwa flagging for edge channels, beginning/end of obs, center channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Routine flagging of MWA coarse band edges and center channels, as well as beginning and end integrations. Only done during `read_mwa_corr_fits`.
+
 ## [1.5.0] - 2020-1-15
 
 ### Added

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -184,7 +184,8 @@ i) MWA correlator -> uvfits
 
    # Use the file type specific read_mwa_corr_fits
    # Apply cable corrections and phase data before writing to uvfits
-   >>> UV.read_mwa_corr_fits(filelist, correct_cable_len=True, phase_data=True)
+   # Skip routine time/frequency flagging - see flag_init and associated keywords in documentation
+   >>> UV.read_mwa_corr_fits(filelist, correct_cable_len=True, phase_data=True, flag_init=False)
 
    # Write out uvfits file
    >>> UV.write_uvfits('tutorial.uvfits', spoof_nonessential=True)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -173,6 +173,13 @@ h) uvfits -> uvh5
 
 i) MWA correlator -> uvfits
 *****************
+The MWA correlator writes FITS files containing the correlator dumps (but
+lacking metadata and not conforming to the uvfits format). pyuvdata can read
+these files along with MWA metafits files (containing the required metadata)
+into a UVData object which can then be written out to uvfits or any other
+supported file type. There are also options for applying cable length corrections,
+common flagging patterns and phasing the data to the pointing center.
+
 ::
 
    >>> from pyuvdata import UVData
@@ -182,10 +189,14 @@ i) MWA correlator -> uvfits
    >>> data_path = 'pyuvdata/data/mwa_corr_fits_testfiles/'
    >>> filelist = [data_path + i for i in ['1131733552.metafits', '1131733552_20151116182537_mini_gpubox01_00.fits']]
 
-   # Use the file type specific read_mwa_corr_fits
+   # Use the `read` method, optionally specify the file type. Can also use the
+   # file type specific `read_mwa_corr_fits` method, but only if reading files
+   # from a single observation.
    # Apply cable corrections and phase data before writing to uvfits
    # Skip routine time/frequency flagging - see flag_init and associated keywords in documentation
-   >>> UV.read_mwa_corr_fits(filelist, correct_cable_len=True, phase_data=True, flag_init=False)
+   >>> UV.read(filelist, correct_cable_len=True, phase_to_pointing_center=True, flag_init=False)
+   >>> UV.read(filelist, file_type='mwa_corr_fits', correct_cable_len=True, phase_to_pointing_center=True, flag_init=False)
+   >>> UV.read_mwa_corr_fits(filelist, correct_cable_len=True, phase_to_pointing_center=True, flag_init=False)
 
    # Write out uvfits file
    >>> UV.write_uvfits('tutorial.uvfits', spoof_nonessential=True)

--- a/pyuvdata/mwa_corr_fits.py
+++ b/pyuvdata/mwa_corr_fits.py
@@ -139,7 +139,7 @@ class MWACorrFITS(UVData):
     def read_mwa_corr_fits(self, filelist, use_cotter_flags=False, correct_cable_len=False,
                            phase_to_pointing_center=False, run_check=True, check_extra=True,
                            run_check_acceptability=True, flag_init=False,
-                           edge_width=80e3, start_flag=4.0, end_flag=6.0,
+                           edge_width=80e3, start_flag=2.0, end_flag=2.0,
                            flag_dc_offset=True):
         """
         Read in MWA correlator gpu box files.

--- a/pyuvdata/mwa_corr_fits.py
+++ b/pyuvdata/mwa_corr_fits.py
@@ -78,11 +78,14 @@ class MWACorrFITS(UVData):
         Parameters
         ----------
         edge_width: float
-            The width to flag on the edge of each coarse channel, in hz.
+            The width to flag on the edge of each coarse channel, in hz. Set to
+            0 for no edge flagging.
         start_flag: float
             The number of seconds to flag at the beginning of the observation.
+            Set to 0 for no flagging.
         end_flag: floats
-            The number of seconds to flag at the end of the observation.
+            The number of seconds to flag at the end of the observation. Set to
+            0 for no flagging.
         flag_dc_offset: bool
             Set to True to flag the center fine channel of each coarse channel.
 
@@ -182,14 +185,14 @@ class MWACorrFITS(UVData):
             channel. See associated keywords.
         edge_width: float
             Only used if flag_init is True. The width to flag on the edge of
-            each coarse channel, in hz. Errors if less than the channel_width of
-            the observation.
+            each coarse channel, in hz. Errors if not equal to integer multiple
+            of channel_width. Set to 0 for no edge flagging.
         start_flag: float
             Only used if flag_init is True. The number of seconds to flag at the
-            beginning of the observation.
+            beginning of the observation. Set to 0 for no flagging.
         end_flag: floats
             Only used if flag_init is True. The number of seconds to flag at the
-            end of the observation.
+            end of the observation. Set to 0 for no flagging.
         flag_dc_offset: bool
             Only used if flag_init is True. Set to True to flag the center fine
             channel of each coarse channel.

--- a/pyuvdata/mwa_corr_fits.py
+++ b/pyuvdata/mwa_corr_fits.py
@@ -137,8 +137,6 @@ class MWACorrFITS(UVData):
                 self.flag_array[-num_end_flag:, :, :, :, :] = True
             self.flag_array = np.reshape(self.flag_array, shape)
 
-
-
     def read_mwa_corr_fits(self, filelist, use_cotter_flags=False, correct_cable_len=False,
                            phase_to_pointing_center=False, run_check=True, check_extra=True,
                            run_check_acceptability=True, flag_init=False,

--- a/pyuvdata/mwa_corr_fits.py
+++ b/pyuvdata/mwa_corr_fits.py
@@ -122,7 +122,7 @@ class MWACorrFITS(UVData):
             self.flag_array[:, :, edge_inds, :] = True
 
         if flag_dc_offset:
-            center_inds = list(range(num_fine_chan / 2, self.Nfreqs, num_fine_chan))
+            center_inds = list(range(num_fine_chan // 2, self.Nfreqs, num_fine_chan))
 
             self.flag_array[:, :, center_inds, :] = True
 

--- a/pyuvdata/mwa_corr_fits.py
+++ b/pyuvdata/mwa_corr_fits.py
@@ -69,8 +69,8 @@ class MWACorrFITS(UVData):
         self.data_array *= np.exp(-1j * 2 * np.pi * cable_len_diffs / const.c.to('m/s').value
                                   * self.freq_array.reshape(1, self.Nfreqs))[:, :, None]
 
-    def flag_init(self, edge_width=80e3, start_flag=4.0, end_flag=6.0,
-                  flag_dc_offset=True):
+    def flag_init(self, num_fine_chan, edge_width=80e3, start_flag=4.0,
+                  end_flag=6.0, flag_dc_offset=True):
         """
         Do routine flagging of the edges, beginning and end of obs, as well as
         the center fine channel of each coarse channel.
@@ -109,10 +109,6 @@ class MWACorrFITS(UVData):
         num_ch_flag = int(edge_width / self.channel_width)
         num_start_flag = int(start_flag / self.integration_time)
         num_end_flag = int(end_flag / self.integration_time)
-
-        # Constant from the DSP architecture
-        num_coarse_chan = 24
-        num_fine_chan = len(self.Nfreqs) / num_coarse_chan
 
         if num_ch_flag > 0:
             edge_inds = []
@@ -593,8 +589,9 @@ class MWACorrFITS(UVData):
             self.phase(ra_rad, dec_rad)
 
         if flag_init:
-            self.flag_init(edge_width=edge_width, start_flag=start_flag,
-                           end_flag=end_flag, flag_dc_offset=flag_dc_offset)
+            self.flag_init(num_fine_chans, edge_width=edge_width,
+                           start_flag=start_flag, end_flag=end_flag,
+                           flag_dc_offset=flag_dc_offset)
 
         if use_cotter_flags:
             raise NotImplementedError('reading in cotter flag files is not yet available')

--- a/pyuvdata/mwa_corr_fits.py
+++ b/pyuvdata/mwa_corr_fits.py
@@ -69,8 +69,8 @@ class MWACorrFITS(UVData):
         self.data_array *= np.exp(-1j * 2 * np.pi * cable_len_diffs / const.c.to('m/s').value
                                   * self.freq_array.reshape(1, self.Nfreqs))[:, :, None]
 
-    def flag_init(self, num_fine_chan, edge_width=80e3, start_flag=4.0,
-                  end_flag=6.0, flag_dc_offset=True):
+    def flag_init(self, num_fine_chan, edge_width=80e3, start_flag=2.0,
+                  end_flag=2.0, flag_dc_offset=True):
         """
         Do routine flagging of the edges, beginning and end of obs, as well as
         the center fine channel of each coarse channel.

--- a/pyuvdata/mwa_corr_fits.py
+++ b/pyuvdata/mwa_corr_fits.py
@@ -116,7 +116,7 @@ class MWACorrFITS(UVData):
                 # count up from the left
                 left_chans = list(range(ch_count, self.Nfreqs, num_fine_chan))
                 # count down from the right
-                right_chans = list(range(self.Nfreqs - 1 - ch_count, 0, -num_fine_chans))
+                right_chans = list(range(self.Nfreqs - 1 - ch_count, 0, -num_fine_chan))
                 edge_inds = edge_inds + left_chans + right_chans
 
             self.flag_array[:, :, edge_inds, :] = True

--- a/pyuvdata/mwa_corr_fits.py
+++ b/pyuvdata/mwa_corr_fits.py
@@ -138,7 +138,7 @@ class MWACorrFITS(UVData):
 
     def read_mwa_corr_fits(self, filelist, use_cotter_flags=False, correct_cable_len=False,
                            phase_to_pointing_center=False, run_check=True, check_extra=True,
-                           run_check_acceptability=True, flag_init=False,
+                           run_check_acceptability=True, flag_init=True,
                            edge_width=80e3, start_flag=2.0, end_flag=2.0,
                            flag_dc_offset=True):
         """

--- a/pyuvdata/mwa_corr_fits.py
+++ b/pyuvdata/mwa_corr_fits.py
@@ -99,16 +99,16 @@ class MWACorrFITS(UVData):
         if (edge_width % self.channel_width) > 0:
             raise ValueError("The edge_width must be an integer multiple of the"
                              "channel_width of the data or zero.")
-        if (start_flag % self.integration_time) > 0:
+        if (start_flag % self.integration_time[0]) > 0:
             raise ValueError("The start_flag must be an integer multiple of the"
                              "integration_time of the data or zero.")
-        if (end_flag % self.integration_time) > 0:
+        if (end_flag % self.integration_time[0]) > 0:
             raise ValueError("The end_flag must be an integer multiple of the"
                              "integration_time of the data or zero.")
 
         num_ch_flag = int(edge_width / self.channel_width)
-        num_start_flag = int(start_flag / self.integration_time)
-        num_end_flag = int(end_flag / self.integration_time)
+        num_start_flag = int(start_flag / self.integration_time[0])
+        num_end_flag = int(end_flag / self.integration_time[0])
 
         if num_ch_flag > 0:
             edge_inds = []

--- a/pyuvdata/mwa_corr_fits.py
+++ b/pyuvdata/mwa_corr_fits.py
@@ -185,10 +185,12 @@ class MWACorrFITS(UVData):
             of channel_width. Set to 0 for no edge flagging.
         start_flag: float
             Only used if flag_init is True. The number of seconds to flag at the
-            beginning of the observation. Set to 0 for no flagging.
+            beginning of the observation. Set to 0 for no flagging. Errors if
+            not equal to an integer multiple of the integration time.
         end_flag: floats
             Only used if flag_init is True. The number of seconds to flag at the
-            end of the observation. Set to 0 for no flagging.
+            end of the observation. Set to 0 for no flagging. Errors if not
+            equal to an integer multiple of the integration time.
         flag_dc_offset: bool
             Only used if flag_init is True. Set to True to flag the center fine
             channel of each coarse channel.

--- a/pyuvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/tests/test_mwa_corr_fits.py
@@ -348,7 +348,9 @@ def test_flag_init():
     # give noninteger multiple inputs
     with pytest.raises(ValueError):
         uv.read(flag_testfiles, flag_init=True, start_flag=0, end_flag=0, edge_width=90e3)
+    with pytest.raises(ValueError):
         uv.read(flag_testfiles, flag_init=True, start_flag=1.2, end_flag=0)
+    with pytest.raises(ValueError):
         uv.read(flag_testfiles, flag_init=True, start_flag=0, end_flag=1.2)
 
     for path in [spoof_file1, spoof_file6]:

--- a/pyuvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/tests/test_mwa_corr_fits.py
@@ -334,8 +334,10 @@ def test_flag_init():
     uv = UVData()
     uv.read(flag_testfiles, flag_init=True, start_flag=0, end_flag=0)
     freq_inds = [0, 1, 4, 6, 7, 8, 9, 12, 14, 15]
+    freq_inds_complement = [ind for ind in range(16) if ind not in freq_inds]
 
     assert np.all(uv.flag_array[:, :, freq_inds, :]), "Not all of edge and center channels are flagged!"
+    assert not np.any(np.all(uv.flag_array[:, :, freq_inds_complement, :], axis=(0, 1, -1))), "Some non-edge/center channels are entirely flagged!"
 
     uv.read(flag_testfiles, flag_init=True, start_flag=1.0, end_flag=1.0,
             edge_width=0, flag_dc_offset=False)

--- a/pyuvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/tests/test_mwa_corr_fits.py
@@ -307,7 +307,6 @@ def test_flag_init():
     spoof_file6 = os.path.join(DATA_PATH, 'test/spoof_06_00.fits')
     # spoof box files of the appropriate size
     with fits.open(filelist[1]) as mini1:
-        print(len(mini1))
         mini1[1].data = np.repeat(mini1[1].data, 8, axis=0)
         extra_dat = np.copy(mini1[1].data)
         for app_ind in range(2):
@@ -334,9 +333,7 @@ def test_flag_init():
 
     uv = UVData()
     uv.read(flag_testfiles, flag_init=True, start_flag=0, end_flag=0)
-    test_flags = np.zeros_like(uv.flag_array)
     freq_inds = [0, 1, 4, 6, 7, 8, 9, 12, 14, 15]
-    print(uv.Ntimes)
 
     assert np.all(uv.flag_array[:, :, freq_inds, :]), "Not all of edge and center channels are flagged!"
 

--- a/pyuvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/tests/test_mwa_corr_fits.py
@@ -313,7 +313,7 @@ def test_flag_init():
             mini1.append(fits.ImageHDU(extra_dat))
         mini1[2].header['MILLITIM'] = 500
         mini1[2].header['TIME'] = mini1[1].header['TIME']
-        mini1[3].header['MILLITIM'] = 1000
+        mini1[3].header['MILLITIM'] = 0
         mini1[3].header['TIME'] = mini1[1].header['TIME'] + 1
         print(mini1[1].data.shape)
         mini1.writeto(spoof_file1)
@@ -325,7 +325,7 @@ def test_flag_init():
             mini6.append(fits.ImageHDU(extra_dat))
         mini6[2].header['MILLITIM'] = 500
         mini6[2].header['TIME'] = mini6[1].header['TIME']
-        mini6[3].header['MILLITIM'] = 1000
+        mini6[3].header['MILLITIM'] = 0
         mini6[3].header['TIME'] = mini6[1].header['TIME'] + 1
         mini6.writeto(spoof_file6)
 

--- a/pyuvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/tests/test_mwa_corr_fits.py
@@ -312,7 +312,7 @@ def test_flag_init():
         for app_ind in range(2):
             mini1.append(fits.ImageHDU(extra_dat))
         mini1[2].header['MILLITIM'] = 500
-        mini1[2].header['TIME'] = mini1[1].header['TIME'] + 0.5
+        mini1[2].header['TIME'] = mini1[1].header['TIME']
         mini1[3].header['MILLITIM'] = 1000
         mini1[3].header['TIME'] = mini1[1].header['TIME'] + 1
         print(mini1[1].data.shape)
@@ -324,7 +324,7 @@ def test_flag_init():
         for app_ind in range(2):
             mini6.append(fits.ImageHDU(extra_dat))
         mini6[2].header['MILLITIM'] = 500
-        mini6[2].header['TIME'] = mini6[1].header['TIME'] + 0.5
+        mini6[2].header['TIME'] = mini6[1].header['TIME']
         mini6[3].header['MILLITIM'] = 1000
         mini6[3].header['TIME'] = mini6[1].header['TIME'] + 1
         mini6.writeto(spoof_file6)
@@ -345,7 +345,7 @@ def test_flag_init():
     time_inds = [0, 1, -1, -2]
     assert np.all(uv.flag_array.reshape(reshape)[time_inds, :, :, :, :]), "Not all of start and end times are flagged."
     # Check that it didn't just flag everything
-    assert not np.all(uv.flag_array.reshape(reshape)[2:-2, :, :, :, :]), "All the data is flagged!"
+    assert not np.any(np.all(uv.flag_array.reshape(reshape)[2:-2, :, :, :, :], axis=(1, 2, 3, 4))), "All the data is flagged for some intermediate times!"
 
     # give noninteger multiple inputs
     with pytest.raises(ValueError):

--- a/pyuvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/tests/test_mwa_corr_fits.py
@@ -300,29 +300,29 @@ def test_flag_init():
     """
     Test that routine MWA flagging works as intended.
     """
-    spoof_file1 = os.path.join(DATA_PATH, 'test/spoof1.fits')
-    spoof_file6 = os.path.join(DATA_PATH, 'test/spoof6.fits')
+    spoof_file1 = os.path.join(DATA_PATH, 'test/spoof_01_00.fits')
+    spoof_file6 = os.path.join(DATA_PATH, 'test/spoof_06_00.fits')
     # spoof box files of the appropriate size
     with fits.open(filelist[1]) as mini1:
         mini1[1].data = np.repeat(mini1[1].data, 8, axis=0)
         extra_dat = np.copy(mini1[1].data)
         for app_ind in range(2):
             mini1.append(fits.ImageHDU(extra_dat))
-        mini1[2].header['MILLITIM'] = 0
-        mini1[3].header['MILLITIM'] = 500
+        mini1[2].header['MILLITIM'] = 500
+        mini1[2].header['TIME'] = mini1[1].header['TIME'] + 0.5
         mini1[3].header['MILLITIM'] = 1000
-        mini1[3].header['TIME'] = mini1[1].header + 1
+        mini1[3].header['TIME'] = mini1[1].header['TIME'] + 1
         mini1.writeto(spoof_file1)
 
     with fits.open(filelist[2]) as mini6:
         mini6[1].data = np.repeat(mini6[1].data, 8, axis=0)
         extra_dat = np.copy(mini6[1].data)
         for app_ind in range(2):
-            mini6[1].append(fits.ImageHDU(extra_dat))
-        mini6[2].header['MILLITIM'] = 0
-        mini6[3].header['MILLITIM'] = 500
+            mini6.append(fits.ImageHDU(extra_dat))
+        mini6[2].header['MILLITIM'] = 500
+        mini6[2].header['TIME'] = mini6[1].header['TIME'] + 0.5
         mini6[3].header['MILLITIM'] = 1000
-        mini6[3].header['TIME'] = mini6[1].header + 1
+        mini6[3].header['TIME'] = mini6[1].header['TIME'] + 1
         mini6.writeto(spoof_file6)
 
     uv = UVData()

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3235,7 +3235,7 @@ class UVData(UVBase):
 
     def read_mwa_corr_fits(self, filelist, axis=None, use_cotter_flags=False,
                            correct_cable_len=False, flag_init=False,
-                           edge_width=80e3, start_flag=4.0, end_flag=6.0,
+                           edge_width=80e3, start_flag=2.0, end_flag=2.0,
                            flag_dc_offset=True, phase_to_pointing_center=False,
                            phase_data=None, phase_center=None, run_check=True,
                            check_extra=True, run_check_acceptability=True):

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3262,6 +3262,26 @@ class UVData(UVBase):
             will only be applied to missing data and bad antennas.
         correct_cable_len : bool
             Option to apply a cable delay correction.
+        flag_init: bool
+            Set to True in order to do routine flagging of coarse channel edges,
+            start or end integrations, or the center fine channel of each coarse
+            channel. See associated keywords.
+        edge_width: float
+            Only used if flag_init is True. Set to the width to flag on the edge
+            of each coarse channel, in hz. Errors if not equal to integer
+            multiple of channel_width. Set to 0 for no edge flagging.
+        start_flag: float
+            Only used if flag_init is True. Set to the number of seconds to flag
+            at the beginning of the observation. Set to 0 for no flagging.
+            Errors if not an integer multiple of the integration time.
+        end_flag: floats
+            Only used if flag_init is True. Set to the number of seconds to flag
+            at the end of the observation. Set to 0 for no flagging. Errors if
+            not an integer multiple of the integration time.
+        flag_dc_offset: bool
+            Only used if flag_init is True. Set to True to flag the center fine
+            channel of each coarse channel. Only used if file_type is
+            'mwa_corr_fits'.
         phase_to_pointing_center : bool
             Option to phase to the observation pointing center.
         phase_data : bool
@@ -3827,26 +3847,29 @@ class UVData(UVBase):
             Flag to apply cable length correction. Only used if file_type is
             'mwa_corr_fits'.
         flag_init: bool
-            Set to True in order to do routine flagging of coarse channel edges,
-            start or end integrations, or the center fine channel of each coarse
-            channel. See associated keywords. Only used if file_type is
-            'mwa_corr_fits'.
+            Only used if file_type is 'mwa_corr_fits'. Set to True in order to
+            do routine flagging of coarse channel edges, start or end
+            integrations, or the center fine channel of each coarse
+            channel. See associated keywords.
         edge_width: float
-            Only used if flag_init is True. The width to flag on the edge of
-            each coarse channel, in hz. Errors if not equal to integer multiple
-            of channel_width. Set to 0 for no edge flagging. Only used if
-            file_type is 'mwa_corr_fits'.
+            Only used if file_type is 'mwa_corr_fits' and flag_init is True. Set
+            to the width to flag on the edge of each coarse channel, in hz.
+            Errors if not equal to integer multiple of channel_width. Set to 0
+            for no edge flagging.
         start_flag: float
-            Only used if flag_init is True. The number of seconds to flag at the
-            beginning of the observation. Set to 0 for no flagging. Only used if
-            file_type is 'mwa_corr_fits'.
+            Only used if file_type is 'mwa_corr_fits' and flag_init is True. Set
+            to the number of seconds to flag at the beginning of the observation.
+            Set to 0 for no flagging. Errors if not an integer multiple of the
+            integration time.
         end_flag: floats
-            Only used if flag_init is True. The number of seconds to flag at the
-            end of the observation. Set to 0 for no flagging. Only used if
-            file_type is 'mwa_corr_fits'.
+            Only used if file_type is 'mwa_corr_fits' and flag_init is True. Set
+            to the number of seconds to flag at the end of the observation. Set
+            to 0 for no flagging. Errors if not an integer multiple of the
+            integration time.
         flag_dc_offset: bool
-            Only used if flag_init is True. Set to True to flag the center fine
-            channel of each coarse channel. Only used if file_type is 'mwa_corr_fits'.
+            Only used if file_type is 'mwa_corr_fits' and flag_init is True. Set
+            to True to flag the center fine channel of each coarse channel. Only
+            used if file_type is 'mwa_corr_fits'.
         phase_to_pointing_center : bool
             Flag to phase to the pointing center. Only used if file_type is
             'mwa_corr_fits'. Cannot be set if phase_center_radec is not None.

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3234,7 +3234,7 @@ class UVData(UVBase):
         del(miriad_obj)
 
     def read_mwa_corr_fits(self, filelist, axis=None, use_cotter_flags=False,
-                           correct_cable_len=False, flag_init=False,
+                           correct_cable_len=False, flag_init=True,
                            edge_width=80e3, start_flag=2.0, end_flag=2.0,
                            flag_dc_offset=True, phase_to_pointing_center=False,
                            phase_data=None, phase_center=None, run_check=True,
@@ -3680,7 +3680,7 @@ class UVData(UVBase):
              phase_type=None, correct_lat_lon=True, use_model=False,
              data_column='DATA', pol_order='AIPS',
              data_array_dtype=np.complex128,
-             use_cotter_flags=False, correct_cable_len=False, flag_init=False,
+             use_cotter_flags=False, correct_cable_len=False, flag_init=True,
              edge_width=80e3, start_flag=2.0, end_flag=2.0, flag_dc_offset=True,
              phase_to_pointing_center=False,
              run_check=True, check_extra=True, run_check_acceptability=True):

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3327,6 +3327,9 @@ class UVData(UVBase):
             self.read(filelist, file_type='mwa_corr_fits', axis=axis,
                       use_cotter_flags=use_cotter_flags,
                       correct_cable_len=correct_cable_len,
+                      flag_init=flag_init, edge_width=edge_width,
+                      start_flag=start_flag, end_flag=end_flag,
+                      flag_dc_offset=flag_dc_offset,
                       phase_to_pointing_center=phase_to_pointing_center,
                       phase_center_radec=phase_center, run_check=run_check,
                       check_extra=check_extra,
@@ -3336,6 +3339,9 @@ class UVData(UVBase):
         corr_obj = mwa_corr_fits.MWACorrFITS()
         corr_obj.read_mwa_corr_fits(filelist, use_cotter_flags=use_cotter_flags,
                                     correct_cable_len=correct_cable_len,
+                                    flag_init=flag_init, edge_width=edge_width,
+                                    start_flag=start_flag, end_flag=end_flag,
+                                    flag_dc_offset=flag_dc_offset,
                                     phase_to_pointing_center=phase_to_pointing_center,
                                     run_check=run_check, check_extra=check_extra,
                                     run_check_acceptability=run_check_acceptability)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3234,7 +3234,9 @@ class UVData(UVBase):
         del(miriad_obj)
 
     def read_mwa_corr_fits(self, filelist, axis=None, use_cotter_flags=False,
-                           correct_cable_len=False, phase_to_pointing_center=False,
+                           correct_cable_len=False, flag_init=False,
+                           edge_width=80e3, start_flag=4.0, end_flag=6.0,
+                           flag_dc_offset=True, phase_to_pointing_center=False,
                            phase_data=None, phase_center=None, run_check=True,
                            check_extra=True, run_check_acceptability=True):
         """

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -4096,7 +4096,7 @@ class UVData(UVBase):
                     correct_cable_len=correct_cable_len,
                     flag_init=flag_init, edge_width=edge_width,
                     start_flag=start_flag, end_flag=end_flag,
-                    flag_dc_offset=True
+                    flag_dc_offset=True,
                     phase_to_pointing_center=phase_to_pointing_center,
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3681,7 +3681,7 @@ class UVData(UVBase):
              data_column='DATA', pol_order='AIPS',
              data_array_dtype=np.complex128,
              use_cotter_flags=False, correct_cable_len=False, flag_init=False,
-             edge_width=80e3, start_flag=4.0, end_flag=6.0, flag_dc_offset=True,
+             edge_width=80e3, start_flag=2.0, end_flag=2.0, flag_dc_offset=True,
              phase_to_pointing_center=False,
              run_check=True, check_extra=True, run_check_acceptability=True):
         """

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3673,7 +3673,7 @@ class UVData(UVBase):
              data_column='DATA', pol_order='AIPS',
              data_array_dtype=np.complex128,
              use_cotter_flags=False, correct_cable_len=False, flag_init=False,
-             edge_width=80e3, start_flag=4.0, end_flag=6.0, flag_dc_offset=True
+             edge_width=80e3, start_flag=4.0, end_flag=6.0, flag_dc_offset=True,
              phase_to_pointing_center=False,
              run_check=True, check_extra=True, run_check_acceptability=True):
         """

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3672,7 +3672,8 @@ class UVData(UVBase):
              phase_type=None, correct_lat_lon=True, use_model=False,
              data_column='DATA', pol_order='AIPS',
              data_array_dtype=np.complex128,
-             use_cotter_flags=False, correct_cable_len=False,
+             use_cotter_flags=False, correct_cable_len=False, flag_init=False,
+             edge_width=80e3, start_flag=4.0, end_flag=6.0, flag_dc_offset=True
              phase_to_pointing_center=False,
              run_check=True, check_extra=True, run_check_acceptability=True):
         """
@@ -3817,6 +3818,24 @@ class UVData(UVBase):
         correct_cable_len : bool
             Flag to apply cable length correction. Only used if file_type is
             'mwa_corr_fits'.
+        flag_init: bool
+            Set to True in order to do routine flagging of coarse channel edges,
+            start or end integrations, or the center fine channel of each coarse
+            channel. See associated keywords. Only used if file_type is
+            'mwa_corr_fits'.
+        edge_width: float
+            Only used if flag_init is True. The width to flag on the edge of
+            each coarse channel, in hz. Errors if less than the channel_width of
+            the observation. Only used if file_type is 'mwa_corr_fits'.
+        start_flag: float
+            Only used if flag_init is True. The number of seconds to flag at the
+            beginning of the observation. Only used if file_type is 'mwa_corr_fits'.
+        end_flag: floats
+            Only used if flag_init is True. The number of seconds to flag at the
+            end of the observation. Only used if file_type is 'mwa_corr_fits'.
+        flag_dc_offset: bool
+            Only used if flag_init is True. Set to True to flag the center fine
+            channel of each coarse channel. Only used if file_type is 'mwa_corr_fits'.
         phase_to_pointing_center : bool
             Flag to phase to the pointing center. Only used if file_type is
             'mwa_corr_fits'. Cannot be set if phase_center_radec is not None.
@@ -4072,6 +4091,9 @@ class UVData(UVBase):
                     filename, run_check=run_check,
                     use_cotter_flags=use_cotter_flags,
                     correct_cable_len=correct_cable_len,
+                    flag_init=flag_init, edge_width=edge_width,
+                    start_flag=start_flag, end_flag=end_flag,
+                    flag_dc_offset=True
                     phase_to_pointing_center=phase_to_pointing_center,
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -3825,14 +3825,17 @@ class UVData(UVBase):
             'mwa_corr_fits'.
         edge_width: float
             Only used if flag_init is True. The width to flag on the edge of
-            each coarse channel, in hz. Errors if less than the channel_width of
-            the observation. Only used if file_type is 'mwa_corr_fits'.
+            each coarse channel, in hz. Errors if not equal to integer multiple
+            of channel_width. Set to 0 for no edge flagging. Only used if
+            file_type is 'mwa_corr_fits'.
         start_flag: float
             Only used if flag_init is True. The number of seconds to flag at the
-            beginning of the observation. Only used if file_type is 'mwa_corr_fits'.
+            beginning of the observation. Set to 0 for no flagging. Only used if
+            file_type is 'mwa_corr_fits'.
         end_flag: floats
             Only used if flag_init is True. The number of seconds to flag at the
-            end of the observation. Only used if file_type is 'mwa_corr_fits'.
+            end of the observation. Set to 0 for no flagging. Only used if
+            file_type is 'mwa_corr_fits'.
         flag_dc_offset: bool
             Only used if flag_init is True. Set to True to flag the center fine
             channel of each coarse channel. Only used if file_type is 'mwa_corr_fits'.


### PR DESCRIPTION
## Description
This adds the option to flag on read when reading in gpubox files using both generic `read` and `read_mwa_corr_fits`. How much of each category to flag (in title) is specified by a float input to a keyword, which needs to be an integer multiple of the corresponding resolution for the desired quanitity e.g. edge_width=80e3 will flag two fine channels per edge per coarse channel if the channel_width is exactly 40 kHz. Flagging the dc_offset is just a bool - default True. Routine flagging is default _off_ (perhaps routine is a bit of a misnomer if that is the default). There is some defensive error messaging for faulty inputs. 

## Motivation and Context
This change helps make the mwa_corr_fits reader emulate cotter slightly more by doing some flagging that cotter would also do when handling box files. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass in both python 2 and python 3.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Breaking change checklist:  
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass in both python 2 and python 3.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
