### PR TITLE
Improve versioning for test PyPI deployment

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -33,7 +33,7 @@ jobs:
       shell: bash
       run: |
         source activate $ENV_NAME
-        version=$(awk -F. '{if (NF > 3) {print $1"."$2"."$3"."$4} else {print $1"."$2"."$3}}' <<< $(awk -F+ '{print $1$2}' <<< $(python setup.py --version | tail -1)))
+        version=$(./ci/make_dev_version.sh)
         echo "::set-env name=SETUPTOOLS_SCM_PRETEND_VERSION::$version"
 
     - name: Check environment variable

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -33,7 +33,7 @@ jobs:
       shell: bash
       run: |
         source activate $ENV_NAME
-        version=$(awk -F+ '{print $1}' <<< $(python setup.py --version | tail -1))
+        version=$(awk -F. '{if (NF > 3) {print $1"."$2"."$3"."$4} else {print $1"."$2"."$3}}' <<< $(awk -F+ '{print $1$2}' <<< $(python setup.py --version | tail -1)))
         echo "::set-env name=SETUPTOOLS_SCM_PRETEND_VERSION::$version"
 
     - name: Check environment variable

--- a/ci/make_dev_version.sh
+++ b/ci/make_dev_version.sh
@@ -25,6 +25,11 @@
 # As an added benefit, this approach also handles tagged release versions (such
 # as "2.0.3" with no trailing "dev" information), and does not mangle the
 # version information.
+#
+# Examples showing the conversion from pyuvdata version to pypi version:
+#   1.0.2 -> 1.0.2
+#   1.0.2.dev1+g0123456.branch.name -> 1.0.2.dev100010203040506
+#   1.0.2.dev197+g9aac2d38.branch.name -> 1.0.2.dev1970910101202130308
 
 # get version from python
 ver=$(python setup.py --version | tail -1)

--- a/ci/make_dev_version.sh
+++ b/ci/make_dev_version.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright (c) 2020 Radio Astronomy Software Group
+# Licensed under the 2-clause BSD License
+
+# This function is make_dev_version.sh
+#
+# Usage:
+#   ./ci/make_dev_version.sh
+#
+# This function *must* be called from the main package folder where the
+# `setup.py` file lives. It echoes a modified version of the package which
+# includes the standard setuptools_scm "number of commits since last release"
+# counter, *plus* a numericized version of the git hash. This allows for uploads
+# to the PyPI test server that do not collide for branches that are both the
+# same number of commits since the last release, but have unique git hashes.
+#
+# This uses the "main" part of the version and the local git hash to generate a
+# version number that is acceptable to the testpypi server. According to PEP
+# 440, only numeric values are allowed in the ".dev" field, and testpypi does
+# not allow for "local" information (such as the git version). To get around
+# these constraints, we substitute the hex characters in the git hash for the
+# corresponding numeric values (e.g., a -> 10, b -> 11, etc.). We also prepend
+# numbers with a leading "0" (e.g., 1 -> 01) to avoid hash collisions.
+#
+# As an added benefit, this approach also handles tagged release versions (such
+# as "2.0.3" with no trailing "dev" information), and does not mangle the
+# version information.
+
+# get version from python
+ver=$(python setup.py --version | tail -1)
+
+# get the first part of the version identifier
+main_ver=$(awk -F+ '{print $1}' <<< $ver)
+
+# extract just the git hash
+git_hash=$(awk -F. '{print $1}' <<< $(awk -F+ '{print $2}' <<< $ver))
+
+# add leading zeros to numbers
+git_hash_zeros=$(echo $git_hash | \
+    sed -E 's/0/00/g' | \
+    sed -E 's/1/01/g' | \
+    sed -E 's/2/02/g' | \
+    sed -E 's/3/03/g' | \
+    sed -E 's/4/04/g' | \
+    sed -E 's/5/05/g' | \
+    sed -E 's/6/06/g' | \
+    sed -E 's/7/07/g' | \
+    sed -E 's/8/08/g' | \
+    sed -E 's/9/09/g')
+
+# only numbers are allowed in dev version; substitute hex values for numeric ones
+git_hash_numeric=$(echo $git_hash_zeros | \
+    sed -E 's/a/10/g' | \
+    sed -E 's/b/11/g' | \
+    sed -E 's/c/12/g' | \
+    sed -E 's/d/13/g' | \
+    sed -E 's/e/14/g' | \
+    sed -E 's/f/15/g')
+
+# strip leading "g" from git hash
+echo ${main_ver}${git_hash_numeric:1}


### PR DESCRIPTION
## Description
This PR creates a unique identifier for a branch when uploading to the test PyPI server as part of CI.

## Motivation and Context
The current way that version numbers are constructed for uploads to the test PyPI server only keeps the "main" version information, and discards the "local" component (which includes the git hash and branch name in our scheme). This led to collisions between branches that were both the same number of commits from the last release, and the test PyPI server does not allow uploading files that have the same name. So, we would like to include the git hash as part of the "dev" tag to make the identifier unique. However, PyPI enforces the versioning scheme described by [PEP 440](https://www.python.org/dev/peps/pep-0440/), which means that only numbers are permitted. So this PR converts the hex characters in the git hash to numeric values and adds it to the end of the commit number, taking care to add leading zeros to the existing numeric values of the hash to avoid hash collisions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
