### PR TITLE
cython util update

### DIFF
--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -105,6 +105,21 @@ def test_LatLonAlt_from_XYZ():
     pytest.raises(ValueError, uvutils.LatLonAlt_from_XYZ, ref_xyz[0:1])
 
 
+def test_lla_xyz_lla_roundtrip():
+    """Test roundtripping an array will yield the same values."""
+    np.random.seed(0)
+    lats = -30.721 + np.random.normal(0, 0.0005, size=30)
+    lons = 21.428 + np.random.normal(0, 0.0005, size=30)
+    alts = np.random.uniform(1051, 1054, size=30)
+    lats *= np.pi / 180.0
+    lons *= np.pi / 180.0
+    xyz = uvutils.XYZ_from_LatLonAlt(lats, lons, alts)
+    lats_new, lons_new, alts_new = uvutils.LatLonAlt_from_XYZ(xyz)
+    assert np.allclose(lats_new, lats)
+    assert np.allclose(lons_new, lons)
+    assert np.allclose(alts_new, alts)
+
+
 @pytest.fixture(scope="module")
 def enu_ecef_info():
     """Some setup info for ENU/ECEF calculations."""

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -787,7 +787,9 @@ def XYZ_from_LatLonAlt(latitude, longitude, altitude):
     latitude = np.ascontiguousarray(latitude, dtype=np.float64)
     longitude = np.ascontiguousarray(longitude, dtype=np.float64)
     altitude = np.ascontiguousarray(altitude, dtype=np.float64)
+
     n_pts = latitude.size
+
     if longitude.size != n_pts:
         raise ValueError(
             "latitude, longitude and altitude must all have the same length"
@@ -797,7 +799,12 @@ def XYZ_from_LatLonAlt(latitude, longitude, altitude):
             "latitude, longitude and altitude must all have the same length"
         )
 
-    return _utils._xyz_from_latlonalt(latitude, longitude, altitude)
+    xyz = _utils._xyz_from_latlonalt(latitude, longitude, altitude)
+    xyz = xyz.T
+    if n_pts == 1:
+        return xyz[0]
+
+    return xyz
 
 
 def rotECEF_from_ECEF(xyz, longitude):

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1000,8 +1000,8 @@ def phase_uvw(ra, dec, initial_uvw):
     return _utils._phase_uvw(
         np.float64(ra),
         np.float64(dec),
-        np.ascontiguousarray(initial_uvw, dtype=np.float64),
-    )
+        np.ascontiguousarray(initial_uvw.T, dtype=np.float64),
+    ).T
 
 
 def unphase_uvw(ra, dec, uvw):
@@ -1032,8 +1032,8 @@ def unphase_uvw(ra, dec, uvw):
         uvw = uvw[np.newaxis, :]
 
     return _utils._unphase_uvw(
-        np.float64(ra), np.float64(dec), np.ascontiguousarray(uvw, dtype=np.float64),
-    )
+        np.float64(ra), np.float64(dec), np.ascontiguousarray(uvw.T, dtype=np.float64),
+    ).T
 
 
 def get_lst_for_time(jd_array, latitude, longitude, altitude):

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -889,7 +889,9 @@ def ENU_from_ECEF(xyz, latitude, longitude, altitude):
     if xyz.ndim > 1 and xyz.shape[1] != 3:
         raise ValueError("The expected shape of ECEF xyz array is (Npts, 3).")
 
+    squeeze = False
     if xyz.ndim == 1:
+        squeeze = True
         xyz = xyz[np.newaxis, :]
     xyz = np.ascontiguousarray(xyz.T, dtype=np.float64)
 
@@ -914,7 +916,7 @@ def ENU_from_ECEF(xyz, latitude, longitude, altitude):
     )
 
     enu = enu.T
-    if len(xyz.shape) == 1:
+    if squeeze:
         enu = np.squeeze(enu)
 
     return enu

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -750,7 +750,7 @@ def LatLonAlt_from_XYZ(xyz, check_acceptability=True):
 
     # checking for acceptable values
     if check_acceptability:
-        norms = np.linalg.norm(xyz, axis=1)
+        norms = np.linalg.norm(xyz, axis=0)
         if not all(np.logical_and(norms >= 6.35e6, norms <= 6.39e6)):
             raise ValueError("xyz values should be ECEF x, y, z coordinates in meters")
     # this helper function returns one 2D array because it is less overhead for cython

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -52,44 +52,39 @@ cpdef tuple baseline_to_antnums(numpy.ndarray[ndim=1, dtype=numpy.int64_t] basel
       _a1[i] = (_bl[i] - (_a2[i] + 1)) // 256 - 1
   return ant1, ant2
 
-
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef numpy.ndarray[dtype=numpy.int64_t] _antnum_to_bl_2048(
-numpy.ndarray[ndim=1, dtype=numpy.int64_t] ant1,
-numpy.ndarray[ndim=1, dtype=numpy.int64_t] ant2,
+numpy.int64_t[::1] ant1,
+numpy.int64_t[::1] ant2,
 ):
-  cdef unsigned long n = ant1.size
-  cdef unsigned int i
+  cdef unsigned long n = ant1.shape[0]
+  cdef Py_ssize_t i
   cdef numpy.ndarray[ndim=1, dtype=numpy.int64_t] baselines = np.empty(n, dtype=np.int64)
   # make views as c-contiguous arrays of a known dtype
   # effectivly turns the numpy array into a c-array
   cdef numpy.int64_t[::1] _bl = baselines
-  cdef numpy.int64_t[::1] _a1 = ant1
-  cdef numpy.int64_t[::1] _a2 = ant2
 
   for i in range(n):
-    _bl[i] = 2048 * (_a1[i] + 1) + (_a2[i] + 1) + 2 ** 16
+    _bl[i] = 2048 * (ant1[i] + 1) + (ant2[i] + 1) + 2 ** 16
 
   return baselines
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef numpy.ndarray[dtype=numpy.int64_t] _antnum_to_bl_256(
-numpy.ndarray[ndim=1, dtype=numpy.int64_t] ant1,
-numpy.ndarray[ndim=1, dtype=numpy.int64_t] ant2,
+numpy.int64_t[::1] ant1,
+numpy.int64_t[::1] ant2,
 ):
-  cdef unsigned long n = ant1.size
-  cdef unsigned int i
+  cdef unsigned long n = ant1.shape[0]
+  cdef Py_ssize_t i
   cdef numpy.ndarray[dtype=numpy.int64_t, ndim=1] baselines = np.empty(n, dtype=np.int64)
   # make views as c-contiguous arrays of a known dtype
   # effectivly turns the numpy array into a c-array
   cdef numpy.int64_t[::1] _bl = baselines
-  cdef numpy.int64_t[::1] _a1 = ant1
-  cdef numpy.int64_t[::1] _a2 = ant2
 
   for i in range(n):
-    _bl[i] = 256 * (_a1[i] + 1) + (_a2[i] + 1)
+    _bl[i] = 256 * (ant1[i] + 1) + (ant2[i] + 1)
   return baselines
 
 cpdef numpy.ndarray[dtype=numpy.int64_t] antnums_to_baseline(

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -113,39 +113,39 @@ cpdef numpy.ndarray[dtype=numpy.int64_t] antnums_to_baseline(
 @cython.wraparound(False)
 @cython.cdivision(True)
 cpdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] _lla_from_xyz(
-    numpy.float64_t[:, ::1] xyz,
+  numpy.float64_t[:, ::1] xyz,
 ):
-    cdef Py_ssize_t ind
-    cdef int n_pts = xyz.shape[1]
-    cdef numpy.float64_t gps_p, gps_theta
+  cdef Py_ssize_t ind
+  cdef int n_pts = xyz.shape[1]
+  cdef numpy.float64_t gps_p, gps_theta
 
-    cdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] lla = np.empty((3, n_pts), dtype=np.float64)
-    cdef numpy.float64_t[:, ::1] _lla = lla
+  cdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] lla = np.empty((3, n_pts), dtype=np.float64)
+  cdef numpy.float64_t[:, ::1] _lla = lla
 
-    # see wikipedia geodetic_datum and Datum transformations of
-    # GPS positions PDF in docs/references folder
-    for ind in range(n_pts):
-        gps_p = sqrt(xyz[0, ind] ** 2 + xyz[1, ind] ** 2)
-        gps_theta = atan2(xyz[2, ind] * _gps_a, gps_p * _gps_b)
+  # see wikipedia geodetic_datum and Datum transformations of
+  # GPS positions PDF in docs/references folder
+  for ind in range(n_pts):
+    gps_p = sqrt(xyz[0, ind] ** 2 + xyz[1, ind] ** 2)
+    gps_theta = atan2(xyz[2, ind] * _gps_a, gps_p * _gps_b)
 
-        _lla[0, ind] = atan2(
-            xyz[2, ind] + _ep2 * _gps_b * sin(gps_theta) ** 3,
-            gps_p - _e2 * _gps_a * cos(gps_theta) ** 3,
-        )
+    _lla[0, ind] = atan2(
+      xyz[2, ind] + _ep2 * _gps_b * sin(gps_theta) ** 3,
+      gps_p - _e2 * _gps_a * cos(gps_theta) ** 3,
+    )
 
-        _lla[1, ind] = atan2(xyz[1, ind], xyz[0, ind])
+    _lla[1, ind] = atan2(xyz[1, ind], xyz[0, ind])
 
-        _lla[2, ind] = (gps_p / cos(lla[0, ind])) - _gps_a / sqrt(1.0 - _e2 * sin(lla[0, ind]) ** 2)
+    _lla[2, ind] = (gps_p / cos(lla[0, ind])) - _gps_a / sqrt(1.0 - _e2 * sin(lla[0, ind]) ** 2)
 
-    return lla
+  return lla
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
 cpdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] _xyz_from_latlonalt(
-    numpy.float64_t[::1] _lat,
-    numpy.float64_t[::1] _lon,
-    numpy.float64_t[::1] _alt,
+  numpy.float64_t[::1] _lat,
+  numpy.float64_t[::1] _lon,
+  numpy.float64_t[::1] _alt,
 ):
   cdef Py_ssize_t i
   cdef int n_pts = _lat.shape[0]
@@ -155,18 +155,18 @@ cpdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] _xyz_from_latlonalt(
   cdef numpy.float64_t  sin_lat, cos_lat, sin_lon, cos_lon, gps_n
 
   for ind in range(n_pts):
-      sin_lat = sin(_lat[ind])
-      sin_lon = sin(_lon[ind])
+    sin_lat = sin(_lat[ind])
+    sin_lon = sin(_lon[ind])
 
-      cos_lat = cos(_lat[ind])
-      cos_lon = cos(_lon[ind])
+    cos_lat = cos(_lat[ind])
+    cos_lon = cos(_lon[ind])
 
-      gps_n = _gps_a / sqrt(1.0 - _e2 * sin_lat ** 2)
+    gps_n = _gps_a / sqrt(1.0 - _e2 * sin_lat ** 2)
 
-      _xyz[0, ind] = (gps_n + _alt[ind]) * cos_lat * cos_lon
-      _xyz[1, ind] = (gps_n + _alt[ind]) * cos_lat * sin_lon
+    _xyz[0, ind] = (gps_n + _alt[ind]) * cos_lat * cos_lon
+    _xyz[1, ind] = (gps_n + _alt[ind]) * cos_lat * sin_lon
 
-      _xyz[2, ind] = (b_div_a2 * gps_n + _alt[ind]) * sin_lat
+    _xyz[2, ind] = (b_div_a2 * gps_n + _alt[ind]) * sin_lat
   return xyz
 
 # this function takes memoryviews as inputs
@@ -174,93 +174,93 @@ cpdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] _xyz_from_latlonalt(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef numpy.ndarray[numpy.float64_t, ndim=2] _ENU_from_ECEF(
-    numpy.float64_t[:, ::1] xyz,
-    numpy.float64_t[::1] _lat,
-    numpy.float64_t[::1] _lon,
-    numpy.float64_t[::1] _alt,
+  numpy.float64_t[:, ::1] xyz,
+  numpy.float64_t[::1] _lat,
+  numpy.float64_t[::1] _lon,
+  numpy.float64_t[::1] _alt,
 ):
-    cdef Py_ssize_t i
-    cdef int nblts = xyz.shape[1]
-    cdef numpy.float64_t xyz_use[3]
+  cdef Py_ssize_t i
+  cdef int nblts = xyz.shape[1]
+  cdef numpy.float64_t xyz_use[3]
 
-    cdef numpy.float64_t sin_lat, cos_lat, sin_lon, cos_lon
+  cdef numpy.float64_t sin_lat, cos_lat, sin_lon, cos_lon
 
-    # we want a memoryview of the xyz of the center
-    # this looks a little silly but we don't have to define 2 different things
-    cdef numpy.float64_t[:] xyz_center = _xyz_from_latlonalt(_lat, _lon, _alt)[:, 0]
+  # we want a memoryview of the xyz of the center
+  # this looks a little silly but we don't have to define 2 different things
+  cdef numpy.float64_t[:] xyz_center = _xyz_from_latlonalt(_lat, _lon, _alt)[:, 0]
 
-    cdef numpy.ndarray[numpy.float64_t, ndim=2] _enu = np.empty((3, nblts), dtype=np.float64)
-    cdef numpy.float64_t[:, ::1] enu = _enu
+  cdef numpy.ndarray[numpy.float64_t, ndim=2] _enu = np.empty((3, nblts), dtype=np.float64)
+  cdef numpy.float64_t[:, ::1] enu = _enu
 
-    sin_lat = sin(_lat[0])
-    cos_lat = cos(_lat[0])
+  sin_lat = sin(_lat[0])
+  cos_lat = cos(_lat[0])
 
-    sin_lon = sin(_lon[0])
-    cos_lon = cos(_lon[0])
+  sin_lon = sin(_lon[0])
+  cos_lon = cos(_lon[0])
 
-    for i in range(nblts):
-        xyz_use[0] = xyz[0, i] - xyz_center[0]
-        xyz_use[1] = xyz[1, i] - xyz_center[1]
-        xyz_use[2] = xyz[2, i] - xyz_center[2]
+  for i in range(nblts):
+    xyz_use[0] = xyz[0, i] - xyz_center[0]
+    xyz_use[1] = xyz[1, i] - xyz_center[1]
+    xyz_use[2] = xyz[2, i] - xyz_center[2]
 
-        enu[0, i] = -sin_lon * xyz_use[0] + cos_lon * xyz_use[1]
-        enu[1, i] = (
-          - sin_lat * cos_lon * xyz_use[0]
-          - sin_lat * sin_lon * xyz_use[1]
-          + cos_lat * xyz_use[2]
-        )
-        enu[2, i] = (
-          cos_lat * cos_lon * xyz_use[0]
-          + cos_lat * sin_lon * xyz_use[1]
-          + sin_lat * xyz_use[2]
-        )
+    enu[0, i] = -sin_lon * xyz_use[0] + cos_lon * xyz_use[1]
+    enu[1, i] = (
+      - sin_lat * cos_lon * xyz_use[0]
+      - sin_lat * sin_lon * xyz_use[1]
+      + cos_lat * xyz_use[2]
+    )
+    enu[2, i] = (
+      cos_lat * cos_lon * xyz_use[0]
+      + cos_lat * sin_lon * xyz_use[1]
+      + sin_lat * xyz_use[2]
+    )
 
-    return _enu
+  return _enu
 
 # this function takes memoryviews as inputs
 # that is why _lat, _lon, and _alt are indexed below to get the 0th entry
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef numpy.ndarray[dtype=numpy.float64_t] _ECEF_FROM_ENU(
-    numpy.float64_t[:, ::1] enu,
-    numpy.float64_t[::1] _lat,
-    numpy.float64_t[::1] _lon,
-    numpy.float64_t[::1] _alt,
+  numpy.float64_t[:, ::1] enu,
+  numpy.float64_t[::1] _lat,
+  numpy.float64_t[::1] _lon,
+  numpy.float64_t[::1] _alt,
 ):
-    cdef Py_ssize_t i
-    cdef int nblts = enu.shape[1]
-    cdef numpy.float64_t sin_lat, cos_lat, sin_lon, cos_lon
+  cdef Py_ssize_t i
+  cdef int nblts = enu.shape[1]
+  cdef numpy.float64_t sin_lat, cos_lat, sin_lon, cos_lon
 
-    # allocate memory then make memory view for faster access
-    cdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] _xyz = np.zeros((3, nblts), dtype=np.float64)
-    cdef numpy.float64_t[:, ::1] xyz = _xyz
+  # allocate memory then make memory view for faster access
+  cdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] _xyz = np.zeros((3, nblts), dtype=np.float64)
+  cdef numpy.float64_t[:, ::1] xyz = _xyz
 
-    # we want a memoryview of the xyz of the center
-    # this looks a little silly but we don't have to define 2 different things
-    cdef numpy.float64_t[:] xyz_center = _xyz_from_latlonalt(_lat, _lon, _alt)[:, 0]
+  # we want a memoryview of the xyz of the center
+  # this looks a little silly but we don't have to define 2 different things
+  cdef numpy.float64_t[:] xyz_center = _xyz_from_latlonalt(_lat, _lon, _alt)[:, 0]
 
-    sin_lat = sin(_lat[0])
-    cos_lat = cos(_lat[0])
+  sin_lat = sin(_lat[0])
+  cos_lat = cos(_lat[0])
 
-    sin_lon = sin(_lon[0])
-    cos_lon = cos(_lon[0])
+  sin_lon = sin(_lon[0])
+  cos_lon = cos(_lon[0])
 
-    for i in range(nblts):
-        xyz[0, i] = (
-            - sin_lat * cos_lon * enu[1, i]
-            - sin_lon * enu[0, i]
-            + cos_lat * cos_lon * enu[2, i]
-            + xyz_center[0]
-        )
-        xyz[1, i] = (
-            - sin_lat * sin_lon * enu[1, i]
-            + cos_lon * enu[0, i]
-            + cos_lat * sin_lon * enu[2, i]
-            + xyz_center[1]
-        )
-        xyz[2, i] = cos_lat * enu[1, i] + sin_lat * enu[2, i] + xyz_center[2]
+  for i in range(nblts):
+    xyz[0, i] = (
+      - sin_lat * cos_lon * enu[1, i]
+      - sin_lon * enu[0, i]
+      + cos_lat * cos_lon * enu[2, i]
+      + xyz_center[0]
+    )
+    xyz[1, i] = (
+      - sin_lat * sin_lon * enu[1, i]
+      + cos_lon * enu[0, i]
+      + cos_lat * sin_lon * enu[2, i]
+      + xyz_center[1]
+    )
+    xyz[2, i] = cos_lat * enu[1, i] + sin_lat * enu[2, i] + xyz_center[2]
 
-    return _xyz
+  return _xyz
 
 # inital_uvw is a memoryviewed array as an input
 @cython.boundscheck(False)

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -36,7 +36,7 @@ cpdef tuple baseline_to_antnums(numpy.ndarray[ndim=1, dtype=numpy.int64_t] basel
   cdef numpy.ndarray[ndim=1, dtype=numpy.int64_t] ant1 = np.empty(n, dtype=np.int64)
   cdef numpy.ndarray[ndim=1, dtype=numpy.int64_t] ant2 = np.empty(n, dtype=np.int64)
   cdef long _min = baseline.min()
-  cdef int i
+  cdef Py_ssize_t i
   # make views as c-contiguous arrays of a known dtype
   # effectivly turns the numpy array into a c-array
   cdef numpy.int64_t[::1] _a1 = ant1
@@ -113,7 +113,7 @@ cpdef numpy.ndarray[dtype=numpy.int64_t] antnums_to_baseline(
 # reduces need to calculate gps_n, assign to memory, read memory to calcuate alt
 @cython.cdivision(True)
 @cython.nonecheck(False)
-cdef inline double gps_n_calc(double lat):
+cdef inline numpy.float64_t gps_n_calc(numpy.float64_t lat):
     return _gps_a / sqrt(1.0 - _e2 * sin(lat) ** 2)
 
 

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -271,59 +271,76 @@ cpdef numpy.ndarray[dtype=numpy.float64_t] _ECEF_FROM_ENU(
 # inital_uvw is a memoryviewed array as an input
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef numpy.ndarray[dtype=numpy.float64_t] _phase_uvw(
+cpdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] _phase_uvw(
     numpy.float64_t ra,
     numpy.float64_t dec,
     numpy.float64_t[:, ::1] initial_uvw
 ):
   cdef int i
-  cdef int nuvw = initial_uvw.shape[0]
-  cdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] uvw = np.empty((nuvw, 3), dtype=np.float64)
+  cdef int nuvw = initial_uvw.shape[1]
+  cdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] uvw = np.empty((3, nuvw), dtype=np.float64)
 
   # make a memoryview for the numpy array in c
   cdef numpy.float64_t[:, ::1] _uvw = uvw
 
+  cdef numpy.float64_t sin_ra, cos_ra, sin_dec, cos_dec
+
+  sin_ra = sin(ra)
+  cos_ra = cos(ra)
+  sin_dec = sin(dec)
+  cos_dec = cos(dec)
+
   for i in range(nuvw):
-    _uvw[i, 0] = - sin(ra) * initial_uvw[i, 0] + cos(ra) * initial_uvw[i, 1]
-    _uvw[i, 1] = (
-      - sin(dec) * cos(ra) * initial_uvw[i, 0]
-      - sin(dec) * sin(ra) * initial_uvw[i, 1]
-      + cos(dec) * initial_uvw[i, 2]
+    _uvw[0, i] = - sin_ra * initial_uvw[0, i] + cos_ra * initial_uvw[1, i]
+
+    _uvw[1, i] = (
+      - sin_dec * cos_ra * initial_uvw[0, i]
+      - sin_dec * sin_ra * initial_uvw[1, i]
+      + cos_dec * initial_uvw[2, i]
     )
-    _uvw[i, 2] = (
-      cos(dec) * cos(ra) * initial_uvw[i, 0]
-      + cos(dec) * sin(ra) * initial_uvw[i, 1]
-      + sin(dec) * initial_uvw[i, 2]
+
+    _uvw[2, i] = (
+      cos_dec * cos_ra * initial_uvw[0, i]
+      + cos_dec * sin_ra * initial_uvw[1, i]
+      + sin_dec * initial_uvw[2, i]
     )
   return uvw
 
 # uvw is a memoryviewed array as an input
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef numpy.ndarray[dtype=numpy.float64_t] _unphase_uvw(
+cpdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] _unphase_uvw(
     numpy.float64_t ra,
     numpy.float64_t dec,
     numpy.float64_t[:, ::1] uvw
 ):
   cdef int i
-  cdef int nuvw = uvw.shape[0]
-  cdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] unphased_uvw = np.empty((nuvw, 3), dtype=np.float64)
+  cdef int nuvw = uvw.shape[1]
+  cdef numpy.ndarray[dtype=numpy.float64_t, ndim=2] unphased_uvw = np.empty((3, nuvw), dtype=np.float64)
 
   # make a memoryview for the numpy array in c
   cdef numpy.float64_t[:, ::1] _u_uvw = unphased_uvw
+
+  cdef numpy.float64_t sin_ra, cos_ra, sin_dec, cos_dec
+
+  sin_ra = sin(ra)
+  cos_ra = cos(ra)
+  sin_dec = sin(dec)
+  cos_dec = cos(dec)
+
   for i in range(nuvw):
-    _u_uvw[i, 0] = (
-      - sin(ra) * uvw[i, 0]
-      - sin(dec) * cos(ra) * uvw[i, 1]
-      + cos(dec) * cos(ra) * uvw[i, 2]
+    _u_uvw[0, i] = (
+      - sin_ra * uvw[0, i]
+      - sin_dec * cos_ra * uvw[1, i]
+      + cos_dec * cos_ra * uvw[2, i]
     )
 
-    _u_uvw[i, 1] = (
-      cos(ra) * uvw[i, 0]
-      - sin(dec) * sin(ra) * uvw[i, 1]
-      + cos(dec) * sin(ra) * uvw[i, 2]
+    _u_uvw[1, i] = (
+      cos_ra * uvw[0, i]
+      - sin_dec * sin_ra * uvw[1, i]
+      + cos_dec * sin_ra * uvw[2, i]
     )
 
-    _u_uvw[i, 2] = cos(dec) * uvw[i, 1] + sin(dec) * uvw[i, 2]
+    _u_uvw[2, i] = cos_dec * uvw[1, i] + sin_dec * uvw[2, i]
 
   return unphased_uvw

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -43,14 +43,13 @@ cpdef tuple baseline_to_antnums(numpy.ndarray[ndim=1, dtype=numpy.int64_t] basel
   cdef numpy.int64_t[::1] _a2 = ant2
   cdef numpy.int64_t[::1] _bl = baseline
 
-  with nogil:
-    for i in range(n):
-      if _min > 2 ** 16:
-        _a2[i] = (_bl[i] - 2 ** 16) % 2048 - 1
-        _a1[i] = (_bl[i] - 2 ** 16 - (_a2[i] + 1)) // 2048 - 1
-      else:
-        _a2[i] = (_bl[i]) % 256 - 1
-        _a1[i] = (_bl[i] - (_a2[i] + 1)) // 256 - 1
+  for i in range(n):
+    if _min > 2 ** 16:
+      _a2[i] = (_bl[i] - 2 ** 16) % 2048 - 1
+      _a1[i] = (_bl[i] - 2 ** 16 - (_a2[i] + 1)) // 2048 - 1
+    else:
+      _a2[i] = (_bl[i]) % 256 - 1
+      _a1[i] = (_bl[i] - (_a2[i] + 1)) // 256 - 1
   return ant1, ant2
 
 
@@ -69,9 +68,8 @@ numpy.ndarray[ndim=1, dtype=numpy.int64_t] ant2,
   cdef numpy.int64_t[::1] _a1 = ant1
   cdef numpy.int64_t[::1] _a2 = ant2
 
-  with nogil:
-    for i in range(n):
-      _bl[i] = 2048 * (_a1[i] + 1) + (_a2[i] + 1) + 2 ** 16
+  for i in range(n):
+    _bl[i] = 2048 * (_a1[i] + 1) + (_a2[i] + 1) + 2 ** 16
 
   return baselines
 
@@ -90,9 +88,8 @@ numpy.ndarray[ndim=1, dtype=numpy.int64_t] ant2,
   cdef numpy.int64_t[::1] _a1 = ant1
   cdef numpy.int64_t[::1] _a2 = ant2
 
-  with nogil:
-    for i in range(n):
-      _bl[i] = 256 * (_a1[i] + 1) + (_a2[i] + 1)
+  for i in range(n):
+    _bl[i] = 256 * (_a1[i] + 1) + (_a2[i] + 1)
   return baselines
 
 cpdef numpy.ndarray[dtype=numpy.int64_t] antnums_to_baseline(
@@ -290,19 +287,19 @@ cpdef numpy.ndarray[dtype=numpy.float64_t] _phase_uvw(
 
   # make a memoryview for the numpy array in c
   cdef numpy.float64_t[:, ::1] _uvw = uvw
-  with nogil:
-    for i in range(nuvw):
-      _uvw[i, 0] = - sin(ra) * initial_uvw[i, 0] + cos(ra) * initial_uvw[i, 1]
-      _uvw[i, 1] = (
-        - sin(dec) * cos(ra) * initial_uvw[i, 0]
-        - sin(dec) * sin(ra) * initial_uvw[i, 1]
-        + cos(dec) * initial_uvw[i, 2]
-      )
-      _uvw[i, 2] = (
-        cos(dec) * cos(ra) * initial_uvw[i, 0]
-        + cos(dec) * sin(ra) * initial_uvw[i, 1]
-        + sin(dec) * initial_uvw[i, 2]
-      )
+
+  for i in range(nuvw):
+    _uvw[i, 0] = - sin(ra) * initial_uvw[i, 0] + cos(ra) * initial_uvw[i, 1]
+    _uvw[i, 1] = (
+      - sin(dec) * cos(ra) * initial_uvw[i, 0]
+      - sin(dec) * sin(ra) * initial_uvw[i, 1]
+      + cos(dec) * initial_uvw[i, 2]
+    )
+    _uvw[i, 2] = (
+      cos(dec) * cos(ra) * initial_uvw[i, 0]
+      + cos(dec) * sin(ra) * initial_uvw[i, 1]
+      + sin(dec) * initial_uvw[i, 2]
+    )
   return uvw
 
 # uvw is a memoryviewed array as an input
@@ -319,20 +316,19 @@ cpdef numpy.ndarray[dtype=numpy.float64_t] _unphase_uvw(
 
   # make a memoryview for the numpy array in c
   cdef numpy.float64_t[:, ::1] _u_uvw = unphased_uvw
-  with nogil:
-    for i in range(nuvw):
-      _u_uvw[i, 0] = (
-        - sin(ra) * uvw[i, 0]
-        - sin(dec) * cos(ra) * uvw[i, 1]
-        + cos(dec) * cos(ra) * uvw[i, 2]
-      )
+  for i in range(nuvw):
+    _u_uvw[i, 0] = (
+      - sin(ra) * uvw[i, 0]
+      - sin(dec) * cos(ra) * uvw[i, 1]
+      + cos(dec) * cos(ra) * uvw[i, 2]
+    )
 
-      _u_uvw[i, 1] = (
-        cos(ra) * uvw[i, 0]
-        - sin(dec) * sin(ra) * uvw[i, 1]
-        + cos(dec) * sin(ra) * uvw[i, 2]
-      )
+    _u_uvw[i, 1] = (
+      cos(ra) * uvw[i, 0]
+      - sin(dec) * sin(ra) * uvw[i, 1]
+      + cos(dec) * sin(ra) * uvw[i, 2]
+    )
 
-      _u_uvw[i, 2] = cos(dec) * uvw[i, 1] + sin(dec) * uvw[i, 2]
+    _u_uvw[i, 2] = cos(dec) * uvw[i, 1] + sin(dec) * uvw[i, 2]
 
   return unphased_uvw


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated the cython utilities to perform better under wider ranges of inputs.
## Description

<!--- Describe your changes in detail -->
Moved the fast axis dimension to be nblts for all sizes of inputs (before the 3 dimenions was the fast one). This provides significant improvements over the last version especially for larger arrays sizes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
See my attached PDF for timing profiling. "Python" is the original implementation, "Cython" the current, and "Cython 2" the implementation in this pr. 
[xyz_calcs.pdf](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/files/5655578/xyz_calcs.pdf)

I guess it can be considered a bug fix, I fixed the bug that was my poor design last time I wrote this file.

Do we want a changelog update for this? I think there is considerable evidence that the phasing and ECEF/ENU code was actually _slowed down_ last time for large number of `Nblts`. That being said, I didn't want to focus too much on the phasing given the major overhaul that is coming in with the multi-source update.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
