### PR TITLE
Make UVFlag.__add__ iterate over _data_params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - `utils.uvcalibrate` will error rather than warn if some of the newly added checks do not pass, including if antenna names do not match between the objects, starting in version 2.2. In addition, the `flag_missing` keyword is deprecated and will be removed in version 2.2.
 
 ### Fixed
+- UVFlag.__add__ now properly concatenates all existing data-like parameters of the object, including optional ones.
 - A bug in `UVData.downsample_in_time` where the data were not being properly weighted by the nsample array and the nsample_array was not being properly weighted by the integration times.
 - A bug in `UVData.downsample_in_time` that lead to duplicated data on the final object if a baseline had varying integration times and some integration times were greater than or equal to the requested minimum integration time.
 

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -1104,12 +1104,9 @@ def test_to_waterfall_bl_ret_wt_sq():
     uvf.to_waterfall(return_weights_square=True)
     assert np.all(uvf.weights_square_array == 4 * Nbls)
 
-    # Check that weights_square_array is required
-    assert uvf._weights_square_array.required
-
-    # Switch to flag and check that it is now unrequired
+    # Switch to flag and check that it is now set to None
     uvf.to_flag()
-    assert not uvf._weights_square_array.required
+    assert uvf.weights_square_array is None
 
 
 def test_collapse_pol(test_outfile):

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -859,6 +859,20 @@ def test_add_frequency():
     assert "Data combined along frequency axis. " in uv3.history
 
 
+def test_add_frequency_with_weights_square():
+    # Same test as above, just checking an optional parameter (also in waterfall mode)
+    uvf1 = UVFlag(test_f_file)
+    uvf1.weights_array = 2 * np.ones_like(uvf1.weights_array)
+    uvf1.to_waterfall(return_weights_square=True)
+    uvf2 = copy.deepcopy(uvf1)
+    uvf2.freq_array += 1e4
+    uvf3 = uvf1.__add__(uvf2, axis="frequency")
+    assert np.array_equal(
+        np.concatenate((uvf1.weights_square_array, uvf2.weights_square_array), axis=1),
+        uvf3.weights_square_array,
+    )
+
+
 def test_add_pol():
     uv1 = UVFlag(test_f_file)
     uv2 = copy.deepcopy(uv1)

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -873,6 +873,21 @@ def test_add_frequency_with_weights_square():
     )
 
 
+def test_add_frequency_mix_weights_square():
+    # Same test as above, checking some error handling
+    uvf1 = UVFlag(test_f_file)
+    uvf1.weights_array = 2 * np.ones_like(uvf1.weights_array)
+    uvf2 = copy.deepcopy(uvf1)
+    uvf1.to_waterfall(return_weights_square=True)
+    uvf2.to_waterfall(return_weights_square=False)
+    uvf2.freq_array += 1e4
+    with pytest.raises(
+        ValueError,
+        match="weights_square_array optional parameter is missing from second UVFlag",
+    ):
+        uvf1.__add__(uvf2, axis="frequency", inplace=True)
+
+
 def test_add_pol():
     uv1 = UVFlag(test_f_file)
     uv2 = copy.deepcopy(uv1)
@@ -1088,6 +1103,13 @@ def test_to_waterfall_bl_ret_wt_sq():
     uvf.weights_array = 2 * np.ones_like(uvf.weights_array)
     uvf.to_waterfall(return_weights_square=True)
     assert np.all(uvf.weights_square_array == 4 * Nbls)
+
+    # Check that weights_square_array is required
+    assert uvf._weights_square_array.required
+
+    # Switch to flag and check that it is now unrequired
+    uvf.to_flag()
+    assert not uvf._weights_square_array.required
 
 
 def test_collapse_pol(test_outfile):

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -559,7 +559,8 @@ class UVFlag(UVBase):
         self._flag_array.required = True
         self._metric_array.required = False
         self._weights_array.required = False
-        self._weights_square_array.required = False
+        if self.weights_square_array is not None:
+            self.weights_square_array = None
 
         return
 
@@ -739,6 +740,7 @@ class UVFlag(UVBase):
                 not attr.required
                 and attr.value is not None
                 and attr.name != "x_orientation"
+                and attr.name != "weights_square_array"
             ):
                 attr.value = None
                 setattr(self, p, attr)
@@ -1005,9 +1007,6 @@ class UVFlag(UVBase):
                 self.weights_array = w
                 if return_weights_square:
                     self.weights_square_array = ws
-                    # Once this is calculated it needs to be required
-                    # until switch out of metric mode
-                    self._weights_square_array.required = True
             self.time_array, ri = np.unique(self.time_array, return_index=True)
             self.lst_array = self.lst_array[ri]
         if ((method == "or") or (method == "and")) and (self.mode == "flag"):
@@ -2541,8 +2540,6 @@ class UVFlag(UVBase):
                     self.weights_array = dgrp["weights_array"][()]
                     if "weights_square_array" in dgrp:
                         self.weights_square_array = dgrp["weights_square_array"][()]
-                        # Needs to be required now that it exists and is non-null
-                        self._weights_square_array.required = True
                 elif self.mode == "flag":
                     self.flag_array = dgrp["flag_array"][()]
 

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -1550,16 +1550,13 @@ class UVFlag(UVBase):
             )
             this.Npols = len(this.polarization_array)
 
-        if this.mode == "flag":
-            this.flag_array = np.concatenate(
-                [this.flag_array, other.flag_array], axis=ax
-            )
-        elif this.mode == "metric":
-            this.metric_array = np.concatenate(
-                [this.metric_array, other.metric_array], axis=ax
-            )
-            this.weights_array = np.concatenate(
-                [this.weights_array, other.weights_array], axis=ax
+        # Will fail with AttributeError if the objects have different _data_params
+        # Might want a more straight-forward check ahead of time
+        for attr in this._data_params:
+            setattr(
+                this,
+                attr,
+                np.concatenate([getattr(this, attr), getattr(other, attr)], axis=ax),
             )
 
         this.history += "Data combined along " + axis + " axis. "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR ensures that all data-like parameters are concatenated appropriately during addition of two UVFlag objects.

## Description
<!--- Describe your changes in detail -->
The data-like attributes to be concatenated were hardcoded in `__add__`. Now an iteration over `UVFlag._data_params` catches all of them, including the optional `weights_square_array`, if present.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

This enhancement ensures concatenation of the optional parameter `weights_square_array` if it exists, and is also a little friendlier to people subclassing UVFlag. See issue #843 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Breaking change checklist:
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
