### PR TITLE
Add array precision options for mwa_corr_fits files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - `background` keyword in `uvdata.set_lsts_from_time_array` to allow lst calculation in a background thread.
 - `read_data` keyword to read_mwa_corr_fits, allows from metadata only reads of MWA correlator fits files.
 - `propagate_flags` keyword for `UVData.frequency_average` which flags averaged samples if any contributing samples were flagged
+- `nsample_array_dtype` keyword for `UVData.read`, which sets the datatype for the nsample_array. Currently only used for mwa_corr_fits files.
 
 ### Changed
 - The `time_range` parameter on UVCal is no longer required and it is suggested to only set it if the Ntimes axis is length one.
@@ -18,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Updated Nants calculations for speed up.
 - updated HERA telescope location to match the HERA defined center of array.
 - `utils.uvcalibrate` now incorporates many more consistency checks between the uvcal and uvdata object. The new keywords `time_check` and `ant_check` were added to control some of these checks.
+- `data_array_dtype` keyword for `UVData.read` is now also respected by mwa_corr_fits files. Previously it was only used by uvh5 files.
 
 ### Deprecated
 - The UVCal methods `set_gain`, `set_delay`, `set_unknown_cal_type`, `set_sky`, and `set_redundant` have been made private. The public methods will be removed in version 2.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,22 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `nsample_array_dtype` keyword for `UVData.read`, which sets the datatype for the nsample_array. Currently only used for mwa_corr_fits files.
 - `utils` cython module to speed up some common utility functions.
 - Added support for installing the package on Windows.
 - 'background_lsts' keyword in `uvdata.read` to calculate lsts in the background while reading. Defaults to True.
 - `background` keyword in `uvdata.set_lsts_from_time_array` to allow lst calculation in a background thread.
 - `read_data` keyword to read_mwa_corr_fits, allows from metadata only reads of MWA correlator fits files.
 - `propagate_flags` keyword for `UVData.frequency_average` which flags averaged samples if any contributing samples were flagged
-- `nsample_array_dtype` keyword for `UVData.read`, which sets the datatype for the nsample_array. Currently only used for mwa_corr_fits files.
 
 ### Changed
+- `data_array_dtype` keyword for `UVData.read` is now also respected by mwa_corr_fits files. Previously it was only used by uvh5 files.
 - The `time_range` parameter on UVCal is no longer required and it is suggested to only set it if the Ntimes axis is length one.
 - FHD now supports metadata only reads.
 - Updated formatting and added more explicit typing in corr_fits.pyx
 - Updated Nants calculations for speed up.
 - updated HERA telescope location to match the HERA defined center of array.
 - `utils.uvcalibrate` now incorporates many more consistency checks between the uvcal and uvdata object. The new keywords `time_check` and `ant_check` were added to control some of these checks.
-- `data_array_dtype` keyword for `UVData.read` is now also respected by mwa_corr_fits files. Previously it was only used by uvh5 files.
 
 ### Deprecated
 - The UVCal methods `set_gain`, `set_delay`, `set_unknown_cal_type`, `set_sky`, and `set_redundant` have been made private. The public methods will be removed in version 2.2.

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -208,6 +208,10 @@ class MWACorrFITS(UVData):
             channel of each coarse channel.
         background_lsts : bool
             When set to True, the lst_array is calculated in a background thread.
+        read_data : bool
+            Read in the visibility, nsample and flag data. If set to False, only
+            the metadata will be read in. Setting read_data to False results in
+            a metadata only object.
         data_array_dtype : numpy dtype
             Datatype to store the output data_array as. Must be either
             np.complex64 (single-precision real and imaginary) or np.complex128

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -158,7 +158,7 @@ class MWACorrFITS(UVData):
         flag_dc_offset=True,
         background_lsts=True,
         read_data=True,
-        data_array_dtype=np.complex128,
+        data_array_dtype=np.complex64,
         nsample_array_dtype=np.float32,
         run_check=True,
         check_extra=True,

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -572,3 +572,55 @@ def test_read_metadata_only(tmp_path):
         category=category,
     )
     assert uvd.metadata_only
+
+
+@pytest.mark.filterwarnings("ignore:telescope_location is not set.")
+@pytest.mark.filterwarnings("ignore:some coarse channel files were not submitted")
+def test_data_array_precision():
+    uv = UVData()
+    uv2 = UVData()
+    # read in data array as single precision
+    uv.read(filelist[0:2], data_array_dtype=np.complex64)
+    # now read as double precision
+    uv2.read(filelist[0:2], data_array_dtype=np.complex128)
+
+    assert uv == uv2
+    assert uv.data_array.dtype.type is np.complex64
+    assert uv2.data_array.dtype.type is np.complex128
+
+    return
+
+
+@pytest.mark.filterwarnings("ignore:telescope_location is not set.")
+@pytest.mark.filterwarnings("ignore:some coarse channel files were not submitted")
+def test_nsample_array_precision():
+    uv = UVData()
+    uv2 = UVData()
+    uv3 = UVData()
+    # read in nsample array at different precisions
+    uv.read(filelist[0:2], nsample_array_dtype=np.float32)
+    uv2.read(filelist[0:2], nsample_array_dtype=np.float64)
+    uv3.read(filelist[0:2], nsample_array_dtype=np.float16)
+
+    assert uv == uv2
+    assert uv == uv3
+    assert uv.nsample_array.dtype.type is np.float32
+    assert uv2.nsample_array.dtype.type is np.float64
+    assert uv3.nsample_array.dtype.type is np.float16
+
+    return
+
+
+def test_invalid_precision_errors():
+    uv = UVData()
+
+    # raise errors by passing bogus precision values
+    with pytest.raises(ValueError, match="data_array_dtype must be np.complex64"):
+        uv.read_mwa_corr_fits(filelist[0:2], data_array_dtype=np.float64)
+
+    with pytest.raises(
+        ValueError, match="nsample_array_dtype must be one of: np.float64"
+    ):
+        uv.read_mwa_corr_fits(filelist[0:2], nsample_array_dtype=np.complex128)
+
+    return

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6004,9 +6004,9 @@ class UVData(UVBase):
         end_flag=2.0,
         flag_dc_offset=True,
         phase_to_pointing_center=False,
-        phase_data=None,
-        phase_center=None,
         read_data=True,
+        data_array_dtype=np.complex64,
+        nsample_array_dtype=np.float32,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -6058,6 +6058,16 @@ class UVData(UVBase):
             Read in the visibility and flag data. If set to false, only the
             basic header info and metadata read in. Setting read_data to False
             results in a metdata only object.
+        data_array_dtype : numpy dtype
+            Datatype to store the output data_array as. Must be either
+            np.complex64 (single-precision real and imaginary) or np.complex128
+            (double-precision real and imaginary).
+        nsample_array_dtype : numpy dtype
+            Datatype to store the output nsample_array as. Must be either
+            np.float64 (double-precision), np.float32 (single-precision), or
+            np.float16 (half-precision). Half-precision is only recommended for
+            cases where no sampling or averaging of baselines will occur,
+            because round-off errors can be quite large (~1e-3).
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after after reading in the file (the default is True,
@@ -6104,6 +6114,8 @@ class UVData(UVBase):
             flag_dc_offset=flag_dc_offset,
             phase_to_pointing_center=phase_to_pointing_center,
             read_data=read_data,
+            data_array_dtype=data_array_dtype,
+            nsample_array_dtype=nsample_array_dtype,
             run_check=run_check,
             check_extra=check_extra,
             run_check_acceptability=run_check_acceptability,
@@ -6463,6 +6475,7 @@ class UVData(UVBase):
         data_column="DATA",
         pol_order="AIPS",
         data_array_dtype=np.complex128,
+        nsample_array_dtype=np.float32,
         use_cotter_flags=False,
         correct_cable_len=False,
         flag_init=True,
@@ -6606,7 +6619,15 @@ class UVData(UVBase):
             Datatype to store the output data_array as. Must be either
             np.complex64 (single-precision real and imaginary) or np.complex128 (double-
             precision real and imaginary). Only used if the datatype of the visibility
-            data on-disk is not 'c8' or 'c16'. Only used if file_type is 'uvh5'.
+            data on-disk is not 'c8' or 'c16'. Only used if file_type is 'uvh5' or
+            'mwa_corr_fits'.
+        nsample_array_dtype : numpy dtype
+            Datatype to store the output nsample_array as. Must be either
+            np.float64 (double-precision), np.float32 (single-precision), or
+            np.float16 (half-precision). Half-precision is only recommended for
+            cases where no sampling or averaging of baselines will occur,
+            because round-off errors can be quite large (~1e-3). Only used if
+            file_type is 'mwa_corr_fits'.
         use_cotter_flags : bool
             Flag to apply cotter flags. Only used if file_type is 'mwa_corr_fits'.
         correct_cable_len : bool
@@ -6774,6 +6795,7 @@ class UVData(UVBase):
                         data_column=data_column,
                         pol_order=pol_order,
                         data_array_dtype=data_array_dtype,
+                        nsample_array_dtype=nsample_array_dtype,
                         run_check=run_check,
                         check_extra=check_extra,
                         run_check_acceptability=run_check_acceptability,
@@ -6822,6 +6844,7 @@ class UVData(UVBase):
                             data_column=data_column,
                             pol_order=pol_order,
                             data_array_dtype=data_array_dtype,
+                            nsample_array_dtype=nsample_array_dtype,
                             run_check=run_check,
                             check_extra=check_extra,
                             run_check_acceptability=run_check_acceptability,
@@ -6999,6 +7022,8 @@ class UVData(UVBase):
                     flag_dc_offset=True,
                     phase_to_pointing_center=phase_to_pointing_center,
                     read_data=read_data,
+                    data_array_dtype=data_array_dtype,
+                    nsample_array_dtype=nsample_array_dtype,
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability,
                     background_lsts=background_lsts,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -5167,8 +5167,16 @@ class UVData(UVBase):
 
                         # nsample array is the fraction of data that we actually kept,
                         # relative to the amount that went into the sum or average
+                        nsample_dtype = self.nsample_array.dtype.type
+                        # promote nsample dtype if half-precision
+                        if nsample_dtype is np.float16:
+                            masked_nsample_dtype = np.float32
+                        else:
+                            masked_nsample_dtype = nsample_dtype
                         masked_nsample = np.ma.masked_array(
-                            self.nsample_array[averaging_idx], mask=mask
+                            self.nsample_array[averaging_idx],
+                            mask=mask,
+                            dtype=masked_nsample_dtype,
                         )
 
                         masked_int_time = np.ma.masked_array(
@@ -5192,6 +5200,9 @@ class UVData(UVBase):
                                 weighted_data, axis=0
                             ) / np.sum(weights, axis=0)
 
+                        # output of masked array calculation should be coerced
+                        # to the datatype of temp_nsample (which has the same
+                        # precision as the original nsample_array)
                         temp_nsample[temp_idx] = np.sum(
                             masked_nsample * masked_int_time, axis=0
                         ) / np.sum(self.integration_time[averaging_idx])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change is motivated by #826, and gives the user the opportunity to select data types for the `data_array` and `nsample_array` when reading in MWA corr_fits files. The previous hard-coded defaults of `np.complex128` and `np.float32`, respectively, consumed more memory than typically necessary, especially for instances where no manipulation of these arrays was being done (e.g., when RFI flagging with SSINS).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Part of the motivation for this change is that the data for MWA corr_fits files is saved at single precision (`np.complex64`), so the previous default was artificially increasing the precision. Though subsequent calculations (e.g., applying calibration solutions) would benefit from this increased precision, analysis steps that only required reading the values without modifying them would not.

For the nsample array, the option of half-precision floats (`np.float16`) is added, though its use is discouraged (and mentioned in the docstrings). Floating-point round-off errors can be relatively large (~1e-3), but for raw corr_fits data that contains only 1s and 0s, there is no loss of precision. Care should be taken when averaging or down-selecting (e.g., LST-binning) to ensure that the calculation is being done at sufficient precision.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
