### PR TITLE
add support for extra_keywords loading from uvdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added support for `extra_keywords` in UVFlag construction from UVData objects (and paths)
+
 ## [2.1.3] - 2020-12-15
 
 ### Added

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -197,6 +197,16 @@ def test_add_extra_keywords(uvdata_obj):
     assert uvf.extra_keywords.get("keyword3") == 3
 
 
+def test_read_extra_keywords(uvdata_obj):
+    uv = uvdata_obj
+    uv.extra_keywords = {"keyword1": 1, "keyword2": 2}
+    assert "keyword1" in uv.extra_keywords
+    assert "keyword2" in uv.extra_keywords
+    uvf = UVFlag(uv, history="I made a UVFlag object", label="test")
+    assert "keyword1" in uvf.extra_keywords
+    assert "keyword2" in uvf.extra_keywords
+
+
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_init_uvdata_x_orientation(uvdata_obj):
     uv = uvdata_obj

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -2606,6 +2606,8 @@ class UVFlag(UVBase):
                             ).decode("utf8")
                         else:
                             self.extra_keywords[key] = header["extra_keywords"][key][()]
+                else:
+                    self.extra_keywords = {}
 
                 if "label" in header.keys():
                     self.label = header["label"][()].decode("utf8")
@@ -2950,6 +2952,9 @@ class UVFlag(UVBase):
 
         if self.mode == "metric":
             self.weights_array = np.ones(self.metric_array.shape)
+
+        if indata.extra_keywords is not None:
+            self.extra_keywords = indata.extra_keywords
 
         if history not in self.history:
             self.history += history


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request allows loading `UVData` objects bearing `extra_keywords` into `UVFlag` objects, through direct read of a `UVData` object or via loading via file path.

## Motivation and Context

This allows transferable metadata to be shared between related objects (in this case, SS and INS uvdata/uvflag derived objects). The relevant issues are https://github.com/mwilensky768/SSINS/issues/78 https://github.com/mwilensky768/SSINS/issues/73.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [X] My code follows the code style of this project.

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [X] I have added tests to cover my new feature.
- [X] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).