### PR TITLE
Properly scale MWA digital gains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [2.1.1] - 2020-8-07
 
 ### Added
+- Adjustment to digital gain removal from mwa_corr_fits files to account for a division by 64 due to a bit selection shift.
 - Options to remove coarse band shape and digital gains from mwa_corr_fits files.
 - Support for cotter flags in mwa_corr_fits files.
 - Added read-only support for MIR files, adding the `Mir` class to `UVData`.

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -437,8 +437,7 @@ class MWACorrFITS(UVData):
             antenna_names = meta_tbl["TileName"][1::2]
             antenna_flags = meta_tbl["Flag"][1::2]
             cable_lens = np.asarray(meta_tbl["Length"][1::2]).astype(np.str_)
-            # the digital gains have been multiplied by a factor of 64
-            dig_gains = meta_tbl["Gains"][1::2, :].astype(np.float64) / 64
+            dig_gains = meta_tbl["Gains"][1::2, :].astype(np.float64)
 
             # get antenna postions in enu coordinates
             antenna_positions = np.zeros((len(antenna_numbers), 3))
@@ -705,7 +704,11 @@ class MWACorrFITS(UVData):
             if remove_dig_gains:
                 # get gains for included coarse channels
                 coarse_inds = np.where(np.isin(coarse_chans, included_coarse_chans))[0]
-                dig_gains = dig_gains[:, coarse_inds]
+                # during commissioning a shift in the bit selection in the digital
+                # receiver was implemented which effectively multiplies the data by
+                # a factor of 64. To account for this, the digital gains are divided
+                # by a factor of 64 here. For a more detailed explanation, see PR #908.
+                dig_gains = dig_gains[:, coarse_inds] / 64
                 dig_gains = np.repeat(dig_gains, num_fine_chans, axis=1)
                 dig_gains1 = dig_gains[self.ant_1_array, :]
                 dig_gains2 = dig_gains[self.ant_2_array, :]

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -437,7 +437,8 @@ class MWACorrFITS(UVData):
             antenna_names = meta_tbl["TileName"][1::2]
             antenna_flags = meta_tbl["Flag"][1::2]
             cable_lens = np.asarray(meta_tbl["Length"][1::2]).astype(np.str_)
-            dig_gains = meta_tbl["Gains"][1::2, :]
+            # the digital gains have been multiplied by a factor of 64
+            dig_gains = meta_tbl["Gains"][1::2, :].astype(np.float64) / 64
 
             # get antenna postions in enu coordinates
             antenna_positions = np.zeros((len(antenna_numbers), 3))
@@ -710,8 +711,11 @@ class MWACorrFITS(UVData):
                 dig_gains2 = dig_gains[self.ant_2_array, :]
                 dig_gains1 = dig_gains1[:, :, np.newaxis]
                 dig_gains2 = dig_gains2[:, :, np.newaxis]
+                if self.data_array.dtype != np.complex128:
+                    self.data_array = self.data_array.astype(np.complex128)
                 self.data_array = self.data_array / (dig_gains1 * dig_gains2)
-
+                if self.data_array.dtype != data_array_dtype:
+                    self.data_array = self.data_array.astype(data_array_dtype)
             # divide out coarse band shape
             if remove_coarse_band:
                 # get coarse band shape

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -607,7 +607,7 @@ def test_remove_dig_gains():
     with fits.open(filelist[0]) as meta:
         meta_tbl = meta[1].data
         antenna_numbers = meta_tbl["Antenna"][1::2]
-        dig_gains = meta_tbl["Gains"][1::2, :]
+        dig_gains = meta_tbl["Gains"][1::2, :].astype(np.float64) / 64
     reordered_inds = antenna_numbers.argsort()
     dig_gains = dig_gains[reordered_inds, :]
     dig_gains = dig_gains[:, np.array([23])]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
MWA digital gains have been scaled by a factor of 64 before being recorded in the metafits file. This fix properly accounts for that scaling in `mwa_corr_fits`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [X] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [X] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/CHANGELOG.md).