### PR TITLE
Remove UVFlag Nblts requirement under the hood

### DIFF
--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -1897,7 +1897,7 @@ class UVFlag(UVBase):
         blt_inds : array_like of int, optional
             The baseline-time indices to keep in the object. This is
             not commonly used.
-        blt_inds : array_like of int, optional
+        ant_inds : array_like of int, optional
             The antenna indices to keep in the object. This is
             not commonly used.
 

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -2552,13 +2552,6 @@ class UVFlag(UVBase):
                 else:
                     self.Ntimes = np.unique(self.time_array).size
 
-                # for antenna and waterfall, Nblts is used to define
-                # the size of some arrays but is equivalent to _Ntimes
-                # for baseline type nblts is should be stored
-                # if not it is read later
-                if "Nblts" in header.keys():
-                    self.Nblts = int(header["Nblts"][()])
-
                 self.lst_array = header["lst_array"][()]
 
                 self.freq_array = header["freq_array"][()]
@@ -2597,11 +2590,12 @@ class UVFlag(UVBase):
                     self.Npols = len(self.polarization_array)
 
                 if self.type == "baseline":
+
                     self.baseline_array = header["baseline_array"][()]
 
-                    #  if the Nblts was set via the antenna/waterfall method
-                    # it needs to be overwritten  with the correct shape.
-                    if self.Nblts == self.Ntimes:
+                    if "Nblts" in header.keys():
+                        self.Nblts = int(header["Nblts"][()])
+                    else:
                         self.Nblts = len(self.baseline_array)
 
                     if "Nbls" in header.keys():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When UVFlag was converted to a UVBased object, the "Nblts" axis was kept around under the hood as a comparison parameter for many tests even when the object did not have a physical sense of baselines. This removes that to make the object more pedantically self consistent. 
## Description
<!--- Describe your changes in detail -->
Added logic statements to check the type of the UVFlag object when a comparison vs Nblts is necessary to compare against Ntimes in waterfall and antenna types.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixed #661 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [x] Pedantic verbiage and self-consistency


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
