### PR TITLE
Better nants data calc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ controlled by the `method` keyword.
 - `propagate_flags` keyword for `UVData.frequency_average` which flags averaged samples if any contributing samples were flagged
 
 ### Changed
+- Nants data calculation changed to use numpy functions for small speed up.
 - Changed `input` variable to `indata` in UVFlag to avoid shadowing python builtin.
 - `select` now also accepts a list of baseline indices for the `bls` parameter.
 - `data_array_dtype` keyword for `UVData.read` is now also respected by mwa_corr_fits files. Previously it was only used by uvh5 files.

--- a/pyuvdata/uvdata/fhd.py
+++ b/pyuvdata/uvdata/fhd.py
@@ -546,9 +546,7 @@ class FHD(UVData):
         self.ant_1_array = bl_info["TILE_A"][0] - 1
         self.ant_2_array = bl_info["TILE_B"][0] - 1
 
-        self.Nants_data = int(
-            np.unique(np.union1d(self.ant_1_array, self.ant_2_array)).size
-        )
+        self.Nants_data = int(np.union1d(self.ant_1_array, self.ant_2_array).size)
 
         self.baseline_array = self.antnums_to_baseline(
             self.ant_1_array, self.ant_2_array

--- a/pyuvdata/uvdata/fhd.py
+++ b/pyuvdata/uvdata/fhd.py
@@ -547,7 +547,7 @@ class FHD(UVData):
         self.ant_2_array = bl_info["TILE_B"][0] - 1
 
         self.Nants_data = int(
-            len(np.unique(self.ant_1_array.tolist() + self.ant_2_array.tolist()))
+            np.unique(np.union1d(self.ant_1_array, self.ant_2_array)).size
         )
 
         self.baseline_array = self.antnums_to_baseline(

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -817,8 +817,7 @@ class UVData(UVBase):
 
     def _calc_nants_data(self):
         """Calculate the number of antennas from ant_1_array and ant_2_array arrays."""
-        # a numpy unique of the numpy union seems to be best optimized for numpy arrays
-        return int(np.unique(np.union1d(self.ant_1_array, self.ant_2_array)).size)
+        return int(np.union1d(self.ant_1_array, self.ant_2_array).size)
 
     def check(
         self, check_extra=True, run_check_acceptability=True, check_freq_spacing=False

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -817,11 +817,8 @@ class UVData(UVBase):
 
     def _calc_nants_data(self):
         """Calculate the number of antennas from ant_1_array and ant_2_array arrays."""
-        # lots of inline testing resulted in this odd combination of sets and
-        # numpy uniques to quickly find the number of unique ants
-        return int(
-            len(set(np.unique(self.ant_1_array)).union(np.unique(self.ant_2_array)))
-        )
+        # a numpy unique of the numpy union seems to be best optimized for numpy arrays
+        return int(np.unique(np.union1d(self.ant_1_array, self.ant_2_array)).size)
 
     def check(
         self, check_extra=True, run_check_acceptability=True, check_freq_spacing=False

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -132,7 +132,7 @@ class UVFITS(UVData):
 
         # initialize internal variables based on the antenna lists
         self.Nants_data = int(
-            len(np.unique(self.ant_1_array.tolist() + self.ant_2_array.tolist()))
+            np.unique(np.union1d(self.ant_1_array, self.ant_2_array)).size
         )
 
         # read baseline vectors in units of seconds, return in meters

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -131,9 +131,7 @@ class UVFITS(UVData):
         self.Nbls = len(np.unique(self.baseline_array))
 
         # initialize internal variables based on the antenna lists
-        self.Nants_data = int(
-            np.unique(np.union1d(self.ant_1_array, self.ant_2_array)).size
-        )
+        self.Nants_data = int(np.union1d(self.ant_1_array, self.ant_2_array).size)
 
         # read baseline vectors in units of seconds, return in meters
         # FITS uvw direction convention is opposite ours and Miriad's.

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -1175,7 +1175,7 @@ class UVFlag(UVBase):
         self.ant_1_array = uv.ant_1_array
         self.ant_2_array = uv.ant_2_array
         self.Nants_data = int(
-            len(set(self.ant_1_array.tolist() + self.ant_2_array.tolist()))
+            np.unique(np.union1d(self.ant_1_array, self.ant_2_array)).size
         )
 
         self.time_array = uv.time_array
@@ -1501,7 +1501,7 @@ class UVFlag(UVBase):
                 this.ant_1_array = np.concatenate([this.ant_1_array, other.ant_1_array])
                 this.ant_2_array = np.concatenate([this.ant_2_array, other.ant_2_array])
                 this.Nants_data = int(
-                    len(set(self.ant_1_array.tolist() + self.ant_2_array.tolist()))
+                    np.unique(np.union1d(this.ant_1_array, this.ant_2_array)).size
                 )
 
             this.Ntimes = np.unique(this.time_array).size
@@ -1521,7 +1521,7 @@ class UVFlag(UVBase):
             this.ant_1_array = np.concatenate([this.ant_1_array, other.ant_1_array])
             this.ant_2_array = np.concatenate([this.ant_2_array, other.ant_2_array])
             this.Nants_data = int(
-                len(set(self.ant_1_array.tolist() + self.ant_2_array.tolist()))
+                np.unique(np.union1d(self.ant_1_array, self.ant_2_array)).size
             )
 
             this.Nbls = np.unique(this.baseline_array).size
@@ -2146,7 +2146,7 @@ class UVFlag(UVBase):
                 self.ant_1_array = self.ant_1_array[blt_inds]
                 self.ant_2_array = self.ant_2_array[blt_inds]
                 self.Nants_data = int(
-                    len(set(self.ant_1_array.tolist() + self.ant_2_array.tolist()))
+                    np.unique(np.union1d(self.ant_1_array, self.ant_2_array)).size
                 )
 
             self.time_array = self.time_array[blt_inds]
@@ -2509,7 +2509,9 @@ class UVFlag(UVBase):
                         self.Nants_data = int(header["Nants_data"][()])
                     else:
                         self.Nants_data = int(
-                            len(self.ant_1_array.tolist() + self.ant_2_array.tolist())
+                            np.unique(
+                                np.union1d(self.ant_1_array, self.ant_2_array)
+                            ).size
                         )
 
                     if "Nspws" in header.keys():

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -1174,9 +1174,7 @@ class UVFlag(UVBase):
         self.Nbls = np.unique(self.baseline_array).size
         self.ant_1_array = uv.ant_1_array
         self.ant_2_array = uv.ant_2_array
-        self.Nants_data = int(
-            np.unique(np.union1d(self.ant_1_array, self.ant_2_array)).size
-        )
+        self.Nants_data = int(np.union1d(self.ant_1_array, self.ant_2_array).size)
 
         self.time_array = uv.time_array
         self.lst_array = uv.lst_array
@@ -1501,7 +1499,7 @@ class UVFlag(UVBase):
                 this.ant_1_array = np.concatenate([this.ant_1_array, other.ant_1_array])
                 this.ant_2_array = np.concatenate([this.ant_2_array, other.ant_2_array])
                 this.Nants_data = int(
-                    np.unique(np.union1d(this.ant_1_array, this.ant_2_array)).size
+                    np.union1d(this.ant_1_array, this.ant_2_array).size
                 )
 
             this.Ntimes = np.unique(this.time_array).size
@@ -1520,9 +1518,7 @@ class UVFlag(UVBase):
             )
             this.ant_1_array = np.concatenate([this.ant_1_array, other.ant_1_array])
             this.ant_2_array = np.concatenate([this.ant_2_array, other.ant_2_array])
-            this.Nants_data = int(
-                np.unique(np.union1d(self.ant_1_array, self.ant_2_array)).size
-            )
+            this.Nants_data = int(np.union1d(self.ant_1_array, self.ant_2_array).size)
 
             this.Nbls = np.unique(this.baseline_array).size
             this.Nblts = len(this.baseline_array)
@@ -2146,7 +2142,7 @@ class UVFlag(UVBase):
                 self.ant_1_array = self.ant_1_array[blt_inds]
                 self.ant_2_array = self.ant_2_array[blt_inds]
                 self.Nants_data = int(
-                    np.unique(np.union1d(self.ant_1_array, self.ant_2_array)).size
+                    np.union1d(self.ant_1_array, self.ant_2_array).size
                 )
 
             self.time_array = self.time_array[blt_inds]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed how `Nants_data` is calculated to be a little faster
## Description
<!--- Describe your changes in detail -->
changed from crazy set/union/numpy implementation to a pure numpy one.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This change provides a small speed up for Nants calculation and looks cleaner overall.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).


Here are some profiling I did in an interpreter to verify this works better in a number of cases.
```
In [16]: this = np.random.randint(0,200, 125)                                                            

In [17]: that = np.random.randint(100,300, 125)                                                          

In [23]: %timeit -r 10 -n 10000 int(np.union1d(this,that).size)                                                                                                                                                     
11.8 µs ± 891 ns per loop (mean ± std. dev. of 10 runs, 10000 loops each)

In [24]: %timeit -r 10 -n 10000 int(len(set(np.unique(this)).union(np.unique(that))))                                                                                                                               
44.4 µs ± 3.53 µs per loop (mean ± std. dev. of 10 runs, 10000 loops each)

In [25]: this = np.random.randint(0,340, 60000)                                                                                                                                                                     

In [26]: that = np.random.randint(1, 350, 60000)                                                                                                                                                                    

In [27]: %timeit -r 10 -n 10000 int(np.union1d(this,that).size)                                                                                                                                                     
6.03 ms ± 96.9 µs per loop (mean ± std. dev. of 10 runs, 10000 loops each)

In [28]: %timeit -r 10 -n 10000 int(len(set(np.unique(this)).union(np.unique(that))))                    
8 ms ± 1.09 ms per loop (mean ± std. dev. of 10 runs, 10000 loops each)

In [29]: this = np.random.randint(0,10000, 30000)                                                                                                                                                                   

In [30]: that = np.random.randint(5000,65000, 30000)                                                                                                                                                                

In [31]: %timeit -r 10 -n 10000 int(np.union1d(this,that).size)                                                                                                                                                     
5.91 ms ± 66.4 µs per loop (mean ± std. dev. of 10 runs, 10000 loops each)

In [32]: %timeit -r 10 -n 10000 int(len(set(np.unique(this)).union(np.unique(that))))                    
12.9 ms ± 185 µs per loop (mean ± std. dev. of 10 runs, 10000 loops each)

```