### PR TITLE
Fix a bug in compress_by_redundancy when averaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Modified `UVData.read` to do faster concatenation of files, changed the interface to `UVData.fast_concat` to allow lists of `UVData` objects to be passed in.
 
+### Fixed
+- Fixed an indexing error bug in `compress_by_redundancy` when using `method='average'`.
 
 ## [2.1.2] - 2020-10-07
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -5816,7 +5816,11 @@ class UVData(UVBase):
                     )
                     regular_inds = group_inds[np.array(regular_orientation)]
                     conj_orientation = np.array(
-                        [time_ind for time_ind in gp if time_ind >= len(group_times)],
+                        [
+                            time_ind - len(group_times)
+                            for time_ind in gp
+                            if time_ind >= len(group_times)
+                        ],
                         dtype=np.int,
                     )
                     conj_inds = np.array(conj_group_inds[np.array(conj_orientation)])

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -5823,7 +5823,7 @@ class UVData(UVBase):
                         ],
                         dtype=np.int,
                     )
-                    conj_inds = np.array(conj_group_inds[np.array(conj_orientation)])
+                    conj_inds = conj_group_inds[np.array(conj_orientation)]
                     # check that the integration times are all the same
                     int_times = np.concatenate(
                         (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes an indexing error when using `method='average'` in `compress_by_redundancy` that only appeared when the redundant groups contained a mix of baselines with different conjugations. In testing we found that the test file we had been using to test this code with had redundant groups with all the same conjugations. This adds a test where one baseline from each group is conjugated before calling `compress_by_redundancy` and checks that we get the same answer in that case as when no conjugation is done (this new test errors on the main branch).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #935

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
