### PR TITLE
Allow UVParameters to be equal if they contain NaNs in arrays in the same locations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - `frequency_average` method on UVData to average data along the frequency axis.
 
 ### Fixed
+- UVParameters that are array_like and have NaNs are now properly identified as equal if the NaNs are in the same locations and all non-NaN entries are equal.
 - A bug in `mwa_corr_fits.read` in filling flag and nsample arrays.
 - A bug in `UVData.downsample_in_time` in calculating the number of new blts.
 

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -123,7 +123,11 @@ class UVParameter(object):
                     )
                     return False
                 elif not np.allclose(
-                    self.value, other.value, rtol=self.tols[0], atol=self.tols[1]
+                    self.value,
+                    other.value,
+                    rtol=self.tols[0],
+                    atol=self.tols[1],
+                    equal_nan=True,
                 ):
                     print(
                         "{name} parameter value is array, values are not "
@@ -145,6 +149,7 @@ class UVParameter(object):
                             np.array(other.value),
                             rtol=self.tols[0],
                             atol=self.tols[1],
+                            equal_nan=True,
                         ):
                             print(
                                 "{name} parameter value can be cast to an array"

--- a/pyuvdata/tests/test_parameter.py
+++ b/pyuvdata/tests/test_parameter.py
@@ -37,6 +37,13 @@ def test_array_inequality():
     assert param1 != param3
 
 
+def test_array_equality_nans():
+    """Test array equality with nans present."""
+    param1 = uvp.UVParameter(name="p1", value=np.array([0, 1, np.nan]))
+    param2 = uvp.UVParameter(name="p2", value=np.array([0, 1, np.nan]))
+    assert param1 == param2
+
+
 def test_string_inequality():
     """Test equality error for different string values."""
     param1 = uvp.UVParameter(name="p1", value="Alice")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Set equal_nan=True in all np.allclose tests in `UVParameter.__eq__` method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
A problem came up in pyradiosky where two arrays were equal everywhere that they were not NaN and had NaNs in the same places, but our equality check failed because we didn't have the `equal_nan` parameter on `np.allclose` set to True. This fixes that and adds a test that fails on master.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
