### PR TITLE
Additional corr_fits speed-ups and enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable changes to this project will be documented in this file.
 - `propagate_flags` keyword for `UVData.frequency_average` which flags averaged samples if any contributing samples were flagged
 
 ### Changed
+- Updated formatting and added more explicit typing in corr_fits.pyx
+- Updated Nants calculations for speed up.
 - updated HERA telescope location to match the HERA defined center of array.
 - `utils.uvcalibrate` now incorporates many more consistency checks between the uvcal and uvdata object. The new keywords `time_check` and `ant_check` were added to control some of these checks.
 
-### Deprecated
 - `utils.uvcalibrate` will error rather than warn if some of the newly added checks do not pass, including if antenna names do not match between the objects, starting in version 2.2. In addition, the `flag_missing` keyword is deprecated and will be removed in version 2.2.
+### Deprecated
 
 ## [2.0.2] - 2020-4-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `read_data` keyword to read_mwa_corr_fits, allows from metadata only reads of MWA correlator fits files.
 - `propagate_flags` keyword for `UVData.frequency_average` which flags averaged samples if any contributing samples were flagged
 
 ### Changed
@@ -12,9 +13,8 @@ All notable changes to this project will be documented in this file.
 - updated HERA telescope location to match the HERA defined center of array.
 - `utils.uvcalibrate` now incorporates many more consistency checks between the uvcal and uvdata object. The new keywords `time_check` and `ant_check` were added to control some of these checks.
 
-- `utils.uvcalibrate` will error rather than warn if some of the newly added checks do not pass, including if antenna names do not match between the objects, starting in version 2.2. In addition, the `flag_missing` keyword is deprecated and will be removed in version 2.2.
 ### Deprecated
-
+- `utils.uvcalibrate` will error rather than warn if some of the newly added checks do not pass, including if antenna names do not match between the objects, starting in version 2.2. In addition, the `flag_missing` keyword is deprecated and will be removed in version 2.2.
 ## [2.0.2] - 2020-4-29
 
 ### Added

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -954,13 +954,13 @@ miriad, and MWA correlator fits files.
 
 a) Reading the metadata of a uvfits, uvh5, miriad, or mwa corr fits file
 ********************************************************
-For uvh5, uvfits, miriad, and MWA correlator fits files, reading in the metadata results in a metadata only
+For uvh5, uvfits, and MWA correlator fits files, reading in the metadata results in a metadata only
 UVData object (which has every attribute except the data_array,
 flag_array and nsample_array filled out). For Miriad files, less of the
 metadata can be read without reading the data, but many of the attributes
 are available.
 
-FHD, and measurement set (ms) files do not support
+FHD and measurement set (ms) files do not support
 reading only the metadata
 (the read_data keyword is ignored for these file types).
 ::

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -949,18 +949,18 @@ and ``diff_vis`` methods.
 
 UVData: Working with large files
 --------------------------------
-To save on memory and time, pyuvdata supports reading only parts of uvfits, uvh5 and
-miriad files.
+To save on memory and time, pyuvdata supports reading only parts of uvfits, uvh5,
+miriad, and MWA correlator fits files.
 
-a) Reading the metadata of a uvfits, uvh5 or miriad file
+a) Reading the metadata of a uvfits, uvh5, miriad, or mwa corr fits file
 ********************************************************
-For uvh5 and uvfits files, reading in the metadata results in a metadata only
+For uvh5, uvfits, miriad, and MWA correlator fits files, reading in the metadata results in a metadata only
 UVData object (which has every attribute except the data_array,
 flag_array and nsample_array filled out). For Miriad files, less of the
 metadata can be read without reading the data, but many of the attributes
 are available.
 
-FHD, MWA correlator FITS files, and measurement set (ms) files do not support
+FHD, and measurement set (ms) files do not support
 reading only the metadata
 (the read_data keyword is ignored for these file types).
 ::

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -7,7 +7,7 @@ import numpy as np
 cimport cython
 cimport numpy
 
-def input_output_mapping():
+cpdef dict input_output_mapping():
   """Build a mapping dictionary from pfb input to output numbers."""
   # the polyphase filter bank maps inputs to outputs, which the MWA
   # correlator then records as the antenna indices.
@@ -31,7 +31,7 @@ def input_output_mapping():
           pfb_inputs_to_outputs[pfb_mapper[i] + p * 64] = p * 64 + i
   return pfb_inputs_to_outputs
 
-cpdef generate_map(
+cpdef tuple generate_map(
   dict ants_to_pf,
   dict in_to_out,
   numpy.ndarray[ndim=1, dtype=numpy.int32_t] map_inds,
@@ -89,7 +89,7 @@ cpdef generate_map(
                     map_inds[bls_ind * 4 + pol_ind] = data_index
   return map_inds, conj
 
-cpdef get_bad_ants(numpy.ndarray[dtype=numpy.int32_t, ndim=1] flagged_ants):
+cpdef list get_bad_ants(numpy.ndarray[dtype=numpy.int32_t, ndim=1] flagged_ants):
   cdef list bad_ants = []
   cdef int ant1, ant2
   for ant1 in range(128):

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -110,8 +110,8 @@ cpdef numpy.ndarray get_cable_len_diffs(
   numpy.ndarray cable_lens,
 ):
   cdef int i
-  cdef list cable_array = []
-  cdef numpy.ndarray[ndim=2, dtype=numpy.float64_t] cable_diffs = np.zeros((Nblts, 1))
+  cdef numpy.ndarray[ndim=1, dtype=numpy.float64_t] cable_array = np.zeros(len(cable_lens), dtype=np.float_)
+  cdef numpy.ndarray[ndim=1, dtype=numpy.float64_t] cable_diffs = np.zeros(Nblts, dtype=np.float_)
 
   # "the velocity factor of electic fields in RG-6 like coax"
   # from MWA_Tools/CONV2UVFITS/convutils.h
@@ -119,12 +119,12 @@ cpdef numpy.ndarray get_cable_len_diffs(
 
   # check if the cable length already has the velocity factor applied
   for i in range(len(cable_lens)):
-   if cable_lens[i][0:3] == "EL_":
-     cable_array.append(float(cable_lens[i][3:]))
-   else:
-     cable_array.append(float(cable_lens[i]) * v_factor)
+    if cable_lens[i][0:3] == "EL_":
+      cable_array[i] = float(cable_lens[i][3:])
+    else:
+      cable_array[i] = float(cable_lens[i]) * v_factor
 
   # build array of differences
-  for i in range(Nblts):
-    cable_diffs[i] = cable_array[ant2_array[i]] - cable_array[ant1_array[i]]
+  cable_diffs = cable_array[ant2_array] - cable_array[ant1_array]
+
   return cable_diffs

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -97,3 +97,26 @@ cpdef list get_bad_ants(numpy.ndarray[dtype=numpy.int32_t, ndim=1] flagged_ants)
           if ant1 in flagged_ants or ant2 in flagged_ants:
               bad_ants.append(<int>(128 * ant1 - ant1 * (ant1 + 1) / 2 + ant2))
   return bad_ants
+
+cpdef numpy.ndarray get_cable_len_diffs(
+  int Nblts,
+  numpy.ndarray[dtype=numpy.int_t, ndim=1] ant1_array,
+  numpy.ndarray[dtype=numpy.int_t, ndim=1] ant2_array,
+  numpy.ndarray cable_lens,
+):
+  cdef int i
+  cdef list cable_array = []
+  cdef numpy.ndarray[ndim=2, dtype=numpy.float64_t] cable_diffs = np.zeros((Nblts, 1))
+  # "the velocity factor of electic fields in RG-6 like coax"
+  # from MWA_Tools/CONV2UVFITS/convutils.h
+  cdef float v_factor = 1.204
+ # check if the cable length already has the velocity factor applied
+  for i in range(len(cable_lens)):
+   if cable_lens[i][0:3] == "EL_":
+     cable_array.append(float(cable_lens[i][3:]))
+   else:
+     cable_array.append(float(cable_lens[i]) * v_factor)
+  # build array of differences
+  for i in range(Nblts):
+    cable_diffs[i] = cable_array[ant2_array[i]] - cable_array[ant1_array[i]]
+  return cable_diffs

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -38,7 +38,7 @@ cpdef tuple generate_map(
   numpy.ndarray[ndim=1, dtype=numpy.int32_t] map_inds,
   numpy.ndarray[ndim=1, dtype=numpy.npy_bool] conj
 ):
-  cdef int ant1, atn2, p1, p2, pol_ind, bls_ind, out_ant1, out_ant2
+  cdef int ant1, ant2, p1, p2, pol_ind, bls_ind, out_ant1, out_ant2
   cdef int out_p1, out_p2, ind1_1, ind1_2, ind2_1, ind2_2, data_index
 
   for ant1 in range(128):

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -92,17 +92,6 @@ cpdef tuple generate_map(
 
   return map_inds, conj
 
-cpdef list get_bad_ants(numpy.ndarray[dtype=numpy.int32_t, ndim=1] flagged_ants):
-  cdef list bad_ants = []
-  cdef int ant1, ant2
-
-  for ant1 in range(128):
-    for ant2 in range(ant1, 128):
-      if ant1 in flagged_ants or ant2 in flagged_ants:
-        bad_ants.append(<int>(128 * ant1 - ant1 * (ant1 + 1) / 2 + ant2))
-
-  return bad_ants
-
 cpdef numpy.ndarray get_cable_len_diffs(
   int Nblts,
   numpy.ndarray[dtype=numpy.int_t, ndim=1] ant1_array,

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -85,3 +85,11 @@ cpdef generate_map(
                     )
                     map_inds[bls_ind * 4 + pol_ind] = data_index
   return map_inds, conj
+
+cpdef get_bad_ants(numpy.ndarray[dtype=numpy.int32_t, ndim=1] flagged_ants):
+  cpdef list bad_ants = []
+  for ant1 in range(128):
+      for ant2 in range(ant1, 128):
+          if ant1 in flagged_ants or ant2 in flagged_ants:
+              bad_ants.append(<int>(128 * ant1 - ant1 * (ant1 + 1) / 2 + ant2))
+  return bad_ants

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -92,7 +92,7 @@ cpdef tuple generate_map(
 
   return map_inds, conj
 
-cpdef numpy.ndarray get_cable_len_diffs(
+cpdef numpy.ndarray[ndim=1, dtype=numpy.float64_t] get_cable_len_diffs(
   int Nblts,
   numpy.ndarray[dtype=numpy.int_t, ndim=1] ant1_array,
   numpy.ndarray[dtype=numpy.int_t, ndim=1] ant2_array,

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -16,6 +16,8 @@ def input_output_mapping():
   # (from mwa_build_lfiles/antenna_mapping.h):
   # floor(index/4) + index%4 * 16 = input
   # for the first 64 outputs, pfb_mapper[output] = input
+  cdef int p, i
+  cdef dict pfb_inputs_to_outputs = {}
   # fmt: off
   pfb_mapper = [0, 16, 32, 48, 1, 17, 33, 49, 2, 18, 34, 50, 3, 19, 35, 51,
                 4, 20, 36, 52, 5, 21, 37, 53, 6, 22, 38, 54, 7, 23, 39, 55,
@@ -24,7 +26,6 @@ def input_output_mapping():
                 63]
   # fmt: on
   # build a mapper for all 256 inputs
-  pfb_inputs_to_outputs = {}
   for p in range(4):
       for i in range(64):
           pfb_inputs_to_outputs[pfb_mapper[i] + p * 64] = p * 64 + i
@@ -36,6 +37,8 @@ cpdef generate_map(
   numpy.ndarray[ndim=1, dtype=numpy.int32_t] map_inds,
   numpy.ndarray[ndim=1, dtype=numpy.npy_bool] conj
 ):
+  cdef int ant1, atn2, p1, p2, pol_ind, bls_ind, out_ant1, out_ant2
+  cdef int out_p1, out_p2, ind1_1, ind1_2, ind2_1, ind2_2, data_index
   for ant1 in range(128):
     for ant2 in range(ant1, 128):
         for p1 in range(2):
@@ -87,7 +90,8 @@ cpdef generate_map(
   return map_inds, conj
 
 cpdef get_bad_ants(numpy.ndarray[dtype=numpy.int32_t, ndim=1] flagged_ants):
-  cpdef list bad_ants = []
+  cdef list bad_ants = []
+  cdef int ant1, ant2
   for ant1 in range(128):
       for ant2 in range(ant1, 128):
           if ant1 in flagged_ants or ant2 in flagged_ants:

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -429,9 +429,7 @@ class MWACorrFITS(UVData):
         self.Nblts = int(self.Nbls * self.Ntimes)
 
         # convert times to lst
-        self.lst_array = uvutils.get_lst_for_time(
-            self.time_array, *self.telescope_location_lat_lon_alt_degrees
-        )
+        self.set_lsts_from_time_array()
 
         self.integration_time = np.full((self.Nblts), int_time)
 

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -54,7 +54,7 @@ class MWACorrFITS(UVData):
             -1j
             * 2
             * np.pi
-            * cable_len_diffs
+            * cable_len_diffs.reshape(self.Nblts, 1)
             / const.c.to("m/s").value
             * self.freq_array.reshape(1, self.Nfreqs)
         )[:, :, None]

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -3,8 +3,9 @@
 # Licensed under the 2-clause BSD License
 
 """Class for reading MWA correlator FITS files."""
-import numpy as np
 import warnings
+import itertools
+import numpy as np
 from astropy.io import fits
 from astropy.time import Time
 from astropy import constants as const
@@ -445,12 +446,13 @@ class MWACorrFITS(UVData):
         self.antenna_positions = antenna_positions_ecef - self.telescope_location
 
         # make initial antenna arrays, where ant_1 <= ant_2
-        ant_1_array = []
-        ant_2_array = []
-        for i in range(self.Nants_telescope):
-            for j in range(i, self.Nants_telescope):
-                ant_1_array.append(i)
-                ant_2_array.append(j)
+        ant_1_array, ant_2_array = np.transpose(
+            list(
+                itertools.combinations_with_replacement(
+                    np.arange(self.Nants_telescope), 2
+                )
+            )
+        )
 
         self.ant_1_array = np.tile(np.array(ant_1_array), self.Ntimes)
         self.ant_2_array = np.tile(np.array(ant_2_array), self.Ntimes)

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -446,6 +446,11 @@ class MWACorrFITS(UVData):
         self.antenna_positions = antenna_positions_ecef - self.telescope_location
 
         # make initial antenna arrays, where ant_1 <= ant_2
+        # itertools.combinations_with_replacement returns
+        # all pairs in the range 0...Nants_telescope
+        # including pairs with the same number (e.g. (0,0) auto-correlation).
+        # this is a little faster than having nested for-loops moving over the
+        # upper triangle of antenna-pair combinations matrix.
         ant_1_array, ant_2_array = np.transpose(
             list(
                 itertools.combinations_with_replacement(

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -616,8 +616,8 @@ class MWACorrFITS(UVData):
             corr_ants_to_pfb_inputs, pfb_inputs_to_outputs, map_inds, conj,
         )
         # reorder data
-        self.data_array = self.data_array[:, :, map_inds]
-        self.nsample_array = self.nsample_array[:, :, map_inds]
+        self.data_array = np.take(self.data_array, map_inds, axis=2)
+        self.nsample_array = np.take(self.nsample_array, map_inds, axis=2)
         self.flag_array = self.flag_array[:, :, map_inds]
         # conjugate data
         self.data_array[:, :, conj] = np.conj(self.data_array[:, :, conj])

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -46,22 +46,10 @@ class MWACorrFITS(UVData):
         cable_lens : list of strings
         A list of strings containing the cable lengths for each antenna.
         """
-        # "the velocity factor of electic fields in RG-6 like coax"
         # from MWA_Tools/CONV2UVFITS/convutils.h
-        v_factor = 1.204
-        # check if the cable length already has the velocity factor applied
-        cable_array = []
-        for i in cable_lens:
-            if i[0:3] == "EL_":
-                cable_array.append(float(i[3:]))
-            else:
-                cable_array.append(float(i) * v_factor)
-        # build array of differences
-        cable_len_diffs = np.zeros((self.Nblts, 1))
-        for j in range(self.Nblts):
-            cable_len_diffs[j] = (
-                cable_array[self.ant_2_array[j]] - cable_array[self.ant_1_array[j]]
-            )
+        cable_len_diffs = _corr_fits.get_cable_len_diffs(
+            self.Nblts, self.ant_1_array, self.ant_2_array, cable_lens
+        )
         self.data_array *= np.exp(
             -1j
             * 2
@@ -396,7 +384,7 @@ class MWACorrFITS(UVData):
             antenna_numbers = meta_tbl["Antenna"][1::2]
             antenna_names = meta_tbl["TileName"][1::2]
             antenna_flags = meta_tbl["Flag"][1::2]
-            cable_lens = meta_tbl["Length"][1::2]
+            cable_lens = np.asarray(meta_tbl["Length"][1::2]).astype(np.str_)
 
             # get antenna postions in enu coordinates
             antenna_positions = np.zeros((len(antenna_numbers), 3))

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -470,11 +470,7 @@ class MWACorrFITS(UVData):
         # channel 128 will be assigned to the second file
         # then the highest channel will be assigned to the third file
         # and the next hightest channel assigned to the fourth file, and so on
-        count = 0
-        # count the number of channels that are in group 0-128
-        for i in coarse_chans:
-            if i <= 128:
-                count += 1
+        count = np.count_nonzero(coarse_chans <= 128)
         # map all file numbers to coarse channel numbers
         file_nums_to_coarse = {
             i + 1: coarse_chans[i]

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -618,7 +618,8 @@ class MWACorrFITS(UVData):
         # reorder data
         self.data_array = np.take(self.data_array, map_inds, axis=2)
         self.nsample_array = np.take(self.nsample_array, map_inds, axis=2)
-        self.flag_array = self.flag_array[:, :, map_inds]
+        self.flag_array = np.take(self.flag_array, map_inds, axis=2)
+        # self.flag_array = self.flag_array[:, :, map_inds]
         # conjugate data
         self.data_array[:, :, conj] = np.conj(self.data_array[:, :, conj])
         # reshape data

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -605,7 +605,7 @@ class MWACorrFITS(UVData):
         self.data_array = np.take(self.data_array, map_inds, axis=2)
         self.nsample_array = np.take(self.nsample_array, map_inds, axis=2)
         self.flag_array = np.take(self.flag_array, map_inds, axis=2)
-        # self.flag_array = self.flag_array[:, :, map_inds]
+
         # conjugate data
         self.data_array[:, :, conj] = np.conj(self.data_array[:, :, conj])
         # reshape data

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -625,8 +625,11 @@ class MWACorrFITS(UVData):
         self.flag_array = np.swapaxes(self.flag_array, 1, 2)
 
         # generage baseline flags for flagged ants
-        bad_ant_inds = _corr_fits.get_bad_ants(flagged_ants.astype(np.int32))
-
+        bad_ant_inds = np.nonzero(
+            np.logical_or(
+                np.in1d(ant_1_array, flagged_ants), np.in1d(ant_2_array, flagged_ants),
+            )
+        )[0]
         self.flag_array[:, bad_ant_inds, :, :] = True
 
         # combine baseline and time axes

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -636,11 +636,8 @@ class MWACorrFITS(UVData):
         self.flag_array = np.swapaxes(self.flag_array, 1, 2)
 
         # generage baseline flags for flagged ants
-        bad_ant_inds = []
-        for ant1 in range(128):
-            for ant2 in range(ant1, 128):
-                if ant1 in flagged_ants or ant2 in flagged_ants:
-                    bad_ant_inds.append(int(128 * ant1 - ant1 * (ant1 + 1) / 2 + ant2))
+        bad_ant_inds = _corr_fits.get_bad_ants(flagged_ants.astype(np.int32))
+
         self.flag_array[:, bad_ant_inds, :, :] = True
 
         # combine baseline and time axes

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -549,3 +549,31 @@ def test_flag_init_errors(flag_file_init, err_type, read_kwargs, err_msg):
     with pytest.raises(err_type) as cm:
         uv.read(flag_file_init, **read_kwargs)
     assert str(cm.value).startswith(err_msg)
+
+
+def test_read_metadata_only(tmp_path):
+    """
+    MWA correlator fits to uvfits loopback test.
+
+    Read in MWA correlator files, write out as uvfits, read back in and check
+    for object equality.
+    """
+    uvd = UVData()
+    messages = [
+        "telescope_location is not set",
+        "some coarse channel files were not submitted",
+    ]
+    category = [UserWarning] * 2
+    uvtest.checkWarnings(
+        uvd.read_mwa_corr_fits,
+        func_args=[filelist[0:2]],
+        func_kwargs={
+            "correct_cable_len": True,
+            "phase_to_pointing_center": True,
+            "read_data": False,
+        },
+        nwarnings=len(messages),
+        message=messages,
+        category=category,
+    )
+    assert uvd.metadata_only

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -552,12 +552,7 @@ def test_flag_init_errors(flag_file_init, err_type, read_kwargs, err_msg):
 
 
 def test_read_metadata_only(tmp_path):
-    """
-    MWA correlator fits to uvfits loopback test.
-
-    Read in MWA correlator files, write out as uvfits, read back in and check
-    for object equality.
-    """
+    """Test reading an MWA corr fits file as metadata only."""
     uvd = UVData()
     messages = [
         "telescope_location is not set",

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -5907,6 +5907,7 @@ class UVData(UVBase):
         phase_to_pointing_center=False,
         phase_data=None,
         phase_center=None,
+        read_data=True,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -5953,6 +5954,10 @@ class UVData(UVBase):
             'mwa_corr_fits'.
         phase_to_pointing_center : bool
             Option to phase to the observation pointing center.
+        read_data : bool
+            Read in the visibility and flag data. If set to false, only the
+            basic header info and metadata read in. Setting read_data to False
+            results in a metdata only object.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after after reading in the file (the default is True,
@@ -5996,6 +6001,7 @@ class UVData(UVBase):
             end_flag=end_flag,
             flag_dc_offset=flag_dc_offset,
             phase_to_pointing_center=phase_to_pointing_center,
+            read_data=read_data,
             run_check=run_check,
             check_extra=check_extra,
             run_check_acceptability=run_check_acceptability,
@@ -6874,6 +6880,7 @@ class UVData(UVBase):
                     end_flag=end_flag,
                     flag_dc_offset=True,
                     phase_to_pointing_center=phase_to_pointing_center,
+                    read_data=read_data,
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability,
                 )

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -833,9 +833,8 @@ class UVData(UVBase):
         # to the shape of another array.
         nants_data_calc = int(
             len(
-                set(
-                    np.unique(self.ant_1_array).tolist()
-                    + np.unique(self.ant_2_array).tolist()
+                set(np.unique(self.ant_1_array).tolist()).union(
+                    np.unique(self.ant_2_array).tolist()
                 )
             )
         )
@@ -897,7 +896,11 @@ class UVData(UVBase):
             )
         if np.any(
             np.isclose(
-                np.linalg.norm(self.uvw_array[~autos], axis=1),
+                np.sqrt(
+                    self.uvw_array[~autos, 0] ** 2
+                    + self.uvw_array[~autos, 1] ** 2
+                    + self.uvw_array[~autos, 2] ** 2
+                ),
                 0.0,
                 rtol=self._uvw_array.tols[0],
                 atol=self._uvw_array.tols[1],
@@ -1865,7 +1868,8 @@ class UVData(UVBase):
             )
 
         self.polarization_array = self.polarization_array[index_array]
-        self.data_array = self.data_array[:, :, :, index_array]
+        # data array is special and large, take is faster here
+        self.data_array = np.take(self.data_array, index_array, axis=3)
         self.nsample_array = self.nsample_array[:, :, :, index_array]
         self.flag_array = self.flag_array[:, :, :, index_array]
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -791,6 +791,8 @@ class UVData(UVBase):
 
     def _calc_nants_data(self):
         """Calculate the number of antennas from ant_1_array and ant_2_array arrays."""
+        # lots of inline testing resulted in this odd combination of sets and
+        # numpy uniques to quickly find the number of unique ants
         return int(
             len(set(np.unique(self.ant_1_array)).union(np.unique(self.ant_2_array)))
         )
@@ -895,6 +897,9 @@ class UVData(UVBase):
             )
         if np.any(
             np.isclose(
+                # this line used to use np.linalg.norm but it turns out
+                # squaring and sqrt is slightly more efficient unless the array
+                # is "very large".
                 np.sqrt(
                     self.uvw_array[~autos, 0] ** 2
                     + self.uvw_array[~autos, 1] ** 2

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -832,11 +832,7 @@ class UVData(UVBase):
         # Check internal consistency of numbers which don't explicitly correspond
         # to the shape of another array.
         nants_data_calc = int(
-            len(
-                set(np.unique(self.ant_1_array).tolist()).union(
-                    np.unique(self.ant_2_array).tolist()
-                )
-            )
+            len(set(np.unique(self.ant_1_array)).union(np.unique(self.ant_2_array)))
         )
         if self.Nants_data != nants_data_calc:
             raise ValueError(
@@ -3095,7 +3091,7 @@ class UVData(UVBase):
         this.Nfreqs = this.freq_array.shape[1]
         this.Npols = this.polarization_array.shape[0]
         this.Nants_data = len(
-            np.unique(this.ant_1_array.tolist() + this.ant_2_array.tolist())
+            set(np.unique(this.ant_1_array)).union(np.unique(this.ant_2_array))
         )
 
         # Check specific requirements
@@ -3503,7 +3499,7 @@ class UVData(UVBase):
             this.ant_1_array = np.concatenate([this.ant_1_array, other.ant_1_array])
             this.ant_2_array = np.concatenate([this.ant_2_array, other.ant_2_array])
             this.Nants_data = int(
-                len(np.unique(self.ant_1_array.tolist() + self.ant_2_array.tolist()))
+                len(set(np.unique(self.ant_1_array)).union(np.unique(self.ant_2_array)))
             )
             this.uvw_array = np.concatenate([this.uvw_array, other.uvw_array], axis=0)
             this.time_array = np.concatenate([this.time_array, other.time_array])
@@ -4369,14 +4365,15 @@ class UVData(UVBase):
             self.ant_1_array = self.ant_1_array[blt_inds]
             self.ant_2_array = self.ant_2_array[blt_inds]
             self.Nants_data = int(
-                len(set(self.ant_1_array.tolist() + self.ant_2_array.tolist()))
+                len(set(np.unique(self.ant_1_array)).union(np.unique(self.ant_2_array)))
             )
 
             self.Ntimes = len(np.unique(self.time_array))
             if not keep_all_metadata:
-                ants_to_keep = set(
-                    self.ant_1_array.tolist() + self.ant_2_array.tolist()
+                ants_to_keep = set(np.unique(self.ant_1_array)).union(
+                    np.unique(self.ant_2_array)
                 )
+
                 inds_to_keep = [
                     self.antenna_numbers.tolist().index(ant) for ant in ants_to_keep
                 ]
@@ -5568,9 +5565,9 @@ class UVData(UVBase):
         self.ant_1_array, self.ant_2_array = self.baseline_to_antnums(
             self.baseline_array
         )
-        self.Nants_data = np.unique(
-            self.ant_1_array.tolist() + self.ant_2_array.tolist()
-        ).size
+        self.Nants_data = len(
+            set(np.unique(self.ant_1_array)).union(np.unique(self.ant_2_array))
+        )
         self.Nbls = np.unique(self.baseline_array).size
         self.Nblts = Nblts_full
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -789,6 +789,12 @@ class UVData(UVBase):
                 )
         return True
 
+    def _calc_nants_data(self):
+        """Calculate the number of antennas from ant_1_array and ant_2_array arrays."""
+        return int(
+            len(set(np.unique(self.ant_1_array)).union(np.unique(self.ant_2_array)))
+        )
+
     def check(
         self, check_extra=True, run_check_acceptability=True, check_freq_spacing=False
     ):
@@ -831,10 +837,7 @@ class UVData(UVBase):
 
         # Check internal consistency of numbers which don't explicitly correspond
         # to the shape of another array.
-        nants_data_calc = int(
-            len(set(np.unique(self.ant_1_array)).union(np.unique(self.ant_2_array)))
-        )
-        if self.Nants_data != nants_data_calc:
+        if self.Nants_data != self._calc_nants_data():
             raise ValueError(
                 "Nants_data must be equal to the number of unique "
                 "values in ant_1_array and ant_2_array"
@@ -3090,9 +3093,7 @@ class UVData(UVBase):
         this.Nblts = this.uvw_array.shape[0]
         this.Nfreqs = this.freq_array.shape[1]
         this.Npols = this.polarization_array.shape[0]
-        this.Nants_data = len(
-            set(np.unique(this.ant_1_array)).union(np.unique(this.ant_2_array))
-        )
+        this.Nants_data = this._calc_nants_data()
 
         # Check specific requirements
         if this.Nfreqs > 1:
@@ -3498,9 +3499,7 @@ class UVData(UVBase):
             this.Nblts = this.Nblts + other.Nblts
             this.ant_1_array = np.concatenate([this.ant_1_array, other.ant_1_array])
             this.ant_2_array = np.concatenate([this.ant_2_array, other.ant_2_array])
-            this.Nants_data = int(
-                len(set(np.unique(self.ant_1_array)).union(np.unique(self.ant_2_array)))
-            )
+            this.Nants_data = this._calc_nants_data()
             this.uvw_array = np.concatenate([this.uvw_array, other.uvw_array], axis=0)
             this.time_array = np.concatenate([this.time_array, other.time_array])
             this.Ntimes = len(np.unique(this.time_array))
@@ -4364,9 +4363,7 @@ class UVData(UVBase):
 
             self.ant_1_array = self.ant_1_array[blt_inds]
             self.ant_2_array = self.ant_2_array[blt_inds]
-            self.Nants_data = int(
-                len(set(np.unique(self.ant_1_array)).union(np.unique(self.ant_2_array)))
-            )
+            self.Nants_data = self._calc_nants_data()
 
             self.Ntimes = len(np.unique(self.time_array))
             if not keep_all_metadata:
@@ -5565,9 +5562,7 @@ class UVData(UVBase):
         self.ant_1_array, self.ant_2_array = self.baseline_to_antnums(
             self.baseline_array
         )
-        self.Nants_data = len(
-            set(np.unique(self.ant_1_array)).union(np.unique(self.ant_2_array))
-        )
+        self.Nants_data = self._calc_nants_data()
         self.Nbls = np.unique(self.baseline_array).size
         self.Nblts = Nblts_full
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A few more tweaks to corr fits and `uvdata.check`
adds metadata only reads to mwa_corr_fits
enables check related keyword features in read_mwa_corr_fits
closes #830 

## Description
<!--- Describe your changes in detail -->
unloaded some more corr_fits functions to the cython code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Does some explicit typing in cython (which is good) and a speed up of cable length correction which will be important if a file has many Nblts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have updated the CHANELOG