### PR TITLE
Fix hera_cal test environment

### DIFF
--- a/ci/hera_cal.yml
+++ b/ci/hera_cal.yml
@@ -5,18 +5,19 @@ channels:
 dependencies:
   - aipy
   - astropy
+  - astropy-healpix
+  - basemap
   - cached-property
   - h5py
-  - astropy-healpix
   - matplotlib
-  - pytest
   - numpy
   - pandas
+  - pytest
+  - pytest-cov
   - pyyaml
   - scikit-learn
   - scipy
   - setuptools_scm
-  - basemap
   - pip:
     - git+https://github.com/HERA-Team/linsolve.git
     - git+https://github.com/HERA-Team/hera_qm.git


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR makes sure that the `pytest-cov` package is installed for hera_cal tests. It was not explicitly in the yaml previously, so this adds it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
We were noticing intermittent failures in the running of hera_cal jobs. It seems like it has to do with the environment not being set up properly. This should fix that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
