### PR TITLE
Fix version capture for developer installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Required:
 * scipy
 * astropy >= 3.2.3
 * h5py
+* setuptools_scm
 
 Optional:
 

--- a/ci/hera_cal.yml
+++ b/ci/hera_cal.yml
@@ -15,6 +15,7 @@ dependencies:
   - pyyaml
   - scikit-learn
   - scipy
+  - setuptools_scm
   - basemap
   - pip:
     - git+https://github.com/HERA-Team/linsolve.git

--- a/ci/hera_qm.yml
+++ b/ci/hera_qm.yml
@@ -12,6 +12,7 @@ dependencies:
   - numpy
   - scikit-learn
   - scipy
+  - setuptools_scm
   - basemap
   - pytest
   - pytest-cov

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,6 +11,7 @@ dependencies:
   - python-casacore
   - pyyaml
   - scipy
+  - setuptools_scm
   - sphinx
   - coverage
   - pytest-cov

--- a/pyuvdata/__init__.py
+++ b/pyuvdata/__init__.py
@@ -12,7 +12,7 @@ from pkg_resources import get_distribution, DistributionNotFound
 from .branch_scheme import branch_scheme
 
 
-try:
+try:  # pragma: nocover
     # get accurate version for developer installs
     version_str = get_version(Path(__file__).parent.parent, local_scheme=branch_scheme)
 

--- a/pyuvdata/__init__.py
+++ b/pyuvdata/__init__.py
@@ -5,14 +5,26 @@
 """Init file for pyuvdata."""
 from __future__ import absolute_import, division, print_function
 import warnings
+from setuptools_scm import get_version
+from pathlib import Path
 from pkg_resources import get_distribution, DistributionNotFound
 
-# Set the version automatically from the package details.
+from .branch_scheme import branch_scheme
+
+
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:  # pragma: nocover
-    # package is not installed
-    pass
+    # get accurate version for developer installs
+    version_str = get_version(Path(__file__).parent.parent, local_scheme=branch_scheme)
+
+    __version__ = version_str
+
+except (LookupError, ImportError):
+    try:
+        # Set the version automatically from the package details.
+        __version__ = get_distribution(__name__).version
+    except DistributionNotFound:  # pragma: nocover
+        # package is not installed
+        pass
 
 # Filter annoying Cython warnings that serve no good purpose. see numpy#432
 # needs to be done before the imports to work properly

--- a/pyuvdata/branch_scheme.py
+++ b/pyuvdata/branch_scheme.py
@@ -1,0 +1,20 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright (c) 2020 Radio Astronomy Software Group
+# Licensed under the 2-clause BSD License
+
+"""Define branch_scheme for versioning."""
+
+
+def branch_scheme(version):
+    """
+    Local version scheme that adds the branch name for absolute reproducibility.
+
+    If and when this is added to setuptools_scm this function and file can be removed.
+    """
+    if version.exact or version.node is None:
+        return version.format_choice("", "+d{time:{time_format}}", time_format="%Y%m%d")
+    else:
+        if version.branch == "master":
+            return version.format_choice("+{node}", "+{node}.dirty")
+        else:
+            return version.format_choice("+{node}.{branch}", "+{node}.{branch}.dirty")

--- a/pyuvdata/branch_scheme.py
+++ b/pyuvdata/branch_scheme.py
@@ -5,7 +5,7 @@
 """Define branch_scheme for versioning."""
 
 
-def branch_scheme(version):
+def branch_scheme(version):  # pragma: nocover
     """
     Local version scheme that adds the branch name for absolute reproducibility.
 

--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,9 @@ from distutils.version import LooseVersion
 # without a workaround we can't use the pyuvdata code to get the version.
 os.environ["PYUVDATA_IGNORE_EXTMOD_IMPORT_FAIL"] = "1"
 
-
-def branch_scheme(version):
-    """Local version scheme that adds the branch name for absolute reproducibility."""
-    if version.exact or version.node is None:
-        return version.format_choice("", "+d{time:{time_format}}", time_format="%Y%m%d")
-    else:
-        if version.branch == "master":
-            return version.format_choice("+{node}", "+{node}.dirty")
-        else:
-            return version.format_choice("+{node}.{branch}", "+{node}.{branch}.dirty")
+# add pyuvdata to our path in order to use the branch_scheme function
+sys.path.append("pyuvdata")
+from branch_scheme import branch_scheme  # noqa
 
 
 # this solution works for `pip install .`` but not `python setup.py install`...
@@ -119,7 +112,13 @@ setup_args = {
     "scripts": [fl for fl in glob.glob("scripts/*") if not os.path.isdir(fl)],
     "use_scm_version": {"local_scheme": branch_scheme},
     "include_package_data": True,
-    "install_requires": ["numpy>=1.15", "scipy", "astropy>=3.2.3", "h5py"],
+    "install_requires": [
+        "numpy>=1.15",
+        "scipy",
+        "astropy>=3.2.3",
+        "h5py",
+        "setuptools_scm",
+    ],
     "tests_require": ["pytest", "pytest-cases"],
     "extras_require": {
         "casa": casa_reqs,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use `setuptools_scm` to get the actual version of the running code in the case of a developer install.

Note this adds a runtime dependency (rather than just an install dependency) on setuptools_scm.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
When pyuvdata was installed with a developer install (`pip install -e .`), we were getting the version as of the time the developer install was done rather than the current code version in `pyuvdata.__version__`, which is used when we set the version string on our objects.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
