### PR TITLE
Multi-spectral window support for UVFITS, MIR, and UVH5 formats

### DIFF
--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -37,8 +37,8 @@ class Mir(UVData):
 
         Note that with the exception of filename, the rest of the parameters are
         used to sub-select a range of data that matches the limitations of the current
-        instantiation of pyuvdata  -- namely 1 spectral window, 1 source. These could
-        be dropped in the future, as pyuvdata capabilities grow.
+        instantiation of pyuvdata  -- namely 1 source. This could be dropped in the
+        future, as pyuvdata capabilities grow.
 
         Parameters
         ----------

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -168,7 +168,7 @@ class Mir(UVData):
             raise NotImplementedError(
                 "Cannot handle spectral windows with different channel sizes (yet)..."
             )
-        self.channel_width = float(abs(mir_data.sp_data["fres"][0]))
+        self.channel_width = float(abs(mir_data.sp_data["fres"][0])) * 1e6  # MHz->Hz
 
         self.history = "Raw Data"
         self.instrument = "SWARM"
@@ -185,7 +185,7 @@ class Mir(UVData):
         # TODO: We change between xx yy and rr ll, so we will need to update this.
         self.polarization_array = np.asarray([-5])
 
-        self.spw_array = np.array(corrchunk)
+        self.spw_array = np.arange(len(corrchunk))
 
         self.telescope_name = "SMA"
         time_array_mjd = mir_data.in_read["mjd"][bl_in_maparr]
@@ -229,7 +229,7 @@ class Mir(UVData):
         for idx in range(len(corrchunk)):
             data_mask = mir_data.sp_data["corrchunk"] == corrchunk[idx]
             spw_fsky = np.unique(mir_data.sp_data["fsky"][data_mask])
-            spw_fres = np.abs(np.unique(mir_data.sp_data["fres"][data_mask]))
+            spw_fres = np.unique(mir_data.sp_data["fres"][data_mask])
             if (len(spw_fsky) != 1) or (len(spw_fres) != 1):
                 raise ValueError(
                     "Spectral window must have the same fsky and fres for whole obs!"

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -82,6 +82,7 @@ def test_read_mir_write_uvfits(uv_in_uvfits):
     )
 
     mir_uv.history = uvfits_uv.history
+    print(mir_uv.freq_array - uvfits_uv.freq_array)
     assert mir_uv == uvfits_uv
 
 

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -1634,7 +1634,7 @@ def test_select_frequencies_uvfits(casa_uvfits, tmp_path):
             "positions.",
             "Values of freq array do not line up with what is expected, given "
             "channel_width. Spoofing value for now.",
-        ]
+        ],
     ):
         uv_object2.write_uvfits(write_file_uvfits)
 

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -1626,7 +1626,17 @@ def test_select_frequencies_uvfits(casa_uvfits, tmp_path):
         ],
     ):
         uv_object2.select(frequencies=uv_object2.freq_array[0, [0, 2, 4]])
-    pytest.raises(ValueError, uv_object2.write_uvfits, write_file_uvfits)
+
+    with uvtest.check_warnings(
+        UserWarning,
+        [
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
+            "Values of freq array do not line up with what is expected, given "
+            "channel_width. Spoofing value for now.",
+        ]
+    ):
+        uv_object2.write_uvfits(write_file_uvfits)
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -181,6 +181,8 @@ def test_multisource_error(casa_uvfits, tmp_path):
     assert str(cm.value).startswith("This file has multiple sources")
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_spwsupported():
     """Test eading in a uvfits file with multiple spws."""
     uvobj = UVData()

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -181,17 +181,6 @@ def test_multisource_error(casa_uvfits, tmp_path):
     assert str(cm.value).startswith("This file has multiple sources")
 
 
-def test_spwnotsupported():
-    """Test errors on reading in a uvfits file with multiple spws."""
-    uvobj = UVData()
-    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1scan.uvfits")
-    with pytest.raises(ValueError) as cm:
-        uvobj.read(testfile)
-    assert str(cm.value).startswith(
-        "Sorry.  Files with more than one spectral" "window (spw) are not yet supported"
-    )
-
-
 def test_casa_nonascii_bytes_antenna_names():
     """Test that nonascii bytes in antenna names are handled properly."""
     uv1 = UVData()

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -181,6 +181,25 @@ def test_multisource_error(casa_uvfits, tmp_path):
     assert str(cm.value).startswith("This file has multiple sources")
 
 
+def test_spwsupported():
+    """Test eading in a uvfits file with multiple spws."""
+    uvobj = UVData()
+    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1scan.uvfits")
+    uvobj.read(testfile)
+
+    # We know this file has two spws
+    assert uvobj.Nspws == 2
+
+    # Verify that the data array has the right shape
+    assert np.size(uvobj.data_array, axis=1) == uvobj.Nspws
+
+    # Verify that the freq array has the right shape
+    assert np.size(uvobj.freq_array, axis=0) == uvobj.Nspws
+
+    # Verift thaat the spw_array is the right length
+    assert len(uvobj.spw_array) == uvobj.Nspws
+
+
 def test_casa_nonascii_bytes_antenna_names():
     """Test that nonascii bytes in antenna names are handled properly."""
     uv1 = UVData()

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -5902,13 +5902,13 @@ class UVData(UVBase):
         del fhd_obj
 
     def read_mir(
-            self,
-            filepath,
-            isource=None,
-            irec=None,
-            isb=None,
-            corrchunk=None,
-            pseudo_cont=False,
+        self,
+        filepath,
+        isource=None,
+        irec=None,
+        isb=None,
+        corrchunk=None,
+        pseudo_cont=False,
     ):
         """
         Read in data from an SMA MIR file.
@@ -5940,7 +5940,7 @@ class UVData(UVBase):
             irec=irec,
             isb=isb,
             corrchunk=corrchunk,
-            pseudo_cont=pseudo_cont
+            pseudo_cont=pseudo_cont,
         )
         self._convert_from_filetype(mir_obj)
         del mir_obj

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -121,9 +121,7 @@ class UVData(UVBase):
         self._Nspws = uvp.UVParameter(
             "Nspws",
             description="Number of spectral windows "
-            "(ie non-contiguous spectral chunks). "
-            "More than one spectral window is not "
-            "currently supported.",
+            "(ie non-contiguous spectral chunks). ",
             expected_type=int,
         )
 
@@ -5915,8 +5913,8 @@ class UVData(UVBase):
 
         Note that with the exception of filepath, the reset of the parameters are
         used to sub-select a range of data that matches the limitations of the current
-        instantiation of pyuvdata  -- namely 1 spectral window, 1 source. These could
-        be dropped in the future, as pyuvdata capabilities grow.
+        instantiation of pyuvdata  -- namely 1 source. This could be dropped in the
+        future, as pyuvdata capabilities grow.
 
         Parameters
         ----------
@@ -5930,6 +5928,9 @@ class UVData(UVBase):
             Sideband code for MIR dataset
         corrchunk : int
             Correlator chunk code for MIR dataset
+        pseudo_cont: boolean
+            Whether to load spectral windows or pseudo-cont winodws (cant do both, due
+            to different Nfreqs). Default is false.
         """
         from . import mir
 
@@ -6418,7 +6419,7 @@ class UVData(UVBase):
             antenna selectors, `times` and `time_range`) or select keywords
             exclude all data or if keywords are set to the wrong type.
             If the data are multi source or have multiple
-            spectral windows.
+            spectral windows with differing channel widths.
             If the metadata are not internally consistent or missing.
 
         """
@@ -6890,7 +6891,7 @@ class UVData(UVBase):
             antenna selectors, `times` and `time_range`) or select keywords
             exclude all data or if keywords are set to the wrong type.
             If the data are multi source or have multiple
-            spectral windows.
+            spectral windows (for all but MIR, UVH5, UVFITS formats).
             If phase_center_radec is not None and is not length 2.
 
         """

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -5901,7 +5901,15 @@ class UVData(UVBase):
         self._convert_from_filetype(fhd_obj)
         del fhd_obj
 
-    def read_mir(self, filepath, isource=None, irec=None, isb=None, corrchunk=None):
+    def read_mir(
+            self,
+            filepath,
+            isource=None,
+            irec=None,
+            isb=None,
+            corrchunk=None,
+            pseudo_cont=False,
+    ):
         """
         Read in data from an SMA MIR file.
 
@@ -5927,7 +5935,12 @@ class UVData(UVBase):
 
         mir_obj = mir.Mir()
         mir_obj.read_mir(
-            filepath, isource=isource, irec=irec, isb=isb, corrchunk=corrchunk
+            filepath,
+            isource=isource,
+            irec=irec,
+            isb=isb,
+            corrchunk=corrchunk,
+            pseudo_cont=pseudo_cont
         )
         self._convert_from_filetype(mir_obj)
         del mir_obj

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -745,6 +745,14 @@ class UVFITS(UVData):
 
         freq_spacing = self.channel_width
 
+        if np.any(np.diff(self.freq_array) != self.channel_width):
+            raise ValueError(
+                "The separation in frequency values do not match what is specified "
+                "by the channel_width parameter, and therefore frequencies are not "
+                "guaranteed to be contiguious. The uvfits format requires spectral "
+                "windows to be contiguious."
+            )
+
         if self.Npols > 1:
             pol_spacing = np.diff(self.polarization_array)
             if np.min(pol_spacing) < np.max(pol_spacing):

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -458,7 +458,7 @@ class UVFITS(UVData):
 
             if self.Nspws > 1:
                 fq_hdu = hdu_list[hdunames["AIPS FQ"]]
-                if self.Nspws != fq_hdu.header['NO_IF']:
+                if self.Nspws != fq_hdu.header["NO_IF"]:
                     raise IndexError(
                         "NO_IF in AIPS FQ does not match size of primary vis table"
                     )
@@ -468,12 +468,15 @@ class UVFITS(UVData):
 
                 # Get rest freq value
                 rest_freq = uvutils._fits_gethduaxis(vis_hdu, 4)[0]
-                self.freq_array = np.transpose((
-                    rest_freq + fq_hdu.data['IF FREQ']
-                    + np.outer(np.arange(self.Nfreqs), fq_hdu.data['CH WIDTH'])
-                ))
-                self.channel_width = float(fq_hdu.data['CH WIDTH'][0, 0])
-                if np.any(self.channel_width != fq_hdu.data['CH WIDTH']):
+                self.freq_array = np.transpose(
+                    (
+                        rest_freq
+                        + fq_hdu.data["IF FREQ"]
+                        + np.outer(np.arange(self.Nfreqs), fq_hdu.data["CH WIDTH"])
+                    )
+                )
+                self.channel_width = float(fq_hdu.data["CH WIDTH"][0, 0])
+                if np.any(self.channel_width != fq_hdu.data["CH WIDTH"]):
                     raise ValueError(
                         "UVFITS files with different channel widths per spw are not "
                         "supported (yet)."
@@ -743,24 +746,24 @@ class UVFITS(UVData):
         freq_spacing = self.channel_width
         freq_spacing_check = np.unique(np.diff(self.freq_array))
         if not np.allclose(
-                freq_spacing_check,
-                freq_spacing,
-                rtol=self._channel_width.tols[0],
-                atol=self._channel_width.tols[1],
+            freq_spacing_check,
+            freq_spacing,
+            rtol=self._channel_width.tols[0],
+            atol=self._channel_width.tols[1],
         ):
             if len(freq_spacing_check) == 1:
                 freq_spacing = freq_spacing_check[0]
                 warnings.warn(
                     "Values of freq array do not line up with what is expected, given "
                     "channel_width. Spoofing value for now. Expected "
-                    f"{self.channel_width} , got "f"{freq_spacing} instead."
+                    f"{self.channel_width} , got "
+                    f"{freq_spacing} instead."
                 )
                 print("Expected %f, got %f" % (freq_spacing, self.channel_width))
             else:
                 raise ValueError(
                     "The separation in frequency values is non-uniform, which is not "
-                    "supported in the UVFITS file format (should be %f)." %
-                    freq_spacing
+                    "supported in the UVFITS file format (should be %f)." % freq_spacing
                 )
 
         if self.Npols > 1:
@@ -1104,8 +1107,7 @@ class UVFITS(UVData):
             fmt_j = "%iJ" % self.Nspws
 
             # TODO Karto: Temp implementation until we fix some other things in UVData
-            if_freq = np.reshape(self.freq_array[:, 0]
-                                 - self.freq_array[0, 0], (1, -1))
+            if_freq = np.reshape(self.freq_array[:, 0] - self.freq_array[0, 0], (1, -1))
             ch_width = self.channel_width * np.ones((1, self.Nspws))
             tot_bw = self.channel_width * self.Nfreqs * np.ones((1, self.Nspws))
             sideband = np.sign(self.channel_width) * np.ones((1, self.Nspws))

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -423,8 +423,8 @@ class UVFITS(UVData):
             If incompatible select keywords are set (e.g. `ant_str` with other
             antenna selectors, `times` and `time_range`) or select keywords
             exclude all data or if keywords are set to the wrong type.
-            If the data are multi source or have multiple
-            spectral windows.
+            If the data are multi source.
+            If the data have multi spw with different channel widths.
             If the metadata are not internally consistent or missing.
 
         """
@@ -737,11 +737,6 @@ class UVFITS(UVData):
                 "Set the phase_type to drift or phased to "
                 "reflect the phasing status of the data"
             )
-
-        # if self.Nfreqs > 1:
-        #    freq_spacing = np.diff(self.freq_array, axis=1)
-        #    freq_spacing = freq_spacing[0, 0]
-        # else:
 
         freq_spacing = self.channel_width
         freq_spacing_check = np.unique(np.diff(self.freq_array))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allows for multi-spw datasets to be handled in between the UVFITS, MIR, and UVH5 formats.

## Description
<!--- Describe your changes in detail -->
I have updated the `Mir` class to be able to pass on to `UVData` a multi-spw data set (`MirParser` -- the low-level class that acts as a pythonic interface for the MIR file format -- already had this functionality built in), and have additionally updated the
`UVFITS` to be able to both read AND write out UFFITS-style files with multiple spectral windows. The UVH5 file format (and more broadly, the `UVData` class) really required no changes to help support `Nspws > 1` -- basically worked right out of the box. Most of the changes I made on this end were updated doc strings and converting tests that were originally designed to detect fail conditions into tests which verified that various pieces of the code saw multi-spw datasets correctly.

**Note:** I've not attempted to modify the `Miriad`, `MS`, or `FHD` classes to support this, since I don't know if there is any desire to expand these. I know at least a bit about MIRIAD, although I'm reticent to touch the `MS` class since I know there was _some_ chatter on improving general CASA support, and I have no idea what FHD is. I figured I would start this as a draft PR to give some heads up and gather feedback before I start down the path of closing this out (and move on to the next issue -- multiple sources).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These changes are desired in part for better support of SMA data, since the observatory can presently have up to 24 separate spectral windows at a time (counting LSB and USB separately), with the potential of up to 32 windows coming up in the near future. Needing to handle each one of these windows as separate file is cumbersome, not to mention that there are some tasks (e.g., gains cal) which benefit from multiple spectral windows being present together. I suspect that other telescopes may benefit through from being able to handle multiple spectral windows all at once.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Closes #1 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).