### PR TITLE
Code speedup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,7 @@
 [run]
+plugins = Cython.Coverage
+concurrency = multiprocessing
+parallel = true
 omit =
   */tests/*
   */conftest.py

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ docs/references/*.out
 .pytest_cache
 
 pyuvdata/uvdata/src/miriad_wrap.cpp
+
+pyuvdata/uvdata/corr_fits_src/corr_fits.c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- New `_corr_fits` C extension for performing the index and conjugation mapping calculation for read_mwa_corr_fits
 - `copy` method to UVCal and UVBeam objects
 - `chunks` to `UVH5.write_uvh5` and `UVData.write_uvh5` for HDF5 dataset chunking.
 - `multidim_index` to `UVH5.read_uvh5` and `UVData.read` for multidimensional slicing into HDF5 datasets
 
 ### Changed
+- Various serialized calculations in uvdata.py and utils.py to be vectorized with numpy
 - Miriad interface was re-written from a hand written CPython interface to a Cython interface which dynamically creates the CPython during package setup/build.
 - uvfits, calfits and beamfits files should now be read faster due to a simplified handling of fits header objects, especially when the history is very long.
 - The UVData methods `set_drift`, `set_phased`, and `set_unknown_phase_type` have been made private. The public methods will be removed in a future version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - `multidim_index` to `UVH5.read_uvh5` and `UVData.read` for multidimensional slicing into HDF5 datasets
 
 ### Changed
-- Various serialized calculations in uvdata.py and utils.py to be vectorized with numpy
+- Various serialized calculations in uvdata.py, uvbeam.py, and utils.py to be vectorized with numpy
 - Miriad interface was re-written from a hand written CPython interface to a Cython interface which dynamically creates the CPython during package setup/build.
 - uvfits, calfits and beamfits files should now be read faster due to a simplified handling of fits header objects, especially when the history is very long.
 - The UVData methods `set_drift`, `set_phased`, and `set_unknown_phase_type` have been made private. The public methods will be removed in a future version.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ you will need the following packages:
 * pytest-cases >= 1.12.1
 * pytest-xdist
 * pytest-cov
+* cython   (This is necessary for coverage reporting of cython extensions)
 * coverage
 * pre-commit
 * sphinx

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -9,6 +9,7 @@ dependencies:
   - h5py
   - coverage
   - pytest-cov
+  - cython
   - setuptools_scm
   - pip
   - pip:

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -12,6 +12,7 @@ dependencies:
   - scipy
   - coverage
   - pytest-cov
+  - cython
   - setuptools_scm
   - pip
   - pip:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1763,6 +1763,12 @@ e) Writing a HEALPix beam FITS file
   >>> beam.interpolation_function = 'az_za_simple'
 
   # note that the `to_healpix` method requires astropy_healpix to be installed
+  # this beam file is very large. Let's cut down the size to ease the computation
+  # More on the `select` method is covered in the following section
+  >>> za_max = np.deg2rad(10.0)
+  >>> za_inds_use = np.nonzero(beam.axis2_array <= za_max)[0]
+  >>> beam.select(axis2_inds=za_inds_use)
+
   >>> beam.to_healpix()
   >>> write_file = os.path.join(DATA_PATH, 'tutorial_output', 'tutorial.fits')
   >>> beam.write_beamfits(write_file, clobber=True)
@@ -1815,6 +1821,12 @@ a) Convert a regularly gridded az_za power beam to HEALpix (leaving original int
 
   # have to specify which interpolation function to use
   >>> beam.interpolation_function = 'az_za_simple'
+
+  # this beam file is very large. Let's cut down the size to ease the computation
+  >>> za_max = np.deg2rad(10.0)
+  >>> za_inds_use = np.nonzero(beam.axis2_array <= za_max)[0]
+  >>> beam.select(axis2_inds=za_inds_use)
+
   >>> hpx_beam = beam.to_healpix(inplace=False)
   >>> hpx_obj = HEALPix(nside=hpx_beam.nside, order=hpx_beam.ordering)
   >>> lon, lat = hpx_obj.healpix_to_lonlat(hpx_beam.pixel_array)
@@ -1837,6 +1849,12 @@ b) Convert a regularly gridded az_za efield beam to HEALpix (leaving original in
 
   # have to specify which interpolation function to use
   >>> beam.interpolation_function = 'az_za_simple'
+
+  # this beam file is very large. Let's cut down the size to ease the computation
+  >>> za_max = np.deg2rad(10.0)
+  >>> za_inds_use = np.nonzero(beam.axis2_array <= za_max)[0]
+  >>> beam.select(axis2_inds=za_inds_use)
+
   >>> hpx_beam = beam.to_healpix(inplace=False)
   >>> hpx_obj = HEALPix(nside=hpx_beam.nside, order=hpx_beam.ordering)
   >>> lon, lat = hpx_obj.healpix_to_lonlat(hpx_beam.pixel_array)
@@ -1882,6 +1900,12 @@ Generating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beams
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
   >>> beam.read_cst_beam(settings_file, beam_type='efield')
   >>> beam.interpolation_function = 'az_za_simple'
+
+  # this beam file is very large. Let's cut down the size to ease the computation
+  >>> za_max = np.deg2rad(10.0)
+  >>> za_inds_use = np.nonzero(beam.axis2_array <= za_max)[0]
+  >>> beam.select(axis2_inds=za_inds_use)
+
   >>> pstokes_beam = beam.to_healpix(inplace=False)
   >>> pstokes_beam.efield_to_pstokes()
   >>> pstokes_beam.peak_normalize()
@@ -1908,6 +1932,11 @@ Calculating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beam area and beam squared ar
   >>> beam.interpolation_function = 'az_za_simple'
 
   # note that the `to_healpix` method requires astropy_healpix to be installed
+  # this beam file is very large. Let's cut down the size to ease the computation
+  >>> za_max = np.deg2rad(10.0)
+  >>> za_inds_use = np.nonzero(beam.axis2_array <= za_max)[0]
+  >>> beam.select(axis2_inds=za_inds_use)
+
   >>> pstokes_beam = beam.to_healpix(inplace=False)
   >>> pstokes_beam.efield_to_pstokes()
   >>> pstokes_beam.peak_normalize()
@@ -1925,17 +1954,19 @@ Calculating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beam area and beam squared ar
 
   >>> print ('Beam area at {} MHz for pseudo-stokes\nI: {}\nQ: {}\nU: {}\nV: {}'.format(freqs[0][0]*1e-6, pI_area1, pU_area1, pU_area1, pV_area1))
   Beam area at 123.0 MHz for pseudo-stokes
-  I: 0.05734
-  Q: 0.03339
-  U: 0.03339
-  V: 0.05372
+  I: 0.04674
+  Q: 0.02879
+  U: 0.02879
+  V: 0.0464
+
 
   >>> print ('Beam area at {} MHz for pseudo-stokes\nI: {}\nQ: {}\nU: {}\nV: {}'.format(freqs[0][1]*1e-6, pI_area2, pU_area2, pU_area2, pV_area2))
   Beam area at 150.0 MHz for pseudo-stokes
-  I: 0.03965
-  Q: 0.02265
-  U: 0.02265
-  V: 0.03664
+  I: 0.03237
+  Q: 0.01956
+  U: 0.01956
+  V: 0.03186
+
 
   # calculating beam squared area
   >>> freqs = pstokes_beam.freq_array
@@ -1950,14 +1981,15 @@ Calculating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beam area and beam squared ar
 
   >>> print ('Beam squared area at {} MHz for pseudo-stokes\nI: {}\nQ: {}\nU: {}\nV: {}'.format(freqs[0][0]*1e-6, pI_sq_area1, pU_sq_area1, pU_sq_area1, pV_sq_area1))
   Beam squared area at 123.0 MHz for pseudo-stokes
-  I: 0.02439
-  Q: 0.01161
-  U: 0.01161
-  V: 0.02426
+  I: 0.02474
+  Q: 0.01179
+  U: 0.01179
+  V: 0.0246
+
 
   >>> print ('Beam squared area at {} MHz for pseudo-stokes\nI: {}\nQ: {}\nU: {}\nV: {}'.format(freqs[0][1]*1e-6, pI_sq_area2, pU_sq_area2, pU_sq_area2, pV_sq_area2))
   Beam squared area at 150.0 MHz for pseudo-stokes
-  I: 0.01693
-  Q: 0.0079
-  U: 0.0079
-  V: 0.01683
+  I: 0.01696
+  Q: 0.00792
+  U: 0.00792
+  V: 0.01686

--- a/environment.yaml
+++ b/environment.yaml
@@ -15,6 +15,7 @@ dependencies:
   - sphinx
   - coverage
   - pytest-cov
+  - cython
   - pip
   - pip:
       - pytest-cases>=1.12.1

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1115,27 +1115,23 @@ def get_lst_for_time(jd_array, latitude, longitude, altitude):
 
     """
     lst_array = np.zeros_like(jd_array)
-    for ind, jd in enumerate(np.unique(jd_array)):
-        t = Time(
-            jd,
-            format="jd",
-            location=(Angle(longitude, unit="deg"), Angle(latitude, unit="deg")),
-        )
-
-        # avoid errors if iers.conf.auto_max_age is set to None, as we do in
-        # testing if the iers url is down
-        if iers.conf.auto_max_age is None:  # pragma: no cover
-            delta, status = t.get_delta_ut1_utc(return_status=True)
-            if status in (iers.TIME_BEFORE_IERS_RANGE, iers.TIME_BEYOND_IERS_RANGE):
-                warnings.warn(
-                    "time is out of IERS range, setting delta ut1 utc to "
-                    "extrapolated value"
-                )
-                t.delta_ut1_utc = delta
-
-        lst_array[
-            np.where(np.isclose(jd, jd_array, atol=1e-6, rtol=1e-12))
-        ] = t.sidereal_time("apparent").radian
+    jd, reverse_inds = np.unique(jd_array, return_inverse=True)
+    times = Time(
+        jd,
+        format="jd",
+        location=(Angle(longitude, unit="deg"), Angle(latitude, unit="deg")),
+    )
+    if iers.conf.auto_max_age is None:  # pragma: no cover
+        delta, status = times.get_delta_ut1_utc(return_status=True)
+        if np.any(
+            np.isin(status, (iers.TIME_BEFORE_IERS_RANGE, iers.TIME_BEYOND_IERS_RANGE))
+        ):
+            warnings.warn(
+                "time is out of IERS range, setting delta ut1 utc to "
+                "extrapolated value"
+            )
+            times.delta_ut1_utc = delta
+    lst_array = times.sidereal_time("apparent").radian[reverse_inds]
 
     return lst_array
 

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -1903,16 +1903,15 @@ class UVBeam(UVBase):
         phi_vals, theta_vals = np.meshgrid(self.axis1_array, self.axis2_array)
 
         # Don't ask for interpolation to pixels that aren't inside the beam area
-        inds_to_use = []
-        for index in range(pixels.size):
-            pix_dists = np.sqrt(
-                (theta_vals - hpx_theta[index]) ** 2.0
-                + (phi_vals - hpx_phi[index]) ** 2.0
-            )
-            if np.min(pix_dists) < hp_obj.pixel_resolution.to_value(units.radian) * 2:
-                inds_to_use.append(index)
+        pix_dists = np.sqrt(
+            (theta_vals.ravel() - hpx_theta.reshape(-1, 1)) ** 2
+            + (phi_vals.ravel() - hpx_phi.reshape(-1, 1)) ** 2
+        )
 
-        inds_to_use = np.array(inds_to_use)
+        inds_to_use = np.argwhere(
+            np.min(pix_dists, axis=1)
+            < hp_obj.pixel_resolution.to_value(units.radian) * 2
+        ).squeeze(1)
 
         if inds_to_use.size < hp_obj.npix:
             pixels = pixels[inds_to_use]

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -34,7 +34,7 @@ cpdef generate_map(
   dict ants_to_pf,
   dict in_to_out,
   numpy.ndarray[ndim=1, dtype=numpy.int32_t] map_inds,
-  numpy.ndarray[ndim=1, dtype=numpy.int_t] conj
+  numpy.ndarray[ndim=1, dtype=numpy.npy_bool] conj
 ):
   for ant1 in range(128):
     for ant2 in range(ant1, 128):
@@ -75,7 +75,7 @@ cpdef generate_map(
                     )
                     # need to take the complex conjugate of the data
                     map_inds[bls_ind * 4 + pol_ind] = data_index
-                    conj[bls_ind * 4 + pol_ind] = 1
+                    conj[bls_ind * 4 + pol_ind] = True
                 else:
                     data_index = int(
                         2 * out_ant1 * (out_ant1 + 1)

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -1,0 +1,63 @@
+# distutils: language = c
+# python imports
+import numpy as np
+# cython imports
+cimport cython
+cimport numpy
+
+
+cpdef generate_map(
+  dict ants_to_pf,
+  dict in_to_out,
+  numpy.ndarray[ndim=1, dtype=numpy.int32_t] map_inds,
+  numpy.ndarray[ndim=1, dtype=numpy.int_t] conj
+):
+  for ant1 in range(128):
+    for ant2 in range(ant1, 128):
+        for p1 in range(2):
+            for p2 in range(2):
+                # generate the indices in self.data_array for this combination
+                # baselines are ordered (0,0),(0,1),...,(0,127),(1,1),.....
+                # polarizion of 0 (1) corresponds to y (x)
+                pol_ind = int(2 * p1 + p2)
+                bls_ind = int(128 * ant1 - ant1 * (ant1 + 1) / 2 + ant2)
+                # find the pfb input indices for this combination
+                (ind1_1, ind1_2) = (
+                    ants_to_pf[(ant1, p1)],
+                    ants_to_pf[(ant2, p2)],
+                )
+                # find the pfb output indices
+                (ind2_1, ind2_2) = (
+                    in_to_out[(ind1_1)],
+                    in_to_out[(ind1_2)],
+                )
+                out_ant1 = int(ind2_1 / 2)
+                out_ant2 = int(ind2_2 / 2)
+                out_p1 = ind2_1 % 2
+                out_p2 = ind2_2 % 2
+                # the correlator has ind2_2 <= ind2_1 except for
+                # redundant data. The redundant data is not perfectly
+                # redundant; sometimes the values of redundant data
+                # are off by one in the imaginary part.
+                # For consistency, we are ignoring the redundant values
+                # that have ind2_2 > ind2_1
+                if ind2_2 > ind2_1:
+                    # get the index for the data
+                    data_index = int(
+                        2 * out_ant2 * (out_ant2 + 1)
+                        + 4 * out_ant1
+                        + 2 * out_p2
+                        + out_p1
+                    )
+                    # need to take the complex conjugate of the data
+                    map_inds[bls_ind * 4 + pol_ind] = data_index
+                    conj[bls_ind * 4 + pol_ind] = True
+                else:
+                    data_index = int(
+                        2 * out_ant1 * (out_ant1 + 1)
+                        + 4 * out_ant2
+                        + 2 * out_p1
+                        + out_p2
+                    )
+                    map_inds[bls_ind * 4 + pol_ind] = data_index
+  return map_inds, conj

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -51,7 +51,7 @@ cpdef generate_map(
                     )
                     # need to take the complex conjugate of the data
                     map_inds[bls_ind * 4 + pol_ind] = data_index
-                    conj[bls_ind * 4 + pol_ind] = True
+                    conj[bls_ind * 4 + pol_ind] = 1
                 else:
                     data_index = int(
                         2 * out_ant1 * (out_ant1 + 1)

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -1,4 +1,6 @@
 # distutils: language = c
+# cython: linetrace=True
+# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 # python imports
 import numpy as np
 # cython imports

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -5,6 +5,28 @@ import numpy as np
 cimport cython
 cimport numpy
 
+def input_output_mapping():
+  """Build a mapping dictionary from pfb input to output numbers."""
+  # the polyphase filter bank maps inputs to outputs, which the MWA
+  # correlator then records as the antenna indices.
+  # the following is taken from mwa_build_lfiles/mwac_utils.c
+  # inputs are mapped to outputs via pfb_mapper as follows
+  # (from mwa_build_lfiles/antenna_mapping.h):
+  # floor(index/4) + index%4 * 16 = input
+  # for the first 64 outputs, pfb_mapper[output] = input
+  # fmt: off
+  pfb_mapper = [0, 16, 32, 48, 1, 17, 33, 49, 2, 18, 34, 50, 3, 19, 35, 51,
+                4, 20, 36, 52, 5, 21, 37, 53, 6, 22, 38, 54, 7, 23, 39, 55,
+                8, 24, 40, 56, 9, 25, 41, 57, 10, 26, 42, 58, 11, 27, 43, 59,
+                12, 28, 44, 60, 13, 29, 45, 61, 14, 30, 46, 62, 15, 31, 47,
+                63]
+  # fmt: on
+  # build a mapper for all 256 inputs
+  pfb_inputs_to_outputs = {}
+  for p in range(4):
+      for i in range(64):
+          pfb_inputs_to_outputs[pfb_mapper[i] + p * 64] = p * 64 + i
+  return pfb_inputs_to_outputs
 
 cpdef generate_map(
   dict ants_to_pf,

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -619,15 +619,15 @@ class MWACorrFITS(UVData):
         # these are the indices for the data corresponding to the initial
         # antenna/pol pair
         # generate a mapping index array
-        map_inds = np.zeros(self.Nbls * self.Npols, dtype=np.int32)
+        map_inds = np.zeros((self.Nbls * self.Npols), dtype=np.int32)
         # generate a conjugation array
-        conj = np.full(self.Nbls * self.Npols, False)
+        conj = np.full((self.Nbls * self.Npols), 0, dtype=np.int_)
         pfb_inputs_to_outputs = input_output_mapping()
 
         map_inds, conj = _corr_fits.generate_map(
             corr_ants_to_pfb_inputs, pfb_inputs_to_outputs, map_inds, conj,
         )
-
+        conj = conj.astype(bool)
         # reorder data
         self.data_array = self.data_array[:, :, map_inds]
         self.nsample_array = self.nsample_array[:, :, map_inds]

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -440,11 +440,8 @@ class MWACorrFITS(UVData):
             start_time + int_time / 2.0, end_time + int_time / 2.0 + int_time, int_time
         )
 
-        # convert from unix to julian times
-        julian_time_array = [Time(i, format="unix", scale="utc").jd for i in time_array]
-
-        # convert to integers
-        float_time_array = np.array([float(i) for i in julian_time_array])
+        # convert to time to jd floats
+        float_time_array = Time(time_array, format="unix", scale="utc").jd.astype(float)
         # build into time array
         self.time_array = np.repeat(float_time_array, self.Nbls)
 
@@ -457,7 +454,7 @@ class MWACorrFITS(UVData):
             self.time_array, *self.telescope_location_lat_lon_alt_degrees
         )
 
-        self.integration_time = np.array([int_time for i in range(self.Nblts)])
+        self.integration_time = np.full((self.Nblts), int_time)
 
         # convert antenna positions from enu to ecef
         # antenna positions are "relative to

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -9,6 +9,8 @@ from astropy.io import fits
 from astropy.time import Time
 from astropy import constants as const
 
+from pyuvdata import _corr_fits
+
 from . import UVData
 from .. import utils as uvutils
 
@@ -621,54 +623,11 @@ class MWACorrFITS(UVData):
         # generate a conjugation array
         conj = np.full(self.Nbls * self.Npols, False)
         pfb_inputs_to_outputs = input_output_mapping()
-        for ant1 in range(128):
-            for ant2 in range(ant1, 128):
-                for p1 in range(2):
-                    for p2 in range(2):
-                        # generate the indices in self.data_array for this combination
-                        # baselines are ordered (0,0),(0,1),...,(0,127),(1,1),.....
-                        # polarizion of 0 (1) corresponds to y (x)
-                        pol_ind = int(2 * p1 + p2)
-                        bls_ind = int(128 * ant1 - ant1 * (ant1 + 1) / 2 + ant2)
-                        # find the pfb input indices for this combination
-                        (ind1_1, ind1_2) = (
-                            corr_ants_to_pfb_inputs[(ant1, p1)],
-                            corr_ants_to_pfb_inputs[(ant2, p2)],
-                        )
-                        # find the pfb output indices
-                        (ind2_1, ind2_2) = (
-                            pfb_inputs_to_outputs[(ind1_1)],
-                            pfb_inputs_to_outputs[(ind1_2)],
-                        )
-                        out_ant1 = int(ind2_1 / 2)
-                        out_ant2 = int(ind2_2 / 2)
-                        out_p1 = ind2_1 % 2
-                        out_p2 = ind2_2 % 2
-                        # the correlator has ind2_2 <= ind2_1 except for
-                        # redundant data. The redundant data is not perfectly
-                        # redundant; sometimes the values of redundant data
-                        # are off by one in the imaginary part.
-                        # For consistency, we are ignoring the redundant values
-                        # that have ind2_2 > ind2_1
-                        if ind2_2 > ind2_1:
-                            # get the index for the data
-                            data_index = int(
-                                2 * out_ant2 * (out_ant2 + 1)
-                                + 4 * out_ant1
-                                + 2 * out_p2
-                                + out_p1
-                            )
-                            # need to take the complex conjugate of the data
-                            map_inds[bls_ind * 4 + pol_ind] = data_index
-                            conj[bls_ind * 4 + pol_ind] = True
-                        else:
-                            data_index = int(
-                                2 * out_ant1 * (out_ant1 + 1)
-                                + 4 * out_ant2
-                                + 2 * out_p1
-                                + out_p2
-                            )
-                            map_inds[bls_ind * 4 + pol_ind] = data_index
+
+        map_inds, conj = _corr_fits.generate_map(
+            corr_ants_to_pfb_inputs, pfb_inputs_to_outputs, map_inds, conj,
+        )
+
         # reorder data
         self.data_array = self.data_array[:, :, map_inds]
         self.nsample_array = self.nsample_array[:, :, map_inds]

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -609,13 +609,12 @@ class MWACorrFITS(UVData):
         # generate a mapping index array
         map_inds = np.zeros((self.Nbls * self.Npols), dtype=np.int32)
         # generate a conjugation array
-        conj = np.full((self.Nbls * self.Npols), 0, dtype=np.int_)
+        conj = np.full((self.Nbls * self.Npols), False, dtype=np.bool_)
         pfb_inputs_to_outputs = input_output_mapping()
 
         map_inds, conj = _corr_fits.generate_map(
             corr_ants_to_pfb_inputs, pfb_inputs_to_outputs, map_inds, conj,
         )
-        conj = conj.astype(bool)
         # reorder data
         self.data_array = self.data_array[:, :, map_inds]
         self.nsample_array = self.nsample_array[:, :, map_inds]

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -26,19 +26,7 @@ def input_output_mapping():
     # (from mwa_build_lfiles/antenna_mapping.h):
     # floor(index/4) + index%4 * 16 = input
     # for the first 64 outputs, pfb_mapper[output] = input
-    # fmt: off
-    pfb_mapper = [0, 16, 32, 48, 1, 17, 33, 49, 2, 18, 34, 50, 3, 19, 35, 51,
-                  4, 20, 36, 52, 5, 21, 37, 53, 6, 22, 38, 54, 7, 23, 39, 55,
-                  8, 24, 40, 56, 9, 25, 41, 57, 10, 26, 42, 58, 11, 27, 43, 59,
-                  12, 28, 44, 60, 13, 29, 45, 61, 14, 30, 46, 62, 15, 31, 47,
-                  63]
-    # fmt: on
-    # build a mapper for all 256 inputs
-    pfb_inputs_to_outputs = {}
-    for p in range(4):
-        for i in range(64):
-            pfb_inputs_to_outputs[pfb_mapper[i] + p * 64] = p * 64 + i
-    return pfb_inputs_to_outputs
+    return _corr_fits.input_output_mapping()
 
 
 class MWACorrFITS(UVData):

--- a/pyuvdata/uvdata/src/miriad_wrap.pyx
+++ b/pyuvdata/uvdata/src/miriad_wrap.pyx
@@ -6,7 +6,6 @@ cimport cython
 cimport numpy
 cimport libcpp.complex
 from libc.string cimport strcmp
-from libcpp.vector cimport vector
 
 DEF PREAMBLE_SIZE=5
 

--- a/pyuvdata/uvdata/src/miriad_wrap.pyx
+++ b/pyuvdata/uvdata/src/miriad_wrap.pyx
@@ -91,10 +91,10 @@ ctypedef numpy.float64_t DTYPE_f64
 ctypedef numpy.int64_t DTYPE_sl
 
 cdef inline int GETI(int bl):
-  return (bl - 65536) / 2048 - 1 if bl > 65536 else (bl >> 8) - 1
+  return (bl - 65536) // 2048 - 1 if bl > 65536 else (bl >> 8) - 1
 
 cdef inline int GETJ(int bl):
-  return (bl - 65536) % 2048 -1 if bl > 65536 else (bl & 255) - 1
+  return (bl - 65536) % 2048 - 1 if bl > 65536 else (bl & 255) - 1
 
 cdef inline float MKBL(int i, int j):
   return (i + 1) << 8 | (j + 1) if (i + 1 < 256 and j + 1 < 256) else (i + 1) * 2048 + (j + 1 + 65536)

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2618,10 +2618,19 @@ class UVData(UVBase):
                     "allow_phasing=True."
                 )
         antenna_locs_ENU, _ = self.get_ENU_antpos(center=False)
+        # this code used to loop through every bl in the unique,
+        # find the index into self.antenna_array of ant1 and ant2
+        # and fill out the self.uvw_array for all matching bls.
 
+        # instead, find the indices and reverse inds from the unique,
+        # create the unique ant1 and ant2 arrays
+        # use searchsorted to find the index of the antenna numbers into ant1 and ant2
+        # create the unique uvw array then broadcast to self.uvw_array
         bls, unique_inds, reverse_inds = np.unique(
             self.baseline_array, return_index=True, return_inverse=True
         )
+        # the first argument of searchsorted must be sorted so find the sort indices
+        # to help with indexing without changing the object.
         ant_sort = np.argsort(self.antenna_numbers)
         ant1_index = np.searchsorted(
             self.antenna_numbers[ant_sort], self.ant_1_array[unique_inds],

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2622,16 +2622,18 @@ class UVData(UVBase):
         bls, unique_inds, reverse_inds = np.unique(
             self.baseline_array, return_index=True, return_inverse=True
         )
-
+        ant_sort = np.argsort(self.antenna_numbers)
         ant1_index = np.searchsorted(
-            self.antenna_numbers, self.ant_1_array[unique_inds],
+            self.antenna_numbers[ant_sort], self.ant_1_array[unique_inds],
         )
         ant2_index = np.searchsorted(
-            self.antenna_numbers, self.ant_2_array[unique_inds],
+            self.antenna_numbers[ant_sort], self.ant_2_array[unique_inds],
         )
-
         _uvw_array = np.zeros((bls.size, 3))
-        _uvw_array = antenna_locs_ENU[ant2_index, :] - antenna_locs_ENU[ant1_index, :]
+        _uvw_array = (
+            antenna_locs_ENU[ant_sort][ant2_index, :]
+            - antenna_locs_ENU[ant_sort][ant1_index, :]
+        )
         self.uvw_array = _uvw_array[reverse_inds]
 
         if phase_type == "phased":

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2619,19 +2619,21 @@ class UVData(UVBase):
                 )
         antenna_locs_ENU, _ = self.get_ENU_antpos(center=False)
 
-        uvw_array = np.zeros((self.baseline_array.size, 3))
-        for baseline in list(set(self.baseline_array)):
-            baseline_inds = np.where(self.baseline_array == baseline)[0]
-            ant1_index = np.where(
-                self.antenna_numbers == self.ant_1_array[baseline_inds[0]]
-            )[0][0]
-            ant2_index = np.where(
-                self.antenna_numbers == self.ant_2_array[baseline_inds[0]]
-            )[0][0]
-            uvw_array[baseline_inds, :] = (
-                antenna_locs_ENU[ant2_index, :] - antenna_locs_ENU[ant1_index, :]
-            )
-        self.uvw_array = uvw_array
+        bls, unique_inds, reverse_inds = np.unique(
+            self.baseline_array, return_index=True, return_inverse=True
+        )
+
+        ant1_index = np.searchsorted(
+            self.antenna_numbers, self.ant_1_array[unique_inds],
+        )
+        ant2_index = np.searchsorted(
+            self.antenna_numbers, self.ant_2_array[unique_inds],
+        )
+
+        _uvw_array = np.zeros((bls.size, 3))
+        _uvw_array = antenna_locs_ENU[ant2_index, :] - antenna_locs_ENU[ant1_index, :]
+        self.uvw_array = _uvw_array[reverse_inds]
+
         if phase_type == "phased":
             self.phase(
                 phase_center_ra,

--- a/scripts/test_cover_noinstall.sh
+++ b/scripts/test_cover_noinstall.sh
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR/..
 
-cd pyuvdata/tests
-python -m pytest --cov=pyuvdata --cov-config=../../.coveragerc\
-       --cov-report term --cov-report html:cover \
+cd pyuvdata
+python -m pytest --cov=pyuvdata --cov-config=../.coveragerc\
+       --cov-report term --cov-report html:tests/cover \
        "$@"

--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -5,7 +5,7 @@ cd $DIR/..
 
 python setup.py install
 
-cd pyuvdata/tests
-python -m pytest --cov=pyuvdata --cov-config=../../.coveragerc\
-       --cov-report term --cov-report html:cover \
+cd pyuvdata
+python -m pytest --cov=pyuvdata --cov-config=../.coveragerc\
+       --cov-report term --cov-report html:tests/cover \
        "$@"

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ test_reqs = (
         "pytest-xdist",
         "pytest-cases>=1.12.1",
         "pytest-cov",
+        "cython",
         "coverage",
         "pre-commit",
     ]

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,13 @@ extensions = [
         ],
         define_macros=global_c_macros,
         include_dirs=["pyuvdata/uvdata/src/"],
-    )
+    ),
+    Extension(
+        "pyuvdata._corr_fits",
+        sources=["pyuvdata/uvdata/corr_fits_src/corr_fits.pyx"],
+        define_macros=global_c_macros,
+        include_dirs=["pyuvdata/uvdata/corr_fits_src/"],
+    ),
 ]
 
 casa_reqs = ["python-casacore"]

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup_args = {
         "pyuvdata.uvflag",
     ],
     "cmdclass": {"build_ext": CustomBuildExtCommand},
-    "ext_modules": cythonize(extensions),
+    "ext_modules": cythonize(extensions, language_level=3),
     "scripts": [fl for fl in glob.glob("scripts/*") if not os.path.isdir(fl)],
     "use_scm_version": {"local_scheme": branch_scheme},
     "include_package_data": True,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Some general vectorization and speed up of code.
## Description
<!--- Describe your changes in detail -->
Vectorized some for loop with numpy instead.
Added `_corr_fits` C extension to perform the bulk of the mwa_corr_fits reading 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Things were slow before, now they go vroom.
Further work on the way to #800

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).


I will also attach some profiling output I used to make these changes.
This first is a break out of the `test_mwa_corr_fits.py::test_multiple_coarse` test before (above) and after (below)
### **Before**
```
None
Wrote profile results to profile_corr_fits.py.lprof
Timer unit: 1e-06 s

Total time: 42.5514 s
File: ./profile_corr_fits.py
Function: read_multi at line 27

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    27                                           @profile
    28                                           def read_multi():
    29         1          3.0      3.0      0.0   order1 = [filelist[0:3]]
    30         1          1.0      1.0      0.0   order2 = [filelist[0], filelist[2], filelist[1]]
    31         1       2223.0   2223.0      0.0   mwa_uv1 = UVData()
    32         1       2069.0   2069.0      0.0   mwa_uv2 = UVData()
    33         1          1.0      1.0      0.0   messages = [
    34         1          1.0      1.0      0.0       "telescope_location is not set",
    35         1          0.0      0.0      0.0       "coarse channels are not contiguous for this observation",
    36         1          1.0      1.0      0.0       "some coarse channel files were not submitted",
    37                                            ]
    38         2   20137511.0 10068755.5     47.3   uvtest.checkWarnings(
    39         1          1.0      1.0      0.0       mwa_uv1.read, func_args=[order1], nwarnings=3, message=messages
    40                                            )
    41         2   22042822.0 11021411.0     51.8   uvtest.checkWarnings(
    42         1          1.0      1.0      0.0       mwa_uv2.read, func_args=[order2], nwarnings=3, message=messages
    43                                            )
    44         1     366779.0 366779.0      0.9   assert mwa_uv1 == mwa_uv2

Total time: 5.75414 s
File: /home/matthew/work/src/pyuvdata/pyuvdata/utils.py
Function: get_lst_for_time at line 1095

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
  1095                                           @profile
  1096                                           def get_lst_for_time(jd_array, latitude, longitude, altitude):
  1097                                               """
  1098                                               Get the lsts for a set of jd times at an earth location.
  1099                                           
  1100                                               Parameters
  1101                                               ----------
  1102                                               jd_array : ndarray of float
  1103                                                   JD times to get lsts for.
  1104                                               latitude : float
  1105                                                   Latitude of location to get lst for in degrees.
  1106                                               longitude : float
  1107                                                   Longitude of location to get lst for in degrees.
  1108                                               altitude : float
  1109                                                   Altitude of location to get lst for in meters.
  1110                                           
  1111                                               Returns
  1112                                               -------
  1113                                               ndarray of float
  1114                                                   LSTs in radians corresponding to the jd_array.
  1115                                           
  1116                                               """
  1117         2       2308.0   1154.0      0.0      lst_array = np.zeros_like(jd_array)
  1118       244      35678.0    146.2      0.6      for ind, jd in enumerate(np.unique(jd_array)):
  1119       484     259382.0    535.9      4.5          t = Time(
  1120       242        214.0      0.9      0.0              jd,
  1121       242        212.0      0.9      0.0              format="jd",
  1122       242      71377.0    294.9      1.2              location=(Angle(longitude, unit="deg"), Angle(latitude, unit="deg")),
  1123                                                   )
  1124                                           
  1125                                                   # avoid errors if iers.conf.auto_max_age is set to None, as we do in
  1126                                                   # testing if the iers url is down
  1127       242      16931.0     70.0      0.3          if iers.conf.auto_max_age is None:  # pragma: no cover
  1128                                                       delta, status = t.get_delta_ut1_utc(return_status=True)
  1129                                                       if status in (iers.TIME_BEFORE_IERS_RANGE, iers.TIME_BEYOND_IERS_RANGE):
  1130                                                           warnings.warn(
  1131                                                               "time is out of IERS range, setting delta ut1 utc to "
  1132                                                               "extrapolated value"
  1133                                                           )
  1134                                                           t.delta_ut1_utc = delta
  1135                                           
  1136       484       6747.0     13.9      0.1          lst_array[
  1137       242    2069987.0   8553.7     36.0              np.where(np.isclose(jd, jd_array, atol=1e-6, rtol=1e-12))
  1138       242    3291304.0  13600.4     57.2          ] = t.sidereal_time("apparent").radian
  1139                                           
  1140         2          3.0      1.5      0.0      return lst_array

Total time: 33.3523 s
File: /home/matthew/work/src/pyuvdata/pyuvdata/uvdata/mwa_corr_fits.py
Function: read_mwa_corr_fits at line 168

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   168                                               @profile
   169                                               def read_mwa_corr_fits(
   170                                                   self,
   171                                                   filelist,
   172                                                   use_cotter_flags=False,
   173                                                   correct_cable_len=False,
   174                                                   phase_to_pointing_center=False,
   175                                                   run_check=True,
   176                                                   check_extra=True,
   177                                                   run_check_acceptability=True,
   178                                                   flag_init=True,
   179                                                   edge_width=80e3,
   180                                                   start_flag=2.0,
   181                                                   end_flag=2.0,
   182                                                   flag_dc_offset=True,
   183                                               ):
   184                                                   """
   185                                                   Read in MWA correlator gpu box files.
   186                                           
   187                                                   Parameters
   188                                                   ----------
   189                                                   filelist : list of str
   190                                                       The list of MWA correlator files to read from. Must include at
   191                                                       least one fits file and only one metafits file per data set.
   192                                                       Can also be a list of lists to read multiple data sets.
   193                                                   axis : str
   194                                                       Axis to concatenate files along. This enables fast concatenation
   195                                                       along the specified axis without the normal checking that all other
   196                                                       metadata agrees. This method does not guarantee correct resulting
   197                                                       objects. Please see the docstring for fast_concat for details.
   198                                                       Allowed values are: 'blt', 'freq', 'polarization'. Only used if
   199                                                       multiple files are passed.
   200                                                   use_cotter_flags : bool
   201                                                       Option to use cotter output mwaf flag files. Otherwise flagging
   202                                                       will only be applied to missing data and bad antennas.
   203                                                   correct_cable_len : bool
   204                                                       Option to apply a cable delay correction.
   205                                                   phase_to_pointing_center : bool
   206                                                       Option to phase to the observation pointing center.
   207                                                   run_check : bool
   208                                                       Option to check for the existence and proper shapes of parameters
   209                                                       after after reading in the file (the default is True,
   210                                                       meaning the check will be run).
   211                                                   check_extra : bool
   212                                                       Option to check optional parameters as well as required ones (the
   213                                                       default is True, meaning the optional parameters will be checked).
   214                                                   run_check_acceptability : bool
   215                                                       Option to check acceptable range of the values of parameters after
   216                                                       reading in the file (the default is True, meaning the acceptable
   217                                                       range check will be done).
   218                                                   flag_init: bool
   219                                                       Set to True in order to do routine flagging of coarse channel edges,
   220                                                       start or end integrations, or the center fine channel of each coarse
   221                                                       channel. See associated keywords.
   222                                                   edge_width: float
   223                                                       Only used if flag_init is True. The width to flag on the edge of
   224                                                       each coarse channel, in hz. Errors if not equal to integer multiple
   225                                                       of channel_width. Set to 0 for no edge flagging.
   226                                                   start_flag: float
   227                                                       Only used if flag_init is True. The number of seconds to flag at the
   228                                                       beginning of the observation. Set to 0 for no flagging. Errors if
   229                                                       not equal to an integer multiple of the integration time.
   230                                                   end_flag: floats
   231                                                       Only used if flag_init is True. The number of seconds to flag at the
   232                                                       end of the observation. Set to 0 for no flagging. Errors if not
   233                                                       equal to an integer multiple of the integration time.
   234                                                   flag_dc_offset: bool
   235                                                       Only used if flag_init is True. Set to True to flag the center fine
   236                                                       channel of each coarse channel.
   237                                           
   238                                                   Raises
   239                                                   ------
   240                                                   ValueError
   241                                                       If required files are missing or multiple files metafits files are
   242                                                       included in filelist.
   243                                                       If files from different observations are included in filelist.
   244                                                       If files in fileslist have different fine channel widths
   245                                                       If file types other than fits, metafits, and mwaf files are included
   246                                                       in filelist.
   247                                           
   248                                                   """
   249         2         10.0      5.0      0.0          metafits_file = None
   250         2          6.0      3.0      0.0          ppds_file = None
   251         2          7.0      3.5      0.0          obs_id = None
   252         2          6.0      3.0      0.0          file_dict = {}
   253         2          7.0      3.5      0.0          start_time = 0.0
   254         2          6.0      3.0      0.0          end_time = 0.0
   255         2          7.0      3.5      0.0          included_file_nums = []
   256         2          8.0      4.0      0.0          cotter_warning = False
   257         2          7.0      3.5      0.0          num_fine_chans = 0
   258                                           
   259                                                   # iterate through files and organize
   260                                                   # create a list of included coarse channels
   261                                                   # find the first and last times that have data
   262         8         32.0      4.0      0.0          for file in filelist:
   263         6         30.0      5.0      0.0              if file.lower().endswith(".metafits"):
   264                                                           # force only one metafits file
   265         2          7.0      3.5      0.0                  if metafits_file is not None:
   266                                                               raise ValueError("multiple metafits files in filelist")
   267         2          6.0      3.0      0.0                  metafits_file = file
   268         4         17.0      4.2      0.0              elif file.lower().endswith(".fits"):
   269                                                           # check if ppds file
   270         4         14.0      3.5      0.0                  try:
   271         4      16217.0   4054.2      0.0                      fits.getheader(file, extname="ppds")
   272                                                               ppds_file = file
   273         4         18.0      4.5      0.0                  except Exception:
   274                                                               # check obsid
   275         4       7899.0   1974.8      0.0                      head0 = fits.getheader(file, 0)
   276         4         22.0      5.5      0.0                      if obs_id is None:
   277         2        274.0    137.0      0.0                          obs_id = head0["OBSID"]
   278                                                               else:
   279         2        252.0    126.0      0.0                          if head0["OBSID"] != obs_id:
   280                                                                       raise ValueError(
   281                                                                           "files from different observations submitted "
   282                                                                           "in same list"
   283                                                                       )
   284                                                               # check headers for first and last times containing data
   285         4      16355.0   4088.8      0.0                      headstart = fits.getheader(file, 1)
   286         4      14373.0   3593.2      0.0                      headfin = fits.getheader(file, -1)
   287         4        964.0    241.0      0.0                      first_time = headstart["TIME"] + headstart["MILLITIM"] / 1000.0
   288         4        885.0    221.2      0.0                      last_time = headfin["TIME"] + headfin["MILLITIM"] / 1000.0
   289         4         16.0      4.0      0.0                      if start_time == 0.0:
   290         2          8.0      4.0      0.0                          start_time = first_time
   291                                                               # check that files with a timing offset can be aligned
   292         2        271.0    135.5      0.0                      elif np.abs(start_time - first_time) % headstart["INTTIME"] != 0.0:
   293                                                                   raise ValueError(
   294                                                                       "coarse channel start times are misaligned by an amount that is not \
   295                                                                           an integer multiple of the integration time"
   296                                                                   )
   297         2          8.0      4.0      0.0                      elif start_time > first_time:
   298         1          3.0      3.0      0.0                          start_time = first_time
   299         4         13.0      3.2      0.0                      if end_time < last_time:
   300         3         10.0      3.3      0.0                          end_time = last_time
   301                                                               # get number of fine channels
   302         4         15.0      3.8      0.0                      if num_fine_chans == 0:
   303         2        227.0    113.5      0.0                          num_fine_chans = headstart["NAXIS2"]
   304         2        210.0    105.0      0.0                      elif num_fine_chans != headstart["NAXIS2"]:
   305                                                                   raise ValueError(
   306                                                                       "files submitted have different fine channel widths"
   307                                                                   )
   308                                                               # get the file number from the file name;
   309                                                               # this will later be mapped to a coarse channel
   310         4         23.0      5.8      0.0                      file_num = int(file.split("_")[-2][-2:])
   311         4         15.0      3.8      0.0                      if file_num not in included_file_nums:
   312         4         14.0      3.5      0.0                          included_file_nums.append(file_num)
   313                                                               # organize files
   314         4         15.0      3.8      0.0                      if "data" not in file_dict.keys():
   315         2         33.0     16.5      0.0                          file_dict["data"] = [file]
   316                                                               else:
   317         2         27.0     13.5      0.0                          file_dict["data"].append(file)
   318                                                       # look for flag files
   319                                                       elif file.lower().endswith(".mwaf"):
   320                                                           if use_cotter_flags is False and cotter_warning is False:
   321                                                               warnings.warn("mwaf files submitted with use_cotter_flags=False")
   322                                                               cotter_warning = True
   323                                                           elif "flags" not in file_dict.keys():
   324                                                               file_dict["flags"] = [file]
   325                                                           else:
   326                                                               file_dict["flags"].append(file)
   327                                                       else:
   328                                                           raise ValueError("only fits, metafits, and mwaf files supported")
   329                                           
   330                                                   # checks:
   331         2          7.0      3.5      0.0          if metafits_file is None and ppds_file is None:
   332                                                       raise ValueError("no metafits file submitted")
   333         2          6.0      3.0      0.0          elif metafits_file is None:
   334                                                       metafits_file = ppds_file
   335         2          6.0      3.0      0.0          elif ppds_file is not None:
   336                                                       ppds = fits.getheader(ppds_file, 0)
   337                                                       meta = fits.getheader(metafits_file, 0)
   338                                                       for key in ppds.keys():
   339                                                           if key not in meta.keys():
   340                                                               self.extra_keywords[key] = ppds[key]
   341         2          8.0      4.0      0.0          if "data" not in file_dict.keys():
   342                                                       raise ValueError("no data files submitted")
   343         2          7.0      3.5      0.0          if "flags" not in file_dict.keys() and use_cotter_flags:
   344                                                       raise ValueError(
   345                                                           "no flag files submitted. Rerun with flag files \
   346                                                                        or use_cotter_flags=False"
   347                                                       )
   348                                           
   349                                                   # first set parameters that are always true
   350         2         15.0      7.5      0.0          self.Nspws = 1
   351         2         23.0     11.5      0.0          self.spw_array = np.array([0])
   352         2         10.0      5.0      0.0          self.phase_type = "drift"
   353         2         10.0      5.0      0.0          self.vis_units = "uncalib"
   354         2          9.0      4.5      0.0          self.Npols = 4
   355         2          7.0      3.5      0.0          self.xorientation = "east"
   356                                           
   357                                                   # get information from metafits file
   358         2       4843.0   2421.5      0.0          with fits.open(metafits_file, memmap=True) as meta:
   359         2         26.0     13.0      0.0              meta_hdr = meta[0].header
   360                                           
   361                                                       # get a list of coarse channels
   362         2        939.0    469.5      0.0              coarse_chans = meta_hdr["CHANNELS"].split(",")
   363         2         45.0     22.5      0.0              coarse_chans = np.array(sorted(int(i) for i in coarse_chans))
   364                                           
   365                                                       # integration time in seconds
   366         2        245.0    122.5      0.0              int_time = meta_hdr["INTTIME"]
   367                                           
   368                                                       # pointing center in degrees
   369         2        232.0    116.0      0.0              ra_deg = meta_hdr["RA"]
   370         2        261.0    130.5      0.0              dec_deg = meta_hdr["DEC"]
   371         2         10.0      5.0      0.0              ra_rad = np.pi * ra_deg / 180
   372         2          7.0      3.5      0.0              dec_rad = np.pi * dec_deg / 180
   373                                           
   374                                                       # get parameters from header
   375                                                       # this assumes no averaging by this code so will need to be updated
   376         2        390.0    195.0      0.0              self.channel_width = float(meta_hdr.pop("FINECHAN") * 1000)
   377         2         11.0      5.5      0.0              if "HISTORY" in meta_hdr:
   378         2        310.0    155.0      0.0                  self.history = str(meta_hdr["HISTORY"])
   379         2        362.0    181.0      0.0                  meta_hdr.remove("HISTORY", remove_all=True)
   380                                                       else:
   381                                                           self.history = ""
   382         4         27.0      6.8      0.0              if not uvutils._check_history_version(
   383         2         12.0      6.0      0.0                  self.history, self.pyuvdata_version_str
   384                                                       ):
   385         2         13.0      6.5      0.0                  self.history += self.pyuvdata_version_str
   386         2        218.0    109.0      0.0              self.instrument = meta_hdr["TELESCOP"]
   387         2        228.0    114.0      0.0              self.telescope_name = meta_hdr.pop("TELESCOP")
   388         2        369.0    184.5      0.0              self.object_name = meta_hdr.pop("FILENAME")
   389                                           
   390                                                       # get rid of the instrument keyword so it doesn't get put back in
   391         2        124.0     62.0      0.0              meta_hdr.remove("INSTRUME")
   392                                                       # get rid of keywords that uvfits.py gets rid of
   393         2          7.0      3.5      0.0              bad_keys = ["SIMPLE", "EXTEND", "BITPIX", "NAXIS", "DATE-OBS"]
   394        12         44.0      3.7      0.0              for key in bad_keys:
   395        10        660.0     66.0      0.0                  meta_hdr.remove(key, remove_all=True)
   396                                                       # store remaining keys in extra keywords
   397        94        584.0      6.2      0.0              for key in meta_hdr:
   398        92        340.0      3.7      0.0                  if key == "COMMENT":
   399        16       4827.0    301.7      0.0                      self.extra_keywords[key] = str(meta_hdr.get(key))
   400        76        263.0      3.5      0.0                  elif key != "":
   401        76       9909.0    130.4      0.0                      self.extra_keywords[key] = meta_hdr.get(key)
   402                                                       # get antenna data from metafits file table
   403         2      52658.0  26329.0      0.2              meta_tbl = meta[1].data
   404                                           
   405                                                       # because of polarization, each antenna # is listed twice
   406         2        246.0    123.0      0.0              antenna_numbers = meta_tbl["Antenna"][1::2]
   407         2        652.0    326.0      0.0              antenna_names = meta_tbl["TileName"][1::2]
   408         2        196.0     98.0      0.0              antenna_flags = meta_tbl["Flag"][1::2]
   409         2        550.0    275.0      0.0              cable_lens = meta_tbl["Length"][1::2]
   410                                           
   411                                                       # get antenna postions in enu coordinates
   412         2         15.0      7.5      0.0              antenna_positions = np.zeros((len(antenna_numbers), 3))
   413         2        203.0    101.5      0.0              antenna_positions[:, 0] = meta_tbl["East"][1::2]
   414         2        184.0     92.0      0.0              antenna_positions[:, 1] = meta_tbl["North"][1::2]
   415         2        351.0    175.5      0.0              antenna_positions[:, 2] = meta_tbl["Height"][1::2]
   416                                           
   417                                                   # reorder antenna parameters from metafits ordering
   418         2         26.0     13.0      0.0          reordered_inds = antenna_numbers.argsort()
   419         2         29.0     14.5      0.0          self.antenna_numbers = antenna_numbers[reordered_inds]
   420         2        476.0    238.0      0.0          self.antenna_names = list(antenna_names[reordered_inds])
   421         2         30.0     15.0      0.0          antenna_positions = antenna_positions[reordered_inds, :]
   422         2         16.0      8.0      0.0          antenna_flags = antenna_flags[reordered_inds]
   423         2         18.0      9.0      0.0          cable_lens = cable_lens[reordered_inds]
   424                                           
   425                                                   # find flagged antenna
   426         2        361.0    180.5      0.0          flagged_ants = self.antenna_numbers[np.where(antenna_flags == 1)]
   427                                           
   428                                                   # set parameters from other parameters
   429         2         14.0      7.0      0.0          self.Nants_data = len(self.antenna_numbers)
   430         2         13.0      6.5      0.0          self.Nants_telescope = len(self.antenna_numbers)
   431         4         20.0      5.0      0.0          self.Nbls = int(
   432         2         12.0      6.0      0.0              len(self.antenna_numbers) * (len(self.antenna_numbers) + 1) / 2.0
   433                                                   )
   434                                           
   435                                                   # get telescope parameters
   436         2       2233.0   1116.5      0.0          self.set_telescope_params()
   437                                           
   438                                                   # build time array of centers
   439         4         28.0      7.0      0.0          time_array = np.arange(
   440         2          9.0      4.5      0.0              start_time + int_time / 2.0, end_time + int_time / 2.0 + int_time, int_time
   441                                                   )
   442                                           
   443                                                   # convert from unix to julian times
   444         2     190710.0  95355.0      0.6          julian_time_array = [Time(i, format="unix", scale="utc").jd for i in time_array]
   445                                           
   446                                                   # convert to integers
   447         2         80.0     40.0      0.0          float_time_array = np.array([float(i) for i in julian_time_array])
   448                                                   # build into time array
   449         2       7366.0   3683.0      0.0          self.time_array = np.repeat(float_time_array, self.Nbls)
   450                                           
   451         2         16.0      8.0      0.0          self.Ntimes = len(time_array)
   452                                           
   453         2         17.0      8.5      0.0          self.Nblts = int(self.Nbls * self.Ntimes)
   454                                           
   455                                                   # convert times to lst
   456         6    5758888.0 959814.7     17.3          self.lst_array = uvutils.get_lst_for_time(
   457         4        188.0     47.0      0.0              self.time_array, *self.telescope_location_lat_lon_alt_degrees
   458                                                   )
   459                                           
   460         2     322031.0 161015.5      1.0          self.integration_time = np.array([int_time for i in range(self.Nblts)])
   461                                           
   462                                                   # convert antenna positions from enu to ecef
   463                                                   # antenna positions are "relative to
   464                                                   # the centre of the array in local topocentric \"east\", \"north\",
   465                                                   # \"height\". Units are meters."
   466         6        589.0     98.2      0.0          antenna_positions_ecef = uvutils.ECEF_from_ENU(
   467         4        336.0     84.0      0.0              antenna_positions, *self.telescope_location_lat_lon_alt
   468                                                   )
   469                                                   # make antenna positions relative to telescope location
   470         2         87.0     43.5      0.0          self.antenna_positions = antenna_positions_ecef - self.telescope_location
   471                                           
   472                                                   # make initial antenna arrays, where ant_1 <= ant_2
   473         2         12.0      6.0      0.0          ant_1_array = []
   474         2         11.0      5.5      0.0          ant_2_array = []
   475       258        984.0      3.8      0.0          for i in range(self.Nants_telescope):
   476     16768      62485.0      3.7      0.2              for j in range(i, self.Nants_telescope):
   477     16512      62222.0      3.8      0.2                  ant_1_array.append(i)
   478     16512      62226.0      3.8      0.2                  ant_2_array.append(j)
   479                                           
   480         2       2807.0   1403.5      0.0          self.ant_1_array = np.tile(np.array(ant_1_array), self.Ntimes)
   481         2       3125.0   1562.5      0.0          self.ant_2_array = np.tile(np.array(ant_2_array), self.Ntimes)
   482                                           
   483         4      18099.0   4524.8      0.1          self.baseline_array = self.antnums_to_baseline(
   484         2         12.0      6.0      0.0              self.ant_1_array, self.ant_2_array
   485                                                   )
   486                                           
   487                                                   # create self.uvw_array
   488         2   17244012.0 8622006.0     51.7          self.set_uvws_from_antenna_positions(allow_phasing=False)
   489                                           
   490                                                   # coarse channel mapping:
   491                                                   # channels in group 0-128 go in order; channels in group 129-155 go in
   492                                                   # reverse order
   493                                                   # that is, if the lowest channel is 127, it will be assigned to the
   494                                                   # first file
   495                                                   # channel 128 will be assigned to the second file
   496                                                   # then the highest channel will be assigned to the third file
   497                                                   # and the next hightest channel assigned to the fourth file, and so on
   498         2          8.0      4.0      0.0          count = 0
   499                                                   # count the number of channels that are in group 0-128
   500        50        203.0      4.1      0.0          for i in coarse_chans:
   501        48        184.0      3.8      0.0              if i <= 128:
   502                                                           count += 1
   503                                                   # map all file numbers to coarse channel numbers
   504         4         70.0     17.5      0.0          file_nums_to_coarse = {
   505                                                       i + 1: coarse_chans[i]
   506                                                       if i < count
   507                                                       else coarse_chans[(len(coarse_chans) + count - i - 1)]
   508         2         13.0      6.5      0.0              for i in range(len(coarse_chans))
   509                                                   }
   510                                                   # map included coarse channels to file numbers
   511         2          7.0      3.5      0.0          coarse_to_incl_files = {}
   512         6         24.0      4.0      0.0          for i in included_file_nums:
   513         4         16.0      4.0      0.0              coarse_to_incl_files[file_nums_to_coarse[i]] = i
   514                                                   # sort included coarse channels
   515         2         18.0      9.0      0.0          included_coarse_chans = sorted(coarse_to_incl_files.keys())
   516                                                   # map included file numbers to an index that orders them
   517         2          6.0      3.0      0.0          file_nums_to_index = {}
   518         6         22.0      3.7      0.0          for i in included_coarse_chans:
   519         4         17.0      4.2      0.0              file_nums_to_index[coarse_to_incl_files[i]] = included_coarse_chans.index(i)
   520                                                   # check that coarse channels are contiguous.
   521         2         28.0     14.0      0.0          chans = np.array(included_coarse_chans)
   522         2         85.0     42.5      0.0          for i in np.diff(chans):
   523         2         10.0      5.0      0.0              if i != 1:
   524         2         51.0     25.5      0.0                  warnings.warn("coarse channels are not contiguous for this observation")
   525         2          8.0      4.0      0.0                  break
   526                                           
   527                                                   # warn user if not all coarse channels are included
   528         2          8.0      4.0      0.0          if len(included_coarse_chans) != len(coarse_chans):
   529         2         21.0     10.5      0.0              warnings.warn("some coarse channel files were not submitted")
   530                                           
   531                                                   # build frequency array
   532         2         14.0      7.0      0.0          self.Nfreqs = len(included_coarse_chans) * num_fine_chans
   533         2         20.0     10.0      0.0          self.freq_array = np.zeros((self.Nspws, self.Nfreqs))
   534                                           
   535                                                   # each coarse channel is split into 128 fine channels of width 10 kHz.
   536                                                   # The first fine channel for each coarse channel is centered on the
   537                                                   # lower bound frequency of that channel and its center frequency is
   538                                                   # computed as fine_center = coarse_channel_number * 1280-640 (kHz).
   539                                                   # If the fine channels have been averaged (added) by some factor, the
   540                                                   # center of the resulting channel is found by averaging the centers of
   541                                                   # the first and last fine channels it is made up of.
   542                                                   # That is, avg_fine_center=(lowest_fine_center+highest_fine_center)/2
   543                                                   # where highest_fine_center=lowest_fine_center+(avg_factor-1)*10 kHz
   544                                                   # so avg_fine_center=(lowest_fine_center+lowest_fine_center+(avg_factor-1)*10)/2
   545                                                   #                   =lowest_fine_center+((avg_factor-1)*10)/2
   546                                                   #                   =lowest_fine_center+offset
   547                                                   # Calculate offset=((avg_factor-1)*10)/2 to build the frequency array
   548         2         12.0      6.0      0.0          avg_factor = self.channel_width / 10000
   549         2         10.0      5.0      0.0          width = self.channel_width / 1000
   550         2          9.0      4.5      0.0          offset = (avg_factor - 1) * 10 / 2.0
   551                                           
   552         6         25.0      4.2      0.0          for i in range(len(included_coarse_chans)):
   553                                                       # get the lowest fine freq of the coarse channel (kHz)
   554         4         20.0      5.0      0.0              lower_fine_freq = included_coarse_chans[i] * 1280 - 640
   555                                                       # find the center of the lowest averaged channel
   556         4         44.0     11.0      0.0              first_center = lower_fine_freq + offset
   557                                                       # add the channel centers for this coarse channel into
   558                                                       # the frequency array (converting from kHz to Hz)
   559         8         41.0      5.1      0.0              self.freq_array[
   560         4         18.0      4.5      0.0                  0, int(i * num_fine_chans) : int((i + 1) * num_fine_chans)
   561                                                       ] = (
   562         8         61.0      7.6      0.0                  np.arange(first_center, first_center + num_fine_chans * width, width)
   563         4         14.0      3.5      0.0                  * 1000
   564                                                       )
   565                                           
   566                                                   # read data into an array with dimensions (time, uv, baselines*pols)
   567         4         64.0     16.0      0.0          self.data_array = np.zeros(
   568         2         16.0      8.0      0.0              (self.Ntimes, self.Nfreqs, self.Nbls * self.Npols), dtype=np.complex128
   569                                                   )
   570         4        103.0     25.8      0.0          self.nsample_array = np.zeros(
   571         2         13.0      6.5      0.0              (self.Ntimes, self.Nfreqs, self.Nbls * self.Npols), dtype=np.float32
   572                                                   )
   573         4        751.0    187.8      0.0          self.flag_array = np.full(
   574         2         12.0      6.0      0.0              (self.Ntimes, self.Nfreqs, self.Nbls * self.Npols), True
   575                                                   )
   576                                           
   577                                                   # read data files
   578         6         32.0      5.3      0.0          for file in file_dict["data"]:
   579                                                       # get the file number from the file name
   580         4         45.0     11.2      0.0              file_num = int(file.split("_")[-2][-2:])
   581                                                       # map file number to frequency index
   582         4         21.0      5.2      0.0              freq_ind = file_nums_to_index[file_num] * num_fine_chans
   583         8       7983.0    997.9      0.0              with fits.open(
   584         4         18.0      4.5      0.0                  file, memmap=False, do_not_scale_image_data=False
   585         4         50.0     12.5      0.0              ) as hdu_list:
   586                                                           # count number of times
   587         4       8579.0   2144.8      0.0                  end_list = len(hdu_list)
   588         8        351.0     43.9      0.0                  for i in range(1, end_list):
   589         4         15.0      3.8      0.0                      time = (
   590        12       2452.0    204.3      0.0                          hdu_list[i].header["TIME"]
   591         4        571.0    142.8      0.0                          + hdu_list[i].header["MILLITIM"] / 1000.0
   592         4         18.0      4.5      0.0                          + int_time / 2.0
   593                                                               )
   594         4        115.0     28.8      0.0                      time_ind = np.where(time_array == time)[0][0]
   595                                                               # dump data into matrix
   596                                                               # and take data from real to complex numbers
   597         8       1259.0    157.4      0.0                      self.data_array[
   598         4         20.0      5.0      0.0                          time_ind, freq_ind : freq_ind + num_fine_chans, :
   599         4       3855.0    963.8      0.0                      ] = (hdu_list[i].data[:, 0::2] + 1j * hdu_list[i].data[:, 1::2])
   600         8        327.0     40.9      0.0                      self.nsample_array[
   601         4         19.0      4.8      0.0                          time_ind, freq_ind : freq_ind + num_fine_chans, :
   602         4         18.0      4.5      0.0                      ] = 1.0
   603         8         66.0      8.2      0.0                      self.flag_array[
   604         4         19.0      4.8      0.0                          time_ind, freq_ind : freq_ind + num_fine_chans, :
   605         4         18.0      4.5      0.0                      ] = False
   606                                           
   607                                                   # polarizations are ordered yy, yx, xy, xx
   608         2         34.0     17.0      0.0          self.polarization_array = np.array([-6, -8, -7, -5])
   609                                           
   610                                                   # build mapper from antenna numbers and polarizations to pfb inputs
   611         2          8.0      4.0      0.0          corr_ants_to_pfb_inputs = {}
   612       258       1054.0      4.1      0.0          for i in range(len(antenna_numbers)):
   613       768       3367.0      4.4      0.0              for p in range(2):
   614       512       2310.0      4.5      0.0                  corr_ants_to_pfb_inputs[(antenna_numbers[i], p)] = 2 * i + p
   615                                           
   616                                                   # for mapping, start with a pair of antennas/polarizations
   617                                                   # this is the pair we want to find the data for
   618                                                   # map the pair to the corresponding pfb input indices
   619                                                   # map the pfb input indices to the pfb output indices
   620                                                   # these are the indices for the data corresponding to the initial
   621                                                   # antenna/pol pair
   622                                                   # generate a mapping index array
   623         2         51.0     25.5      0.0          map_inds = np.zeros(self.Nbls * self.Npols, dtype=np.int32)
   624                                                   # generate a conjugation array
   625         2         56.0     28.0      0.0          conj = np.full(self.Nbls * self.Npols, False)
   626         2        518.0    259.0      0.0          pfb_inputs_to_outputs = input_output_mapping()
   627       258       1076.0      4.2      0.0          for ant1 in range(128):
   628     16768      66385.0      4.0      0.2              for ant2 in range(ant1, 128):
   629     49536     212849.0      4.3      0.6                  for p1 in range(2):
   630     99072     422449.0      4.3      1.3                      for p2 in range(2):
   631                                                                   # generate the indices in self.data_array for this combination
   632                                                                   # baselines are ordered (0,0),(0,1),...,(0,127),(1,1),.....
   633                                                                   # polarizion of 0 (1) corresponds to y (x)
   634     66048     276609.0      4.2      0.8                          pol_ind = int(2 * p1 + p2)
   635     66048     297490.0      4.5      0.9                          bls_ind = int(128 * ant1 - ant1 * (ant1 + 1) / 2 + ant2)
   636                                                                   # find the pfb input indices for this combination
   637     66048     258964.0      3.9      0.8                          (ind1_1, ind1_2) = (
   638     66048     521287.0      7.9      1.6                              corr_ants_to_pfb_inputs[(ant1, p1)],
   639     66048     411874.0      6.2      1.2                              corr_ants_to_pfb_inputs[(ant2, p2)],
   640                                                                   )
   641                                                                   # find the pfb output indices
   642     66048     254452.0      3.9      0.8                          (ind2_1, ind2_2) = (
   643     66048     258456.0      3.9      0.8                              pfb_inputs_to_outputs[(ind1_1)],
   644     66048     256812.0      3.9      0.8                              pfb_inputs_to_outputs[(ind1_2)],
   645                                                                   )
   646     66048     284410.0      4.3      0.9                          out_ant1 = int(ind2_1 / 2)
   647     66048     268723.0      4.1      0.8                          out_ant2 = int(ind2_2 / 2)
   648     66048     262245.0      4.0      0.8                          out_p1 = ind2_1 % 2
   649     66048     256899.0      3.9      0.8                          out_p2 = ind2_2 % 2
   650                                                                   # the correlator has ind2_2 <= ind2_1 except for
   651                                                                   # redundant data. The redundant data is not perfectly
   652                                                                   # redundant; sometimes the values of redundant data
   653                                                                   # are off by one in the imaginary part.
   654                                                                   # For consistency, we are ignoring the redundant values
   655                                                                   # that have ind2_2 > ind2_1
   656     66048     262513.0      4.0      0.8                          if ind2_2 > ind2_1:
   657                                                                       # get the index for the data
   658     51968     211658.0      4.1      0.6                              data_index = int(
   659    103936     417311.0      4.0      1.3                                  2 * out_ant2 * (out_ant2 + 1)
   660     25984     103564.0      4.0      0.3                                  + 4 * out_ant1
   661     25984     103707.0      4.0      0.3                                  + 2 * out_p2
   662     25984     102426.0      3.9      0.3                                  + out_p1
   663                                                                       )
   664                                                                       # need to take the complex conjugate of the data
   665     25984     120398.0      4.6      0.4                              map_inds[bls_ind * 4 + pol_ind] = data_index
   666     25984     122733.0      4.7      0.4                              conj[bls_ind * 4 + pol_ind] = True
   667                                                                   else:
   668     80128     317512.0      4.0      1.0                              data_index = int(
   669    160256     624949.0      3.9      1.9                                  2 * out_ant1 * (out_ant1 + 1)
   670     40064     154764.0      3.9      0.5                                  + 4 * out_ant2
   671     40064     155099.0      3.9      0.5                                  + 2 * out_p1
   672     40064     153877.0      3.8      0.5                                  + out_p2
   673                                                                       )
   674     40064     178220.0      4.4      0.5                              map_inds[bls_ind * 4 + pol_ind] = data_index
   675                                                   # reorder data
   676         2     148675.0  74337.5      0.4          self.data_array = self.data_array[:, :, map_inds]
   677         2      70407.0  35203.5      0.2          self.nsample_array = self.nsample_array[:, :, map_inds]
   678         2      27871.0  13935.5      0.1          self.flag_array = self.flag_array[:, :, map_inds]
   679                                                   # conjugate data
   680         2      62990.0  31495.0      0.2          self.data_array[:, :, conj] = np.conj(self.data_array[:, :, conj])
   681                                                   # reshape data
   682         4         84.0     21.0      0.0          self.data_array = self.data_array.reshape(
   683         2         28.0     14.0      0.0              (self.Ntimes, self.Nfreqs, self.Nbls, self.Npols)
   684                                                   )
   685         4         42.0     10.5      0.0          self.nsample_array = self.nsample_array.reshape(
   686         2         23.0     11.5      0.0              (self.Ntimes, self.Nfreqs, self.Nbls, self.Npols)
   687                                                   )
   688         4         32.0      8.0      0.0          self.flag_array = self.flag_array.reshape(
   689         2         18.0      9.0      0.0              (self.Ntimes, self.Nfreqs, self.Nbls, self.Npols)
   690                                                   )
   691         2         62.0     31.0      0.0          self.data_array = np.swapaxes(self.data_array, 1, 2)
   692         2         30.0     15.0      0.0          self.nsample_array = np.swapaxes(self.nsample_array, 1, 2)
   693         2         23.0     11.5      0.0          self.flag_array = np.swapaxes(self.flag_array, 1, 2)
   694                                           
   695                                                   # generage baseline flags for flagged ants
   696         2         11.0      5.5      0.0          bad_ant_inds = []
   697       258       1142.0      4.4      0.0          for ant1 in range(128):
   698     16768      77878.0      4.6      0.2              for ant2 in range(ant1, 128):
   699     16512     255131.0     15.5      0.8                  if ant1 in flagged_ants or ant2 in flagged_ants:
   700       510       3717.0      7.3      0.0                      bad_ant_inds.append(int(128 * ant1 - ant1 * (ant1 + 1) / 2 + ant2))
   701         2        175.0     87.5      0.0          self.flag_array[:, bad_ant_inds, :, :] = True
   702                                           
   703                                                   # combine baseline and time axes
   704         2     261400.0 130700.0      0.8          self.data_array = self.data_array.reshape((self.Nblts, self.Nfreqs, self.Npols))
   705         2     176399.0  88199.5      0.5          self.flag_array = self.flag_array.reshape((self.Nblts, self.Nfreqs, self.Npols))
   706         4     212883.0  53220.8      0.6          self.nsample_array = self.nsample_array.reshape(
   707         2         19.0      9.5      0.0              (self.Nblts, self.Nfreqs, self.Npols)
   708                                                   )
   709                                           
   710                                                   # cable delay corrections
   711         2         21.0     10.5      0.0          if correct_cable_len:
   712                                                       self.correct_cable_length(cable_lens)
   713                                           
   714                                                   # add spectral window index
   715         2         47.0     23.5      0.0          self.data_array = self.data_array[:, np.newaxis, :, :]
   716         2         29.0     14.5      0.0          self.flag_array = self.flag_array[:, np.newaxis, :, :]
   717         2         27.0     13.5      0.0          self.nsample_array = self.nsample_array[:, np.newaxis, :, :]
   718                                           
   719                                                   # because of an annoying discrepancy between file conventions, in order
   720                                                   # to be consistent with the uvw vector direction, all the data must
   721                                                   # be conjugated
   722         2      78897.0  39448.5      0.2          self.data_array = np.conj(self.data_array)
   723                                           
   724                                                   # reorder polarizations
   725         2     701056.0 350528.0      2.1          self.reorder_pols()
   726                                           
   727                                                   # phasing
   728         2          8.0      4.0      0.0          if phase_to_pointing_center:
   729                                                       self.phase(ra_rad, dec_rad)
   730                                           
   731         2          8.0      4.0      0.0          if flag_init:
   732         4      19738.0   4934.5      0.1              self.flag_init(
   733         2          8.0      4.0      0.0                  num_fine_chans,
   734         2          8.0      4.0      0.0                  edge_width=edge_width,
   735         2          7.0      3.5      0.0                  start_flag=start_flag,
   736         2          7.0      3.5      0.0                  end_flag=end_flag,
   737         2          8.0      4.0      0.0                  flag_dc_offset=flag_dc_offset,
   738                                                       )
   739                                           
   740         2         12.0      6.0      0.0          if use_cotter_flags:
   741                                                       raise NotImplementedError(
   742                                                           "reading in cotter flag files is not yet available"
   743                                                       )

Total time: 0 s
File: /home/matthew/work/src/pyuvdata/pyuvdata/uvdata/uvdata.py
Function: set_lsts_from_time_array at line 748

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   748                                               @profile
   749                                               def set_lsts_from_time_array(self):
   750                                                   """Set the lst_array based from the time_array."""
   751                                                   latitude, longitude, altitude = self.telescope_location_lat_lon_alt_degrees
   752                                                   unique_times, inverse_inds = np.unique(self.time_array, return_inverse=True)
   753                                                   unique_lst_array = uvutils.get_lst_for_time(
   754                                                       unique_times, latitude, longitude, altitude
   755                                                   )
   756                                                   self.lst_array = unique_lst_array[inverse_inds]

Total time: 0.489957 s
File: /home/matthew/work/src/pyuvdata/pyuvdata/uvdata/uvdata.py
Function: check at line 793

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   793                                               @profile
   794                                               def check(
   795                                                   self, check_extra=True, run_check_acceptability=True, check_freq_spacing=False
   796                                               ):
   797                                                   """
   798                                                   Add some extra checks on top of checks on UVBase class.
   799                                           
   800                                                   Check that required parameters exist. Check that parameters have
   801                                                   appropriate shapes and optionally that the values are acceptable.
   802                                           
   803                                                   Parameters
   804                                                   ----------
   805                                                   check_extra : bool
   806                                                       If true, check all parameters, otherwise only check required parameters.
   807                                                   run_check_acceptability : bool
   808                                                       Option to check if values in parameters are acceptable.
   809                                           
   810                                                   Returns
   811                                                   -------
   812                                                   bool
   813                                                       True if check passes
   814                                           
   815                                                   Raises
   816                                                   ------
   817                                                   ValueError
   818                                                       if parameter shapes or types are wrong or do not have acceptable
   819                                                       values (if run_check_acceptability is True)
   820                                                   """
   821                                                   # first run the basic check from UVBase
   822                                                   # set the phase type based on object's value
   823         2         20.0     10.0      0.0          if self.phase_type == "phased":
   824                                                       self._set_phased()
   825         2          9.0      4.5      0.0          elif self.phase_type == "drift":
   826         2         29.0     14.5      0.0              self._set_drift()
   827                                                   else:
   828                                                       self._set_unknown_phase_type()
   829                                           
   830         4      33692.0   8423.0      6.9          super(UVData, self).check(
   831         2          5.0      2.5      0.0              check_extra=check_extra, run_check_acceptability=run_check_acceptability
   832                                                   )
   833                                           
   834                                                   # Check internal consistency of numbers which don't explicitly correspond
   835                                                   # to the shape of another array.
   836         4         11.0      2.8      0.0          nants_data_calc = int(
   837         4          8.0      2.0      0.0              len(
   838         4         21.0      5.2      0.0                  set(
   839         4      51290.0  12822.5     10.5                      np.unique(self.ant_1_array).tolist()
   840         2      78277.0  39138.5     16.0                      + np.unique(self.ant_2_array).tolist()
   841                                                           )
   842                                                       )
   843                                                   )
   844         2         13.0      6.5      0.0          if self.Nants_data != nants_data_calc:
   845                                                       raise ValueError(
   846                                                           "Nants_data must be equal to the number of unique "
   847                                                           "values in ant_1_array and ant_2_array"
   848                                                       )
   849                                           
   850         2      70520.0  35260.0     14.4          if self.Nbls != len(np.unique(self.baseline_array)):
   851                                                       raise ValueError(
   852                                                           "Nbls must be equal to the number of unique "
   853                                                           "baselines in the data_array"
   854                                                       )
   855                                           
   856         2      39446.0  19723.0      8.1          if self.Ntimes != len(np.unique(self.time_array)):
   857                                                       raise ValueError(
   858                                                           "Ntimes must be equal to the number of unique "
   859                                                           "times in the time_array"
   860                                                       )
   861                                           
   862                                                   # require that all entries in ant_1_array and ant_2_array exist in
   863                                                   # antenna_numbers
   864         2      39682.0  19841.0      8.1          if not set(np.unique(self.ant_1_array)).issubset(self.antenna_numbers):
   865                                                       raise ValueError("All antennas in ant_1_array must be in antenna_numbers.")
   866         2      69598.0  34799.0     14.2          if not set(np.unique(self.ant_2_array)).issubset(self.antenna_numbers):
   867                                                       raise ValueError("All antennas in ant_2_array must be in antenna_numbers.")
   868                                           
   869                                                   # issue warning if extra_keywords keys are longer than 8 characters
   870        80         89.0      1.1      0.0          for key in self.extra_keywords.keys():
   871        78         77.0      1.0      0.0              if len(key) > 8:
   872                                                           warnings.warn(
   873                                                               "key {key} in extra_keywords is longer than 8 "
   874                                                               "characters. It will be truncated to 8 if written "
   875                                                               "to uvfits or miriad file formats.".format(key=key)
   876                                                           )
   877                                           
   878                                                   # issue warning if extra_keywords values are lists, arrays or dicts
   879        80         86.0      1.1      0.0          for key, value in self.extra_keywords.items():
   880        78        100.0      1.3      0.0              if isinstance(value, (list, dict, np.ndarray)):
   881                                                           warnings.warn(
   882                                                               "{key} in extra_keywords is a list, array or dict, "
   883                                                               "which will raise an error when writing uvfits or "
   884                                                               "miriad file types".format(key=key)
   885                                                           )
   886                                           
   887                                                   # check auto and cross-corrs have sensible uvws
   888         2      11140.0   5570.0      2.3          autos = np.isclose(self.ant_1_array - self.ant_2_array, 0.0)
   889         4         43.0     10.8      0.0          if not np.all(
   890         4        579.0    144.8      0.1              np.isclose(
   891         2       5630.0   2815.0      1.1                  self.uvw_array[autos],
   892         2          5.0      2.5      0.0                  0.0,
   893         2          6.0      3.0      0.0                  rtol=self._uvw_array.tols[0],
   894         2          3.0      1.5      0.0                  atol=self._uvw_array.tols[1],
   895                                                       )
   896                                                   ):
   897                                                       raise ValueError(
   898                                                           "Some auto-correlations have non-zero " "uvw_array coordinates."
   899                                                       )
   900         4        184.0     46.0      0.0          if np.any(
   901         4       6016.0   1504.0      1.2              np.isclose(
   902         2      83357.0  41678.5     17.0                  np.linalg.norm(self.uvw_array[~autos], axis=1),
   903         2          5.0      2.5      0.0                  0.0,
   904         2          7.0      3.5      0.0                  rtol=self._uvw_array.tols[0],
   905         2          3.0      1.5      0.0                  atol=self._uvw_array.tols[1],
   906                                                       )
   907                                                   ):
   908                                                       raise ValueError(
   909                                                           "Some cross-correlations have near-zero " "uvw_array magnitudes."
   910                                                       )
   911                                           
   912         2          4.0      2.0      0.0          if check_freq_spacing:
   913                                                       self._check_freq_spacing()
   914                                           
   915         2          2.0      1.0      0.0          return True

Total time: 16.9344 s
File: /home/matthew/work/src/pyuvdata/pyuvdata/uvdata/uvdata.py
Function: set_uvws_from_antenna_positions at line 2559

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
  2559                                               @profile
  2560                                               def set_uvws_from_antenna_positions(
  2561                                                   self, allow_phasing=False, orig_phase_frame=None, output_phase_frame="icrs"
  2562                                               ):
  2563                                                   """
  2564                                                   Calculate UVWs based on antenna_positions.
  2565                                           
  2566                                                   Parameters
  2567                                                   ----------
  2568                                                   allow_phasing : bool
  2569                                                       Option for phased data. If data is phased and allow_phasing is set,
  2570                                                       data will be unphased, UVWs will be calculated, and then data will
  2571                                                       be rephased.
  2572                                                   orig_phase_frame : str
  2573                                                       The astropy frame to phase from. Either 'icrs' or 'gcrs'.
  2574                                                       Defaults to using the 'phase_center_frame' attribute or 'icrs' if
  2575                                                       that attribute is None. Only used if allow_phasing is True.
  2576                                                   output_phase_frame : str
  2577                                                       The astropy frame to phase to. Either 'icrs' or 'gcrs'. Only used if
  2578                                                       allow_phasing is True.
  2579                                           
  2580                                                   Raises
  2581                                                   ------
  2582                                                   ValueError
  2583                                                       If data is phased and allow_phasing is False.
  2584                                           
  2585                                                   Warns
  2586                                                   -----
  2587                                                   UserWarning
  2588                                                       If the phase_type is 'phased'
  2589                                           
  2590                                                   """
  2591         2          7.0      3.5      0.0          phase_type = self.phase_type
  2592         2          2.0      1.0      0.0          if phase_type == "phased":
  2593                                                       if allow_phasing:
  2594                                                           if not self.metadata_only:
  2595                                                               warnings.warn(
  2596                                                                   "Data will be unphased and rephased "
  2597                                                                   "to calculate UVWs, which might introduce small "
  2598                                                                   "inaccuracies to the data."
  2599                                                               )
  2600                                                           if orig_phase_frame not in [None, "icrs", "gcrs"]:
  2601                                                               raise ValueError(
  2602                                                                   "Invalid parameter orig_phase_frame. "
  2603                                                                   'Options are "icrs", "gcrs", or None.'
  2604                                                               )
  2605                                                           if output_phase_frame not in ["icrs", "gcrs"]:
  2606                                                               raise ValueError(
  2607                                                                   "Invalid parameter output_phase_frame. "
  2608                                                                   'Options are "icrs" or "gcrs".'
  2609                                                               )
  2610                                                           phase_center_ra = self.phase_center_ra
  2611                                                           phase_center_dec = self.phase_center_dec
  2612                                                           phase_center_epoch = self.phase_center_epoch
  2613                                                           self.unphase_to_drift(phase_frame=orig_phase_frame)
  2614                                                       else:
  2615                                                           raise ValueError(
  2616                                                               "UVW calculation requires unphased data. "
  2617                                                               "Use unphase_to_drift or set "
  2618                                                               "allow_phasing=True."
  2619                                                           )
  2620         2        686.0    343.0      0.0          antenna_locs_ENU, _ = self.get_ENU_antpos(center=False)
  2621                                           
  2622         2        447.0    223.5      0.0          uvw_array = np.zeros((self.baseline_array.size, 3))
  2623     16514     298765.0     18.1      1.8          for baseline in list(set(self.baseline_array)):
  2624     16512   15807577.0    957.3     93.3              baseline_inds = np.where(self.baseline_array == baseline)[0]
  2625     66048     135407.0      2.1      0.8              ant1_index = np.where(
  2626     16512     191553.0     11.6      1.1                  self.antenna_numbers == self.ant_1_array[baseline_inds[0]]
  2627     33024      29290.0      0.9      0.2              )[0][0]
  2628     66048     107999.0      1.6      0.6              ant2_index = np.where(
  2629     16512     101183.0      6.1      0.6                  self.antenna_numbers == self.ant_2_array[baseline_inds[0]]
  2630     33024      29465.0      0.9      0.2              )[0][0]
  2631     16512     178096.0     10.8      1.1              uvw_array[baseline_inds, :] = (
  2632     16512      53901.0      3.3      0.3                  antenna_locs_ENU[ant2_index, :] - antenna_locs_ENU[ant1_index, :]
  2633                                                       )
  2634         2         16.0      8.0      0.0          self.uvw_array = uvw_array
  2635         2          2.0      1.0      0.0          if phase_type == "phased":
  2636                                                       self.phase(
  2637                                                           phase_center_ra,
  2638                                                           phase_center_dec,
  2639                                                           phase_center_epoch,
  2640                                                           phase_frame=output_phase_frame,
  2641                                                       )
```

**### After**

```
None
Wrote profile results to profile_corr_fits.py.lprof
Timer unit: 1e-06 s

Total time: 4.647 s
File: ./profile_corr_fits.py
Function: read_multi at line 27

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    27                                           @profile
    28                                           def read_multi():
    29         1          3.0      3.0      0.0   order1 = [filelist[0:3]]
    30         1          1.0      1.0      0.0   order2 = [filelist[0], filelist[2], filelist[1]]
    31         1       2114.0   2114.0      0.0   mwa_uv1 = UVData()
    32         1       2035.0   2035.0      0.0   mwa_uv2 = UVData()
    33         1          0.0      0.0      0.0   messages = [
    34         1          1.0      1.0      0.0       "telescope_location is not set",
    35         1          1.0      1.0      0.0       "coarse channels are not contiguous for this observation",
    36         1          0.0      0.0      0.0       "some coarse channel files were not submitted",
    37                                            ]
    38         2    3014409.0 1507204.5     64.9   uvtest.checkWarnings(
    39         1          1.0      1.0      0.0       mwa_uv1.read, func_args=[order1], nwarnings=3, message=messages
    40                                            )
    41         2    1202199.0 601099.5     25.9   uvtest.checkWarnings(
    42         1          1.0      1.0      0.0       mwa_uv2.read, func_args=[order2], nwarnings=3, message=messages
    43                                            )
    44         1     426237.0 426237.0      9.2   assert mwa_uv1 == mwa_uv2

Total time: 1.84262 s
File: /home/matthew/work/src/pyuvdata/pyuvdata/utils.py
Function: get_lst_for_time at line 1095

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
  1095                                           @profile
  1096                                           def get_lst_for_time(jd_array, latitude, longitude, altitude):
  1097                                               """
  1098                                               Get the lsts for a set of jd times at an earth location.
  1099                                           
  1100                                               Parameters
  1101                                               ----------
  1102                                               jd_array : ndarray of float
  1103                                                   JD times to get lsts for.
  1104                                               latitude : float
  1105                                                   Latitude of location to get lst for in degrees.
  1106                                               longitude : float
  1107                                                   Longitude of location to get lst for in degrees.
  1108                                               altitude : float
  1109                                                   Altitude of location to get lst for in meters.
  1110                                           
  1111                                               Returns
  1112                                               -------
  1113                                               ndarray of float
  1114                                                   LSTs in radians corresponding to the jd_array.
  1115                                           
  1116                                               """
  1117         2       2442.0   1221.0      0.1      lst_array = np.zeros_like(jd_array)
  1118         2      59658.0  29829.0      3.2      jd, reverse_inds = np.unique(jd_array, return_inverse=True)
  1119         4       1567.0    391.8      0.1      times = Time(
  1120         2          2.0      1.0      0.0          jd,
  1121         2          2.0      1.0      0.0          format="jd",
  1122         2        499.0    249.5      0.0          location=(Angle(longitude, unit="deg"), Angle(latitude, unit="deg")),
  1123                                               )
  1124         2        119.0     59.5      0.0      if iers.conf.auto_max_age is None:  # pragma: no cover
  1125                                                   delta, status = times.get_delta_ut1_utc(return_status=True)
  1126                                                   if np.any(
  1127                                                       np.isin(status, (iers.TIME_BEFORE_IERS_RANGE, iers.TIME_BEYOND_IERS_RANGE))
  1128                                                   ):
  1129                                                       warnings.warn(
  1130                                                           "time is out of IERS range, setting delta ut1 utc to "
  1131                                                           "extrapolated value"
  1132                                                       )
  1133                                                       times.delta_ut1_utc = delta
  1134         2    1778332.0 889166.0     96.5      lst_array = times.sidereal_time("apparent").radian[reverse_inds]
  1135                                           
  1136         2          4.0      2.0      0.0      return lst_array

Total time: 3.87208 s
File: /home/matthew/work/src/pyuvdata/pyuvdata/uvdata/mwa_corr_fits.py
Function: read_mwa_corr_fits at line 170

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   170                                               @profile
   171                                               def read_mwa_corr_fits(
   172                                                   self,
   173                                                   filelist,
   174                                                   use_cotter_flags=False,
   175                                                   correct_cable_len=False,
   176                                                   phase_to_pointing_center=False,
   177                                                   run_check=True,
   178                                                   check_extra=True,
   179                                                   run_check_acceptability=True,
   180                                                   flag_init=True,
   181                                                   edge_width=80e3,
   182                                                   start_flag=2.0,
   183                                                   end_flag=2.0,
   184                                                   flag_dc_offset=True,
   185                                               ):
   186                                                   """
   187                                                   Read in MWA correlator gpu box files.
   188                                           
   189                                                   Parameters
   190                                                   ----------
   191                                                   filelist : list of str
   192                                                       The list of MWA correlator files to read from. Must include at
   193                                                       least one fits file and only one metafits file per data set.
   194                                                       Can also be a list of lists to read multiple data sets.
   195                                                   axis : str
   196                                                       Axis to concatenate files along. This enables fast concatenation
   197                                                       along the specified axis without the normal checking that all other
   198                                                       metadata agrees. This method does not guarantee correct resulting
   199                                                       objects. Please see the docstring for fast_concat for details.
   200                                                       Allowed values are: 'blt', 'freq', 'polarization'. Only used if
   201                                                       multiple files are passed.
   202                                                   use_cotter_flags : bool
   203                                                       Option to use cotter output mwaf flag files. Otherwise flagging
   204                                                       will only be applied to missing data and bad antennas.
   205                                                   correct_cable_len : bool
   206                                                       Option to apply a cable delay correction.
   207                                                   phase_to_pointing_center : bool
   208                                                       Option to phase to the observation pointing center.
   209                                                   run_check : bool
   210                                                       Option to check for the existence and proper shapes of parameters
   211                                                       after after reading in the file (the default is True,
   212                                                       meaning the check will be run).
   213                                                   check_extra : bool
   214                                                       Option to check optional parameters as well as required ones (the
   215                                                       default is True, meaning the optional parameters will be checked).
   216                                                   run_check_acceptability : bool
   217                                                       Option to check acceptable range of the values of parameters after
   218                                                       reading in the file (the default is True, meaning the acceptable
   219                                                       range check will be done).
   220                                                   flag_init: bool
   221                                                       Set to True in order to do routine flagging of coarse channel edges,
   222                                                       start or end integrations, or the center fine channel of each coarse
   223                                                       channel. See associated keywords.
   224                                                   edge_width: float
   225                                                       Only used if flag_init is True. The width to flag on the edge of
   226                                                       each coarse channel, in hz. Errors if not equal to integer multiple
   227                                                       of channel_width. Set to 0 for no edge flagging.
   228                                                   start_flag: float
   229                                                       Only used if flag_init is True. The number of seconds to flag at the
   230                                                       beginning of the observation. Set to 0 for no flagging. Errors if
   231                                                       not equal to an integer multiple of the integration time.
   232                                                   end_flag: floats
   233                                                       Only used if flag_init is True. The number of seconds to flag at the
   234                                                       end of the observation. Set to 0 for no flagging. Errors if not
   235                                                       equal to an integer multiple of the integration time.
   236                                                   flag_dc_offset: bool
   237                                                       Only used if flag_init is True. Set to True to flag the center fine
   238                                                       channel of each coarse channel.
   239                                           
   240                                                   Raises
   241                                                   ------
   242                                                   ValueError
   243                                                       If required files are missing or multiple files metafits files are
   244                                                       included in filelist.
   245                                                       If files from different observations are included in filelist.
   246                                                       If files in fileslist have different fine channel widths
   247                                                       If file types other than fits, metafits, and mwaf files are included
   248                                                       in filelist.
   249                                           
   250                                                   """
   251         2          8.0      4.0      0.0          metafits_file = None
   252         2          6.0      3.0      0.0          ppds_file = None
   253         2         14.0      7.0      0.0          obs_id = None
   254         2          6.0      3.0      0.0          file_dict = {}
   255         2          5.0      2.5      0.0          start_time = 0.0
   256         2          5.0      2.5      0.0          end_time = 0.0
   257         2          6.0      3.0      0.0          included_file_nums = []
   258         2          6.0      3.0      0.0          cotter_warning = False
   259         2          6.0      3.0      0.0          num_fine_chans = 0
   260                                           
   261                                                   # iterate through files and organize
   262                                                   # create a list of included coarse channels
   263                                                   # find the first and last times that have data
   264         8         24.0      3.0      0.0          for file in filelist:
   265         6         24.0      4.0      0.0              if file.lower().endswith(".metafits"):
   266                                                           # force only one metafits file
   267         2          6.0      3.0      0.0                  if metafits_file is not None:
   268                                                               raise ValueError("multiple metafits files in filelist")
   269         2          6.0      3.0      0.0                  metafits_file = file
   270         4         14.0      3.5      0.0              elif file.lower().endswith(".fits"):
   271                                                           # check if ppds file
   272         4         11.0      2.8      0.0                  try:
   273         4      14180.0   3545.0      0.4                      fits.getheader(file, extname="ppds")
   274                                                               ppds_file = file
   275         4         13.0      3.2      0.0                  except Exception:
   276                                                               # check obsid
   277         4       5944.0   1486.0      0.2                      head0 = fits.getheader(file, 0)
   278         4         15.0      3.8      0.0                      if obs_id is None:
   279         2        218.0    109.0      0.0                          obs_id = head0["OBSID"]
   280                                                               else:
   281         2        207.0    103.5      0.0                          if head0["OBSID"] != obs_id:
   282                                                                       raise ValueError(
   283                                                                           "files from different observations submitted "
   284                                                                           "in same list"
   285                                                                       )
   286                                                               # check headers for first and last times containing data
   287         4      12465.0   3116.2      0.3                      headstart = fits.getheader(file, 1)
   288         4      12815.0   3203.8      0.3                      headfin = fits.getheader(file, -1)
   289         4        880.0    220.0      0.0                      first_time = headstart["TIME"] + headstart["MILLITIM"] / 1000.0
   290         4        763.0    190.8      0.0                      last_time = headfin["TIME"] + headfin["MILLITIM"] / 1000.0
   291         4         14.0      3.5      0.0                      if start_time == 0.0:
   292         2          6.0      3.0      0.0                          start_time = first_time
   293                                                               # check that files with a timing offset can be aligned
   294         2        239.0    119.5      0.0                      elif np.abs(start_time - first_time) % headstart["INTTIME"] != 0.0:
   295                                                                   raise ValueError(
   296                                                                       "coarse channel start times are misaligned by an amount that is not \
   297                                                                           an integer multiple of the integration time"
   298                                                                   )
   299         2          7.0      3.5      0.0                      elif start_time > first_time:
   300         1          3.0      3.0      0.0                          start_time = first_time
   301         4         12.0      3.0      0.0                      if end_time < last_time:
   302         3          9.0      3.0      0.0                          end_time = last_time
   303                                                               # get number of fine channels
   304         4         12.0      3.0      0.0                      if num_fine_chans == 0:
   305         2        188.0     94.0      0.0                          num_fine_chans = headstart["NAXIS2"]
   306         2        184.0     92.0      0.0                      elif num_fine_chans != headstart["NAXIS2"]:
   307                                                                   raise ValueError(
   308                                                                       "files submitted have different fine channel widths"
   309                                                                   )
   310                                                               # get the file number from the file name;
   311                                                               # this will later be mapped to a coarse channel
   312         4         20.0      5.0      0.0                      file_num = int(file.split("_")[-2][-2:])
   313         4         11.0      2.8      0.0                      if file_num not in included_file_nums:
   314         4         11.0      2.8      0.0                          included_file_nums.append(file_num)
   315                                                               # organize files
   316         4         12.0      3.0      0.0                      if "data" not in file_dict.keys():
   317         2         24.0     12.0      0.0                          file_dict["data"] = [file]
   318                                                               else:
   319         2         23.0     11.5      0.0                          file_dict["data"].append(file)
   320                                                       # look for flag files
   321                                                       elif file.lower().endswith(".mwaf"):
   322                                                           if use_cotter_flags is False and cotter_warning is False:
   323                                                               warnings.warn("mwaf files submitted with use_cotter_flags=False")
   324                                                               cotter_warning = True
   325                                                           elif "flags" not in file_dict.keys():
   326                                                               file_dict["flags"] = [file]
   327                                                           else:
   328                                                               file_dict["flags"].append(file)
   329                                                       else:
   330                                                           raise ValueError("only fits, metafits, and mwaf files supported")
   331                                           
   332                                                   # checks:
   333         2          6.0      3.0      0.0          if metafits_file is None and ppds_file is None:
   334                                                       raise ValueError("no metafits file submitted")
   335         2          4.0      2.0      0.0          elif metafits_file is None:
   336                                                       metafits_file = ppds_file
   337         2          6.0      3.0      0.0          elif ppds_file is not None:
   338                                                       ppds = fits.getheader(ppds_file, 0)
   339                                                       meta = fits.getheader(metafits_file, 0)
   340                                                       for key in ppds.keys():
   341                                                           if key not in meta.keys():
   342                                                               self.extra_keywords[key] = ppds[key]
   343         2          6.0      3.0      0.0          if "data" not in file_dict.keys():
   344                                                       raise ValueError("no data files submitted")
   345         2          6.0      3.0      0.0          if "flags" not in file_dict.keys() and use_cotter_flags:
   346                                                       raise ValueError(
   347                                                           "no flag files submitted. Rerun with flag files \
   348                                                                        or use_cotter_flags=False"
   349                                                       )
   350                                           
   351                                                   # first set parameters that are always true
   352         2         11.0      5.5      0.0          self.Nspws = 1
   353         2         21.0     10.5      0.0          self.spw_array = np.array([0])
   354         2          8.0      4.0      0.0          self.phase_type = "drift"
   355         2          7.0      3.5      0.0          self.vis_units = "uncalib"
   356         2          7.0      3.5      0.0          self.Npols = 4
   357         2          6.0      3.0      0.0          self.xorientation = "east"
   358                                           
   359                                                   # get information from metafits file
   360         2       4610.0   2305.0      0.1          with fits.open(metafits_file, memmap=True) as meta:
   361         2         36.0     18.0      0.0              meta_hdr = meta[0].header
   362                                           
   363                                                       # get a list of coarse channels
   364         2       1116.0    558.0      0.0              coarse_chans = meta_hdr["CHANNELS"].split(",")
   365         2         50.0     25.0      0.0              coarse_chans = np.array(sorted(int(i) for i in coarse_chans))
   366                                           
   367                                                       # integration time in seconds
   368         2        236.0    118.0      0.0              int_time = meta_hdr["INTTIME"]
   369                                           
   370                                                       # pointing center in degrees
   371         2        234.0    117.0      0.0              ra_deg = meta_hdr["RA"]
   372         2        211.0    105.5      0.0              dec_deg = meta_hdr["DEC"]
   373         2          9.0      4.5      0.0              ra_rad = np.pi * ra_deg / 180
   374         2          6.0      3.0      0.0              dec_rad = np.pi * dec_deg / 180
   375                                           
   376                                                       # get parameters from header
   377                                                       # this assumes no averaging by this code so will need to be updated
   378         2        390.0    195.0      0.0              self.channel_width = float(meta_hdr.pop("FINECHAN") * 1000)
   379         2         10.0      5.0      0.0              if "HISTORY" in meta_hdr:
   380         2        296.0    148.0      0.0                  self.history = str(meta_hdr["HISTORY"])
   381         2        318.0    159.0      0.0                  meta_hdr.remove("HISTORY", remove_all=True)
   382                                                       else:
   383                                                           self.history = ""
   384         4         22.0      5.5      0.0              if not uvutils._check_history_version(
   385         2         10.0      5.0      0.0                  self.history, self.pyuvdata_version_str
   386                                                       ):
   387         2         10.0      5.0      0.0                  self.history += self.pyuvdata_version_str
   388         2        203.0    101.5      0.0              self.instrument = meta_hdr["TELESCOP"]
   389         2        208.0    104.0      0.0              self.telescope_name = meta_hdr.pop("TELESCOP")
   390         2        394.0    197.0      0.0              self.object_name = meta_hdr.pop("FILENAME")
   391                                           
   392                                                       # get rid of the instrument keyword so it doesn't get put back in
   393         2        123.0     61.5      0.0              meta_hdr.remove("INSTRUME")
   394                                                       # get rid of keywords that uvfits.py gets rid of
   395         2          8.0      4.0      0.0              bad_keys = ["SIMPLE", "EXTEND", "BITPIX", "NAXIS", "DATE-OBS"]
   396        12         36.0      3.0      0.0              for key in bad_keys:
   397        10        626.0     62.6      0.0                  meta_hdr.remove(key, remove_all=True)
   398                                                       # store remaining keys in extra keywords
   399        94        629.0      6.7      0.0              for key in meta_hdr:
   400        92        368.0      4.0      0.0                  if key == "COMMENT":
   401        16       7200.0    450.0      0.2                      self.extra_keywords[key] = str(meta_hdr.get(key))
   402        76        237.0      3.1      0.0                  elif key != "":
   403        76       9823.0    129.2      0.3                      self.extra_keywords[key] = meta_hdr.get(key)
   404                                                       # get antenna data from metafits file table
   405         2      38849.0  19424.5      1.0              meta_tbl = meta[1].data
   406                                           
   407                                                       # because of polarization, each antenna # is listed twice
   408         2        204.0    102.0      0.0              antenna_numbers = meta_tbl["Antenna"][1::2]
   409         2        565.0    282.5      0.0              antenna_names = meta_tbl["TileName"][1::2]
   410         2        186.0     93.0      0.0              antenna_flags = meta_tbl["Flag"][1::2]
   411         2        481.0    240.5      0.0              cable_lens = meta_tbl["Length"][1::2]
   412                                           
   413                                                       # get antenna postions in enu coordinates
   414         2         13.0      6.5      0.0              antenna_positions = np.zeros((len(antenna_numbers), 3))
   415         2        194.0     97.0      0.0              antenna_positions[:, 0] = meta_tbl["East"][1::2]
   416         2        182.0     91.0      0.0              antenna_positions[:, 1] = meta_tbl["North"][1::2]
   417         2        335.0    167.5      0.0              antenna_positions[:, 2] = meta_tbl["Height"][1::2]
   418                                           
   419                                                   # reorder antenna parameters from metafits ordering
   420         2         23.0     11.5      0.0          reordered_inds = antenna_numbers.argsort()
   421         2         20.0     10.0      0.0          self.antenna_numbers = antenna_numbers[reordered_inds]
   422         2        421.0    210.5      0.0          self.antenna_names = list(antenna_names[reordered_inds])
   423         2         25.0     12.5      0.0          antenna_positions = antenna_positions[reordered_inds, :]
   424         2         10.0      5.0      0.0          antenna_flags = antenna_flags[reordered_inds]
   425         2         15.0      7.5      0.0          cable_lens = cable_lens[reordered_inds]
   426                                           
   427                                                   # find flagged antenna
   428         2         58.0     29.0      0.0          flagged_ants = self.antenna_numbers[np.where(antenna_flags == 1)]
   429                                           
   430                                                   # set parameters from other parameters
   431         2         14.0      7.0      0.0          self.Nants_data = len(self.antenna_numbers)
   432         2         12.0      6.0      0.0          self.Nants_telescope = len(self.antenna_numbers)
   433         4         18.0      4.5      0.0          self.Nbls = int(
   434         2         12.0      6.0      0.0              len(self.antenna_numbers) * (len(self.antenna_numbers) + 1) / 2.0
   435                                                   )
   436                                           
   437                                                   # get telescope parameters
   438         2       1921.0    960.5      0.0          self.set_telescope_params()
   439                                           
   440                                                   # build time array of centers
   441         4         25.0      6.2      0.0          time_array = np.arange(
   442         2          7.0      3.5      0.0              start_time + int_time / 2.0, end_time + int_time / 2.0 + int_time, int_time
   443                                                   )
   444                                           
   445                                                   # convert to time to jd floats
   446         2       1806.0    903.0      0.0          float_time_array = Time(time_array, format="unix", scale="utc").jd.astype(float)
   447                                                   # build into time array
   448         2       6825.0   3412.5      0.2          self.time_array = np.repeat(float_time_array, self.Nbls)
   449                                           
   450         2         15.0      7.5      0.0          self.Ntimes = len(time_array)
   451                                           
   452         2         18.0      9.0      0.0          self.Nblts = int(self.Nbls * self.Ntimes)
   453                                           
   454                                                   # convert times to lst
   455         6    1842769.0 307128.2     47.6          self.lst_array = uvutils.get_lst_for_time(
   456         4        163.0     40.8      0.0              self.time_array, *self.telescope_location_lat_lon_alt_degrees
   457                                                   )
   458                                           
   459         2       1832.0    916.0      0.0          self.integration_time = np.full((self.Nblts), int_time)
   460                                           
   461                                                   # convert antenna positions from enu to ecef
   462                                                   # antenna positions are "relative to
   463                                                   # the centre of the array in local topocentric \"east\", \"north\",
   464                                                   # \"height\". Units are meters."
   465         6        243.0     40.5      0.0          antenna_positions_ecef = uvutils.ECEF_from_ENU(
   466         4        142.0     35.5      0.0              antenna_positions, *self.telescope_location_lat_lon_alt
   467                                                   )
   468                                                   # make antenna positions relative to telescope location
   469         2         30.0     15.0      0.0          self.antenna_positions = antenna_positions_ecef - self.telescope_location
   470                                           
   471                                                   # make initial antenna arrays, where ant_1 <= ant_2
   472         2          6.0      3.0      0.0          ant_1_array = []
   473         2          6.0      3.0      0.0          ant_2_array = []
   474       258        742.0      2.9      0.0          for i in range(self.Nants_telescope):
   475     16768      47580.0      2.8      1.2              for j in range(i, self.Nants_telescope):
   476     16512      47346.0      2.9      1.2                  ant_1_array.append(i)
   477     16512      47415.0      2.9      1.2                  ant_2_array.append(j)
   478                                           
   479         2       3962.0   1981.0      0.1          self.ant_1_array = np.tile(np.array(ant_1_array), self.Ntimes)
   480         2       5793.0   2896.5      0.1          self.ant_2_array = np.tile(np.array(ant_2_array), self.Ntimes)
   481                                           
   482         4      16374.0   4093.5      0.4          self.baseline_array = self.antnums_to_baseline(
   483         2         10.0      5.0      0.0              self.ant_1_array, self.ant_2_array
   484                                                   )
   485                                           
   486                                                   # create self.uvw_array
   487         2      88208.0  44104.0      2.3          self.set_uvws_from_antenna_positions(allow_phasing=False)
   488                                           
   489                                                   # coarse channel mapping:
   490                                                   # channels in group 0-128 go in order; channels in group 129-155 go in
   491                                                   # reverse order
   492                                                   # that is, if the lowest channel is 127, it will be assigned to the
   493                                                   # first file
   494                                                   # channel 128 will be assigned to the second file
   495                                                   # then the highest channel will be assigned to the third file
   496                                                   # and the next hightest channel assigned to the fourth file, and so on
   497         2          6.0      3.0      0.0          count = 0
   498                                                   # count the number of channels that are in group 0-128
   499        50        168.0      3.4      0.0          for i in coarse_chans:
   500        48        154.0      3.2      0.0              if i <= 128:
   501                                                           count += 1
   502                                                   # map all file numbers to coarse channel numbers
   503         4         62.0     15.5      0.0          file_nums_to_coarse = {
   504                                                       i + 1: coarse_chans[i]
   505                                                       if i < count
   506                                                       else coarse_chans[(len(coarse_chans) + count - i - 1)]
   507         2         10.0      5.0      0.0              for i in range(len(coarse_chans))
   508                                                   }
   509                                                   # map included coarse channels to file numbers
   510         2          6.0      3.0      0.0          coarse_to_incl_files = {}
   511         6         19.0      3.2      0.0          for i in included_file_nums:
   512         4         13.0      3.2      0.0              coarse_to_incl_files[file_nums_to_coarse[i]] = i
   513                                                   # sort included coarse channels
   514         2         14.0      7.0      0.0          included_coarse_chans = sorted(coarse_to_incl_files.keys())
   515                                                   # map included file numbers to an index that orders them
   516         2          6.0      3.0      0.0          file_nums_to_index = {}
   517         6         18.0      3.0      0.0          for i in included_coarse_chans:
   518         4         14.0      3.5      0.0              file_nums_to_index[coarse_to_incl_files[i]] = included_coarse_chans.index(i)
   519                                                   # check that coarse channels are contiguous.
   520         2         20.0     10.0      0.0          chans = np.array(included_coarse_chans)
   521         2         74.0     37.0      0.0          for i in np.diff(chans):
   522         2          7.0      3.5      0.0              if i != 1:
   523         2         44.0     22.0      0.0                  warnings.warn("coarse channels are not contiguous for this observation")
   524         2          6.0      3.0      0.0                  break
   525                                           
   526                                                   # warn user if not all coarse channels are included
   527         2         12.0      6.0      0.0          if len(included_coarse_chans) != len(coarse_chans):
   528         2         18.0      9.0      0.0              warnings.warn("some coarse channel files were not submitted")
   529                                           
   530                                                   # build frequency array
   531         2         14.0      7.0      0.0          self.Nfreqs = len(included_coarse_chans) * num_fine_chans
   532         2         19.0      9.5      0.0          self.freq_array = np.zeros((self.Nspws, self.Nfreqs))
   533                                           
   534                                                   # each coarse channel is split into 128 fine channels of width 10 kHz.
   535                                                   # The first fine channel for each coarse channel is centered on the
   536                                                   # lower bound frequency of that channel and its center frequency is
   537                                                   # computed as fine_center = coarse_channel_number * 1280-640 (kHz).
   538                                                   # If the fine channels have been averaged (added) by some factor, the
   539                                                   # center of the resulting channel is found by averaging the centers of
   540                                                   # the first and last fine channels it is made up of.
   541                                                   # That is, avg_fine_center=(lowest_fine_center+highest_fine_center)/2
   542                                                   # where highest_fine_center=lowest_fine_center+(avg_factor-1)*10 kHz
   543                                                   # so avg_fine_center=(lowest_fine_center+lowest_fine_center+(avg_factor-1)*10)/2
   544                                                   #                   =lowest_fine_center+((avg_factor-1)*10)/2
   545                                                   #                   =lowest_fine_center+offset
   546                                                   # Calculate offset=((avg_factor-1)*10)/2 to build the frequency array
   547         2          9.0      4.5      0.0          avg_factor = self.channel_width / 10000
   548         2          8.0      4.0      0.0          width = self.channel_width / 1000
   549         2          7.0      3.5      0.0          offset = (avg_factor - 1) * 10 / 2.0
   550                                           
   551         6         19.0      3.2      0.0          for i in range(len(included_coarse_chans)):
   552                                                       # get the lowest fine freq of the coarse channel (kHz)
   553         4         17.0      4.2      0.0              lower_fine_freq = included_coarse_chans[i] * 1280 - 640
   554                                                       # find the center of the lowest averaged channel
   555         4         44.0     11.0      0.0              first_center = lower_fine_freq + offset
   556                                                       # add the channel centers for this coarse channel into
   557                                                       # the frequency array (converting from kHz to Hz)
   558         8         41.0      5.1      0.0              self.freq_array[
   559         4         15.0      3.8      0.0                  0, int(i * num_fine_chans) : int((i + 1) * num_fine_chans)
   560                                                       ] = (
   561         8         56.0      7.0      0.0                  np.arange(first_center, first_center + num_fine_chans * width, width)
   562         4         11.0      2.8      0.0                  * 1000
   563                                                       )
   564                                           
   565                                                   # read data into an array with dimensions (time, uv, baselines*pols)
   566         4         53.0     13.2      0.0          self.data_array = np.zeros(
   567         2         22.0     11.0      0.0              (self.Ntimes, self.Nfreqs, self.Nbls * self.Npols), dtype=np.complex128
   568                                                   )
   569         4        385.0     96.2      0.0          self.nsample_array = np.zeros(
   570         2         12.0      6.0      0.0              (self.Ntimes, self.Nfreqs, self.Nbls * self.Npols), dtype=np.float32
   571                                                   )
   572         4        694.0    173.5      0.0          self.flag_array = np.full(
   573         2         12.0      6.0      0.0              (self.Ntimes, self.Nfreqs, self.Nbls * self.Npols), True
   574                                                   )
   575                                           
   576                                                   # read data files
   577         6         26.0      4.3      0.0          for file in file_dict["data"]:
   578                                                       # get the file number from the file name
   579         4         39.0      9.8      0.0              file_num = int(file.split("_")[-2][-2:])
   580                                                       # map file number to frequency index
   581         4         16.0      4.0      0.0              freq_ind = file_nums_to_index[file_num] * num_fine_chans
   582         8       7473.0    934.1      0.2              with fits.open(
   583         4         13.0      3.2      0.0                  file, memmap=False, do_not_scale_image_data=False
   584         4         53.0     13.2      0.0              ) as hdu_list:
   585                                                           # count number of times
   586         4      35731.0   8932.8      0.9                  end_list = len(hdu_list)
   587         8        290.0     36.2      0.0                  for i in range(1, end_list):
   588         4         16.0      4.0      0.0                      time = (
   589        12       2016.0    168.0      0.1                          hdu_list[i].header["TIME"]
   590         4        572.0    143.0      0.0                          + hdu_list[i].header["MILLITIM"] / 1000.0
   591         4         17.0      4.2      0.0                          + int_time / 2.0
   592                                                               )
   593         4        116.0     29.0      0.0                      time_ind = np.where(time_array == time)[0][0]
   594                                                               # dump data into matrix
   595                                                               # and take data from real to complex numbers
   596         8       1167.0    145.9      0.0                      self.data_array[
   597         4         15.0      3.8      0.0                          time_ind, freq_ind : freq_ind + num_fine_chans, :
   598         4       2072.0    518.0      0.1                      ] = (hdu_list[i].data[:, 0::2] + 1j * hdu_list[i].data[:, 1::2])
   599         8        249.0     31.1      0.0                      self.nsample_array[
   600         4         14.0      3.5      0.0                          time_ind, freq_ind : freq_ind + num_fine_chans, :
   601         4         17.0      4.2      0.0                      ] = 1.0
   602         8         50.0      6.2      0.0                      self.flag_array[
   603         4         14.0      3.5      0.0                          time_ind, freq_ind : freq_ind + num_fine_chans, :
   604         4         14.0      3.5      0.0                      ] = False
   605                                           
   606                                                   # polarizations are ordered yy, yx, xy, xx
   607         2         30.0     15.0      0.0          self.polarization_array = np.array([-6, -8, -7, -5])
   608                                           
   609                                                   # build mapper from antenna numbers and polarizations to pfb inputs
   610         2          7.0      3.5      0.0          corr_ants_to_pfb_inputs = {}
   611       258        908.0      3.5      0.0          for i in range(len(antenna_numbers)):
   612       768       2899.0      3.8      0.1              for p in range(2):
   613       512       1987.0      3.9      0.1                  corr_ants_to_pfb_inputs[(antenna_numbers[i], p)] = 2 * i + p
   614                                           
   615                                                   # for mapping, start with a pair of antennas/polarizations
   616                                                   # this is the pair we want to find the data for
   617                                                   # map the pair to the corresponding pfb input indices
   618                                                   # map the pfb input indices to the pfb output indices
   619                                                   # these are the indices for the data corresponding to the initial
   620                                                   # antenna/pol pair
   621                                                   # generate a mapping index array
   622         2         42.0     21.0      0.0          map_inds = np.zeros(self.Nbls * self.Npols, dtype=np.int32)
   623                                                   # generate a conjugation array
   624         2        124.0     62.0      0.0          conj = np.full((self.Nbls * self.Npols), 0, dtype=np.int_)
   625         2        548.0    274.0      0.0          pfb_inputs_to_outputs = input_output_mapping()
   626                                           
   627         4     205440.0  51360.0      5.3          map_inds, conj = _corr_fits.generate_map(
   628         2          7.0      3.5      0.0              corr_ants_to_pfb_inputs, pfb_inputs_to_outputs, map_inds, conj,
   629                                                   )
   630         2         90.0     45.0      0.0          conj = conj.astype(bool)
   631                                                   # reorder data
   632         2     135569.0  67784.5      3.5          self.data_array = self.data_array[:, :, map_inds]
   633         2      48037.0  24018.5      1.2          self.nsample_array = self.nsample_array[:, :, map_inds]
   634         2      17198.0   8599.0      0.4          self.flag_array = self.flag_array[:, :, map_inds]
   635                                                   # conjugate data
   636         2      54845.0  27422.5      1.4          self.data_array[:, :, conj] = np.conj(self.data_array[:, :, conj])
   637                                                   # reshape data
   638         4         58.0     14.5      0.0          self.data_array = self.data_array.reshape(
   639         2         21.0     10.5      0.0              (self.Ntimes, self.Nfreqs, self.Nbls, self.Npols)
   640                                                   )
   641         4         27.0      6.8      0.0          self.nsample_array = self.nsample_array.reshape(
   642         2         14.0      7.0      0.0              (self.Ntimes, self.Nfreqs, self.Nbls, self.Npols)
   643                                                   )
   644         4         25.0      6.2      0.0          self.flag_array = self.flag_array.reshape(
   645         2         14.0      7.0      0.0              (self.Ntimes, self.Nfreqs, self.Nbls, self.Npols)
   646                                                   )
   647         2         54.0     27.0      0.0          self.data_array = np.swapaxes(self.data_array, 1, 2)
   648         2         23.0     11.5      0.0          self.nsample_array = np.swapaxes(self.nsample_array, 1, 2)
   649         2         20.0     10.0      0.0          self.flag_array = np.swapaxes(self.flag_array, 1, 2)
   650                                           
   651                                                   # generage baseline flags for flagged ants
   652         2          8.0      4.0      0.0          bad_ant_inds = []
   653       258        771.0      3.0      0.0          for ant1 in range(128):
   654     16768      53959.0      3.2      1.4              for ant2 in range(ant1, 128):
   655     16512     169440.0     10.3      4.4                  if ant1 in flagged_ants or ant2 in flagged_ants:
   656       510       2066.0      4.1      0.1                      bad_ant_inds.append(int(128 * ant1 - ant1 * (ant1 + 1) / 2 + ant2))
   657         2        165.0     82.5      0.0          self.flag_array[:, bad_ant_inds, :, :] = True
   658                                           
   659                                                   # combine baseline and time axes
   660         2     165401.0  82700.5      4.3          self.data_array = self.data_array.reshape((self.Nblts, self.Nfreqs, self.Npols))
   661         2      48536.0  24268.0      1.3          self.flag_array = self.flag_array.reshape((self.Nblts, self.Nfreqs, self.Npols))
   662         4      93931.0  23482.8      2.4          self.nsample_array = self.nsample_array.reshape(
   663         2         17.0      8.5      0.0              (self.Nblts, self.Nfreqs, self.Npols)
   664                                                   )
   665                                           
   666                                                   # cable delay corrections
   667         2         14.0      7.0      0.0          if correct_cable_len:
   668                                                       self.correct_cable_length(cable_lens)
   669                                           
   670                                                   # add spectral window index
   671         2         31.0     15.5      0.0          self.data_array = self.data_array[:, np.newaxis, :, :]
   672         2         18.0      9.0      0.0          self.flag_array = self.flag_array[:, np.newaxis, :, :]
   673         2         17.0      8.5      0.0          self.nsample_array = self.nsample_array[:, np.newaxis, :, :]
   674                                           
   675                                                   # because of an annoying discrepancy between file conventions, in order
   676                                                   # to be consistent with the uvw vector direction, all the data must
   677                                                   # be conjugated
   678         2      55853.0  27926.5      1.4          self.data_array = np.conj(self.data_array)
   679                                           
   680                                                   # reorder polarizations
   681         2     513367.0 256683.5     13.3          self.reorder_pols()
   682                                           
   683                                                   # phasing
   684         2          7.0      3.5      0.0          if phase_to_pointing_center:
   685                                                       self.phase(ra_rad, dec_rad)
   686                                           
   687         2          8.0      4.0      0.0          if flag_init:
   688         4      17543.0   4385.8      0.5              self.flag_init(
   689         2          7.0      3.5      0.0                  num_fine_chans,
   690         2          6.0      3.0      0.0                  edge_width=edge_width,
   691         2          7.0      3.5      0.0                  start_flag=start_flag,
   692         2          6.0      3.0      0.0                  end_flag=end_flag,
   693         2          6.0      3.0      0.0                  flag_dc_offset=flag_dc_offset,
   694                                                       )
   695                                           
   696         2          9.0      4.5      0.0          if use_cotter_flags:
   697                                                       raise NotImplementedError(
   698                                                           "reading in cotter flag files is not yet available"
   699                                                       )

Total time: 0 s
File: /home/matthew/work/src/pyuvdata/pyuvdata/uvdata/uvdata.py
Function: set_lsts_from_time_array at line 748

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   748                                               @profile
   749                                               def set_lsts_from_time_array(self):
   750                                                   """Set the lst_array based from the time_array."""
   751                                                   latitude, longitude, altitude = self.telescope_location_lat_lon_alt_degrees
   752                                                   unique_times, inverse_inds = np.unique(self.time_array, return_inverse=True)
   753                                                   unique_lst_array = uvutils.get_lst_for_time(
   754                                                       unique_times, latitude, longitude, altitude
   755                                                   )
   756                                                   self.lst_array = unique_lst_array[inverse_inds]

Total time: 0.376732 s
File: /home/matthew/work/src/pyuvdata/pyuvdata/uvdata/uvdata.py
Function: check at line 793

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   793                                               @profile
   794                                               def check(
   795                                                   self, check_extra=True, run_check_acceptability=True, check_freq_spacing=False
   796                                               ):
   797                                                   """
   798                                                   Add some extra checks on top of checks on UVBase class.
   799                                           
   800                                                   Check that required parameters exist. Check that parameters have
   801                                                   appropriate shapes and optionally that the values are acceptable.
   802                                           
   803                                                   Parameters
   804                                                   ----------
   805                                                   check_extra : bool
   806                                                       If true, check all parameters, otherwise only check required parameters.
   807                                                   run_check_acceptability : bool
   808                                                       Option to check if values in parameters are acceptable.
   809                                           
   810                                                   Returns
   811                                                   -------
   812                                                   bool
   813                                                       True if check passes
   814                                           
   815                                                   Raises
   816                                                   ------
   817                                                   ValueError
   818                                                       if parameter shapes or types are wrong or do not have acceptable
   819                                                       values (if run_check_acceptability is True)
   820                                                   """
   821                                                   # first run the basic check from UVBase
   822                                                   # set the phase type based on object's value
   823         2         12.0      6.0      0.0          if self.phase_type == "phased":
   824                                                       self._set_phased()
   825         2          5.0      2.5      0.0          elif self.phase_type == "drift":
   826         2         19.0      9.5      0.0              self._set_drift()
   827                                                   else:
   828                                                       self._set_unknown_phase_type()
   829                                           
   830         4      19316.0   4829.0      5.1          super(UVData, self).check(
   831         2          3.0      1.5      0.0              check_extra=check_extra, run_check_acceptability=run_check_acceptability
   832                                                   )
   833                                           
   834                                                   # Check internal consistency of numbers which don't explicitly correspond
   835                                                   # to the shape of another array.
   836         4         10.0      2.5      0.0          nants_data_calc = int(
   837         4          6.0      1.5      0.0              len(
   838         4         18.0      4.5      0.0                  set(
   839         4      32087.0   8021.8      8.5                      np.unique(self.ant_1_array).tolist()
   840         2      59259.0  29629.5     15.7                      + np.unique(self.ant_2_array).tolist()
   841                                                           )
   842                                                       )
   843                                                   )
   844         2         13.0      6.5      0.0          if self.Nants_data != nants_data_calc:
   845                                                       raise ValueError(
   846                                                           "Nants_data must be equal to the number of unique "
   847                                                           "values in ant_1_array and ant_2_array"
   848                                                       )
   849                                           
   850         2      61738.0  30869.0     16.4          if self.Nbls != len(np.unique(self.baseline_array)):
   851                                                       raise ValueError(
   852                                                           "Nbls must be equal to the number of unique "
   853                                                           "baselines in the data_array"
   854                                                       )
   855                                           
   856         2      29746.0  14873.0      7.9          if self.Ntimes != len(np.unique(self.time_array)):
   857                                                       raise ValueError(
   858                                                           "Ntimes must be equal to the number of unique "
   859                                                           "times in the time_array"
   860                                                       )
   861                                           
   862                                                   # require that all entries in ant_1_array and ant_2_array exist in
   863                                                   # antenna_numbers
   864         2      26845.0  13422.5      7.1          if not set(np.unique(self.ant_1_array)).issubset(self.antenna_numbers):
   865                                                       raise ValueError("All antennas in ant_1_array must be in antenna_numbers.")
   866         2      52884.0  26442.0     14.0          if not set(np.unique(self.ant_2_array)).issubset(self.antenna_numbers):
   867                                                       raise ValueError("All antennas in ant_2_array must be in antenna_numbers.")
   868                                           
   869                                                   # issue warning if extra_keywords keys are longer than 8 characters
   870        80         80.0      1.0      0.0          for key in self.extra_keywords.keys():
   871        78         71.0      0.9      0.0              if len(key) > 8:
   872                                                           warnings.warn(
   873                                                               "key {key} in extra_keywords is longer than 8 "
   874                                                               "characters. It will be truncated to 8 if written "
   875                                                               "to uvfits or miriad file formats.".format(key=key)
   876                                                           )
   877                                           
   878                                                   # issue warning if extra_keywords values are lists, arrays or dicts
   879        80         79.0      1.0      0.0          for key, value in self.extra_keywords.items():
   880        78         87.0      1.1      0.0              if isinstance(value, (list, dict, np.ndarray)):
   881                                                           warnings.warn(
   882                                                               "{key} in extra_keywords is a list, array or dict, "
   883                                                               "which will raise an error when writing uvfits or "
   884                                                               "miriad file types".format(key=key)
   885                                                           )
   886                                           
   887                                                   # check auto and cross-corrs have sensible uvws
   888         2      10199.0   5099.5      2.7          autos = np.isclose(self.ant_1_array - self.ant_2_array, 0.0)
   889         4         39.0      9.8      0.0          if not np.all(
   890         4        470.0    117.5      0.1              np.isclose(
   891         2       4859.0   2429.5      1.3                  self.uvw_array[autos],
   892         2          3.0      1.5      0.0                  0.0,
   893         2          6.0      3.0      0.0                  rtol=self._uvw_array.tols[0],
   894         2          2.0      1.0      0.0                  atol=self._uvw_array.tols[1],
   895                                                       )
   896                                                   ):
   897                                                       raise ValueError(
   898                                                           "Some auto-correlations have non-zero " "uvw_array coordinates."
   899                                                       )
   900         4        172.0     43.0      0.0          if np.any(
   901         4       6045.0   1511.2      1.6              np.isclose(
   902         2      72641.0  36320.5     19.3                  np.linalg.norm(self.uvw_array[~autos], axis=1),
   903         2          4.0      2.0      0.0                  0.0,
   904         2          8.0      4.0      0.0                  rtol=self._uvw_array.tols[0],
   905         2          2.0      1.0      0.0                  atol=self._uvw_array.tols[1],
   906                                                       )
   907                                                   ):
   908                                                       raise ValueError(
   909                                                           "Some cross-correlations have near-zero " "uvw_array magnitudes."
   910                                                       )
   911                                           
   912         2          2.0      1.0      0.0          if check_freq_spacing:
   913                                                       self._check_freq_spacing()
   914                                           
   915         2          2.0      1.0      0.0          return True

Total time: 0.088101 s
File: /home/matthew/work/src/pyuvdata/pyuvdata/uvdata/uvdata.py
Function: set_uvws_from_antenna_positions at line 2559

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
  2559                                               @profile
  2560                                               def set_uvws_from_antenna_positions(
  2561                                                   self, allow_phasing=False, orig_phase_frame=None, output_phase_frame="icrs"
  2562                                               ):
  2563                                                   """
  2564                                                   Calculate UVWs based on antenna_positions.
  2565                                           
  2566                                                   Parameters
  2567                                                   ----------
  2568                                                   allow_phasing : bool
  2569                                                       Option for phased data. If data is phased and allow_phasing is set,
  2570                                                       data will be unphased, UVWs will be calculated, and then data will
  2571                                                       be rephased.
  2572                                                   orig_phase_frame : str
  2573                                                       The astropy frame to phase from. Either 'icrs' or 'gcrs'.
  2574                                                       Defaults to using the 'phase_center_frame' attribute or 'icrs' if
  2575                                                       that attribute is None. Only used if allow_phasing is True.
  2576                                                   output_phase_frame : str
  2577                                                       The astropy frame to phase to. Either 'icrs' or 'gcrs'. Only used if
  2578                                                       allow_phasing is True.
  2579                                           
  2580                                                   Raises
  2581                                                   ------
  2582                                                   ValueError
  2583                                                       If data is phased and allow_phasing is False.
  2584                                           
  2585                                                   Warns
  2586                                                   -----
  2587                                                   UserWarning
  2588                                                       If the phase_type is 'phased'
  2589                                           
  2590                                                   """
  2591         2          7.0      3.5      0.0          phase_type = self.phase_type
  2592         2          1.0      0.5      0.0          if phase_type == "phased":
  2593                                                       if allow_phasing:
  2594                                                           if not self.metadata_only:
  2595                                                               warnings.warn(
  2596                                                                   "Data will be unphased and rephased "
  2597                                                                   "to calculate UVWs, which might introduce small "
  2598                                                                   "inaccuracies to the data."
  2599                                                               )
  2600                                                           if orig_phase_frame not in [None, "icrs", "gcrs"]:
  2601                                                               raise ValueError(
  2602                                                                   "Invalid parameter orig_phase_frame. "
  2603                                                                   'Options are "icrs", "gcrs", or None.'
  2604                                                               )
  2605                                                           if output_phase_frame not in ["icrs", "gcrs"]:
  2606                                                               raise ValueError(
  2607                                                                   "Invalid parameter output_phase_frame. "
  2608                                                                   'Options are "icrs" or "gcrs".'
  2609                                                               )
  2610                                                           phase_center_ra = self.phase_center_ra
  2611                                                           phase_center_dec = self.phase_center_dec
  2612                                                           phase_center_epoch = self.phase_center_epoch
  2613                                                           self.unphase_to_drift(phase_frame=orig_phase_frame)
  2614                                                       else:
  2615                                                           raise ValueError(
  2616                                                               "UVW calculation requires unphased data. "
  2617                                                               "Use unphase_to_drift or set "
  2618                                                               "allow_phasing=True."
  2619                                                           )
  2620         2        617.0    308.5      0.7          antenna_locs_ENU, _ = self.get_ENU_antpos(center=False)
  2621                                           
  2622         4      63730.0  15932.5     72.3          bls, unique_inds, reverse_inds = np.unique(
  2623         2          4.0      2.0      0.0              self.baseline_array, return_index=True, return_inverse=True
  2624                                                   )
  2625                                           
  2626         4        181.0     45.2      0.2          ant1_index = np.searchsorted(
  2627         2         52.0     26.0      0.1              self.antenna_numbers, self.ant_1_array[unique_inds],
  2628                                                   )
  2629         4        150.0     37.5      0.2          ant2_index = np.searchsorted(
  2630         2         29.0     14.5      0.0              self.antenna_numbers, self.ant_2_array[unique_inds],
  2631                                                   )
  2632                                           
  2633         2         22.0     11.0      0.0          _uvw_array = np.zeros((bls.size, 3))
  2634         2        460.0    230.0      0.5          _uvw_array = antenna_locs_ENU[ant2_index, :] - antenna_locs_ENU[ant1_index, :]
  2635         2      22845.0  11422.5     25.9          self.uvw_array = _uvw_array[reverse_inds]
  2636                                           
  2637         2          3.0      1.5      0.0          if phase_type == "phased":
  2638                                                       self.phase(
  2639                                                           phase_center_ra,
  2640                                                           phase_center_dec,
  2641                                                           phase_center_epoch,
  2642                                                           phase_frame=output_phase_frame,
  2643                                                       )
```


Here's a look at our 10 slowest tests after the changes in commit  https://github.com/RadioAstronomySoftwareGroup/pyuvdata/commit/c6d934e908883d9e48b634fb9b9e0167213ed921
```
======================================= slowest 10 test durations =======================================
17.26s setup    pyuvdata/uvbeam/tests/test_uvbeam.py::test_efield_to_pstokes
17.24s setup    pyuvdata/uvbeam/tests/test_beamfits.py::test_writeread_healpix
16.01s call     pyuvdata/uvbeam/tests/test_uvbeam.py::test_to_healpix
12.78s call     pyuvdata/uvbeam/tests/test_uvbeam.py::test_efield_to_pstokes
9.80s call     pyuvdata/uvbeam/tests/test_uvbeam.py::test_efield_to_power
9.61s call     pyuvdata/uvdata/tests/test_mwa_corr_fits.py::test_flag_init_errors[ValueError-read_kwargs2-The end_flag must be an integer multiple of the integration_time]
8.76s setup    pyuvdata/uvbeam/tests/test_uvbeam.py::test_to_healpix
7.45s call     pyuvdata/uvdata/tests/test_mwa_corr_fits.py::test_flag_nsample_basic
6.85s call     pyuvdata/uvdata/tests/test_mwa_corr_fits.py::test_flag_init_errors[ValueError-read_kwargs1-The start_flag must be an integer multiple of the integration_time]
6.54s call     pyuvdata/uvbeam/tests/test_cst_beam.py::test_read_yaml_multi_pol
```
Here's a look at our 10 slowest tests after the changes in commit  https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/818/commits/b45dc6624c3fde9248baaf021c0255e64bfea574
```
======================================= slowest 10 test durations =======================================
8.22s call     pyuvdata/uvdata/tests/test_mwa_corr_fits.py::test_flag_nsample_basic
7.10s call     pyuvdata/uvbeam/tests/test_cst_beam.py::test_read_yaml_multi_pol
6.48s call     pyuvdata/uvdata/tests/test_miriad.py::test_multi_files
5.76s call     pyuvdata/uvdata/tests/test_mwa_corr_fits.py::test_flag_init
5.65s call     pyuvdata/uvbeam/tests/test_cst_beam.py::test_no_deg_units
5.59s call     pyuvdata/uvbeam/tests/test_uvbeam.py::test_to_healpix
4.95s setup    pyuvdata/uvbeam/tests/test_beamfits.py::test_read_cst_write_read_fits
4.77s call     pyuvdata/tests/test_utils.py::test_redundancy_finder
4.73s call     pyuvdata/uvdata/tests/test_uvfits.py::test_read_uvfits_write_miriad
4.73s setup    pyuvdata/uvbeam/tests/test_uvbeam.py::test_peak_normalize
======================== 734 passed, 3 skipped, 18 warnings in 83.66s (0:01:23) =========================
```