### PR TITLE
added fast H5PY slice indexing for UVH5.read_uvh5()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Handling of strings in UVFlag files has been made more widely compatible.
 
 ### Added
+- `chunks` to `UVH5.write_uvh5` and `UVData.write_uvh5` for HDF5 dataset chunking.
+- `multidim_index` to `UVH5.read_uvh5` and `UVData.read` for multidimensional slicing into HDF5 datasets
 - Option to provide parameters for RectBivariatespline through interp
 - `weights_square_array` (optional) parameter on UVFlag - stores sum of squares of weights when converting to waterfall
 - `frequency_average` method on UVData to average data along the frequency axis.

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -620,7 +620,8 @@ def test_uvh5_partial_read_multi2(uv_uvfits):
     blts_to_keep = np.arange(100)
     uvh5_uv3 = UVData()
     uvh5_uv4 = UVData()
-    for chans_to_keep in [[0, 2, 5], np.arange(50)]:
+    random_freqs = np.random.choice(np.arange(uv_in.Nfreqs), size=50, replace=False)
+    for chans_to_keep in [random_freqs, np.arange(50)]:
         for pols_to_keep in [[-1, -2], [-1, -2, -4]]:
             uvh5_uv3.read(
                 testfile,
@@ -2560,5 +2561,6 @@ def test_read_slicing(uv_uvfits):
     # dataset indexing
     # check various kinds of indexing give the right answer
     slices = [uvh5._convert_to_slices(ind)[0] for ind in indices]
+    slices[1] = 0
     data = uvh5._index_dset(dset, slices)
     assert data.shape == tuple(shape)

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -468,9 +468,10 @@ def test_uvh5_partial_read_pols(uv_uvfits):
     assert uvh5_uv == uvh5_uv2
 
     # select on pols (non contiguous in file)
+    # and check consistent results with and without multidim_slice
     pols_to_keep = [-1, -2, -4]
-    uvh5_uv.read(testfile, polarizations=pols_to_keep)
-    uvh5_uv2.read(testfile)
+    uvh5_uv.read(testfile, polarizations=pols_to_keep, multidim_slice=True)
+    uvh5_uv2.read(testfile, multidim_slice=False)
     uvh5_uv2.select(polarizations=pols_to_keep)
     assert uvh5_uv == uvh5_uv2
 

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -467,6 +467,13 @@ def test_uvh5_partial_read_pols(uv_uvfits):
     uvh5_uv2.select(polarizations=pols_to_keep)
     assert uvh5_uv == uvh5_uv2
 
+    # select on pols (non contiguous in file)
+    pols_to_keep = [-1, -2, -4]
+    uvh5_uv.read(testfile, polarizations=pols_to_keep)
+    uvh5_uv2.read(testfile)
+    uvh5_uv2.select(polarizations=pols_to_keep)
+    assert uvh5_uv == uvh5_uv2
+
     return
 
 

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -468,10 +468,10 @@ def test_uvh5_partial_read_pols(uv_uvfits):
     assert uvh5_uv == uvh5_uv2
 
     # select on pols (non contiguous in file)
-    # and check consistent results with and without multidim_slice
+    # and check consistent results with and without multidim_index
     pols_to_keep = [-1, -2, -4]
-    uvh5_uv.read(testfile, polarizations=pols_to_keep, multidim_slice=True)
-    uvh5_uv2.read(testfile, multidim_slice=False)
+    uvh5_uv.read(testfile, polarizations=pols_to_keep, multidim_index=True)
+    uvh5_uv2.read(testfile, multidim_index=False)
     uvh5_uv2.select(polarizations=pols_to_keep)
     assert uvh5_uv == uvh5_uv2
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6999,6 +6999,7 @@ class UVData(UVBase):
         check_extra=True,
         run_check_acceptability=True,
         clobber=False,
+        chunks=True,
         data_compression=None,
         flags_compression="lzf",
         nsample_compression="lzf",
@@ -7013,15 +7014,18 @@ class UVData(UVBase):
              The UVH5 file to write to.
         clobber : bool
             Option to overwrite the file if it already exists.
+        chunks : tuple or bool
+            h5py.create_dataset chunks keyword. Tuple for chunk shape,
+            True for auto-chunking, None for no chunking. Default is True.
         data_compression : str
             HDF5 filter to apply when writing the data_array. Default is
-            None meaning no filter or compression.
+            None meaning no filter or compression. Dataset must be chunked.
         flags_compression : str
             HDF5 filter to apply when writing the flags_array. Default is "lzf"
-            for the LZF filter.
+            for the LZF filter. Dataset must be chunked.
         nsample_compression : str
             HDF5 filter to apply when writing the nsample_array. Default is "lzf"
-            for the LZF filter.
+            for the LZF filter. Dataset must be chunked.
         data_write_dtype : numpy dtype
             datatype of output visibility data. If 'None', then the same datatype
             as data_array will be used. Otherwise, a numpy dtype object must be
@@ -7046,6 +7050,7 @@ class UVData(UVBase):
             check_extra=check_extra,
             run_check_acceptability=run_check_acceptability,
             clobber=clobber,
+            chunks=chunks,
             data_compression=data_compression,
             flags_compression=flags_compression,
             nsample_compression=nsample_compression,
@@ -7057,6 +7062,7 @@ class UVData(UVBase):
         self,
         filename,
         clobber=False,
+        chunks=True,
         data_compression=None,
         flags_compression="lzf",
         nsample_compression="lzf",
@@ -7071,15 +7077,18 @@ class UVData(UVBase):
              The UVH5 file to write to.
         clobber : bool
             Option to overwrite the file if it already exists.
+        chunks : tuple or bool
+            h5py.create_dataset chunks keyword. Tuple for chunk shape,
+            True for auto-chunking, None for no chunking. Default is True.
         data_compression : str
             HDF5 filter to apply when writing the data_array. Default is
-            None meaning no filter or compression.
+            None meaning no filter or compression. Dataset must be chunked.
         flags_compression : str
             HDF5 filter to apply when writing the flags_array. Default is "lzf"
-            for the LZF filter.
+            for the LZF filter. Dataset must be chunked.
         nsample_compression : str
             HDF5 filter to apply when writing the nsample_array. Default is "lzf"
-            for the LZF filter.
+            for the LZF filter. Dataset must be chunked.
         data_write_dtype : numpy dtype
             datatype of output visibility data. If 'None', then the same datatype
             as data_array will be used. Otherwise, a numpy dtype object must be
@@ -7098,6 +7107,7 @@ class UVData(UVBase):
         uvh5_obj.initialize_uvh5_file(
             filename,
             clobber=clobber,
+            chunks=chunks,
             data_compression=data_compression,
             flags_compression=flags_compression,
             nsample_compression=nsample_compression,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6071,6 +6071,7 @@ class UVData(UVBase):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
+        multidim_slice=False,
     ):
         """
         Read a UVH5 file.
@@ -6163,6 +6164,10 @@ class UVData(UVBase):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done). Ignored if read_data is False.
+        multidim_slice : bool
+            [Only for HDF5] If True, attempt to slice the HDF5 dataset
+            simultaneously along all data axes. Otherwise load one axis at-a-time.
+            If axis indices are not well-matched to data chunks, this can be slow.
 
         Raises
         ------
@@ -6203,6 +6208,7 @@ class UVData(UVBase):
             run_check_acceptability=run_check_acceptability,
             data_array_dtype=data_array_dtype,
             keep_all_metadata=keep_all_metadata,
+            multidim_slice=multidim_slice,
         )
         self._convert_from_filetype(uvh5_obj)
         del uvh5_obj
@@ -6248,6 +6254,7 @@ class UVData(UVBase):
         check_extra=True,
         run_check_acceptability=True,
         skip_bad_files=False,
+        multidim_slice=False,
     ):
         """
         Read a generic file into a UVData object.
@@ -6427,6 +6434,10 @@ class UVData(UVBase):
             the read continues even if one or more files are corrupted. Files
             that produce errors will be printed. Default is False (files will
             not be skipped).
+        multidim_slice : bool
+            [Only for HDF5] If True, attempt to slice the HDF5 dataset
+            simultaneously along all data axes. Otherwise load one axis at-a-time.
+            If axis indices are not well-matched to data chunks, this can be slow.
 
         Raises
         ------
@@ -6800,6 +6811,7 @@ class UVData(UVBase):
                     run_check_acceptability=run_check_acceptability,
                     data_array_dtype=data_array_dtype,
                     keep_all_metadata=keep_all_metadata,
+                    multidim_slice=multidim_slice,
                 )
                 select = False
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6071,7 +6071,7 @@ class UVData(UVBase):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
-        multidim_slice=False,
+        multidim_index=False,
     ):
         """
         Read a UVH5 file.
@@ -6164,10 +6164,11 @@ class UVData(UVBase):
             Option to check acceptable range of the values of parameters after
             reading in the file (the default is True, meaning the acceptable
             range check will be done). Ignored if read_data is False.
-        multidim_slice : bool
-            [Only for HDF5] If True, attempt to slice the HDF5 dataset
-            simultaneously along all data axes. Otherwise load one axis at-a-time.
-            If axis indices are not well-matched to data chunks, this can be slow.
+        multidim_index : bool
+            [Only for HDF5] If True, attempt to index the HDF5 dataset
+            simultaneously along all data axes. Otherwise index one axis at-a-time.
+            This only works if data selection is sliceable along all but one axis.
+            If indices are not well-matched to data chunks, this can be slow.
 
         Raises
         ------
@@ -6208,7 +6209,7 @@ class UVData(UVBase):
             run_check_acceptability=run_check_acceptability,
             data_array_dtype=data_array_dtype,
             keep_all_metadata=keep_all_metadata,
-            multidim_slice=multidim_slice,
+            multidim_index=multidim_index,
         )
         self._convert_from_filetype(uvh5_obj)
         del uvh5_obj
@@ -6254,7 +6255,7 @@ class UVData(UVBase):
         check_extra=True,
         run_check_acceptability=True,
         skip_bad_files=False,
-        multidim_slice=False,
+        multidim_index=False,
     ):
         """
         Read a generic file into a UVData object.
@@ -6434,10 +6435,11 @@ class UVData(UVBase):
             the read continues even if one or more files are corrupted. Files
             that produce errors will be printed. Default is False (files will
             not be skipped).
-        multidim_slice : bool
-            [Only for HDF5] If True, attempt to slice the HDF5 dataset
-            simultaneously along all data axes. Otherwise load one axis at-a-time.
-            If axis indices are not well-matched to data chunks, this can be slow.
+        multidim_index : bool
+            [Only for HDF5] If True, attempt to index the HDF5 dataset
+            simultaneously along all data axes. Otherwise index one axis at-a-time.
+            This only works if data selection is sliceable along all but one axis.
+            If indices are not well-matched to data chunks, this can be slow.
 
         Raises
         ------
@@ -6811,7 +6813,7 @@ class UVData(UVBase):
                     run_check_acceptability=run_check_acceptability,
                     data_array_dtype=data_array_dtype,
                     keep_all_metadata=keep_all_metadata,
-                    multidim_slice=multidim_slice,
+                    multidim_index=multidim_index,
                 )
                 select = False
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -227,13 +227,13 @@ def _get_slice_len(s, axlen):
     if s.stop is None:
         stop = axlen
     else:
-        stop = s.stop
+        stop = np.min([s.stop, axlen])
     if s.step is None:
         step = 1
     else:
         step = s.step
 
-    return (stop - start) // step
+    return (stop - 1 - start) // step + 1
 
 
 def _get_dset_shape(dset, indices):
@@ -293,11 +293,12 @@ def _index_dset(dset, indices):
     ndarray
         The indexed dset
     """
-    # get dset shape
-    dset_shape = _get_dset_shape(dset, indices)
+    # get dset and arr shape
+    dset_shape = dset.shape
+    arr_shape = _get_dset_shape(dset, indices)
 
     # create empty array of dset dtype
-    arr = np.empty(dset_shape, dtype=dset.dtype)
+    arr = np.empty(arr_shape, dtype=dset.dtype)
 
     # get arr and dest indices for each dimension in indices
     dset_indices = []
@@ -321,8 +322,8 @@ def _index_dset(dset, indices):
             elif isinstance(dset_inds[0], slice):
                 # this is a list of slices, need list of slice lens
                 slens = [_get_slice_len(s, dset_shape[i]) for s in dset_inds]
-                ssums = [sum(slens[:i]) for i in range(len(slens))]
-                arr_inds = [slice(ssums[i], ssums[i] + slens[i]) for i in range(len(slens))]
+                ssums = [sum(slens[:j]) for j in range(len(slens))]
+                arr_inds = [slice(ssums[j], ssums[j] + slens[j]) for j in range(len(slens))]
                 arr_indices.append(arr_inds)
                 dset_indices.append(dset_inds)
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -95,6 +95,7 @@ def _read_complex_astype(dset, indices, dtype_out=np.complex64):
     output_array = np.empty(dset_shape, dtype=dtype_out)
     dtype_in = dset.dtype
     with dset.astype(dtype_in):
+        # dset is indexed in native dtype, but is upcast upon assignment
         output_array.real = _index_dset(dset["r"], indices)
         output_array.imag = _index_dset(dset["i"], indices)
 
@@ -159,6 +160,12 @@ def _convert_to_slices(indices, max_nslice_frac=0.1):
         if: indices = [1, 2, 3, 4, 10, 11, 12, 13, 14]
         then: slices = [slice(1, 5, 1), slice(11, 15, 1)]
     """
+    # check for integer index
+    if isinstance(indices, (int, np.integer)):
+        indices = [indices]
+    # check for already a slice
+    if isinstance(indices, slice):
+        return [indices], True
     # assert indices is longer than 2, or return trivial solutions
     if len(indices) == 0:
         return [slice(0, 0, 0)], False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added smarter h5py dataset slicing upon UVH5 read call.

## Description
<!--- Describe your changes in detail -->
 In general, if one is loading a subset of the blts axis it defaults to a fancy index, which is very slow for HDF5 (see [this stack overflow post](https://stackoverflow.com/questions/21766145/h5py-correct-way-to-slice-array-datasets)). This can be sped up if we are able to slice the datasets when possible. 

Furthermore, default behavior was to slice only one data axis at a time. This PR lets us slice as many axes simultaneously as possible, so we don't need to load in more data than what is requested.

This also exposes the `chunks` kwarg to `UVH5.write_uvh5` and `UVData.write_uvh5` for writing HDF5 files with custom chunking, which can significantly accelerate or degrade I/O performance depending on how the data are typically being read.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Very slow read times when working with Nblts > 20k elements files but trying to select only a subset of the antennas.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Breaking change checklist:
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
