### PR TITLE
Add option to use baseline numbers with the select method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ controlled by the `method` keyword.
 - `propagate_flags` keyword for `UVData.frequency_average` which flags averaged samples if any contributing samples were flagged
 
 ### Changed
+- `select` now also accepts a list of baseline indices for the `bls` parameter.
 - `data_array_dtype` keyword for `UVData.read` is now also respected by mwa_corr_fits files. Previously it was only used by uvh5 files.
 - The `time_range` parameter on UVCal is no longer required and it is suggested to only set it if the Ntimes axis is length one.
 - FHD now supports metadata only reads.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -632,7 +632,32 @@ c) Select a few antenna pairs to keep
   >>> print(list(set(zip(UV.ant_1_array, UV.ant_2_array))))
   [(0, 6), (0, 21), (0, 2)]
 
-d) Select antenna pairs and polarizations using ant_str argument
+d) Select antenna pairs using baseline numbers
+**********************************************
+::
+
+  >>> import os
+  >>> import numpy as np
+  >>> from pyuvdata import UVData
+  >>> from pyuvdata.data import DATA_PATH
+  >>> UV = UVData()
+  >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+  >>> UV.read(filename)
+
+  # baseline numbers can be found in the baseline_array
+  >>> print(len(UV.baseline_array))
+  1360
+
+  # select baselines using the baseline numbers
+  >>> UV.select(bls=[73736, 73753, 81945])
+
+  # print unique baselines and antennas after select
+  >>> print(np.unique(UV.baseline_array))
+  [73736 73753 81945]
+  >>> print(list(set(zip(UV.ant_1_array, UV.ant_2_array))))
+  [(3, 24), (3, 7), (7, 24)]
+
+e) Select antenna pairs and polarizations using ant_str argument
 ****************************************************************
 
 Basic options are 'auto', 'cross', or 'all'. 'auto' returns just the

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -1167,13 +1167,13 @@ def test_select_bls():
         uv_object2.history,
     )
 
-    # check using baseline index parameter
+    # check using baseline number parameter
     uv_object3 = uv_object.copy()
-    bls_inds_to_keep = [
+    bls_nums_to_keep = [
         uv_object.antnums_to_baseline(ant1, ant2) for ant1, ant2 in sorted_pairs_to_keep
     ]
 
-    uv_object3.select(bls=bls_inds_to_keep)
+    uv_object3.select(bls=bls_nums_to_keep)
     sorted_pairs_object3 = [
         sort_bl(p) for p in zip(uv_object3.ant_1_array, uv_object3.ant_2_array)
     ]
@@ -1308,7 +1308,7 @@ def test_select_bls():
     assert str(cm.value).startswith("bls must be a list of tuples of antenna numbers")
     with pytest.raises(ValueError) as cm:
         uv_object.select(bls=[100])
-    assert str(cm.value).startswith("Baseline index number 100 is not present in the")
+    assert str(cm.value).startswith("Baseline number 100 is not present in the")
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -4021,12 +4021,13 @@ class UVData(UVBase):
             `keep_all_metadata` is False). This cannot be provided if
             `antenna_nums` is also provided.
         bls : list of tuple or list of int, optional
-            A list of antenna number tuples (e.g. [(0, 1), (3, 2)]) or a list of
-            baseline 3-tuples (e.g. [(0, 1, 'xx'), (2, 3, 'yy')]) specifying baselines
-            to keep in the object. For length-2 tuples, the ordering of the numbers
-            within the tuple does not matter. For length-3 tuples, the polarization
-            string is in the order of the two antennas. If length-3 tuples are
-            provided, `polarizations` must be None.
+            A list of antenna number tuples (e.g. [(0, 1), (3, 2)]), a list of
+            baseline 3-tuples (e.g. [(0, 1, 'xx'), (2, 3, 'yy')]), or a list of
+            baseline numbers (e.g. [67599, 71699, 73743]) specifying baselines
+            to keep in the object. For length-2 tuples, the ordering of the
+            numbers within the tuple does not matter. For length-3 tuples, the
+            polarization string is in the order of the two antennas. If
+            length-3 tuples are provided, `polarizations` must be None.
         ant_str : str, optional
             A string containing information about what antenna numbers
             and polarizations to keep in the object.  Can be 'auto', 'cross', 'all',
@@ -4159,7 +4160,7 @@ class UVData(UVBase):
                 for bl_ind in bls:
                     if not (bl_ind in self.baseline_array):
                         raise ValueError(
-                            "Baseline index number {i} is not present in the "
+                            "Baseline number {i} is not present in the "
                             "baseline_array".format(i=bl_ind)
                         )
                 bls = [self.baseline_to_antnums(bl) for bl in bls]
@@ -4168,7 +4169,7 @@ class UVData(UVBase):
             if len(bls) == 0 or not all(isinstance(item, tuple) for item in bls):
                 raise ValueError(
                     "bls must be a list of tuples of antenna numbers "
-                    "(optionally with polarization) or a list of baseline indices."
+                    "(optionally with polarization) or a list of baseline numbers."
                 )
             if not all(
                 [isinstance(item[0], (int, np.integer,)) for item in bls]
@@ -4176,7 +4177,7 @@ class UVData(UVBase):
             ):
                 raise ValueError(
                     "bls must be a list of tuples of antenna numbers "
-                    "(optionally with polarization) or a list of baseline indices."
+                    "(optionally with polarization) or a list of baseline numbers."
                 )
             if all(len(item) == 3 for item in bls):
                 if polarizations is not None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds functionality to the select method so that the `bls` keyword accepts a list of baseline indices in addition to list of tuples options. 

## Motivation and Context
closes #620 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
