### PR TITLE
remove macosx forced ncurses update in install_conda.sh

### DIFF
--- a/ci/install_conda.sh
+++ b/ci/install_conda.sh
@@ -18,12 +18,6 @@ conda create --name=${ENV_NAME}  python=$PYTHON --quiet
 conda env update -n ${ENV_NAME} -f ci/${ENV_NAME}.yml
 source activate ${ENV_NAME}
 
-# Mac OSX is having some trouble on python 3.8 with ncurses
-# not being up to date. Trye manually updating it.
-if [[ $OS == 'macos-latest' ]]; then
-conda update -n ${ENV_NAME} -c conda-forge ncurses
-fi
-
 conda list -n ${ENV_NAME}
 # check that the python version matches the desired one; exit immediately if not
 PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removes a forced `ncurses` conda update.
closes #746
## Description
<!--- Describe your changes in detail -->
removed an if statement in `install_conda.sh`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The CI providers required a force `ncurses` update on macosx build from conda some time ago. This removes that forced update.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
