### PR TITLE
Relaxed type comparisons

### DIFF
--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -160,7 +160,7 @@ class UVParameter(object):
                 )
                 return False
             if isinstance(self.value, np.ndarray) and not isinstance(
-                self.value[0], str
+                self.value.item(0), str
             ):
                 if self.value.shape != other.value.shape:
                     print(f"{self.name} parameter value is array, shapes are different")

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -53,7 +53,7 @@ def _get_generic_type(expected_type, strict_type_check=False):
 
     for types in [
         (float, np.floating),
-        (np.unsignedinteger),  # unexpected by unsigned integer could be possible
+        (np.unsignedinteger),  # unexpected but just in case
         (int, np.integer),
         (complex, np.complexfloating),
     ]:

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -275,14 +275,14 @@ class UVParameter(object):
         """
         if self.form == "str":
             return self.form
-        elif isinstance(self.form, np.int):
+        elif isinstance(self.form, (int, np.integer)):
             # Fixed shape, just return the form
             return (self.form,)
         else:
             # Given by other attributes, look up values
             eshape = ()
             for p in self.form:
-                if isinstance(p, np.int):
+                if isinstance(p, (int, np.integer)):
                     eshape = eshape + (p,)
                 else:
                     val = getattr(uvbase, p)

--- a/pyuvdata/tests/test_parameter.py
+++ b/pyuvdata/tests/test_parameter.py
@@ -256,3 +256,37 @@ def test_location_acceptable_none():
     param1 = uvp.LocationParameter(name="p2", value=1, acceptable_range=None)
 
     assert param1.check_acceptability()
+
+
+def test_non_builtin_expected_type():
+    with pytest.raises(ValueError) as cm:
+        uvp.UVParameter(
+            "_test", expected_type="integer",
+        )
+    assert str(cm.value).startswith("Input expected_type is a string with value")
+
+
+def test_strict_expected_type():
+    param1 = uvp.UVParameter("_test", expected_type=np.float128, strict_type_check=True)
+    assert param1.expected_type == np.float128
+
+
+@pytest.mark.parametrize(
+    "in_type,out_type",
+    [
+        (np.float128, (float, np.floating)),
+        (int, (int, np.integer)),
+        (np.complex64, (complex, np.complexfloating)),
+        (np.uint, (np.unsignedinteger)),
+        # str type tests the pass through fallback
+        (str, str),
+        # check builtin attributes too
+        ("str", str),
+        ("int", (int, np.integer)),
+        ("float", (float, np.floating)),
+        ("complex", (complex, np.complexfloating)),
+    ],
+)
+def test_generic_type_conversion(in_type, out_type):
+    param1 = uvp.UVParameter("_test", expected_type=in_type)
+    assert param1.expected_type == out_type

--- a/pyuvdata/tests/test_parameter.py
+++ b/pyuvdata/tests/test_parameter.py
@@ -267,14 +267,14 @@ def test_non_builtin_expected_type():
 
 
 def test_strict_expected_type():
-    param1 = uvp.UVParameter("_test", expected_type=np.float128, strict_type_check=True)
-    assert param1.expected_type == np.float128
+    param1 = uvp.UVParameter("_test", expected_type=np.float64, strict_type_check=True)
+    assert param1.expected_type == np.float64
 
 
 @pytest.mark.parametrize(
     "in_type,out_type",
     [
-        (np.float128, (float, np.floating)),
+        (np.float64, (float, np.floating)),
         (int, (int, np.integer)),
         (np.complex64, (complex, np.complexfloating)),
         (np.uint, (np.unsignedinteger)),

--- a/pyuvdata/tests/test_uvbase.py
+++ b/pyuvdata/tests/test_uvbase.py
@@ -8,6 +8,7 @@
 from astropy.time import Time
 import pytest
 import numpy as np
+from astropy import units
 
 from pyuvdata.uvbase import UVBase
 from pyuvdata.uvbase import _warning
@@ -204,6 +205,17 @@ def test_check_array_type():
     test_obj = UVTest()
     test_obj.floatarr = test_obj.floatarr + 1j * test_obj.floatarr
     pytest.raises(ValueError, test_obj.check)
+
+
+def test_check_quantity_type():
+    """Test check function with wrong array type."""
+    test_obj = UVTest()
+    test_obj.floatarr = (test_obj.floatarr + 1j * test_obj.floatarr) * units.m
+    with pytest.raises(ValueError) as cm:
+        test_obj.check()
+    assert str(cm.value).startswith(
+        "UVParameter _floatarr is not the appropriate type. "
+    )
 
 
 def test_check_array_shape():

--- a/pyuvdata/tests/test_uvbase.py
+++ b/pyuvdata/tests/test_uvbase.py
@@ -9,6 +9,7 @@ from astropy.time import Time
 import pytest
 import numpy as np
 from astropy import units
+from astropy.coordinates import Distance
 
 from pyuvdata.uvbase import UVBase
 from pyuvdata.uvbase import _warning
@@ -114,6 +115,22 @@ class UVTest(UVBase):
             required=False,
         )
 
+        self._quantity_array = uvp.UVParameter(
+            "quantity_array",
+            description="A quantity object.",
+            expected_type=units.Quantity,
+            value=self._floatarr2.value * units.m,
+            form=self._floatarr2.value.size,
+        )
+
+        self._quantity_with_precision = uvp.UVParameter(
+            "quantity_with_precision",
+            description="A quantity, but want a specific precision.",
+            expected_type=float,
+            value=self._floatarr2.value * units.s,
+            form=self._floatarr2.value.size,
+        )
+
         super(UVTest, self).__init__()
 
 
@@ -216,6 +233,18 @@ def test_check_quantity_type():
     assert str(cm.value).startswith(
         "UVParameter _floatarr is not the appropriate type. "
     )
+
+
+def test_wrong_quantity_type():
+    """Test check when given the wrong kind of Quantity."""
+    test_obj = UVTest()
+    test_obj._quantity_array.expected_type = Distance
+    with pytest.raises(
+        ValueError,
+        match="UVParameter _quantity_array is a Quantity "
+        "object but not the appropriate type.",
+    ):
+        test_obj.check()
 
 
 def test_check_array_shape():

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -12,6 +12,7 @@ import warnings
 
 from astropy.time import Time
 import numpy as np
+from astropy.units import Quantity
 
 from . import parameter as uvp
 from . import __version__
@@ -356,8 +357,12 @@ class UVBase(object):
                                         " be: " + str(param.expected_type)
                                     )
                         else:
-                            # Array
-                            if not isinstance(param.value.item(0), param.expected_type):
+                            # Array or quantity
+                            if isinstance(param.value, Quantity):
+                                check_val = param.value.item(0).value
+                            else:
+                                check_val = param.value.item(0)
+                            if not isinstance(check_val, param.expected_type):
                                 raise ValueError(
                                     "UVParameter " + p + " is not the appropriate"
                                     " type. Is: "

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -377,7 +377,7 @@ class UVBase(object):
                                         )
                                     else:
                                         # matches expected type
-                                        continue
+                                        continue  # pragma: no cover
                                 else:
                                     # Expected type is not a Quantity subclass
                                     # Assuming it is a data type like float, int, etc

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -85,7 +85,7 @@ class UVBase(object):
 
         # String to add to history of any files written with this version of pyuvdata
         self.pyuvdata_version_str = (
-            "  Read/written with pyuvdata version: " + __version__ + "."
+            f"  Read/written with pyuvdata version: {__version__ }."
         )
 
     def prop_fget(self, param_name):
@@ -231,8 +231,9 @@ class UVBase(object):
                 other_required.append(p)
             if set(self_required) != set(other_required):
                 print(
-                    "Sets of required parameters do not match. Left is {lset},"
-                    " right is {rset}".format(lset=self_required, rset=other_required)
+                    "Sets of required parameters do not match. "
+                    f"Left is {self_required},"
+                    f" right is {other_required}."
                 )
                 return False
 
@@ -245,8 +246,9 @@ class UVBase(object):
                     other_extra.append(p)
                 if set(self_extra) != set(other_extra):
                     print(
-                        "Sets of extra parameters do not match. Left is {lset},"
-                        " right is {rset}".format(lset=self_extra, rset=other_extra)
+                        "Sets of extra parameters do not match. "
+                        f"Left is {self_extra},"
+                        f" right is {other_extra}."
                     )
                     return False
 
@@ -260,8 +262,8 @@ class UVBase(object):
                 other_param = getattr(other, p)
                 if self_param != other_param:
                     print(
-                        "parameter {} does not match. Left is {},"
-                        " right is {}".format(p, self_param.value, other_param.value)
+                        f"parameter {p} does not match. Left is {self_param.value},"
+                        f" right is {other_param.value}."
                     )
                     p_equal = False
             return p_equal
@@ -306,7 +308,7 @@ class UVBase(object):
                 if ignore_requirements:
                     continue
                 if param.required is True:
-                    raise ValueError("Required UVParameter " + p + " has not been set.")
+                    raise ValueError(f"Required UVParameter {p} has not been set.")
             else:
                 # Check parameter shape
                 eshape = param.expected_shape(self)
@@ -315,7 +317,7 @@ class UVBase(object):
                     # Check that it's a string
                     if not isinstance(param.value, str):
                         raise ValueError(
-                            "UVParameter " + p + " expected to be " "string, but is not"
+                            f"UVParameter {p} expected to be string, but is not."
                         )
                 else:
                     # Check the shape of the parameter value. Note that np.shape
@@ -385,14 +387,14 @@ class UVBase(object):
                             raise ValueError(
                                 f"UVParameter {p} is not the appropriate"
                                 f" type. Is:  {type(val)}. "
-                                f"Should be: {param.expected_type}"
+                                f"Should be: {param.expected_type}."
                             )
 
                 if run_check_acceptability:
                     accept, message = param.check_acceptability()
                     if not accept:
                         raise ValueError(
-                            "UVParameter " + p + " has unacceptable values. " + message
+                            f"UVParameter {p} has unacceptable values. {message}"
                         )
 
         return True

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -360,7 +360,7 @@ class UVBase(object):
                         else:
                             # Array or quantity
                             if isinstance(param.value, Quantity):
-                                # user put expected type as a type of quantity object
+                                # check if user put expected type as a type of quantity
                                 # not a more generic type of number.
                                 if any(
                                     issubclass(param_type, Quantity)

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -749,7 +749,10 @@ class UVData(UVBase):
                         # does will cause an error
                         assert telescope_shape == () and self_shape != "str"
                         array_val = (
-                            np.zeros(self_shape, dtype=telescope_param.expected_type)
+                            np.zeros(
+                                self_shape,
+                                dtype=np.asarray(telescope_param.value).dtype,
+                            )
                             + telescope_param.value
                         )
                         params_set.append(self_param.name)

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -748,11 +748,12 @@ class UVData(UVBase):
                         # object definition, but nothing that a normal user
                         # does will cause an error
                         assert telescope_shape == () and self_shape != "str"
+                        # this parameter is as of this comment most likely a float
+                        # since only diameters and antenna positions will probably
+                        # trigger this else statement
+                        # assign float64 as the type of the array
                         array_val = (
-                            np.zeros(
-                                self_shape,
-                                dtype=np.asarray(telescope_param.value).dtype,
-                            )
+                            np.zeros(self_shape, dtype=np.float64,)
                             + telescope_param.value
                         )
                         params_set.append(self_param.name)

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2767,7 +2767,7 @@ class UVData(UVBase):
         TypeError
             If time is not an astropy.time.Time object or Julian Date as a float
         """
-        if isinstance(time, (float, np.float32)):
+        if isinstance(time, (float, np.floating)):
             time = Time(time, format="jd")
 
         if not isinstance(time, Time):
@@ -5093,7 +5093,7 @@ class UVData(UVBase):
                 )
                 return
         else:
-            if not isinstance(n_times_to_avg, (int, np.int)):
+            if not isinstance(n_times_to_avg, (int, np.integer)):
                 raise ValueError("n_times_to_avg must be an integer.")
         # If we're going to do actual work, reorder the baselines to ensure time is
         # monotonically increasing.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Relaxes the requirement that `expected_type` for a UVParameter object must match precision. Also relaxes some check against explicit precision in `if/else` clauses.
closes #947
## Description
<!--- Describe your changes in detail -->
Makes `expected_type` a tuple of more generic type classes based on inputs (e.g. `expected_type=float` gets cast to `expected_type=(float, numpy.floating)` this allows the parameter value to change precision without breaking a `UVBase.check` call. 
These generic expected types **do not** change the actual precision of the parameter value, just let it change. There are tests is mwa_corr_fits which I've linked that explicitly test against input precisions.
https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/90537f78230d3d34f5db4d39a9f2a18373435437/pyuvdata/uvdata/tests/test_mwa_corr_fits.py#L565-L582

I've added a `strict_type_check` kwarg when instantiating a `UVParameter` object. This negates the generic conversion and requires the value on the parameter to match exactly the input type when a `UVBase.check` call is made.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Some `if/else` statements were checking if inputs were a very specific precision during `isinstance` this should alleviate that in the case where a  user inputs an unusual precision. 

TODO: 
- changelog once we are ready to merge.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Breaking change checklist:
- [x] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [x] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
