### PR TITLE
Add error for misaligned MWA correlator files

### DIFF
--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -290,6 +290,15 @@ class MWACorrFITS(UVData):
                     )
                     if start_time == 0.0:
                         start_time = first_time
+                    # check that files with a timing offset can be aligned
+                    elif (
+                        np.abs(start_time - first_time) % data[1].header["INTTIME"]
+                        != 0.0
+                    ):
+                        raise ValueError(
+                            "coarse channel start times are misaligned by an amount that is not \
+                                an integer multiple of the integration time"
+                        )
                     elif start_time > first_time:
                         start_time = first_time
                     if end_time < last_time:

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -352,6 +352,24 @@ def test_diff_obs():
     del mwa_uv
 
 
+def test_misaligned_times():
+    """
+    Break read_mwa_corr_fits by submitting files with misaligned times.
+
+    Test that error is raised if file start times are different by an amount
+    that is not an integer multiiple of the integration time.
+    """
+    mwa_uv = UVData()
+    bad_obs = os.path.join(DATA_PATH, "test/bad3_gpubox06_01.fits")
+    with fits.open(filelist[2]) as mini6:
+        mini6[1].header["MILLITIM"] = 250
+        mini6.writeto(bad_obs)
+    with pytest.raises(ValueError) as cm:
+        mwa_uv.read([bad_obs, filelist[0], filelist[1]])
+    assert str(cm.value).startswith("coarse channel start times are misaligned")
+    del mwa_uv
+
+
 @pytest.mark.filterwarnings("ignore:telescope_location is not set. ")
 @pytest.mark.filterwarnings(
     "ignore:coarse channels are not contiguous for this observation"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add  code that checks for misaligned files and raises an error when they are found.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
MWA correlator coarse channel files might start at different times. If the start time difference between two files is not an integer multiple of the integration time, it is not possible to align the files and an error should be thrown.
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Breaking change checklist:
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
