### PR TITLE
use utils.conj_pol when conjugating in select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - `frequency_average` method on UVData to average data along the frequency axis.
 
 ### Fixed
+- A bug in `select` where baseline-polarization tuples would not be conjugated correctly in `UVData` and `UVFlag`, and select on read for Miriad files.
 - `metafits_ppds.fits` files can now be passed to `mwa_corr_fits.read` without throwing an error.
 - UVParameters that are array_like and have NaNs are now properly identified as equal if the NaNs are in the same locations and all non-NaN entries are equal.
 - A bug in `mwa_corr_fits.read` in filling flag and nsample arrays.

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -229,7 +229,7 @@ class Miriad(UVData):
                     else:
                         bl_str_list.append(str(bl[1]) + "_" + str(bl[0]))
                         if len(bl) == 3:
-                            bl_pols.add(bl[2][::-1])
+                            bl_pols.add(uvutils.conj_pol(bl[2].lower()))
 
                 if n_selects > 0:
                     # combine antpair_str_list and bl_str_list with an intersection

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -229,7 +229,7 @@ class Miriad(UVData):
                     else:
                         bl_str_list.append(str(bl[1]) + "_" + str(bl[0]))
                         if len(bl) == 3:
-                            bl_pols.add(uvutils.conj_pol(bl[2].lower()))
+                            bl_pols.add(uvutils.conj_pol(bl[2]))
 
                 if n_selects > 0:
                     # combine antpair_str_list and bl_str_list with an intersection

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -4061,7 +4061,8 @@ class UVData(UVBase):
                 elif len(wh2) > 0:
                     bls_blt_inds = np.append(bls_blt_inds, list(wh2))
                     if len(bl) == 3:
-                        bl_pols.add(bl[2][::-1])  # reverse polarization string
+                        # find conjugate polarization
+                        bl_pols.add(uvutils.conj_pol(bl[2]))
                 else:
                     raise ValueError(
                         "Antenna pair {p} does not have any data "

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -1965,7 +1965,7 @@ class UVFlag(UVBase):
                 elif len(wh2) > 0:
                     bls_blt_inds = np.append(bls_blt_inds, list(wh2))
                     if len(bl) == 3:
-                        bl_pols.add(bl[2][::-1])  # reverse polarization string
+                        bl_pols.add(uvutils.conj_pol(bl[2]))
                 else:
                     raise ValueError(
                         "Antenna pair {p} does not have any data "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
closes #796
## Description
<!--- Describe your changes in detail -->
removes lazy string reversing for calling `utils.conj_pol()` when performing select on uvdata, uvlfag, and miriad reads.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The original code for this lazily assumed all polarizations were linear or circular but did not consider (pseudo) Stokes parameters.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

