### PR TITLE
Test file on read

### DIFF
--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -6797,9 +6797,9 @@ def test_multifile_read_errors(read_func, filelist):
 def test_multifile_read_check():
     uv = UVData() 
     uvh5_file = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-    with h5py.File(uvh5_file, "r+") as h5f:
+    with h5py.File(uvh5_file, "r") as h5f:
         del h5f["Header/ant_1_array"]
     with pytest.raises(KeyError) as cm:
         uv.read(uvh5_file)
-    assert str(cm.value).startswith("Unable to open object")
+    assert str(cm.value).startswith("Unable to open object (object \'ant_1_array\' doesn\'t exist)")
         

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -6810,7 +6810,7 @@ def test_multifile_read_check():
 
     # Test that the expected error arises
     with pytest.raises(KeyError) as cm:
-        uv.read(testfile, check_file_status=True)
+        uv.read(testfile, skip_bad_files=True)
     assert "Unable to open object (object 'ant_1_array' doesn't exist)" in str(cm.value)
 
     # Test when the corrupted file is at the end
@@ -6818,7 +6818,7 @@ def test_multifile_read_check():
     uvTrue.read(uvh5_file)
     fileList = [uvh5_file, testfile]
     with pytest.warns(UserWarning) as cm:
-        uv.read(fileList, check_file_status=True)
+        uv.read(fileList, skip_bad_files=True)
     # Check that a warning was issued
     assert len(cm) == 1
     # Check that the uncorrupted file was still read in
@@ -6829,7 +6829,7 @@ def test_multifile_read_check():
     uvTrue.read(uvh5_file)
     fileList = [testfile, uvh5_file]
     with pytest.warns(UserWarning) as cm:
-        uv.read(fileList, check_file_status=True)
+        uv.read(fileList, skip_bad_files=True)
     assert len(cm) == 1
     assert uv == uvTrue
 
@@ -6858,9 +6858,9 @@ def test_multifile_read_check_long_list():
         del h5f["Header/ant_1_array"]
     uvTest = UVData()
     with pytest.warns(UserWarning) as cm:
-        uvTest.read(fileList[0:4], check_file_status=True)
+        uvTest.read(fileList[0:4], skip_bad_files=True)
     uvTrue = UVData()
-    uvTrue.read(fileList[0:3], check_file_status=True)
+    uvTrue.read(fileList[0:3], skip_bad_files=True)
 
     assert len(cm) == 1
     assert uvTest == uvTrue
@@ -6874,9 +6874,9 @@ def test_multifile_read_check_long_list():
         del h5f["Header/ant_1_array"]
     uvTest = UVData()
     with pytest.warns(UserWarning) as cm:
-        uvTest.read(fileList[0:4], check_file_status=True)
+        uvTest.read(fileList[0:4], skip_bad_files=True)
     uvTrue = UVData()
-    uvTrue.read(fileList[1:4], check_file_status=True)
+    uvTrue.read(fileList[1:4], skip_bad_files=True)
 
     assert len(cm) == 1
     assert uvTest == uvTrue
@@ -6890,9 +6890,9 @@ def test_multifile_read_check_long_list():
         del h5f["Header/ant_1_array"]
     uvTest = UVData()
     with pytest.warns(UserWarning) as cm:
-        uvTest.read(fileList[0:4], check_file_status=True)
+        uvTest.read(fileList[0:4], skip_bad_files=True)
     uvTrue = UVData()
-    uvTrue.read([fileList[0], fileList[2], fileList[3]], check_file_status=True)
+    uvTrue.read([fileList[0], fileList[2], fileList[3]], skip_bad_files=True)
 
     assert len(cm) == 1
     assert uvTest == uvTrue

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -9,6 +9,7 @@ import pytest
 import os
 import copy
 import itertools
+import h5py
 
 import numpy as np
 from astropy.time import Time
@@ -6792,3 +6793,13 @@ def test_multifile_read_errors(read_func, filelist):
         "Reading multiple files from class specific read functions is no "
         "longer supported."
     )
+
+def test_multifile_read_check():
+    uv = UVData() 
+    uvh5_file = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
+    with h5py.File(uvh5_file, "r+") as h5f:
+        del h5f["Header/ant_1_array"]
+    with pytest.raises(KeyError) as cm:
+        uv.read(uvh5_file)
+    assert str(cm.value).startswith("Unable to open object")
+        

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -6866,6 +6866,8 @@ def test_multifile_read_check_long_list():
         uv2.write_uvh5(fname)
     with h5py.File(fileList[-1], "r+") as h5f:
         del h5f["Header/ant_1_array"]
+
+    # Test with corrupted file as last file in list, skip_bad_files=True
     uvTest = UVData()
     with pytest.warns(UserWarning) as cm:
         uvTest.read(fileList[0:4], skip_bad_files=True)
@@ -6906,6 +6908,16 @@ def test_multifile_read_check_long_list():
 
     assert len(cm) == 1
     assert uvTest == uvTrue
+
+    # Test with corrupted file in middle of list, but with skip_bad_files=False
+    uvTest = UVData()
+    with pytest.raises(KeyError, match="Unable to open object"):
+        with pytest.warns(UserWarning, match="Failed to read"):
+            uvTest.read(fileList[0:4], skip_bad_files=False)
+    uvTrue = UVData()
+    uvTrue.read([fileList[0], fileList[2], fileList[3]], skip_bad_files=False)
+
+    assert uvTest != uvTrue
 
     os.remove(fileList[0])
     os.remove(fileList[1])

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -6796,7 +6796,7 @@ def test_multifile_read_errors(read_func, filelist):
 
 
 def test_multifile_read_check():
-    """Test setting check_file_status=True when reading in files"""
+    """Test setting skip_bad_files=True when reading in files"""
 
     uv = UVData()
     uvh5_file = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
@@ -6850,7 +6850,7 @@ def test_multifile_read_check():
 
 def test_multifile_read_check_long_list():
     """
-    Test setting check_file_status=True when reading in files for a list of length >2
+    Test setting skip_bad_files=True when reading in files for a list of length >2
     """
     # Create mini files for testing
     uv = UVData()

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6513,7 +6513,7 @@ class UVData(UVBase):
                 phase_center_radec = [self.phase_center_ra, self.phase_center_dec]
 
             if len(filename) > 1:
-                for f in filename[file_num:]:
+                for f in filename[file_num+1:]:
                     uv2 = UVData()
                     if check_file_status:
                         try:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6173,6 +6173,7 @@ class UVData(UVBase):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
+        check_file_status=False,
     ):
         """
         Read a generic file into a UVData object.
@@ -6347,6 +6348,10 @@ class UVData(UVBase):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done). Ignored if read_data is False.
+        check_file_status : bool
+            Option when reading multiple files to catch read errors such that 
+            the read continues even if one or more files are corrupted. Files
+            that produce errors will be printed. 
 
         Raises
         ------
@@ -6457,6 +6462,7 @@ class UVData(UVBase):
                 run_check=run_check,
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
+                check_file_status=check_file_status,
             )
 
             if (
@@ -6471,32 +6477,68 @@ class UVData(UVBase):
             if len(filename) > 1:
                 for f in filename[1:]:
                     uv2 = UVData()
-                    uv2.read(
-                        f,
-                        file_type=file_type,
-                        phase_center_radec=phase_center_radec,
-                        antenna_nums=antenna_nums,
-                        antenna_names=antenna_names,
-                        ant_str=ant_str,
-                        bls=bls,
-                        frequencies=frequencies,
-                        freq_chans=freq_chans,
-                        times=times,
-                        polarizations=polarizations,
-                        blt_inds=blt_inds,
-                        time_range=time_range,
-                        keep_all_metadata=keep_all_metadata,
-                        read_data=read_data,
-                        phase_type=phase_type,
-                        correct_lat_lon=correct_lat_lon,
-                        use_model=use_model,
-                        data_column=data_column,
-                        pol_order=pol_order,
-                        data_array_dtype=data_array_dtype,
-                        run_check=run_check,
-                        check_extra=check_extra,
-                        run_check_acceptability=run_check_acceptability,
-                    )
+                    if check_file_status:
+                        try:
+                            uv2.read(
+                                f,
+                                file_type=file_type,
+                                phase_center_radec=phase_center_radec,
+                                antenna_nums=antenna_nums,
+                                antenna_names=antenna_names,
+                                ant_str=ant_str,
+                                bls=bls,
+                                frequencies=frequencies,
+                                freq_chans=freq_chans,
+                                times=times,
+                                polarizations=polarizations,
+                                blt_inds=blt_inds,
+                                time_range=time_range,
+                                keep_all_metadata=keep_all_metadata,
+                                read_data=read_data,
+                                phase_type=phase_type,
+                                correct_lat_lon=correct_lat_lon,
+                                use_model=use_model,
+                                data_column=data_column,
+                                pol_order=pol_order,
+                                data_array_dtype=data_array_dtype,
+                                run_check=run_check,
+                                check_extra=check_extra,
+                                run_check_acceptability=run_check_acceptability,
+                                check_file_status=check_file_status,
+                            )
+                        except KeyError:
+                            warnings.warn(
+                                "Failed to read {f}".format(f=f)
+                            )
+                            continue
+                    else:
+                        uv2.read(
+                            f,
+                            file_type=file_type,
+                            phase_center_radec=phase_center_radec,
+                            antenna_nums=antenna_nums,
+                            antenna_names=antenna_names,
+                            ant_str=ant_str,
+                            bls=bls,
+                            frequencies=frequencies,
+                            freq_chans=freq_chans,
+                            times=times,
+                            polarizations=polarizations,
+                            blt_inds=blt_inds,
+                            time_range=time_range,
+                            keep_all_metadata=keep_all_metadata,
+                            read_data=read_data,
+                            phase_type=phase_type,
+                            correct_lat_lon=correct_lat_lon,
+                            use_model=use_model,
+                            data_column=data_column,
+                            pol_order=pol_order,
+                            data_array_dtype=data_array_dtype,
+                            run_check=run_check,
+                            check_extra=check_extra,
+                            run_check_acceptability=run_check_acceptability,
+                            check_file_status=check_file_status,
+                        )
                     if axis is not None:
                         self.fast_concat(
                             uv2,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6446,6 +6446,7 @@ class UVData(UVBase):
                     self.read(
                         filename[file_num],
                         file_type=file_type,
+                        phase_center_radec=phase_center_radec,
                         antenna_nums=antenna_nums,
                         antenna_names=antenna_names,
                         ant_str=ant_str,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6351,7 +6351,8 @@ class UVData(UVBase):
         skip_bad_files : bool
             Option when reading multiple files to catch read errors such that
             the read continues even if one or more files are corrupted. Files
-            that produce errors will be printed.
+            that produce errors will be printed. Default is False (files will
+            not be skipped).
 
         Raises
         ------

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6173,7 +6173,7 @@ class UVData(UVBase):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        check_file_status=False,
+        skip_bad_files=False,
     ):
         """
         Read a generic file into a UVData object.
@@ -6348,7 +6348,7 @@ class UVData(UVBase):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done). Ignored if read_data is False.
-        check_file_status : bool
+        skip_bad_files : bool
             Option when reading multiple files to catch read errors such that
             the read continues even if one or more files are corrupted. Files
             that produce errors will be printed.
@@ -6439,7 +6439,7 @@ class UVData(UVBase):
         if multi:
 
             file_num = 0
-            if check_file_status:
+            if skip_bad_files:
                 unread = True
                 while unread:
                     try:
@@ -6467,7 +6467,7 @@ class UVData(UVBase):
                             run_check=run_check,
                             check_extra=check_extra,
                             run_check_acceptability=run_check_acceptability,
-                            check_file_status=check_file_status,
+                            skip_bad_files=skip_bad_files,
                         )
                         unread = False
                     except KeyError:
@@ -6498,7 +6498,7 @@ class UVData(UVBase):
                     run_check=run_check,
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability,
-                    check_file_status=check_file_status,
+                    skip_bad_files=skip_bad_files,
                 )
 
             if (
@@ -6513,7 +6513,7 @@ class UVData(UVBase):
             if len(filename) > file_num + 1:
                 for f in filename[file_num + 1 :]:
                     uv2 = UVData()
-                    if check_file_status:
+                    if skip_bad_files:
                         try:
                             uv2.read(
                                 f,
@@ -6540,7 +6540,7 @@ class UVData(UVBase):
                                 run_check=run_check,
                                 check_extra=check_extra,
                                 run_check_acceptability=run_check_acceptability,
-                                check_file_status=check_file_status,
+                                skip_bad_files=skip_bad_files,
                             )
                         except KeyError:
                             warnings.warn("Failed to read {f}".format(f=f))
@@ -6571,7 +6571,7 @@ class UVData(UVBase):
                             run_check=run_check,
                             check_extra=check_extra,
                             run_check_acceptability=run_check_acceptability,
-                            check_file_status=check_file_status,
+                            skip_bad_files=skip_bad_files,
                         )
                     if axis is not None:
                         self.fast_concat(

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6438,32 +6438,70 @@ class UVData(UVBase):
 
         if multi:
 
-            self.read(
-                filename[0],
-                file_type=file_type,
-                antenna_nums=antenna_nums,
-                antenna_names=antenna_names,
-                ant_str=ant_str,
-                bls=bls,
-                frequencies=frequencies,
-                freq_chans=freq_chans,
-                times=times,
-                polarizations=polarizations,
-                blt_inds=blt_inds,
-                time_range=time_range,
-                keep_all_metadata=keep_all_metadata,
-                read_data=read_data,
-                phase_type=phase_type,
-                correct_lat_lon=correct_lat_lon,
-                use_model=use_model,
-                data_column=data_column,
-                pol_order=pol_order,
-                data_array_dtype=data_array_dtype,
-                run_check=run_check,
-                check_extra=check_extra,
-                run_check_acceptability=run_check_acceptability,
-                check_file_status=check_file_status,
-            )
+            file_num = 0
+            if check_file_status:
+                unread = True
+                while unread:
+                    try:
+                        self.read(
+                            filename[file_num],
+                            file_type=file_type,
+                            antenna_nums=antenna_nums,
+                            antenna_names=antenna_names,
+                            ant_str=ant_str,
+                            bls=bls,
+                            frequencies=frequencies,
+                            freq_chans=freq_chans,
+                            times=times,
+                            polarizations=polarizations,
+                            blt_inds=blt_inds,
+                            time_range=time_range,
+                            keep_all_metadata=keep_all_metadata,
+                            read_data=read_data,
+                            phase_type=phase_type,
+                            correct_lat_lon=correct_lat_lon,
+                            use_model=use_model,
+                            data_column=data_column,
+                            pol_order=pol_order,
+                            data_array_dtype=data_array_dtype,
+                            run_check=run_check,
+                            check_extra=check_extra,
+                            run_check_acceptability=run_check_acceptability,
+                            check_file_status=check_file_status,
+                        )
+                        unread=False
+                    except KeyError:
+                        warnings.warn(
+                            "Failed to read {f}".format(f=f)
+                        )
+                        file_num += 1
+            else:
+                self.read(
+                        filename[0],
+                        file_type=file_type,
+                        antenna_nums=antenna_nums,
+                        antenna_names=antenna_names,
+                        ant_str=ant_str,
+                        bls=bls,
+                        frequencies=frequencies,
+                        freq_chans=freq_chans,
+                        times=times,
+                        polarizations=polarizations,
+                        blt_inds=blt_inds,
+                        time_range=time_range,
+                        keep_all_metadata=keep_all_metadata,
+                        read_data=read_data,
+                        phase_type=phase_type,
+                        correct_lat_lon=correct_lat_lon,
+                        use_model=use_model,
+                        data_column=data_column,
+                        pol_order=pol_order,
+                        data_array_dtype=data_array_dtype,
+                        run_check=run_check,
+                        check_extra=check_extra,
+                        run_check_acceptability=run_check_acceptability,
+                        check_file_status=check_file_status,
+                    )
 
             if (
                 allow_rephase
@@ -6475,7 +6513,7 @@ class UVData(UVBase):
                 phase_center_radec = [self.phase_center_ra, self.phase_center_dec]
 
             if len(filename) > 1:
-                for f in filename[1:]:
+                for f in filename[file_num:]:
                     uv2 = UVData()
                     if check_file_status:
                         try:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6446,7 +6446,6 @@ class UVData(UVBase):
                     self.read(
                         filename[file_num],
                         file_type=file_type,
-                        phase_center_radec=phase_center_radec,
                         antenna_nums=antenna_nums,
                         antenna_names=antenna_names,
                         ant_str=ant_str,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6472,7 +6472,7 @@ class UVData(UVBase):
                         unread=False
                     except KeyError:
                         warnings.warn(
-                            "Failed to read {f}".format(f=f)
+                            "Failed to read {f}".format(f=filename[file_num])
                         )
                         file_num += 1
             else:
@@ -6512,7 +6512,7 @@ class UVData(UVBase):
                 # set the phase center to be the phase center of the first file
                 phase_center_radec = [self.phase_center_ra, self.phase_center_dec]
 
-            if len(filename) > 1:
+            if len(filename) > file_num+1:
                 for f in filename[file_num+1:]:
                     uv2 = UVData()
                     if check_file_status:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6439,67 +6439,41 @@ class UVData(UVBase):
         if multi:
 
             file_num = 0
-            if skip_bad_files:
-                unread = True
-                while unread:
-                    try:
-                        self.read(
-                            filename[file_num],
-                            file_type=file_type,
-                            antenna_nums=antenna_nums,
-                            antenna_names=antenna_names,
-                            ant_str=ant_str,
-                            bls=bls,
-                            frequencies=frequencies,
-                            freq_chans=freq_chans,
-                            times=times,
-                            polarizations=polarizations,
-                            blt_inds=blt_inds,
-                            time_range=time_range,
-                            keep_all_metadata=keep_all_metadata,
-                            read_data=read_data,
-                            phase_type=phase_type,
-                            correct_lat_lon=correct_lat_lon,
-                            use_model=use_model,
-                            data_column=data_column,
-                            pol_order=pol_order,
-                            data_array_dtype=data_array_dtype,
-                            run_check=run_check,
-                            check_extra=check_extra,
-                            run_check_acceptability=run_check_acceptability,
-                            skip_bad_files=skip_bad_files,
-                        )
-                        unread = False
-                    except KeyError:
-                        warnings.warn("Failed to read {f}".format(f=filename[file_num]))
-                        file_num += 1
-            else:
-                self.read(
-                    filename[0],
-                    file_type=file_type,
-                    antenna_nums=antenna_nums,
-                    antenna_names=antenna_names,
-                    ant_str=ant_str,
-                    bls=bls,
-                    frequencies=frequencies,
-                    freq_chans=freq_chans,
-                    times=times,
-                    polarizations=polarizations,
-                    blt_inds=blt_inds,
-                    time_range=time_range,
-                    keep_all_metadata=keep_all_metadata,
-                    read_data=read_data,
-                    phase_type=phase_type,
-                    correct_lat_lon=correct_lat_lon,
-                    use_model=use_model,
-                    data_column=data_column,
-                    pol_order=pol_order,
-                    data_array_dtype=data_array_dtype,
-                    run_check=run_check,
-                    check_extra=check_extra,
-                    run_check_acceptability=run_check_acceptability,
-                    skip_bad_files=skip_bad_files,
-                )
+            unread = True
+            while unread:
+                try:
+                    self.read(
+                        filename[file_num],
+                        file_type=file_type,
+                        antenna_nums=antenna_nums,
+                        antenna_names=antenna_names,
+                        ant_str=ant_str,
+                        bls=bls,
+                        frequencies=frequencies,
+                        freq_chans=freq_chans,
+                        times=times,
+                        polarizations=polarizations,
+                        blt_inds=blt_inds,
+                        time_range=time_range,
+                        keep_all_metadata=keep_all_metadata,
+                        read_data=read_data,
+                        phase_type=phase_type,
+                        correct_lat_lon=correct_lat_lon,
+                        use_model=use_model,
+                        data_column=data_column,
+                        pol_order=pol_order,
+                        data_array_dtype=data_array_dtype,
+                        run_check=run_check,
+                        check_extra=check_extra,
+                        run_check_acceptability=run_check_acceptability,
+                        skip_bad_files=skip_bad_files,
+                    )
+                    unread = False
+                except KeyError:
+                    warnings.warn("Failed to read {f}".format(f=filename[file_num]))
+                    file_num += 1
+                    if skip_bad_files is False:
+                        raise
 
             if (
                 allow_rephase
@@ -6513,39 +6487,7 @@ class UVData(UVBase):
             if len(filename) > file_num + 1:
                 for f in filename[file_num + 1 :]:
                     uv2 = UVData()
-                    if skip_bad_files:
-                        try:
-                            uv2.read(
-                                f,
-                                file_type=file_type,
-                                phase_center_radec=phase_center_radec,
-                                antenna_nums=antenna_nums,
-                                antenna_names=antenna_names,
-                                ant_str=ant_str,
-                                bls=bls,
-                                frequencies=frequencies,
-                                freq_chans=freq_chans,
-                                times=times,
-                                polarizations=polarizations,
-                                blt_inds=blt_inds,
-                                time_range=time_range,
-                                keep_all_metadata=keep_all_metadata,
-                                read_data=read_data,
-                                phase_type=phase_type,
-                                correct_lat_lon=correct_lat_lon,
-                                use_model=use_model,
-                                data_column=data_column,
-                                pol_order=pol_order,
-                                data_array_dtype=data_array_dtype,
-                                run_check=run_check,
-                                check_extra=check_extra,
-                                run_check_acceptability=run_check_acceptability,
-                                skip_bad_files=skip_bad_files,
-                            )
-                        except KeyError:
-                            warnings.warn("Failed to read {f}".format(f=f))
-                            continue
-                    else:
+                    try:
                         uv2.read(
                             f,
                             file_type=file_type,
@@ -6573,6 +6515,12 @@ class UVData(UVBase):
                             run_check_acceptability=run_check_acceptability,
                             skip_bad_files=skip_bad_files,
                         )
+                    except KeyError:
+                        warnings.warn("Failed to read {f}".format(f=f))
+                        if skip_bad_files:
+                            continue
+                        else:
+                            raise
                     if axis is not None:
                         self.fast_concat(
                             uv2,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6349,9 +6349,9 @@ class UVData(UVBase):
             reading in the file (the default is True, meaning the acceptable
             range check will be done). Ignored if read_data is False.
         check_file_status : bool
-            Option when reading multiple files to catch read errors such that 
+            Option when reading multiple files to catch read errors such that
             the read continues even if one or more files are corrupted. Files
-            that produce errors will be printed. 
+            that produce errors will be printed.
 
         Raises
         ------
@@ -6469,39 +6469,37 @@ class UVData(UVBase):
                             run_check_acceptability=run_check_acceptability,
                             check_file_status=check_file_status,
                         )
-                        unread=False
+                        unread = False
                     except KeyError:
-                        warnings.warn(
-                            "Failed to read {f}".format(f=filename[file_num])
-                        )
+                        warnings.warn("Failed to read {f}".format(f=filename[file_num]))
                         file_num += 1
             else:
                 self.read(
-                        filename[0],
-                        file_type=file_type,
-                        antenna_nums=antenna_nums,
-                        antenna_names=antenna_names,
-                        ant_str=ant_str,
-                        bls=bls,
-                        frequencies=frequencies,
-                        freq_chans=freq_chans,
-                        times=times,
-                        polarizations=polarizations,
-                        blt_inds=blt_inds,
-                        time_range=time_range,
-                        keep_all_metadata=keep_all_metadata,
-                        read_data=read_data,
-                        phase_type=phase_type,
-                        correct_lat_lon=correct_lat_lon,
-                        use_model=use_model,
-                        data_column=data_column,
-                        pol_order=pol_order,
-                        data_array_dtype=data_array_dtype,
-                        run_check=run_check,
-                        check_extra=check_extra,
-                        run_check_acceptability=run_check_acceptability,
-                        check_file_status=check_file_status,
-                    )
+                    filename[0],
+                    file_type=file_type,
+                    antenna_nums=antenna_nums,
+                    antenna_names=antenna_names,
+                    ant_str=ant_str,
+                    bls=bls,
+                    frequencies=frequencies,
+                    freq_chans=freq_chans,
+                    times=times,
+                    polarizations=polarizations,
+                    blt_inds=blt_inds,
+                    time_range=time_range,
+                    keep_all_metadata=keep_all_metadata,
+                    read_data=read_data,
+                    phase_type=phase_type,
+                    correct_lat_lon=correct_lat_lon,
+                    use_model=use_model,
+                    data_column=data_column,
+                    pol_order=pol_order,
+                    data_array_dtype=data_array_dtype,
+                    run_check=run_check,
+                    check_extra=check_extra,
+                    run_check_acceptability=run_check_acceptability,
+                    check_file_status=check_file_status,
+                )
 
             if (
                 allow_rephase
@@ -6512,8 +6510,8 @@ class UVData(UVBase):
                 # set the phase center to be the phase center of the first file
                 phase_center_radec = [self.phase_center_ra, self.phase_center_dec]
 
-            if len(filename) > file_num+1:
-                for f in filename[file_num+1:]:
+            if len(filename) > file_num + 1:
+                for f in filename[file_num + 1 :]:
                     uv2 = UVData()
                     if check_file_status:
                         try:
@@ -6545,9 +6543,7 @@ class UVData(UVBase):
                                 check_file_status=check_file_status,
                             )
                         except KeyError:
-                            warnings.warn(
-                                "Failed to read {f}".format(f=f)
-                            )
+                            warnings.warn("Failed to read {f}".format(f=f))
                             continue
                     else:
                         uv2.read(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add an option in the UVData.read() function to, when reading in a list of files, check each file before reading. This way, if one or more files are corrupted, the read call may proceed without crashing, and will instead provide a warning for each file that failed.

## Motivation and Context
This is in response to issue #783. For HERA we have run into problems with files occasionally missing metadata in their headers, and this causing our code to crash when trying to read in a whole night of data in one call. This fix will allow us to proceed without our code crashing, and instead get a warning that there was a corrupted file that was skipped.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.


New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
