### PR TITLE
Optional weights_square_array parameter for UVFlag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable changes to this project will be documented in this file.
 - Handling of strings in UVFlag files has been made more widely compatible.
 
 ### Added
-- `frequency_average` method on UVData to average data along the frequency axis.
 - `weights_square_array` (optional) parameter on UVFlag - stores sum of squares of weights when converting to waterfall
+- `frequency_average` method on UVData to average data along the frequency axis.
+
 
 ### Fixed
 - `metafits_ppds.fits` files can now be passed to `mwa_corr_fits.read` without throwing an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - `frequency_average` method on UVData to average data along the frequency axis.
+- `weights_square_array` (optional) parameter on UVFlag - stores sum of squares of weights when converting to waterfall
 
 ### Fixed
 - `metafits_ppds.fits` files can now be passed to `mwa_corr_fits.read` without throwing an error.

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -434,7 +434,6 @@ def test_read_write_loop_waterfal():
 
 def test_read_write_loop_ret_wt_sq():
     uvf = UVFlag(test_f_file)
-    Nbls = uvf.Nbls
     uvf.weights_array = 2 * np.ones_like(uvf.weights_array)
     uvf.to_waterfall(return_weights_square=True)
     uvf.write(test_outfile, clobber=True)

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -1047,6 +1047,14 @@ def test_to_waterfall_bl_multi_pol():
     )
 
 
+def test_to_waterfall_bl_ret_wt_sq():
+    uvf = UVFlag(test_f_file)
+    Nbls = uvf.Nbls
+    uvf.weights_array = 2 * np.ones_like(uvf.weights_array)
+    uvf.to_waterfall(return_weights_square=True)
+    assert np.all(uvf.weights_square_array == 4 * Nbls)
+
+
 def test_collapse_pol():
     uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -432,6 +432,16 @@ def test_read_write_loop_waterfal():
     assert uvf.__eq__(uvf2, check_history=True)
 
 
+def test_read_write_loop_ret_wt_sq():
+    uvf = UVFlag(test_f_file)
+    Nbls = uvf.Nbls
+    uvf.weights_array = 2 * np.ones_like(uvf.weights_array)
+    uvf.to_waterfall(return_weights_square=True)
+    uvf.write(test_outfile, clobber=True)
+    uvf2 = UVFlag(test_outfile)
+    assert uvf.__eq__(uvf2, check_history=True)
+
+
 def test_bad_mode_savefile():
     uv = UVData()
     uv.read_miriad(test_d_file)

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -968,6 +968,8 @@ class UVFlag(UVBase):
             Np = len(self.polarization_array)
             d = np.zeros((Nt, Nf, Np))
             w = np.zeros((Nt, Nf, Np))
+            if return_weights_square:
+                ws = np.zeros((Nt, Nf, Np))
             for i, t in enumerate(np.unique(self.time_array)):
                 ind = self.time_array == t
                 if self.mode == "metric":
@@ -975,7 +977,6 @@ class UVFlag(UVBase):
                 else:
                     _weights = np.ones_like(darr[ind, :, :], dtype=float)
                 if return_weights_square:
-                    ws = np.zeros((Nt, Nf, Np))
                     d[i, :, :], w[i, :, :], ws[i, :, :] = uvutils.collapse(
                         darr[ind, :, :],
                         method,

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -2630,6 +2630,13 @@ class UVFlag(UVBase):
                     data=self.weights_array,
                     compression=data_compression,
                 )
+                if self.weights_square_array is not None:
+                    dgrp.create_dataset(
+                        "weights_square_array",
+                        chunks=True,
+                        data=self.weights_square_array,
+                        compression=data_compression,
+                    )
             elif self.mode == "flag":
                 dgrp.create_dataset(
                     "flag_array",

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -299,7 +299,7 @@ class UVFlag(UVBase):
             description=desc,
             form=("Nblts", "Nspws", "Nfreqs", "Npols"),
             expected_type=np.float,
-            required=False
+            required=False,
         )
 
         desc = (
@@ -704,7 +704,7 @@ class UVFlag(UVBase):
             " Has shape (Nblts, Nfreqs, Npols)."
         )
         self._weights_square_array.desc = desc
-        self._weights_square_array.form = ("Nblts, Nfreqs, Npols")
+        self._weights_square_array.form = ("Nblts", "Nfreqs", "Npols")
 
         desc = (
             "Array of unique times, center of integration, shape (Ntimes), "
@@ -738,7 +738,7 @@ class UVFlag(UVBase):
             if (
                 not attr.required
                 and attr.value is not None
-                and attr.name != "x-orientation"
+                and attr.name != "x_orientation"
                 and attr.name != "weights_square_array"
             ):
                 attr.value = None
@@ -920,7 +920,7 @@ class UVFlag(UVBase):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        return_weights_square=False
+        return_weights_square=False,
     ):
         """Convert an 'antenna' or 'baseline' type object to waterfall.
 
@@ -994,7 +994,7 @@ class UVFlag(UVBase):
                         axis=0,
                         weights=_weights,
                         return_weights=True,
-                        return_weights_square=return_weights_square
+                        return_weights_square=return_weights_square,
                     )
                 else:
                     d[i, :, :], w[i, :, :] = uvutils.collapse(
@@ -1003,7 +1003,7 @@ class UVFlag(UVBase):
                         axis=0,
                         weights=_weights,
                         return_weights=True,
-                        return_weights_square=return_weights_square
+                        return_weights_square=return_weights_square,
                     )
             darr = d
             if self.mode == "metric":

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -514,7 +514,10 @@ class UVFlag(UVBase):
         elif self.mode == "flag":
             return ["flag_array"]
         elif self.mode == "metric":
-            return ["metric_array", "weights_array"]
+            if self.weights_square_array is None:
+                return ["metric_array", "weights_array"]
+            else:
+                return ["metric_array", "weights_array", "weights_square_array"]
         else:
             raise ValueError(
                 "Invalid mode. Mode must be one of "

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -699,6 +699,14 @@ class UVFlag(UVBase):
         self._weights_array.form = ("Nblts", "Nfreqs", "Npols")
 
         desc = (
+            "Floating point weight information about sum of squares of weights"
+            " when weighted data converted from baseline to waterfall  mode."
+            " Has shape (Nblts, Nfreqs, Npols)."
+        )
+        self._weights_square_array.desc = desc
+        self._weights_square_array.form = ("Nblts, Nfreqs, Npols")
+
+        desc = (
             "Array of unique times, center of integration, shape (Ntimes), "
             "units Julian Date"
         )
@@ -723,12 +731,14 @@ class UVFlag(UVBase):
 
 
         """
+
         for p in self:
             attr = getattr(self, p)
             if (
                 not attr.required
                 and attr.value is not None
-                and attr.name != "x_orientation"
+                and attr.name != "x-orientation"
+                and attr.name != "weights_square_array"
             ):
                 attr.value = None
                 setattr(self, p, attr)

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -2534,6 +2534,8 @@ class UVFlag(UVBase):
                 if self.mode == "metric":
                     self.metric_array = dgrp["metric_array"][()]
                     self.weights_array = dgrp["weights_array"][()]
+                    if "weights_square_array" in dgrp:
+                        self.weights_square_array = dgrp["weights_square_array"][()]
                 elif self.mode == "flag":
                     self.flag_array = dgrp["flag_array"][()]
 

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -977,7 +977,7 @@ class UVFlag(UVBase):
                 if return_weights_square:
                     ws = np.zeros((Nt, Nf, Np))
                     d[i, :, :], w[i, :, :], ws[i, :, :] = uvutils.collapse(
-                        dar[ind, :, :],
+                        darr[ind, :, :],
                         method,
                         axis=0,
                         weights=_weights,

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -682,7 +682,6 @@ class UVFlag(UVBase):
         self._Nants_data.required = False
         self._Nbls.required = False
         self._Nspws.required = False
-        self._weights_square_array.required = False
 
         self.Nblts = self.Ntimes
 

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -291,6 +291,18 @@ class UVFlag(UVBase):
         )
 
         desc = (
+            "Floating point weight information about sum of squares of weights"
+            " when weighted data converted from baseline to waterfall  mode."
+        )
+        self._weights_square_array = uvp.UVParameter(
+            "weights_square_array",
+            description=desc,
+            form=("Nblts", "Nspws", "Nfreqs", "Npols"),
+            expected_type=np.float,
+            required=False
+        )
+
+        desc = (
             "Array of times, center of integration, shape (Nblts), " "units Julian Date"
         )
         self._time_array = uvp.UVParameter(
@@ -667,6 +679,7 @@ class UVFlag(UVBase):
         self._Nants_data.required = False
         self._Nbls.required = False
         self._Nspws.required = False
+        self._weights_square_array.required = False
 
         self.Nblts = self.Ntimes
 

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -979,8 +979,8 @@ class UVFlag(UVBase):
                     d[i, :, :], w[i, :, :], ws[i, :, :] = uvutils.collapse(
                         dar[ind, :, :],
                         method,
-                        axis=0
-                        weights=_weights
+                        axis=0,
+                        weights=_weights,
                         return_weights=True,
                         return_weights_square=return_weights_square
                     )

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -727,7 +727,8 @@ class UVFlag(UVBase):
         """Remove unused attributes.
 
         Useful when changing type or mode or to save memory.
-        Will set all non-required attributes to None, except x_orientation.
+        Will set all non-required attributes to None, except x_orientation and
+        weights_square_array.
 
 
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change adds an optional "weights_square_array" parameter to UVFlag. This is only calculated in `UVFlag.to_waterfall` if the object starts as `baseline` type. This parameter holds the sum of the squares of the weights along the collapsed (baseline) axis. 

## Description
<!--- Describe your changes in detail -->
This adds an optional parameter that is set up during `__init__` and a couple other places (see code changes). This initial setup of the parameter currently needs more work (see comments below). This adds a keyword to `UVFlag.to_waterfall` called `return_weights_square`. When this is `True`, `uvutils.collapse` is called with `return_weights_square=True`, and the attribute `UVFlag.weights_square_array` is set to the output from the collapse function. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This lets the user obtain the sum of the squares of the weights over the baselines when making a waterfall object, which is useful when using general weights.
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Breaking change checklist:
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
