### PR TITLE
Recalculate LSTs after averaging by redundancy

### DIFF
--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -5446,35 +5446,7 @@ def test_compress_redundancy_variable_inttime():
 
 
 @pytest.mark.parametrize("method", ("select", "average"))
-def test_compress_redundancy_metadata_only(method):
-    uv0 = UVData()
-    uv0.read_uvfits(
-        os.path.join(DATA_PATH, "fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits")
-    )
-    tol = 0.05
-
-    # Assign identical data to each redundant group:
-    red_gps, centers, lengths = uv0.get_redundancies(
-        tol=tol, use_antpos=True, conjugate_bls=True
-    )
-    for i, gp in enumerate(red_gps):
-        for bl in gp:
-            inds = np.where(bl == uv0.baseline_array)
-            uv0.data_array[inds] *= 0
-            uv0.data_array[inds] += complex(i)
-
-    uv2 = uv0.copy(metadata_only=True)
-    uv2.compress_by_redundancy(method=method, tol=tol, inplace=True)
-
-    uv0.compress_by_redundancy(method=method, tol=tol)
-    uv0.data_array = None
-    uv0.flag_array = None
-    uv0.nsample_array = None
-    assert uv0 == uv2
-
-
-@pytest.mark.parametrize("metadata_only", (True, False))
-def test_compress_redundancy_times(metadata_only):
+def test_compress_redundancy_metadata_only_lst_update(method):
     uv0 = UVData()
     uv0.read_uvfits(
         os.path.join(DATA_PATH, "fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits")
@@ -5493,14 +5465,13 @@ def test_compress_redundancy_times(metadata_only):
             uv0.data_array[inds] += complex(i)
             uv0.time_array[inds] += (bl_ind - ((len(gp) - 1) / 2.0)) * 0.001
 
-    uv2 = uv0.copy(metadata_only=metadata_only)
-    uv2.compress_by_redundancy(method="average", tol=tol)
+    uv2 = uv0.copy(metadata_only=True)
+    uv2.compress_by_redundancy(method=method, tol=tol, inplace=True)
 
-    uv0.compress_by_redundancy(method="average", tol=tol)
-    if metadata_only:
-        uv0.data_array = None
-        uv0.flag_array = None
-        uv0.nsample_array = None
+    uv0.compress_by_redundancy(method=method, tol=tol)
+    uv0.data_array = None
+    uv0.flag_array = None
+    uv0.nsample_array = None
     assert uv0 == uv2
 
     uv3 = uv2.copy()

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -5463,8 +5463,10 @@ def test_compress_redundancy_metadata_only_lst_update(method):
             inds = np.where(bl == uv0.baseline_array)
             uv0.data_array[inds] *= 0
             uv0.data_array[inds] += complex(i)
-            uv0.time_array[inds] += (bl_ind - ((len(gp) - 1) / 2.0)) * 0.001
+            if bl_ind > 0:
+                uv0.time_array[inds] += uv0._time_array.tols[1] * 0.9
 
+    uv0.set_lsts_from_time_array()
     uv2 = uv0.copy(metadata_only=True)
     uv2.compress_by_redundancy(method=method, tol=tol, inplace=True)
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -5897,7 +5897,7 @@ class UVData(UVBase):
             else:
                 new_obj.time_array = temp_time_array
                 new_obj.Ntimes = temp_ntimes
-                self.set_lsts_from_time_array()
+                new_obj.set_lsts_from_time_array()
                 if not self.metadata_only:
                     new_obj.data_array = temp_data_array
                     new_obj.nsample_array = temp_nsample_array

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -5888,6 +5888,7 @@ class UVData(UVBase):
                 self.select(bls=bl_ants, keep_all_metadata=keep_all_metadata)
                 self.time_array = temp_time_array
                 self.Ntimes = temp_ntimes
+                self.set_lsts_from_time_array()
                 if not self.metadata_only:
                     self.data_array = temp_data_array
                     self.nsample_array = temp_nsample_array
@@ -5896,6 +5897,7 @@ class UVData(UVBase):
             else:
                 new_obj.time_array = temp_time_array
                 new_obj.Ntimes = temp_ntimes
+                self.set_lsts_from_time_array()
                 if not self.metadata_only:
                     new_obj.data_array = temp_data_array
                     new_obj.nsample_array = temp_nsample_array


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Recalculate lst_array after compressing by redundancy with `method=average`. The times can change because they are averaged across the redundant set, so the LSTs need to be recalculated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #958

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
