### PR TITLE
Mwa memory bloat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Added support for `extra_keywords` in UVFlag construction from UVData objects (and paths)
 
 ### Changed
+- Improved memory usage in reading MWA correlator fits files.
 - Speed improvement in redundant group finder.
 
 ### Fixed

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -44,6 +44,18 @@ cpdef void generate_map(
   numpy.int32_t[:] map_inds,
   numpy.npy_bool[:] conj,
 ):
+  """Compute the map between pfb inputs and antenna numbersself.
+
+  This function operates on input `map_inds` and `conj` arrays inplace.
+
+  Parameters
+  ----------
+  map_inds : 1D numpy array of type int32
+    The array into which mapping indices will be populated.
+  conj : 1D numpy array of type np.bool_
+    The array into which indices of baselines to conjugate will be populated.
+
+  """
   cdef int ant1, ant2, p1, p2, pol_ind, bls_ind, out_ant1, out_ant2
   cdef int out_p1, out_p2, ind1_1, ind1_2, ind2_1, ind2_2, data_index
 
@@ -106,6 +118,25 @@ cpdef numpy.ndarray[ndim=1, dtype=numpy.float64_t] get_cable_len_diffs(
   numpy.int_t[:] ant2_array,
   numpy.ndarray cable_lens,
 ):
+  """Computer the difference in cable lengths for each baseline.
+
+  Parameters
+  ----------
+  Nblts : int
+    The number of baseline times
+  ant1_array : numpy array of type int_t
+    Array of antenna 1 numbers for each baseline.
+  ant2_array : numpy array of type int_t
+    Array of antenna 2 numbers for each baseline.
+  cable_lens : numpy array
+    Array of strings of the length of the cable for each antenna.
+
+  Returns
+  -------
+  cable_diffs : numpy array of type float64
+    Array of lenght Nblts with the difference of cable lengths for each baseline.
+
+  """
   cdef Py_ssize_t i
   cdef int n_cables = cable_lens.shape[0]
   cdef numpy.float64_t[::1] cable_array = np.zeros(n_cables, dtype=np.float64)
@@ -117,7 +148,6 @@ cpdef numpy.ndarray[ndim=1, dtype=numpy.float64_t] get_cable_len_diffs(
   # check if the cable length already has the velocity factor applied
   # this loop is very python-y but there is no real gain to trying to make it C-esque
   for i in range(n_cables):
-
     if cable_lens[i][:3] == "EL_":
       cable_array[i] = float(cable_lens[i][3:])
     else:

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -41,8 +41,8 @@ cpdef dict input_output_mapping():
 @cython.wraparound(False)
 cpdef void generate_map(
   dict ants_to_pf,
-  numpy.int32_t[:] map_inds,
-  numpy.npy_bool[:] conj,
+  numpy.int32_t[::1] map_inds,
+  numpy.npy_bool[::1] conj,
 ):
   """Compute the map between pfb inputs and antenna numbersself.
 
@@ -114,11 +114,14 @@ cpdef void generate_map(
 @cython.wraparound(False)
 cpdef numpy.ndarray[ndim=1, dtype=numpy.float64_t] get_cable_len_diffs(
   int Nblts,
-  numpy.int_t[:] ant1_array,
-  numpy.int_t[:] ant2_array,
+  numpy.int_t[::1] ant1_array,
+  numpy.int_t[::1] ant2_array,
   numpy.ndarray cable_lens,
 ):
   """Computer the difference in cable lengths for each baseline.
+
+  The inputs are one dimensional and will be both C and F contiguous but
+  we want to declare the memory layout in a consistent way with the rest of the code.
 
   Parameters
   ----------

--- a/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits_src/corr_fits.pyx
@@ -108,8 +108,8 @@ cpdef numpy.ndarray[ndim=1, dtype=numpy.float64_t] get_cable_len_diffs(
 ):
   cdef Py_ssize_t i
   cdef int n_cables = cable_lens.shape[0]
-  cdef numpy.float64_t[::1] cable_array = np.zeros(n_cables, dtype=np.float_)
-  cdef numpy.float64_t[::1] cable_diffs = np.zeros(Nblts, dtype=np.float_)
+  cdef numpy.float64_t[::1] cable_array = np.zeros(n_cables, dtype=np.float64)
+  cdef numpy.float64_t[::1] cable_diffs = np.zeros(Nblts, dtype=np.float64)
   # "the velocity factor of electic fields in RG-6 like coax"
   # from MWA_Tools/CONV2UVFITS/convutils.h
   cdef float v_factor = 1.204

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -768,15 +768,15 @@ class MWACorrFITS(UVData):
                 # by a factor of 64 here. For a more detailed explanation, see PR #908.
                 dig_gains = dig_gains[:, coarse_inds] / 64
                 dig_gains = np.repeat(dig_gains, num_fine_chans, axis=1)
-                dig_gains1 = dig_gains[self.ant_1_array, :]
-                dig_gains2 = dig_gains[self.ant_2_array, :]
-                dig_gains1 = dig_gains1[:, :, np.newaxis]
-                dig_gains2 = dig_gains2[:, :, np.newaxis]
-                if self.data_array.dtype != np.complex128:
-                    self.data_array = self.data_array.astype(np.complex128)
-                self.data_array = self.data_array / (dig_gains1 * dig_gains2)
+
+                self.data_array /= (
+                    dig_gains[self.ant_1_array, :, np.newaxis]
+                    * dig_gains[self.ant_2_array, :, np.newaxis]
+                )
+
                 if self.data_array.dtype != data_array_dtype:
                     self.data_array = self.data_array.astype(data_array_dtype)
+
             # divide out coarse band shape
             if remove_coarse_band:
                 # get coarse band shape
@@ -789,10 +789,9 @@ class MWACorrFITS(UVData):
                 cb_array = np.average(cb_array, axis=1)
                 cb_array = cb_array[0:num_fine_chans]
                 cb_array = np.tile(cb_array, len(included_coarse_chans))
-                cb_array = cb_array[:, np.newaxis]
-                if self.data_array.dtype != np.complex128:
-                    self.data_array = self.data_array.astype(np.complex128)
-                self.data_array = self.data_array / cb_array
+
+                self.data_array /= cb_array[:, np.newaxis]
+
                 if self.data_array.dtype != data_array_dtype:
                     self.data_array = self.data_array.astype(data_array_dtype)
 

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -776,9 +776,6 @@ class MWACorrFITS(UVData):
                     * dig_gains[self.ant_2_array, :, np.newaxis]
                 )
 
-                if self.data_array.dtype != data_array_dtype:
-                    self.data_array = self.data_array.astype(data_array_dtype)
-
             # divide out coarse band shape
             if remove_coarse_band:
                 # get coarse band shape
@@ -793,9 +790,6 @@ class MWACorrFITS(UVData):
                 cb_array = np.tile(cb_array, len(included_coarse_chans))
 
                 self.data_array /= cb_array[:, np.newaxis]
-
-                if self.data_array.dtype != data_array_dtype:
-                    self.data_array = self.data_array.astype(data_array_dtype)
 
             # cable delay corrections
             if correct_cable_len:

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -708,6 +708,10 @@ class MWACorrFITS(UVData):
             # map the pfb input indices to the pfb output indices
             # these are the indices for the data corresponding to the initial
             # antenna/pol pair
+
+            # These two 1D arrays will be both C and F contiguous
+            # but we are explicitly declaring C to be consistent with the rest
+            # of the python which interacts with the C/Cython code.
             # generate a mapping index array
             map_inds = np.zeros((self.Nbls * self.Npols), dtype=np.int32, order="C",)
             # generate a conjugation array

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -11,6 +11,7 @@ import numpy as np
 from pyuvdata import UVData
 from pyuvdata.data import DATA_PATH
 import pyuvdata.tests as uvtest
+from pyuvdata.uvdata.mwa_corr_fits import input_output_mapping
 from astropy.io import fits
 
 # set up MWA correlator file list
@@ -786,3 +787,25 @@ def test_start_flag_bad_string():
     with pytest.raises(ValueError) as cm:
         uv.read(filelist[0:2], flag_init=True, start_flag="badstring")
     assert str(cm.value).startswith("start_flag must be int or float or 'goodtime'")
+
+
+def test_input_output_mapping():
+    """Test the input_output_mapping function."""
+    mapping_dict = {}
+    # fmt: off
+    pfb_mapper = [
+        0, 16, 32, 48, 1, 17, 33, 49, 2, 18, 34, 50, 3, 19, 35, 51,
+        4, 20, 36, 52, 5, 21, 37, 53, 6, 22, 38, 54, 7, 23, 39, 55,
+        8, 24, 40, 56, 9, 25, 41, 57, 10, 26, 42, 58, 11, 27, 43, 59,
+        12, 28, 44, 60, 13, 29, 45, 61, 14, 30, 46, 62, 15, 31, 47, 63,
+    ]
+    # fmt: on
+    for p in range(4):
+        for i in range(64):
+            mapping_dict[pfb_mapper[i] + p * 64] = p * 64 + i
+
+    # compare with output from function
+    function_output = input_output_mapping()
+    assert function_output == mapping_dict
+
+    return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Moved fits reading code to own function. Some cython clean up as well. 

I actually think there are a few type casting lines that I left in that now _cannot_ be hit by coverage (where previously we would cast up to double precision then back but now the casting is done in cache during an inplace division operation).

## Description
<!--- Describe your changes in detail -->
Moved the inner reading loop to its own function, this provides better clues to the garbage collector to close handles and release memory.
Change the `generate_map` function in the corr_fits extension to operate inplace on the `map_inds` and `conj` arrays. These were already being provided as inputs to the function so it seemed silly for them to also be outputs.
Touched up the cable length differencing code. Made inputs memoryviews and tweaked the actual difference to run in C not python. notebook provided for reference on development. 
[mwa_corr_fits.pdf](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/files/5857191/mwa_corr_fits.pdf)

Notebook from memory profiling. This current implementation looks at least as good as reading each file individually then `fast_concat`ing them together. The latter method started breaking down on test files as the `lst_array` would being to differ when trying to read > 10 files.
[mwa_memory_bloat.pdf](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/files/5857195/mwa_memory_bloat.pdf)



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Closes #954  which identified potential memory leak when reading in MWA corr fits files. Always looking to make the cython better when I touch the corr first code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
