### PR TITLE
Make internal UVBeam methods private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - `utils.uvcalibrate` now incorporates many more consistency checks between the uvcal and uvdata object. The new keywords `time_check` and `ant_check` were added to control some of these checks.
 
 ### Deprecated
+- The UVBeam methods `set_cs_params`, `set_efield`, `set_power`, `set_simple`, and `set_phased_array` have been made private. The public methods will be removed in version 2.2.
 - The UVCal methods `set_gain`, `set_delay`, `set_unknown_cal_type`, `set_sky`, and `set_redundant` have been made private. The public methods will be removed in version 2.2.
 - `utils.uvcalibrate` will error rather than warn if some of the newly added checks do not pass, including if antenna names do not match between the objects, starting in version 2.2. In addition, the `flag_missing` keyword is deprecated and will be removed in version 2.2.
 

--- a/pyuvdata/uvbeam/beamfits.py
+++ b/pyuvdata/uvbeam/beamfits.py
@@ -84,7 +84,7 @@ class BeamFITS(UVBeam):
 
             # only support simple antenna_types for now.
             # support for phased arrays should be added
-            self.set_simple()
+            self._set_simple()
 
             self.beam_type = primary_header.pop("BTYPE", None)
             if self.beam_type is not None:
@@ -201,9 +201,9 @@ class BeamFITS(UVBeam):
                 self.polarization_array = np.int32(
                     uvutils._fits_gethduaxis(primary_hdu, ax_nums["feed_pol"])
                 )
-                self.set_power()
+                self._set_power()
             elif self.beam_type == "efield":
-                self.set_efield()
+                self._set_efield()
                 if n_dimensions < n_efield_dims:
                     raise ValueError(
                         "beam_type is efield and data dimensionality is too low"

--- a/pyuvdata/uvbeam/cst_beam.py
+++ b/pyuvdata/uvbeam/cst_beam.py
@@ -158,7 +158,7 @@ class CSTBeam(UVBeam):
                 self.polarization_array = np.array([uvutils.polstr2num(feed_pol)])
 
             self.Npols = len(self.polarization_array)
-            self.set_power()
+            self._set_power()
         else:
             self.Naxes_vec = 2
             self.Ncomponents_vec = 2
@@ -173,7 +173,7 @@ class CSTBeam(UVBeam):
                 else:
                     self.feed_array = np.array(["y"])
             self.Nfeeds = self.feed_array.size
-            self.set_efield()
+            self._set_efield()
 
         self.data_normalization = "physical"
         self.antenna_type = "simple"
@@ -185,7 +185,7 @@ class CSTBeam(UVBeam):
 
         self.spw_array = np.array([0])
         self.pixel_coordinate_system = "az_za"
-        self.set_cs_params()
+        self._set_cs_params()
 
         out_file = open(filename, "r")
         line = out_file.readline().strip()  # Get the first line

--- a/pyuvdata/uvbeam/mwa_beam.py
+++ b/pyuvdata/uvbeam/mwa_beam.py
@@ -630,7 +630,7 @@ class MWABeam(UVBeam):
 
         self.x_orientation = "east"
 
-        self.set_efield()
+        self._set_efield()
         self.Naxes_vec = 2
         self.Ncomponents_vec = 2
         self.feed_array = np.array([str(pol.lower()) for pol in pol_names])
@@ -650,7 +650,7 @@ class MWABeam(UVBeam):
         self.bandpass_array = np.ones((self.Nspws, self.Nfreqs))
 
         self.pixel_coordinate_system = "az_za"
-        self.set_cs_params()
+        self._set_cs_params()
 
         self.axis1_array = phi_arr
         self.Naxes1 = self.axis1_array.size

--- a/pyuvdata/uvbeam/tests/test_uvbeam.py
+++ b/pyuvdata/uvbeam/tests/test_uvbeam.py
@@ -248,6 +248,64 @@ def test_properties(uvbeam_data):
             raise
 
 
+def test_deprecation_warnings_set_cs_params(cst_efield_2freq):
+    """
+    Test the deprecation warnings in set_cs_params.
+    """
+    efield_beam = cst_efield_2freq
+    efield_beam2 = efield_beam.copy()
+
+    with pytest.warns(DeprecationWarning, match="`set_cs_params` is deprecated"):
+        efield_beam2.set_cs_params()
+
+    assert efield_beam2 == efield_beam
+
+
+def test_deprecation_warnings_set_efield(cst_efield_2freq):
+    """
+    Test the deprecation warnings in set_efield.
+    """
+    efield_beam = cst_efield_2freq
+    efield_beam2 = efield_beam.copy()
+
+    with pytest.warns(DeprecationWarning, match="`set_efield` is deprecated"):
+        efield_beam2.set_efield()
+
+    assert efield_beam2 == efield_beam
+
+
+def test_deprecation_warnings_set_power(cst_power_2freq):
+    """
+    Test the deprecation warnings in set_power.
+    """
+    power_beam = cst_power_2freq
+    power_beam2 = power_beam.copy()
+
+    with pytest.warns(DeprecationWarning, match="`set_power` is deprecated"):
+        power_beam2.set_power()
+
+    assert power_beam2 == power_beam
+
+
+def test_deprecation_warnings_set_antenna_type(cst_efield_2freq):
+    """
+    Test the deprecation warnings in set_simple and set_phased_array.
+    """
+    efield_beam = cst_efield_2freq
+    efield_beam2 = efield_beam.copy()
+
+    with pytest.warns(DeprecationWarning, match="`set_simple` is deprecated"):
+        efield_beam2.set_simple()
+
+    assert efield_beam2 == efield_beam
+
+    efield_beam._set_phased_array()
+    with pytest.warns(DeprecationWarning, match="`set_phased_array` is deprecated"):
+        efield_beam2.set_phased_array()
+
+    assert efield_beam2 == efield_beam
+
+
 def test_errors():
     beam_obj = UVBeam()
     pytest.raises(ValueError, beam_obj._convert_to_filetype, "foo")

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -589,7 +589,7 @@ class UVBeam(UVBase):
 
         super(UVBeam, self).__init__()
 
-    def set_cs_params(self):
+    def _set_cs_params(self):
         """Set parameters depending on pixel_coordinate_system."""
         if self.pixel_coordinate_system == "healpix":
             self._Naxes1.required = False
@@ -654,7 +654,21 @@ class UVBeam(UVBase):
                     "Naxes1",
                 )
 
-    def set_efield(self):
+    def set_cs_params(self):
+        """
+        Set parameters depending on pixel_coordinate_system.
+
+        This method is deprecated, and will be removed in pyuvdata v2.2. Use
+        `_set_cs_params` instead.
+        """
+        warnings.warn(
+            "`set_cs_params` is deprecated, and will be removed in pyuvdata version "
+            "2.2. Use `_set_cs_params` instead.",
+            DeprecationWarning,
+        )
+        self._set_cs_params()
+
+    def _set_efield(self):
         """Set beam_type to 'efield' and adjust required parameters."""
         self.beam_type = "efield"
         self._Naxes_vec.acceptable_vals = [2, 3]
@@ -666,9 +680,23 @@ class UVBeam(UVBase):
         self._polarization_array.required = False
         self._data_array.expected_type = np.complex
         # call set_cs_params to fix data_array form
-        self.set_cs_params()
+        self._set_cs_params()
 
-    def set_power(self):
+    def set_efield(self):
+        """
+        Set beam_type to 'efield' and adjust required parameters.
+
+        This method is deprecated, and will be removed in pyuvdata v2.2. Use
+        `_set_efield` instead.
+        """
+        warnings.warn(
+            "`set_efield` is deprecated, and will be removed in pyuvdata version "
+            "2.2. Use `_set_efield` instead.",
+            DeprecationWarning,
+        )
+        self._set_efield()
+
+    def _set_power(self):
         """Set beam_type to 'power' and adjust required parameters."""
         self.beam_type = "power"
         self._Naxes_vec.acceptable_vals = [1, 2, 3]
@@ -686,9 +714,23 @@ class UVBeam(UVBase):
                 self._data_array.expected_type = np.complex
 
         # call set_cs_params to fix data_array form
-        self.set_cs_params()
+        self._set_cs_params()
 
-    def set_simple(self):
+    def set_power(self):
+        """
+        Set beam_type to 'power' and adjust required parameters.
+
+        This method is deprecated, and will be removed in pyuvdata v2.2. Use
+        `_set_power` instead.
+        """
+        warnings.warn(
+            "`set_power` is deprecated, and will be removed in pyuvdata version "
+            "2.2. Use `_set_power` instead.",
+            DeprecationWarning,
+        )
+        self._set_power()
+
+    def _set_simple(self):
         """Set antenna_type to 'simple' and adjust required parameters."""
         self.antenna_type = "simple"
         self._Nelements.required = False
@@ -698,7 +740,21 @@ class UVBeam(UVBase):
         self._gain_array.required = False
         self._coupling_matrix.required = False
 
-    def set_phased_array(self):
+    def set_simple(self):
+        """
+        Set antenna_type to 'simple' and adjust required parameters.
+
+        This method is deprecated, and will be removed in pyuvdata v2.2. Use
+        `_set_simple` instead.
+        """
+        warnings.warn(
+            "`set_simple` is deprecated, and will be removed in pyuvdata version "
+            "2.2. Use `_set_simple` instead.",
+            DeprecationWarning,
+        )
+        self._set_simple()
+
+    def _set_phased_array(self):
         """Set antenna_type to 'phased_array' and adjust required parameters."""
         self.antenna_type = "phased_array"
         self._Nelements.required = True
@@ -707,6 +763,20 @@ class UVBeam(UVBase):
         self._delay_array.required = True
         self._gain_array.required = True
         self._coupling_matrix.required = True
+
+    def set_phased_array(self):
+        """
+        Set antenna_type to 'simple' and adjust required parameters.
+
+        This method is deprecated, and will be removed in pyuvdata v2.2. Use
+        `_set_phased_array` instead.
+        """
+        warnings.warn(
+            "`set_phased_array` is deprecated, and will be removed in pyuvdata version "
+            "2.2. Use `_set_phased_array` instead.",
+            DeprecationWarning,
+        )
+        self._set_phased_array()
 
     def check(self, check_extra=True, run_check_acceptability=True):
         """
@@ -725,7 +795,7 @@ class UVBeam(UVBase):
         """
         # first make sure the required parameters and forms are set properly
         # for the pixel_coordinate_system
-        self.set_cs_params()
+        self._set_cs_params()
 
         # first run the basic check from UVBase
         super(UVBeam, self).check(
@@ -843,7 +913,7 @@ class UVBeam(UVBase):
             beam_object.Naxes_vec = 1
 
         # adjust requirements, fix data_array form
-        beam_object.set_power()
+        beam_object._set_power()
         power_data = np.zeros(
             beam_object._data_array.expected_shape(beam_object), dtype=np.complex
         )
@@ -1064,7 +1134,7 @@ class UVBeam(UVBase):
             ]
         )
         beam_object.Naxes_vec = 1
-        beam_object.set_power()
+        beam_object._set_power()
 
         history_update_string = (
             " Converted from efield to pseudo-stokes power using pyuvdata."
@@ -1829,7 +1899,7 @@ class UVBeam(UVBase):
             if hasattr(new_uvb, "saved_interp_functions"):
                 delattr(new_uvb, "saved_interp_functions")
 
-            new_uvb.set_cs_params()
+            new_uvb._set_cs_params()
             if run_check:
                 new_uvb.check(
                     check_extra=check_extra,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make the UVBeam methods that modify which parameters are required depending on various beam types private (starting with an underscore) because they should not be called by users directly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #811 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Breaking change checklist:
- [x] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [x] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).
