### PR TITLE
Make sure all tests are run in CI on Windows

### DIFF
--- a/.github/workflows/macosx_windows_ci.yaml
+++ b/.github/workflows/macosx_windows_ci.yaml
@@ -60,7 +60,7 @@ jobs:
           mkdir -p empty
           cd empty
           source activate $ENV_NAME
-          pytest --pyargs pyuvdata --cov=pyuvdata --cov-config=../.coveragerc --cov-report xml:../coverage.xml
+          pytest --pyargs pyuvdata -c ../setup.cfg --cov=pyuvdata --cov-config=../.coveragerc --cov-report xml:../coverage.xml
           cd ..
       - name: Upload Coverage
         shell: bash

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 import io
 import sys
 import platform
-from setuptools import setup, Extension
+from setuptools import setup, Extension, find_namespace_packages
 
 from Cython.Distutils import build_ext
 from distutils.sysconfig import get_config_var
@@ -63,6 +63,12 @@ if is_platform_mac():
         if python_target < "10.9" and current_system >= "10.9":
             os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
 
+# define the cython compile args, depending on platform
+if is_platform_windows():
+    extra_compile_args = ["/Ox"]
+else:
+    extra_compile_args = ["-O3"]
+
 global_c_macros = [
     ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
 ]
@@ -88,14 +94,14 @@ corr_fits_extension = Extension(
     sources=["pyuvdata/uvdata/corr_fits_src/corr_fits.pyx"],
     define_macros=global_c_macros,
     include_dirs=["pyuvdata/uvdata/corr_fits_src/"],
-    extra_compile_args=["-O3"],
+    extra_compile_args=extra_compile_args,
 )
 
 utils_extension = Extension(
     "pyuvdata._utils",
     sources=["pyuvdata/utils.pyx"],
     define_macros=global_c_macros,
-    extra_compile_args=["-O3"],
+    extra_compile_args=extra_compile_args,
 )
 
 extensions = [corr_fits_extension, utils_extension]
@@ -132,14 +138,7 @@ setup_args = {
     "long_description": readme,
     "long_description_content_type": "text/markdown",
     "package_dir": {"pyuvdata": "pyuvdata"},
-    "packages": [
-        "pyuvdata",
-        "pyuvdata.tests",
-        "pyuvdata.uvbeam",
-        "pyuvdata.uvcal",
-        "pyuvdata.uvdata",
-        "pyuvdata.uvflag",
-    ],
+    "packages": find_namespace_packages(),
     "cmdclass": {"build_ext": CustomBuildExtCommand},
     "ext_modules": cythonize(extensions, language_level=3),
     "scripts": [fl for fl in glob.glob("scripts/*") if not os.path.isdir(fl)],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When we added Windows to CI, we noticed that not all tests were being run for python3.6 and 3.7. It seemed that only tests in the top-level `pyuvdata/tests` folder were being run, and it was not discovering tests inside of submodules. ~This PR changes how tests are invoked, making sure that all tests are run for all python versions.~ This PR changes how the package in installed, to make sure all recursive test directories are discovered.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
~It seemed odd that test discovery was behaving differently based on the python version (and only on Windows), especially because the version of `pytest` was the same. Also, previously we were running tests by using the `pytest --pyargs pyuvdata` construction in a separate folder, which may have affected how tests were discovered. Running `pytest` in the root directory seems to have fixed things.~
I think this issue came down to how the package was being handled in `setup.py`. Previously, we were explicitly listing the submodules to install, which included `pyuvdata.tests` but did _not_ include the submodule test directories (e.g., `pyuvdata.uvdata.tests`). Instead of explicitly listing packages, we switched to using the `find_namespace_packages()` function from setuptools, and that seems to have fixed the issue for all versions on all platforms.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.