### PR TITLE
update setup-miniconda action to point to new release

### DIFF
--- a/.github/workflows/macosx_windows_ci.yaml
+++ b/.github/workflows/macosx_windows_ci.yaml
@@ -31,9 +31,9 @@ jobs:
         id: env_name
 
       - name: Setup Miniconda
-        uses: goanpeca/setup-miniconda@v1.6.0
+        uses: conda-incubator/setup-miniconda@v2.0.0
         with:
-          auto-update-conda: "true"
+          auto-update-conda: true
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
           environment-file: ci/${{ steps.env_name.outputs.ENV_NAME }}.yml


### PR DESCRIPTION
I forgot to update the "setup-miniconda" action on my last PR. 