### PR TITLE
Add changelog entry for extra_keywords support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added handling for `extra_keywords` in UVFlag objects, including read/write to/from files.
 - Added handling for `object_name` and `extra_keywords` to `sum_vis` and `diff_vis` methods and added the `override_params` option to override other parameters.
 
 ### Changed


### PR DESCRIPTION
Adds changelog entry missed earlier in #948 .

## Types of changes
- [X] Documentation change (documentation changes only)

## Checklist:
- [X] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main)