### PR TITLE
Speed up calfits reading by not deleting header items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `multidim_index` to `UVH5.read_uvh5` and `UVData.read` for multidimensional slicing into HDF5 datasets
 
 ### Changed
+- UVCal objects should now read calfits files faster due to a simplified handling of fits header objects, especially when the history is very long.
 - The UVData methods `set_drift`, `set_phased`, and `set_unknown_phase_type` have been made private. The public methods will be removed in a future version.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - `multidim_index` to `UVH5.read_uvh5` and `UVData.read` for multidimensional slicing into HDF5 datasets
 
 ### Changed
-- UVCal objects should now read calfits files faster due to a simplified handling of fits header objects, especially when the history is very long.
+- uvfits, calfits and beamfits files should now be read faster due to a simplified handling of fits header objects, especially when the history is very long.
 - The UVData methods `set_drift`, `set_phased`, and `set_unknown_phase_type` have been made private. The public methods will be removed in a future version.
 
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -169,6 +169,63 @@ def _fits_indexhdus(hdulist):
     return tablenames
 
 
+def _get_fits_extra_keywords(header, keywords_to_skip=None):
+    """
+    Get any extra keywords and return as dict.
+
+    Parameters
+    ----------
+    header : FITS header object
+        header object to get extra_keywords from.
+    keywords_to_skip : list of str
+        list of keywords to not include in extra keywords in addition to standard
+        FITS keywords.
+
+    Returns
+    -------
+    dict
+        dict of extra keywords.
+    """
+    # List standard FITS header items that are still should not be included in
+    # extra_keywords
+    std_fits_substrings = [
+        "HISTORY",
+        "SIMPLE",
+        "BITPIX",
+        "EXTEND",
+        "BLOCKED",
+        "GROUPS",
+        "PCOUNT",
+        "BSCALE",
+        "BZERO",
+        "NAXIS",
+        "PTYPE",
+        "PSCAL",
+        "PZERO",
+        "CTYPE",
+        "CRVAL",
+        "CRPIX",
+        "CDELT",
+        "CROTA",
+        "CUNIT",
+    ]
+
+    if keywords_to_skip is not None:
+        std_fits_substrings.extend(keywords_to_skip)
+
+    extra_keywords = {}
+    # find all the other header items and keep them as extra_keywords
+    for key in header:
+        if np.any([sub in key for sub in std_fits_substrings]):
+            continue
+        if key == "COMMENT":
+            extra_keywords[key] = str(header.get(key))
+        elif key != "":
+            extra_keywords[key] = header.get(key)
+
+    return extra_keywords
+
+
 def _check_history_version(history, version_string):
     """Check if version_string is present in history string."""
     if version_string.replace(" ", "") in history.replace("\n", "").replace(" ", ""):

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -188,6 +188,8 @@ def _get_fits_extra_keywords(header, keywords_to_skip=None):
     """
     # List standard FITS header items that are still should not be included in
     # extra_keywords
+    # These are the beginnings of FITS keywords to ignore, the actual keywords
+    # often include integers following these names (e.g. NAXIS1, CTYPE3)
     std_fits_substrings = [
         "HISTORY",
         "SIMPLE",
@@ -216,6 +218,7 @@ def _get_fits_extra_keywords(header, keywords_to_skip=None):
     extra_keywords = {}
     # find all the other header items and keep them as extra_keywords
     for key in header:
+        # check if key contains any of the standard FITS substrings
         if np.any([sub in key for sub in std_fits_substrings]):
             continue
         if key == "COMMENT":

--- a/pyuvdata/uvbeam/beamfits.py
+++ b/pyuvdata/uvbeam/beamfits.py
@@ -297,41 +297,8 @@ class BeamFITS(UVBeam):
                 self.history, self.pyuvdata_version_str
             ):
                 self.history += self.pyuvdata_version_str
-            while "HISTORY" in primary_header.keys():
-                primary_header.remove("HISTORY")
 
-            # remove standard FITS header items that are still around
-            std_fits_substrings = [
-                "SIMPLE",
-                "BITPIX",
-                "EXTEND",
-                "BLOCKED",
-                "GROUPS",
-                "PCOUNT",
-                "BSCALE",
-                "BZERO",
-                "NAXIS",
-                "PTYPE",
-                "PSCAL",
-                "PZERO",
-                "CTYPE",
-                "CRVAL",
-                "CRPIX",
-                "CDELT",
-                "CROTA",
-                "CUNIT",
-            ]
-            for key in list(primary_header.keys()):
-                for sub in std_fits_substrings:
-                    if key.find(sub) > -1:
-                        primary_header.remove(key)
-
-            # find all the remaining header items and keep them as extra_keywords
-            for key in primary_header:
-                if key == "COMMENT":
-                    self.extra_keywords[key] = str(primary_header.get(key))
-                elif key != "":
-                    self.extra_keywords[key] = primary_header.get(key)
+            self.extra_keywords = uvutils._get_fits_extra_keywords(primary_header)
 
             # read BASISVEC HDU if present
             if "BASISVEC" in hdunames:

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -575,7 +575,7 @@ class CALFITS(UVCal):
             # find all the other header items and keep them as extra_keywords
             for key in hdr:
                 if np.any([key in sub for sub in std_fits_substrings]):
-                    pass 
+                    continue 
                 if key == "COMMENT":
                     self.extra_keywords[key] = str(hdr.get(key))
                 elif key != "":

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -443,8 +443,6 @@ class CALFITS(UVCal):
 
                 self.history += self.pyuvdata_version_str
 
-            while "HISTORY" in hdr.keys():
-                hdr.remove("HISTORY")
             self.time_range = list(map(float, hdr.pop("TMERANGE").split(",")))
             self.gain_convention = hdr.pop("GNCONVEN")
             self.gain_scale = hdr.pop("GNSCALE", None)
@@ -553,6 +551,7 @@ class CALFITS(UVCal):
 
             # remove standard FITS header items that are still around
             std_fits_substrings = [
+                "HISTORY",
                 "SIMPLE",
                 "BITPIX",
                 "EXTEND",
@@ -572,13 +571,11 @@ class CALFITS(UVCal):
                 "CROTA",
                 "CUNIT",
             ]
-            for key in list(hdr.keys()):
-                for sub in std_fits_substrings:
-                    if key.find(sub) > -1:
-                        hdr.remove(key)
 
-            # find all the remaining header items and keep them as extra_keywords
+            # find all the other header items and keep them as extra_keywords
             for key in hdr:
+                if np.any([key in sub for sub in std_fits_substrings]):
+                    pass 
                 if key == "COMMENT":
                     self.extra_keywords[key] = str(hdr.get(key))
                 elif key != "":

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -551,7 +551,6 @@ class CALFITS(UVCal):
 
             # remove standard FITS header items that are still around
             std_fits_substrings = [
-                "HISTORY",
                 "SIMPLE",
                 "BITPIX",
                 "EXTEND",
@@ -570,6 +569,7 @@ class CALFITS(UVCal):
                 "CDELT",
                 "CROTA",
                 "CUNIT",
+                "HISTORY",
             ]
 
             # find all the other header items and keep them as extra_keywords

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -549,37 +549,7 @@ class CALFITS(UVCal):
                         "Jones values are different in FLAGS HDU than in primary HDU"
                     )
 
-            # remove standard FITS header items that are still around
-            std_fits_substrings = [
-                "SIMPLE",
-                "BITPIX",
-                "EXTEND",
-                "BLOCKED",
-                "GROUPS",
-                "PCOUNT",
-                "BSCALE",
-                "BZERO",
-                "NAXIS",
-                "PTYPE",
-                "PSCAL",
-                "PZERO",
-                "CTYPE",
-                "CRVAL",
-                "CRPIX",
-                "CDELT",
-                "CROTA",
-                "CUNIT",
-                "HISTORY",
-            ]
-
-            # find all the other header items and keep them as extra_keywords
-            for key in hdr:
-                if np.any([key in sub for sub in std_fits_substrings]):
-                    continue 
-                if key == "COMMENT":
-                    self.extra_keywords[key] = str(hdr.get(key))
-                elif key != "":
-                    self.extra_keywords[key] = hdr.get(key)
+            self.extra_keywords = uvutils._get_fits_extra_keywords(hdr)
 
             # get total quality array if present
             if "TOTQLTY" in hdunames:

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -475,46 +475,13 @@ class UVFITS(UVData):
             ):
                 self.history += self.pyuvdata_version_str
 
-            while "HISTORY" in vis_hdr.keys():
-                vis_hdr.remove("HISTORY")
-
             self.vis_units = vis_hdr.pop("BUNIT", "UNCALIB")
             self.phase_center_epoch = vis_hdr.pop("EPOCH", None)
             self.phase_center_frame = vis_hdr.pop("PHSFRAME", None)
 
-            # remove standard FITS header items that are still around
-            std_fits_substrings = [
-                "SIMPLE",
-                "BITPIX",
-                "EXTEND",
-                "BLOCKED",
-                "GROUPS",
-                "PCOUNT",
-                "BSCALE",
-                "BZERO",
-                "NAXIS",
-                "PTYPE",
-                "PSCAL",
-                "PZERO",
-                "CTYPE",
-                "CRVAL",
-                "CRPIX",
-                "CDELT",
-                "CROTA",
-                "CUNIT",
-                "DATE-OBS",
-            ]
-            for key in list(vis_hdr.keys()):
-                for sub in std_fits_substrings:
-                    if key.find(sub) > -1:
-                        vis_hdr.remove(key)
-
-            # find all the remaining header items and keep them as extra_keywords
-            for key in vis_hdr:
-                if key == "COMMENT":
-                    self.extra_keywords[key] = str(vis_hdr.get(key))
-                elif key != "":
-                    self.extra_keywords[key] = vis_hdr.get(key)
+            self.extra_keywords = uvutils._get_fits_extra_keywords(
+                vis_hdr, keywords_to_skip=["DATE-OBS"]
+            )
 
             # Next read the antenna table
             ant_hdu = hdu_list[hdunames["AIPS AN"]]


### PR DESCRIPTION
## Description
As a UVCal object is being created, fits header items were being deleted for bookkeeping reasons. For calfits files with very long histories (as was in the case in some H3C data) and small amounts of data, this turned out ot be increasing the runtime by roughly an OOM. Now they are deleted and the bookkeeping is done differently.

Bryna: I pulled Josh's logic out to a utility function that is now called by all three FITS readers (uvfits, calfits, beamfits).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
