### PR TITLE
fix a bug where using `ant_str` to select no data errored with a confusing message

### DIFF
--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -4086,6 +4086,10 @@ class UVData(UVBase):
                 )
             else:
                 bls, polarizations = self.parse_ants(ant_str)
+                if bls is not None and len(bls) == 0:
+                    raise ValueError(
+                        f"There is no data matching ant_str={ant_str} in this object."
+                    )
 
         # Antennas, times and blt_inds all need to be combined into a set of
         # blts indices to keep.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If setting `ant_str` in select results in no data being selected then raise a clear error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
@mwilensky768 tried to do a `select(ant_str='auto')` on a data set with no autocorrelations in it and got the following confusing error message:
`"bls must be a list of tuples of antenna numbers (optionally with polarization)."`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
