### PR TITLE
Remove python 2 references in docs that were lost in v2 pr rebase

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,7 @@ http://makeapullrequest.com/ and http://www.firsttimersonly.com/. If you have mo
 2. Do the changes in your fork
 3. If you like the change and think the project could use it:
   - If you're fixing a bug, include a new test that breaks as a result of the bug (if possible)
-  - Ensure that all your new code is covered by tests and that the existing tests pass in both python 2 and 3. Tests can be run and coverage automatically created by running the script `test_coverage.sh` in the `scripts` directory. Coverage reports require the `pytest-cov` plug-in. Testing of `UVFlag` module requires the `pytest-cases` plug-in (available from pip, may require `setuptools_scm` for python 2 developers).
+  - Ensure that all your new code is covered by tests and that the existing tests pass. Tests can be run and coverage automatically created by running the script `test_coverage.sh` in the `scripts` directory. Coverage reports require the `pytest-cov` plug-in. Testing of `UVFlag` module requires the `pytest-cases` plug-in.
   - Ensure that your code meets the PEP8 style guidelines. You can check that your code will pass our linting tests by running `pycodestyle . --ignore=E501,W503` in the top-level pyuvdata directory.
   - Ensure that you fully document any new features via docstrings and in the [tutorial](../docs/tutorial.rst)
   - You can see the full pull request checklist [here](PULL_REQUEST_TEMPLATE.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,7 @@ New feature checklist:
 - [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
 - [ ] I have updated the tutorial to highlight my new feature (if appropriate).
 - [ ] I have added tests to cover my new feature.
-- [ ] All new and existing tests pass in both python 2 and python 3.
+- [ ] All new and existing tests pass.
 - [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
 
 Breaking change checklist:  
@@ -41,7 +41,7 @@ Breaking change checklist:
 - [ ] I have updated the tutorial to reflect my changes (if appropriate).
 - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
 - [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests pass in both python 2 and python 3.
+- [ ] All new and existing tests pass.
 - [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
 
 Documentation change checklist:

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ https://github.com/casacore/python-casacore
 Uses the `pytest` package to execute test suite.
 From the source pyuvdata directory run ```pytest``` or ```python -m pytest```.
 
-Testing of `UVFlag` module requires the `pytest-cases` plug-in (available from pip; may require `setuptools_scm` for python 2 developers).
+Testing of `UVFlag` module requires the `pytest-cases` plug-in.
 
 # API
 The primary interface to data from python is via the UVData object. It provides


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove a few stray python 2 references that were lost in the great v2 pr rebase.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)
