### PR TITLE
Fix handling of astropy Time parameters for astropy 4.2

### DIFF
--- a/pyuvdata/tests/test_uvbase.py
+++ b/pyuvdata/tests/test_uvbase.py
@@ -5,6 +5,7 @@
 """Tests for uvbase object.
 
 """
+from astropy.time import Time
 import pytest
 import numpy as np
 
@@ -79,6 +80,13 @@ class UVTest(UVBase):
 
         self._location = uvp.LocationParameter(
             "location", description="location", value=np.array(ref_xyz)
+        )
+
+        self._time = uvp.UVParameter(
+            "time",
+            description="astropy Time object",
+            value=Time("2015-03-01 00:00:00", scale="utc"),
+            expected_type=Time,
         )
 
         self._optional_int1 = uvp.UVParameter(

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -10,6 +10,7 @@ Subclassed by UVData and Telescope.
 import copy
 import warnings
 
+from astropy.time import Time
 import numpy as np
 
 from . import parameter as uvp
@@ -318,13 +319,16 @@ class UVBase(object):
                     # Check the shape of the parameter value. Note that np.shape
                     # returns an empty tuple for single numbers.
                     # eshape should do the same.
-                    if not np.shape(param.value) == eshape:
+                    if isinstance(param.value, Time):
+                        this_shape = np.shape(param.value.value)
+                    else:
+                        this_shape = np.shape(param.value)
+
+                    if not this_shape == eshape:
                         raise ValueError(
-                            "UVParameter {param} is not expected shape. "
-                            "Parameter shape is {pshape}, expected shape is "
-                            "{eshape}.".format(
-                                param=p, pshape=np.shape(param.value), eshape=eshape
-                            )
+                            f"UVParameter {param} is not expected shape. "
+                            f"Parameter shape is {this_shape}, expected shape is "
+                            f"{eshape}."
                         )
                     if eshape == ():
                         # Single element


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix handling of astropy Time UVParameters in the UVBase `check` method, which broke with astropy 4.2.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #953 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
