### PR TITLE
Fixing tests to handle duplicate astropy entires

### DIFF
--- a/pyuvdata/tests/test_telescopes.py
+++ b/pyuvdata/tests/test_telescopes.py
@@ -41,7 +41,8 @@ astropy_sites = EarthLocation.get_site_names()
 while "" in astropy_sites:
     astropy_sites.remove("")
 
-expected_known_telescopes = astropy_sites + ["PAPER", "HERA", "SMA"]
+# Using set here is a quick way to drop duplicate entries
+expected_known_telescopes = list(set(astropy_sites + ["PAPER", "HERA", "SMA"]))
 
 
 # Tests for Telescope object

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -691,7 +691,8 @@ def test_known_telescopes():
     while "" in astropy_sites:
         astropy_sites.remove("")
 
-    known_telescopes = astropy_sites + ["PAPER", "HERA", "SMA"]
+    # Using set to drop duplicate entries
+    known_telescopes = list(set(astropy_sites + ["PAPER", "HERA", "SMA"]))
     # calling np.sort().tolist() because [].sort() acts inplace and returns None
     # Before test had None == None
     assert (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A minor fix to repair a couple of tests.

## Description
A duplicate entry in astropy's "known locations" lists has apparently triggered a bug within the testing code for pyuvdata. This is a small fix which basically modifies those tests to use the same logic as found in `known_telescopes` so that the comparisons are equivalent (i.e., both will drop duplicate entries from the list).

## Motivation and Context
Fixes tests for two separate modules.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG] (https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
