### PR TITLE
Fixes for numpy v1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ you will need the following packages:
 * pytest-cases >= 3
 * pytest-xdist
 * pytest-cov
-* cython   (This is necessary for coverage reporting of cython extensions)
+* cython >=0.23  (This is necessary for coverage reporting of cython extensions)
 * coverage
 * pre-commit
 * sphinx

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,9 +1,10 @@
 name: pyuvdata
 channels:
-  - defaults
   - conda-forge
+  - defaults
 dependencies:
-  - astropy
+  - python>3.6
+  - astropy>=3.2.3
   - astropy-healpix
   - h5py
   - numpy>=1.18
@@ -15,9 +16,10 @@ dependencies:
   - setuptools_scm
   - sphinx
   - coverage
+  - pytest>=6.2.0
   - pytest-cov
-  - cython
+  - cython>=0.23
   - pip
   - pip:
-      - pytest-cases>=1.12.1
+      - pytest-cases>=3
       - pytest-xdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
-requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm", "numpy>=1.15", "cython>=0.23"]
+requires = ["setuptools>=30.3.0",
+            "wheel",
+            "setuptools_scm",
+            "oldest-supported-numpy",
+            "cython>=0.23"]
 build-backend = "setuptools.build_meta"

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -39,6 +39,7 @@ def _get_generic_type(expected_type, strict_type_check=False):
     Returns
     -------
     Tuple of types based on input expected_type
+
     """
     if isinstance(expected_type, str):
         try:
@@ -108,6 +109,7 @@ class UVParameter(object):
         When True, the input expected_type is used exactly, otherwise a more
         generic type is found to allow changes in precicions or to/from numpy
         dtypes to not break checks.
+
     """
 
     def __init__(

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -446,7 +446,7 @@ class LocationParameter(UVParameter):
             spoof_val=spoof_val,
             form=3,
             description=description,
-            expected_type=np.float,
+            expected_type=np.floating,
             acceptable_range=acceptable_range,
             tols=tols,
         )

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -326,14 +326,14 @@ class UVParameter(object):
         """
         if self.form == "str":
             return self.form
-        elif isinstance(self.form, (int, np.int_)):
+        elif isinstance(self.form, (int, np.integer)):
             # Fixed shape, just return the form
             return (self.form,)
         else:
             # Given by other attributes, look up values
             eshape = ()
             for p in self.form:
-                if isinstance(p, (int, np.int_)):
+                if isinstance(p, (int, np.integer)):
                     eshape = eshape + (p,)
                 else:
                     val = getattr(uvbase, p)

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -171,8 +171,7 @@ class UVParameter(object):
                 if not isinstance(self.value, other.expected_type):
                     print(
                         f"{self.name} parameter has incompatible types. Left is "
-                        f"{self.value.expected_type}, right is "
-                        f"{other.value.expected_type}"
+                        f"{self.expected_type}, right is {other.expected_type}"
                     )
                     return False
             if other.strict_type:
@@ -180,8 +179,7 @@ class UVParameter(object):
                 if not isinstance(other.value, self.expected_type):
                     print(
                         f"{self.name} parameter has incompatible types. Left is "
-                        f"{self.value.expected_type}, right is "
-                        f"{other.value.expected_type}"
+                        f"{self.expected_type}, right is {other.expected_type}"
                     )
                     return False
 
@@ -235,6 +233,12 @@ class UVParameter(object):
                         str_type = True
 
                 if not str_type:
+                    if isinstance(other.value, np.ndarray):
+                        print(
+                            f"{self.name} parameter value is not an array, "
+                            "but other is not"
+                        )
+                        return False
                     try:
                         if not np.allclose(
                             np.array(self.value),

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -54,7 +54,7 @@ def _get_generic_type(expected_type, strict_type_check=False):
     for types in [
         (float, np.floating),
         (np.unsignedinteger),  # unexpected but just in case
-        (int, np.int_),
+        (int, np.integer),
         (complex, np.complexfloating),
     ]:
         if issubclass(expected_type, types):

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -163,8 +163,6 @@ class UVParameter(object):
                 if self.value is not None:
                     print("f{self.name} is None on right, but not left")
                     return False
-                else:
-                    return True
             # check to see if strict types are used
             if self.strict_type:
                 # types must match

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -446,7 +446,7 @@ class LocationParameter(UVParameter):
             spoof_val=spoof_val,
             form=3,
             description=description,
-            expected_type=np.floating,
+            expected_type=float,
             acceptable_range=acceptable_range,
             tols=tols,
         )

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -54,7 +54,7 @@ def _get_generic_type(expected_type, strict_type_check=False):
     for types in [
         (float, np.floating),
         (np.unsignedinteger),  # unexpected but just in case
-        (int, np.integer),
+        (int, np.int_),
         (complex, np.complexfloating),
     ]:
         if issubclass(expected_type, types):
@@ -326,14 +326,14 @@ class UVParameter(object):
         """
         if self.form == "str":
             return self.form
-        elif isinstance(self.form, (int, np.integer)):
+        elif isinstance(self.form, (int, np.int_)):
             # Fixed shape, just return the form
             return (self.form,)
         else:
             # Given by other attributes, look up values
             eshape = ()
             for p in self.form:
-                if isinstance(p, (int, np.integer)):
+                if isinstance(p, (int, np.int_)):
                     eshape = eshape + (p,)
                 else:
                     val = getattr(uvbase, p)

--- a/pyuvdata/telescopes.py
+++ b/pyuvdata/telescopes.py
@@ -99,7 +99,7 @@ class Telescope(uvbase.UVBase):
             "antenna_diameters",
             required=False,
             description=desc,
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3,  # 1 mm
         )
 
@@ -143,7 +143,7 @@ class Telescope(uvbase.UVBase):
             required=False,
             description=desc,
             form=("Nants_telescope", 3),
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3,  # 1 mm
         )
 

--- a/pyuvdata/telescopes.py
+++ b/pyuvdata/telescopes.py
@@ -99,7 +99,7 @@ class Telescope(uvbase.UVBase):
             "antenna_diameters",
             required=False,
             description=desc,
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3,  # 1 mm
         )
 
@@ -143,7 +143,7 @@ class Telescope(uvbase.UVBase):
             required=False,
             description=desc,
             form=("Nants_telescope", 3),
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3,  # 1 mm
         )
 

--- a/pyuvdata/tests/__init__.py
+++ b/pyuvdata/tests/__init__.py
@@ -118,6 +118,10 @@ class WarningsChecker(warnings.catch_warnings):
         # Filter annoying Cython warnings that serve no good purpose. see numpy#432
         warnings.filterwarnings("ignore", message="numpy.dtype size changed")
         warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+        # PLP: Temporarily add this filter as well.
+        # numpy v1.20 causes h5py to issue warnings. Must keep as is for now to
+        # avoid test failures, should change back later.
+        warnings.filterwarnings("ignore", message="Passing None into shape arguments")
 
         # Filter iers warnings if iers.conf.auto_max_age is set to None, as we
         # do in testing if the iers url is down. See conftest.py for more info.

--- a/pyuvdata/tests/test_parameter.py
+++ b/pyuvdata/tests/test_parameter.py
@@ -275,14 +275,14 @@ def test_strict_expected_type():
     "in_type,out_type",
     [
         (np.float64, (float, np.floating)),
-        (int, (int, np.int_)),
+        (int, (int, np.integer)),
         (np.complex64, (complex, np.complexfloating)),
         (np.uint, (np.unsignedinteger)),
         # str type tests the pass through fallback
         (str, str),
         # check builtin attributes too
         ("str", str),
-        ("int", (int, np.int_)),
+        ("int", (int, np.integer)),
         ("float", (float, np.floating)),
         ("complex", (complex, np.complexfloating)),
     ],

--- a/pyuvdata/tests/test_parameter.py
+++ b/pyuvdata/tests/test_parameter.py
@@ -275,14 +275,14 @@ def test_strict_expected_type():
     "in_type,out_type",
     [
         (np.float64, (float, np.floating)),
-        (int, (int, np.integer)),
+        (int, (int, np.int_)),
         (np.complex64, (complex, np.complexfloating)),
         (np.uint, (np.unsignedinteger)),
         # str type tests the pass through fallback
         (str, str),
         # check builtin attributes too
         ("str", str),
-        ("int", (int, np.integer)),
+        ("int", (int, np.int_)),
         ("float", (float, np.floating)),
         ("complex", (complex, np.complexfloating)),
     ],

--- a/pyuvdata/tests/test_parameter.py
+++ b/pyuvdata/tests/test_parameter.py
@@ -290,3 +290,64 @@ def test_strict_expected_type():
 def test_generic_type_conversion(in_type, out_type):
     param1 = uvp.UVParameter("_test", expected_type=in_type)
     assert param1.expected_type == out_type
+
+
+def test_strict_expected_type_equality():
+    # make sure equality passes if one is strict and one is generic
+    param1 = uvp.UVParameter(
+        "_test1",
+        value=np.float64(3.0),
+        expected_type=np.float64,
+        strict_type_check=True,
+    )
+    param2 = uvp.UVParameter(
+        "_test2", value=3.0, expected_type=float, strict_type_check=False
+    )
+    assert param1 == param2
+    assert param2 == param1
+
+    # make sure it fails when both are strict and different
+    param3 = uvp.UVParameter(
+        "_test3", value=3.0, expected_type=float, strict_type_check=True
+    )
+    assert param1 != param3
+    assert param3 != param1
+    assert param2 == param3
+
+    # also try different precision values
+    param4 = uvp.UVParameter(
+        "_test4",
+        value=np.float32(3.0),
+        expected_type=np.float32,
+        strict_type_check=True,
+    )
+    assert param1 != param4
+
+    # make sure it passes when both are strict and equivalent
+    param5 = uvp.UVParameter(
+        "_test5",
+        value=np.float64(3.0),
+        expected_type=np.float64,
+        strict_type_check=True,
+    )
+    assert param1 == param5
+
+    return
+
+
+def test_scalar_array_parameter_mismatch():
+    param1 = uvp.UVParameter("_test1", value=3.0, expected_type=float)
+    param2 = uvp.UVParameter("_test2", value=np.asarray([3.0]), expected_type=float)
+    assert param1 != param2
+    assert param2 != param1
+
+    return
+
+
+def test_value_none_parameter_mismatch():
+    param1 = uvp.UVParameter("_test1", value=3.0, expected_type=float)
+    param2 = uvp.UVParameter("_test2", value=None)
+    assert param1 != param2
+    assert param2 != param1
+
+    return

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -1277,7 +1277,7 @@ def test_mean_weights_and_weights_square():
     w[0, :] = 0
     w[:, 0] = 0
     out, wo = uvutils.mean_collapse(data, weights=w, axis=0, return_weights=True)
-    ans = np.arange(data.shape[1]).astype(np.float) + 1
+    ans = np.arange(data.shape[1]).astype(np.float64) + 1
     ans[0] = np.inf
     assert np.array_equal(out, ans)
     ans = (data.shape[0] - 1) * np.ones(data.shape[1])
@@ -1300,7 +1300,7 @@ def test_mean_infs():
     data[:, 0] = np.inf
     data[0, :] = np.inf
     out, wo = uvutils.mean_collapse(data, axis=0, return_weights=True)
-    ans = np.arange(data.shape[1]).astype(np.float)
+    ans = np.arange(data.shape[1]).astype(np.float64)
     ans[0] = np.inf
     assert np.array_equal(out, ans)
     ans = (data.shape[0] - 1) * np.ones(data.shape[1])
@@ -1360,12 +1360,12 @@ def test_or_collapse_weights():
     # Fake data
     data = np.zeros((50, 25), np.bool_)
     data[0, 8] = True
-    w = np.ones_like(data, np.float)
+    w = np.ones_like(data, np.float64)
     o, wo = uvutils.or_collapse(data, axis=0, weights=w, return_weights=True)
     ans = np.zeros(25, np.bool_)
     ans[8] = True
     assert np.array_equal(o, ans)
-    assert np.array_equal(wo, np.ones_like(o, dtype=np.float))
+    assert np.array_equal(wo, np.ones_like(o, dtype=np.float64))
     w[0, 8] = 0.3
     with uvtest.check_warnings(UserWarning, "Currently weights are"):
         o = uvutils.or_collapse(data, axis=0, weights=w)
@@ -1396,11 +1396,11 @@ def test_and_collapse_weights():
     # Fake data
     data = np.zeros((50, 25), np.bool_)
     data[0, :] = True
-    w = np.ones_like(data, np.float)
+    w = np.ones_like(data, np.float64)
     o, wo = uvutils.and_collapse(data, axis=0, weights=w, return_weights=True)
     ans = np.zeros(25, np.bool_)
     assert np.array_equal(o, ans)
-    assert np.array_equal(wo, np.ones_like(o, dtype=np.float))
+    assert np.array_equal(wo, np.ones_like(o, dtype=np.float64))
     w[0, 8] = 0.3
     with uvtest.check_warnings(UserWarning, "Currently weights are"):
         o = uvutils.and_collapse(data, axis=0, weights=w)

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -1214,7 +1214,7 @@ def test_collapse_quadmean_returned_with_weights_square_without_weights():
 
 def test_collapse_or_no_return_no_weights():
     # Fake data
-    data = np.zeros((50, 25), np.bool)
+    data = np.zeros((50, 25), np.bool_)
     data[0, 8] = True
     o = uvutils.collapse(data, "or", axis=0)
     o1 = uvutils.or_collapse(data, axis=0)
@@ -1223,7 +1223,7 @@ def test_collapse_or_no_return_no_weights():
 
 def test_collapse_and_no_return_no_weights():
     # Fake data
-    data = np.zeros((50, 25), np.bool)
+    data = np.zeros((50, 25), np.bool_)
     data[0, :] = True
     o = uvutils.collapse(data, "and", axis=0)
     o1 = uvutils.and_collapse(data, axis=0)
@@ -1342,14 +1342,14 @@ def test_quadmean():
 
 def test_or_collapse():
     # Fake data
-    data = np.zeros((50, 25), np.bool)
+    data = np.zeros((50, 25), np.bool_)
     data[0, 8] = True
     o = uvutils.or_collapse(data, axis=0)
-    ans = np.zeros(25, np.bool)
+    ans = np.zeros(25, np.bool_)
     ans[8] = True
     assert np.array_equal(o, ans)
     o = uvutils.or_collapse(data, axis=1)
-    ans = np.zeros(50, np.bool)
+    ans = np.zeros(50, np.bool_)
     ans[0] = True
     assert np.array_equal(o, ans)
     o = uvutils.or_collapse(data)
@@ -1358,11 +1358,11 @@ def test_or_collapse():
 
 def test_or_collapse_weights():
     # Fake data
-    data = np.zeros((50, 25), np.bool)
+    data = np.zeros((50, 25), np.bool_)
     data[0, 8] = True
     w = np.ones_like(data, np.float)
     o, wo = uvutils.or_collapse(data, axis=0, weights=w, return_weights=True)
-    ans = np.zeros(25, np.bool)
+    ans = np.zeros(25, np.bool_)
     ans[8] = True
     assert np.array_equal(o, ans)
     assert np.array_equal(wo, np.ones_like(o, dtype=np.float))
@@ -1379,13 +1379,13 @@ def test_or_collapse_errors():
 
 def test_and_collapse():
     # Fake data
-    data = np.zeros((50, 25), np.bool)
+    data = np.zeros((50, 25), np.bool_)
     data[0, :] = True
     o = uvutils.and_collapse(data, axis=0)
-    ans = np.zeros(25, np.bool)
+    ans = np.zeros(25, np.bool_)
     assert np.array_equal(o, ans)
     o = uvutils.and_collapse(data, axis=1)
-    ans = np.zeros(50, np.bool)
+    ans = np.zeros(50, np.bool_)
     ans[0] = True
     assert np.array_equal(o, ans)
     o = uvutils.and_collapse(data)
@@ -1394,11 +1394,11 @@ def test_and_collapse():
 
 def test_and_collapse_weights():
     # Fake data
-    data = np.zeros((50, 25), np.bool)
+    data = np.zeros((50, 25), np.bool_)
     data[0, :] = True
     w = np.ones_like(data, np.float)
     o, wo = uvutils.and_collapse(data, axis=0, weights=w, return_weights=True)
-    ans = np.zeros(25, np.bool)
+    ans = np.zeros(25, np.bool_)
     assert np.array_equal(o, ans)
     assert np.array_equal(wo, np.ones_like(o, dtype=np.float))
     w[0, 8] = 0.3

--- a/pyuvdata/tests/test_uvbase.py
+++ b/pyuvdata/tests/test_uvbase.py
@@ -34,7 +34,7 @@ class UVTest(UVBase):
         )
 
         self._float1 = uvp.UVParameter(
-            "float1", description="float value", expected_type=np.float, value=18.2
+            "float1", description="float value", expected_type=float, value=18.2
         )
 
         self._string1 = uvp.UVParameter(
@@ -49,7 +49,7 @@ class UVTest(UVBase):
             "floatarr",
             description="float array",
             form=("int1", "int2"),
-            expected_type=np.float,
+            expected_type=float,
             value=np.random.rand(self._int1.value, self._int2.value),
         )
 
@@ -57,7 +57,7 @@ class UVTest(UVBase):
             "floatarr2",
             description="float array",
             form=4,
-            expected_type=np.float,
+            expected_type=float,
             value=np.random.rand(4),
         )
 
@@ -78,7 +78,7 @@ class UVTest(UVBase):
         )
 
         self._angle = uvp.AngleParameter(
-            "angle", description="angle", expected_type=np.float, value=np.pi / 4.0
+            "angle", description="angle", expected_type=float, value=np.pi / 4.0
         )
 
         self._location = uvp.LocationParameter(
@@ -222,7 +222,7 @@ def test_string_form_check():
 def test_single_value_check():
     """Test check function with wrong type."""
     test_obj = UVTest()
-    test_obj.int1 = np.float(test_obj.int1)
+    test_obj.int1 = np.float64(test_obj.int1)
     pytest.raises(ValueError, test_obj.check)
 
 
@@ -279,7 +279,7 @@ def test_quantity_scalar_type():
 def test_check_array_shape():
     """Test check function with wrong array dimensions."""
     test_obj = UVTest()
-    test_obj.floatarr = np.array([4, 5, 6], dtype=np.float)
+    test_obj.floatarr = np.array([4, 5, 6], dtype=np.float64)
     pytest.raises(ValueError, test_obj.check)
 
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1456,7 +1456,7 @@ def or_collapse(
     if (weights is not None) and not np.all(weights == weights.reshape(-1)[0]):
         warnings.warn("Currently weights are not handled when OR-ing boolean arrays.")
     if return_weights:
-        return out, np.ones_like(out, dtype=np.float)
+        return out, np.ones_like(out, dtype=np.float64)
     else:
         return out
 
@@ -1488,7 +1488,7 @@ def and_collapse(
     if (weights is not None) and not np.all(weights == weights.reshape(-1)[0]):
         warnings.warn("Currently weights are not handled when AND-ing boolean arrays.")
     if return_weights:
-        return out, np.ones_like(out, dtype=np.float)
+        return out, np.ones_like(out, dtype=np.float64)
     else:
         return out
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1450,7 +1450,7 @@ def or_collapse(
         NOT USED, but kept for symmetry with other collapsing functions.
 
     """
-    if arr.dtype != np.bool:
+    if arr.dtype != np.bool_:
         raise ValueError("Input to or_collapse function must be boolean array")
     out = np.any(arr, axis=axis)
     if (weights is not None) and not np.all(weights == weights.reshape(-1)[0]):
@@ -1482,7 +1482,7 @@ def and_collapse(
         NOT USED, but kept for symmetry with other collapsing functions.
 
     """
-    if arr.dtype != np.bool:
+    if arr.dtype != np.bool_:
         raise ValueError("Input to and_collapse function must be boolean array")
     out = np.all(arr, axis=axis)
     if (weights is not None) and not np.all(weights == weights.reshape(-1)[0]):

--- a/pyuvdata/uvbeam/cst_beam.py
+++ b/pyuvdata/uvbeam/cst_beam.py
@@ -249,7 +249,7 @@ class CSTBeam(UVBeam):
             )
         else:
             self.data_array = np.zeros(
-                self._data_array.expected_shape(self), dtype=np.complex
+                self._data_array.expected_shape(self), dtype=np.complex128
             )
 
         if frequency is not None:

--- a/pyuvdata/uvbeam/mwa_beam.py
+++ b/pyuvdata/uvbeam/mwa_beam.py
@@ -234,7 +234,7 @@ class MWABeam(UVBeam):
                     dipole, freq = name[1:].split("_")
                     pol_names.add(pol)
                     dipole_names.add(dipole)
-                    freq = np.int(freq)
+                    freq = np.int64(freq)
                     freqs_hz.add(freq)
 
                     if pol not in max_length:
@@ -645,7 +645,7 @@ class MWABeam(UVBeam):
         self.Nspws = 1
         self.spw_array = np.array([0])
         self.Nfreqs = freqs_use.size
-        self.freq_array = freqs_use.astype(np.float)
+        self.freq_array = freqs_use.astype(np.float64)
         self.freq_array = self.freq_array[np.newaxis, :]
         self.bandpass_array = np.ones((self.Nspws, self.Nfreqs))
 

--- a/pyuvdata/uvbeam/tests/test_beamfits.py
+++ b/pyuvdata/uvbeam/tests/test_beamfits.py
@@ -658,7 +658,7 @@ def test_extra_keywords_int(tmp_path, hera_beam_casa):
     testfile = str(tmp_path / "outtest_beam.fits")
 
     # check handling of int-like keywords
-    beam_in.extra_keywords["int1"] = np.int(5)
+    beam_in.extra_keywords["int1"] = np.int64(5)
     beam_in.extra_keywords["int2"] = 7
     beam_in.write_beamfits(testfile, clobber=True)
     beam_out.read_beamfits(testfile, run_check=False)

--- a/pyuvdata/uvbeam/tests/test_uvbeam.py
+++ b/pyuvdata/uvbeam/tests/test_uvbeam.py
@@ -661,7 +661,7 @@ def test_freq_interp_real_and_complex(cst_power_2freq):
     pb_int = pbeam.interp(freq_array=freqs)[0]
 
     # interpolate cubic on complex data and compare to ensure they are the same
-    pbeam.data_array = pbeam.data_array.astype(np.complex)
+    pbeam.data_array = pbeam.data_array.astype(np.complex128)
     pb_int2 = pbeam.interp(freq_array=freqs)[0]
     assert np.all(np.isclose(np.abs(pb_int - pb_int2), 0))
 
@@ -1154,7 +1154,7 @@ def test_healpix_interpolation(cst_efield_2freq):
     assert np.allclose(interp_data_array[:, :, 1:2], interp_data_array2[:, :, :1])
 
     # change complex data_array to real data_array and test again
-    assert power_beam.data_array.dtype == np.complex
+    assert power_beam.data_array.dtype == np.complex128
     power_beam.data_array = np.abs(power_beam.data_array)
     interp_data_array, interp_basis_vector = power_beam.interp(
         az_array=az_orig_vals, za_array=za_orig_vals, freq_array=freq_orig_vals

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -136,7 +136,7 @@ class UVBeam(UVBase):
         self._axis1_array = uvp.UVParameter(
             "axis1_array",
             description=desc,
-            expected_type=np.floating,
+            expected_type=float,
             required=False,
             form=("Naxes1",),
         )
@@ -156,7 +156,7 @@ class UVBeam(UVBase):
         self._axis2_array = uvp.UVParameter(
             "axis2_array",
             description=desc,
-            expected_type=np.floating,
+            expected_type=float,
             required=False,
             form=("Naxes2",),
         )
@@ -224,7 +224,7 @@ class UVBeam(UVBase):
             "basis_vector_array",
             description=desc,
             required=False,
-            expected_type=np.floating,
+            expected_type=float,
             form=("Naxes_vec", "Ncomponents_vec", "Naxes2", "Naxes1"),
             acceptable_range=(0, 1),
             tols=1e-3,
@@ -282,7 +282,7 @@ class UVBeam(UVBase):
             "freq_array",
             description=desc,
             form=("Nspws", "Nfreqs"),
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3,
         )  # mHz
 
@@ -343,7 +343,7 @@ class UVBeam(UVBase):
         self._bandpass_array = uvp.UVParameter(
             "bandpass_array",
             description=desc,
-            expected_type=np.floating,
+            expected_type=float,
             form=("Nspws", "Nfreqs"),
             tols=1e-3,
         )
@@ -433,7 +433,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=(2, "Nelements"),
-            expected_type=np.floating,
+            expected_type=float,
         )
 
         desc = (
@@ -445,7 +445,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=("Nelements",),
-            expected_type=np.floating,
+            expected_type=float,
         )
 
         desc = (
@@ -457,7 +457,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=("Nelements",),
-            expected_type=np.floating,
+            expected_type=float,
         )
 
         desc = (
@@ -539,7 +539,7 @@ class UVBeam(UVBase):
             "reference_impedance",
             required=False,
             description=desc,
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3,
         )
 
@@ -549,7 +549,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=("Nspws", "Nfreqs"),
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3,
         )
 
@@ -559,7 +559,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=("Nspws", "Nfreqs"),
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3,
         )
 
@@ -569,7 +569,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=("Nspws", "Nfreqs"),
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3,
         )
 
@@ -583,7 +583,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=(4, "Nspws", "Nfreqs"),
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3,
         )
 
@@ -708,7 +708,7 @@ class UVBeam(UVBase):
         self._polarization_array.required = True
 
         # If cross pols are included, the power beam is complex. Otherwise it's real
-        self._data_array.expected_type = np.floating
+        self._data_array.expected_type = float
         for pol in self.polarization_array:
             if pol in [3, 4, -3, -4, -7, -8]:
                 self._data_array.expected_type = complex
@@ -2030,7 +2030,7 @@ class UVBeam(UVBase):
         ), "pixel_coordinate_system must be healpix"
         # assert beam_type is power
         assert self.beam_type == "power", "beam_type must be power"
-        if isinstance(pol, (str, np.str)):
+        if isinstance(pol, (str, np.str_)):
             pol = uvutils.polstr2num(pol, x_orientation=self.x_orientation)
         pol_array = self.polarization_array
         if pol in pol_array:
@@ -2063,7 +2063,7 @@ class UVBeam(UVBase):
             Integral of the beam across the sky, units: steradians.
 
         """
-        if isinstance(pol, (str, np.str)):
+        if isinstance(pol, (str, np.str_)):
             pol = uvutils.polstr2num(pol, x_orientation=self.x_orientation)
         if self.beam_type != "power":
             raise ValueError("beam_type must be power")
@@ -2105,7 +2105,7 @@ class UVBeam(UVBase):
             Integral of the beam^2 across the sky, units: steradians.
 
         """
-        if isinstance(pol, (str, np.str)):
+        if isinstance(pol, (str, np.str_)):
             pol = uvutils.polstr2num(pol, x_orientation=self.x_orientation)
         if self.beam_type != "power":
             raise ValueError("beam_type must be power")

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -2727,7 +2727,7 @@ class UVBeam(UVBase):
             history_update_string += "healpix pixels"
             n_selects += 1
 
-            pix_inds = np.zeros(0, dtype=np.int)
+            pix_inds = np.zeros(0, dtype=np.int64)
             for p in pixels:
                 if p in beam_object.pixel_array:
                     pix_inds = np.append(
@@ -2766,7 +2766,7 @@ class UVBeam(UVBase):
                 history_update_string += "frequencies"
             n_selects += 1
 
-            freq_inds = np.zeros(0, dtype=np.int)
+            freq_inds = np.zeros(0, dtype=np.int64)
             # this works because we only allow one SPW. This will have to be
             # reworked when we support more.
             freq_arr_use = beam_object.freq_array[0, :]
@@ -2834,7 +2834,7 @@ class UVBeam(UVBase):
                 history_update_string += "feeds"
             n_selects += 1
 
-            feed_inds = np.zeros(0, dtype=np.int)
+            feed_inds = np.zeros(0, dtype=np.int64)
             for f in feeds:
                 if f in beam_object.feed_array:
                     feed_inds = np.append(
@@ -2867,7 +2867,7 @@ class UVBeam(UVBase):
                 history_update_string += "polarizations"
             n_selects += 1
 
-            pol_inds = np.zeros(0, dtype=np.int)
+            pol_inds = np.zeros(0, dtype=np.int64)
             for p in polarizations:
                 if p in beam_object.polarization_array:
                     pol_inds = np.append(

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -136,7 +136,7 @@ class UVBeam(UVBase):
         self._axis1_array = uvp.UVParameter(
             "axis1_array",
             description=desc,
-            expected_type=np.float,
+            expected_type=np.floating,
             required=False,
             form=("Naxes1",),
         )
@@ -156,7 +156,7 @@ class UVBeam(UVBase):
         self._axis2_array = uvp.UVParameter(
             "axis2_array",
             description=desc,
-            expected_type=np.float,
+            expected_type=np.floating,
             required=False,
             form=("Naxes2",),
         )
@@ -224,7 +224,7 @@ class UVBeam(UVBase):
             "basis_vector_array",
             description=desc,
             required=False,
-            expected_type=np.float,
+            expected_type=np.floating,
             form=("Naxes_vec", "Ncomponents_vec", "Naxes2", "Naxes1"),
             acceptable_range=(0, 1),
             tols=1e-3,
@@ -282,7 +282,7 @@ class UVBeam(UVBase):
             "freq_array",
             description=desc,
             form=("Nspws", "Nfreqs"),
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3,
         )  # mHz
 
@@ -329,7 +329,7 @@ class UVBeam(UVBase):
         self._data_array = uvp.UVParameter(
             "data_array",
             description=desc,
-            expected_type=np.complex,
+            expected_type=complex,
             form=("Naxes_vec", "Nspws", "Nfeeds", "Nfreqs", "Naxes2", "Naxes1"),
             tols=1e-3,
         )
@@ -343,7 +343,7 @@ class UVBeam(UVBase):
         self._bandpass_array = uvp.UVParameter(
             "bandpass_array",
             description=desc,
-            expected_type=np.float,
+            expected_type=np.floating,
             form=("Nspws", "Nfreqs"),
             tols=1e-3,
         )
@@ -433,7 +433,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=(2, "Nelements"),
-            expected_type=np.float,
+            expected_type=np.floating,
         )
 
         desc = (
@@ -445,7 +445,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=("Nelements",),
-            expected_type=np.float,
+            expected_type=np.floating,
         )
 
         desc = (
@@ -457,7 +457,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=("Nelements",),
-            expected_type=np.float,
+            expected_type=np.floating,
         )
 
         desc = (
@@ -470,7 +470,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=("Nelements", "Nelements", "Nfeed", "Nfeed", "Nspws", "Nfreqs"),
-            expected_type=np.complex,
+            expected_type=complex,
         )
 
         # -------- extra, non-required parameters ----------
@@ -539,7 +539,7 @@ class UVBeam(UVBase):
             "reference_impedance",
             required=False,
             description=desc,
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3,
         )
 
@@ -549,7 +549,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=("Nspws", "Nfreqs"),
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3,
         )
 
@@ -559,7 +559,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=("Nspws", "Nfreqs"),
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3,
         )
 
@@ -569,7 +569,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=("Nspws", "Nfreqs"),
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3,
         )
 
@@ -583,7 +583,7 @@ class UVBeam(UVBase):
             required=False,
             description=desc,
             form=(4, "Nspws", "Nfreqs"),
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3,
         )
 
@@ -678,7 +678,7 @@ class UVBeam(UVBase):
         self._feed_array.required = True
         self._Npols.required = False
         self._polarization_array.required = False
-        self._data_array.expected_type = np.complex
+        self._data_array.expected_type = complex
         # call set_cs_params to fix data_array form
         self._set_cs_params()
 
@@ -708,10 +708,10 @@ class UVBeam(UVBase):
         self._polarization_array.required = True
 
         # If cross pols are included, the power beam is complex. Otherwise it's real
-        self._data_array.expected_type = np.float
+        self._data_array.expected_type = np.floating
         for pol in self.polarization_array:
             if pol in [3, 4, -3, -4, -7, -8]:
-                self._data_array.expected_type = np.complex
+                self._data_array.expected_type = complex
 
         # call set_cs_params to fix data_array form
         self._set_cs_params()
@@ -915,7 +915,7 @@ class UVBeam(UVBase):
         # adjust requirements, fix data_array form
         beam_object._set_power()
         power_data = np.zeros(
-            beam_object._data_array.expected_shape(beam_object), dtype=np.complex
+            beam_object._data_array.expected_shape(beam_object), dtype=np.complex128
         )
 
         if keep_basis_vector:
@@ -1102,7 +1102,7 @@ class UVBeam(UVBase):
 
         pol_strings = ["pI", "pQ", "pU", "pV"]
         power_data = np.zeros(
-            (1, 1, len(pol_strings), _sh[-2], _sh[-1]), dtype=np.complex
+            (1, 1, len(pol_strings), _sh[-2], _sh[-1]), dtype=np.complex128
         )
         beam_object.polarization_array = np.array(
             [
@@ -1112,7 +1112,7 @@ class UVBeam(UVBase):
         )
 
         for fq_i in range(Nfreqs):
-            jones = np.zeros((_sh[-1], 2, 2), dtype=np.complex)
+            jones = np.zeros((_sh[-1], 2, 2), dtype=np.complex128)
             pol_strings = ["pI", "pQ", "pU", "pV"]
             jones[:, 0, 0] = efield_data[0, 0, 0, fq_i, :]
             jones[:, 0, 1] = efield_data[0, 0, 1, fq_i, :]
@@ -1311,9 +1311,9 @@ class UVBeam(UVBase):
         assert input_data_array.shape[3] == input_nfreqs
 
         if np.iscomplexobj(input_data_array):
-            data_type = np.complex
+            data_type = np.complex128
         else:
-            data_type = np.float
+            data_type = np.float64
 
         if np.isclose(phi_length, 2 * np.pi, atol=axis1_diff):
             # phi wraps around, extend array in each direction to improve interpolation
@@ -1576,9 +1576,9 @@ class UVBeam(UVBase):
             pol_inds = np.arange(Npol_feeds)
 
         if np.iscomplexobj(input_data_array):
-            data_type = np.complex
+            data_type = np.complex128
         else:
-            data_type = np.float
+            data_type = np.float64
         interp_data = np.zeros(
             (self.Naxes_vec, self.Nspws, Npol_feeds, input_nfreqs, len(az_array)),
             dtype=data_type,

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -378,7 +378,7 @@ class CALFITS(UVCal):
             # Pad the extra rows with -1s. Need to undo on read.
             nants_add = self.Nants_telescope - self.Nants_data
             ant_array_use = np.append(
-                self.ant_array, np.zeros(nants_add, dtype=np.int) - 1
+                self.ant_array, np.zeros(nants_add, dtype=np.int64) - 1
             )
             col3 = fits.Column(name="ANTARR", format="D", array=ant_array_use)
         if self.antenna_positions is not None:

--- a/pyuvdata/uvcal/fhd_cal.py
+++ b/pyuvdata/uvcal/fhd_cal.py
@@ -287,7 +287,7 @@ class FHDCal(UVCal):
                     if len(mode_fit) == 1:
                         mode_fit = float(mode_fit[0])
                     else:
-                        mode_fit = np.array(mode_fit, dtype=np.int)
+                        mode_fit = np.array(mode_fit, dtype=np.int64)
 
                     amp_degree = int(settings_lines["amp_degree"][0])
                     phase_degree = int(settings_lines["phase_degree"][0])
@@ -352,7 +352,7 @@ class FHDCal(UVCal):
             # Currently this can't include the times because the flag array
             # dimensions has to match the gain array dimensions.
             # This is somewhat artificial...
-            self.flag_array = np.zeros_like(self.gain_array, dtype=np.bool)
+            self.flag_array = np.zeros_like(self.gain_array, dtype=np.bool_)
             flagged_ants = np.where(ant_use == 0)[0]
             for ant in flagged_ants:
                 self.flag_array[ant, :] = 1

--- a/pyuvdata/uvcal/fhd_cal.py
+++ b/pyuvdata/uvcal/fhd_cal.py
@@ -274,7 +274,7 @@ class FHDCal(UVCal):
                 galaxy_model = int(settings_lines["galaxy_model"][0])
                 diffuse_model = settings_lines["diffuse_model"][0]
                 auto_scale = settings_lines["auto_scale"]
-                n_vis_cal = np.int(settings_lines["n_vis_cal"][0])
+                n_vis_cal = np.int64(settings_lines["n_vis_cal"][0])
                 time_avg = int(settings_lines["time_avg"][0])
                 conv_thresh = float(settings_lines["conv_thresh"][0])
 
@@ -326,14 +326,14 @@ class FHDCal(UVCal):
             # Now read data like arrays
             fit_gain_array_in = cal_data["gain"][0]
             fit_gain_array = np.zeros(
-                self._gain_array.expected_shape(self), dtype=np.complex_
+                self._gain_array.expected_shape(self), dtype=np.complex128
             )
             for jones_i, arr in enumerate(fit_gain_array_in):
                 fit_gain_array[:, 0, :, 0, jones_i] = arr
             if raw:
                 res_gain_array_in = cal_data["gain_residual"][0]
                 res_gain_array = np.zeros(
-                    self._gain_array.expected_shape(self), dtype=np.complex_
+                    self._gain_array.expected_shape(self), dtype=np.complex128
                 )
                 for jones_i, arr in enumerate(res_gain_array_in):
                     res_gain_array[:, 0, :, 0, jones_i] = arr

--- a/pyuvdata/uvcal/tests/test_calfits.py
+++ b/pyuvdata/uvcal/tests/test_calfits.py
@@ -251,7 +251,7 @@ def test_latlonalt_noxyz(tmp_path):
     "kwd1,kwd2,val1,val2",
     [
         ["keyword1", "keyword2", True, False],
-        ["keyword1", "keyword2", np.int(5), 7],
+        ["keyword1", "keyword2", np.int64(5), 7],
         ["keyword1", "keyword2", np.int64(5.3), 6.9],
         ["keyword1", "keyword2", np.complex64(5.3 + 1.2j), 6.9 + 4.6j],
         [

--- a/pyuvdata/uvcal/tests/test_uvcal.py
+++ b/pyuvdata/uvcal/tests/test_uvcal.py
@@ -935,9 +935,9 @@ def test_add_antennas(caltype, gain_data, delay_data):
     if caltype == "delay":
         # test for when input_flag_array is present in first file but not second
         calobj.select(antenna_nums=ants1)
-        ifa = np.zeros(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool)
+        ifa = np.zeros(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool_)
         ifa2 = np.ones(calobj2._input_flag_array.expected_shape(calobj2)).astype(
-            np.bool
+            np.bool_
         )
         tot_ifa = np.concatenate([ifa, ifa2], axis=0)
         calobj.input_flag_array = ifa
@@ -947,9 +947,9 @@ def test_add_antennas(caltype, gain_data, delay_data):
 
         # test for when input_flag_array is present in second file but not first
         calobj.select(antenna_nums=ants1)
-        ifa = np.ones(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool)
+        ifa = np.ones(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool_)
         ifa2 = np.zeros(calobj2._input_flag_array.expected_shape(calobj2)).astype(
-            np.bool
+            np.bool_
         )
         tot_ifa = np.concatenate([ifa, ifa2], axis=0)
         calobj.input_flag_array = None
@@ -1042,8 +1042,8 @@ def test_add_frequencies(gain_data):
     calobj2 = calobj.copy()
     calobj.select(frequencies=freqs1)
     calobj2.select(frequencies=freqs2)
-    ifa = np.zeros(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool)
-    ifa2 = np.ones(calobj2._input_flag_array.expected_shape(calobj2)).astype(np.bool)
+    ifa = np.zeros(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool_)
+    ifa2 = np.ones(calobj2._input_flag_array.expected_shape(calobj2)).astype(np.bool_)
     tot_ifa = np.concatenate([ifa, ifa2], axis=2)
     calobj.input_flag_array = ifa
     calobj2.input_flag_array = None
@@ -1052,8 +1052,8 @@ def test_add_frequencies(gain_data):
 
     # test for when input_flag_array is present in second file but not first
     calobj.select(frequencies=freqs1)
-    ifa = np.ones(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool)
-    ifa2 = np.zeros(calobj2._input_flag_array.expected_shape(calobj2)).astype(np.bool)
+    ifa = np.ones(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool_)
+    ifa2 = np.zeros(calobj2._input_flag_array.expected_shape(calobj2)).astype(np.bool_)
     tot_ifa = np.concatenate([ifa, ifa2], axis=2)
     calobj.input_flag_array = None
     calobj2.input_flag_array = ifa2
@@ -1145,9 +1145,9 @@ def test_add_times(caltype, gain_data, delay_data):
     if caltype == "delay":
         # test for when input_flag_array is present in first file but not second
         calobj.select(times=times1)
-        ifa = np.zeros(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool)
+        ifa = np.zeros(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool_)
         ifa2 = np.ones(calobj2._input_flag_array.expected_shape(calobj2)).astype(
-            np.bool
+            np.bool_
         )
         tot_ifa = np.concatenate([ifa, ifa2], axis=3)
         calobj.input_flag_array = ifa
@@ -1157,9 +1157,9 @@ def test_add_times(caltype, gain_data, delay_data):
 
         # test for when input_flag_array is present in second file but not first
         calobj.select(times=times1)
-        ifa = np.ones(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool)
+        ifa = np.ones(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool_)
         ifa2 = np.zeros(calobj2._input_flag_array.expected_shape(calobj2)).astype(
-            np.bool
+            np.bool_
         )
         tot_ifa = np.concatenate([ifa, ifa2], axis=3)
         calobj.input_flag_array = None
@@ -1246,9 +1246,9 @@ def test_add_jones(caltype, gain_data, delay_data):
     if caltype == "delay":
         # test for when input_flag_array is present in first file but not second
         calobj = calobj_original.copy()
-        ifa = np.zeros(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool)
+        ifa = np.zeros(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool_)
         ifa2 = np.ones(calobj2._input_flag_array.expected_shape(calobj2)).astype(
-            np.bool
+            np.bool_
         )
         tot_ifa = np.concatenate([ifa, ifa2], axis=4)
         calobj.input_flag_array = ifa
@@ -1258,9 +1258,9 @@ def test_add_jones(caltype, gain_data, delay_data):
 
         # test for when input_flag_array is present in second file but not first
         calobj = calobj_original.copy()
-        ifa = np.ones(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool)
+        ifa = np.ones(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool_)
         ifa2 = np.zeros(calobj2._input_flag_array.expected_shape(calobj2)).astype(
-            np.bool
+            np.bool_
         )
         tot_ifa = np.concatenate([ifa, ifa2], axis=4)
         calobj.input_flag_array = None

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -250,7 +250,7 @@ class UVCal(UVBase):
             "flag_array",
             description=desc,
             form=("Nants_data", "Nspws", "Nfreqs", "Ntimes", "Njones"),
-            expected_type=np.bool,
+            expected_type=np.bool_,
         )
 
         desc = (
@@ -409,7 +409,7 @@ class UVCal(UVBase):
             description=desc,
             required=False,
             form=("Nants_data", "Nspws", "Nfreqs", "Ntimes", "Njones"),
-            expected_type=np.bool,
+            expected_type=np.bool_,
         )
 
         desc = "Origin (on github for e.g) of calibration software. Url and branch."
@@ -1324,7 +1324,7 @@ class UVCal(UVBase):
                     )[order, :, :, :, :]
                 this.flag_array = np.concatenate(
                     [this.flag_array, 1 - zero_pad_flags], axis=0
-                ).astype(np.bool)[order, :, :, :, :]
+                ).astype(np.bool_)[order, :, :, :, :]
                 this.quality_array = np.concatenate(
                     [this.quality_array, zero_pad_data], axis=0
                 )[order, :, :, :, :]
@@ -1354,7 +1354,7 @@ class UVCal(UVBase):
                     )
                     this.input_flag_array = np.concatenate(
                         [this.input_flag_array, 1 - zero_pad], axis=0
-                    ).astype(np.bool)[order, :, :, :, :]
+                    ).astype(np.bool_)[order, :, :, :, :]
                 elif other.input_flag_array is not None:
                     zero_pad = np.zeros(
                         (
@@ -1376,10 +1376,10 @@ class UVCal(UVBase):
                                 this.Njones,
                             )
                         )
-                    ).astype(np.bool)
+                    ).astype(np.bool_)
                     this.input_flag_array = np.concatenate(
                         [this.input_flag_array, 1 - zero_pad], axis=0
-                    ).astype(np.bool)[order, :, :, :, :]
+                    ).astype(np.bool_)[order, :, :, :, :]
 
         if len(fnew_inds) > 0:
             # Exploit the fact that quality array has the same dimensions as the
@@ -1405,7 +1405,7 @@ class UVCal(UVBase):
                 ]
                 this.flag_array = np.concatenate(
                     [this.flag_array, 1 - zero_pad], axis=2
-                ).astype(np.bool)[:, :, order, :, :]
+                ).astype(np.bool_)[:, :, order, :, :]
                 this.quality_array = np.concatenate(
                     [this.quality_array, zero_pad], axis=2
                 )[:, :, order, :, :]
@@ -1440,7 +1440,7 @@ class UVCal(UVBase):
                     )
                     this.input_flag_array = np.concatenate(
                         [this.input_flag_array, 1 - zero_pad], axis=2
-                    ).astype(np.bool)[:, :, order, :, :]
+                    ).astype(np.bool_)[:, :, order, :, :]
                 elif other.input_flag_array is not None:
                     zero_pad = np.zeros(
                         (
@@ -1462,10 +1462,10 @@ class UVCal(UVBase):
                                 this.Njones,
                             )
                         )
-                    ).astype(np.bool)
+                    ).astype(np.bool_)
                     this.input_flag_array = np.concatenate(
                         [this.input_flag_array, 1 - zero_pad], axis=2
-                    ).astype(np.bool)[:, :, order, :, :]
+                    ).astype(np.bool_)[:, :, order, :, :]
 
         if len(tnew_inds) > 0:
             # Exploit the fact that quality array has the same dimensions as
@@ -1508,7 +1508,7 @@ class UVCal(UVBase):
                     )[:, :, :, order, :]
                 this.flag_array = np.concatenate(
                     [this.flag_array, 1 - zero_pad_flags], axis=3
-                ).astype(np.bool)[:, :, :, order, :]
+                ).astype(np.bool_)[:, :, :, order, :]
                 this.quality_array = np.concatenate(
                     [this.quality_array, zero_pad_data], axis=3
                 )[:, :, :, order, :]
@@ -1552,7 +1552,7 @@ class UVCal(UVBase):
                     )
                     this.input_flag_array = np.concatenate(
                         [this.input_flag_array, 1 - zero_pad], axis=3
-                    ).astype(np.bool)[:, :, :, order, :]
+                    ).astype(np.bool_)[:, :, :, order, :]
                 elif other.input_flag_array is not None:
                     zero_pad = np.zeros(
                         (
@@ -1574,10 +1574,10 @@ class UVCal(UVBase):
                                 this.Njones,
                             )
                         )
-                    ).astype(np.bool)
+                    ).astype(np.bool_)
                     this.input_flag_array = np.concatenate(
                         [this.input_flag_array, 1 - zero_pad], axis=3
-                    ).astype(np.bool)[:, :, :, order, :]
+                    ).astype(np.bool_)[:, :, :, order, :]
 
         if len(jnew_inds) > 0:
             # Exploit the fact that quality array has the same dimensions as
@@ -1616,7 +1616,7 @@ class UVCal(UVBase):
                     )[:, :, :, :, order]
                 this.flag_array = np.concatenate(
                     [this.flag_array, 1 - zero_pad_flags], axis=4
-                ).astype(np.bool)[:, :, :, :, order]
+                ).astype(np.bool_)[:, :, :, :, order]
                 this.quality_array = np.concatenate(
                     [this.quality_array, zero_pad_data], axis=4
                 )[:, :, :, :, order]
@@ -1661,7 +1661,7 @@ class UVCal(UVBase):
                     )
                     this.input_flag_array = np.concatenate(
                         [this.input_flag_array, 1 - zero_pad], axis=4
-                    ).astype(np.bool)[:, :, :, :, order]
+                    ).astype(np.bool_)[:, :, :, :, order]
                 elif other.input_flag_array is not None:
                     zero_pad = np.zeros(
                         (
@@ -1683,10 +1683,10 @@ class UVCal(UVBase):
                                 this.Njones,
                             )
                         )
-                    ).astype(np.bool)
+                    ).astype(np.bool_)
                     this.input_flag_array = np.concatenate(
                         [this.input_flag_array, 1 - zero_pad], axis=4
-                    ).astype(np.bool)[:, :, :, :, order]
+                    ).astype(np.bool_)[:, :, :, :, order]
 
         # Now populate the data
         if not self.metadata_only:

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -250,7 +250,7 @@ class UVCal(UVBase):
             "flag_array",
             description=desc,
             form=("Nants_data", "Nspws", "Nfreqs", "Ntimes", "Njones"),
-            expected_type=np.bool_,
+            expected_type=bool,
         )
 
         desc = (
@@ -409,7 +409,7 @@ class UVCal(UVBase):
             description=desc,
             required=False,
             form=("Nants_data", "Nspws", "Nfreqs", "Ntimes", "Njones"),
-            expected_type=np.bool_,
+            expected_type=bool,
         )
 
         desc = "Origin (on github for e.g) of calibration software. Url and branch."

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -1899,7 +1899,7 @@ class UVCal(UVBase):
             history_update_string += "antennas"
             n_selects += 1
 
-            ant_inds = np.zeros(0, dtype=np.int)
+            ant_inds = np.zeros(0, dtype=np.int64)
             for ant in antenna_nums:
                 if ant in cal_object.ant_array:
                     ant_inds = np.append(
@@ -1945,7 +1945,7 @@ class UVCal(UVBase):
                 history_update_string += "times"
             n_selects += 1
 
-            time_inds = np.zeros(0, dtype=np.int)
+            time_inds = np.zeros(0, dtype=np.int64)
             for jd in times:
                 if jd in cal_object.time_array:
                     time_inds = np.append(
@@ -2015,7 +2015,7 @@ class UVCal(UVBase):
                 history_update_string += "frequencies"
             n_selects += 1
 
-            freq_inds = np.zeros(0, dtype=np.int)
+            freq_inds = np.zeros(0, dtype=np.int64)
             # this works because we only allow one SPW. This will have to be
             # reworked when we support more.
             freq_arr_use = cal_object.freq_array[0, :]
@@ -2077,7 +2077,7 @@ class UVCal(UVBase):
                 history_update_string += "jones polarization terms"
             n_selects += 1
 
-            jones_inds = np.zeros(0, dtype=np.int)
+            jones_inds = np.zeros(0, dtype=np.int64)
             for j in jones:
                 if j in cal_object.jones_array:
                     jones_inds = np.append(

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -152,7 +152,7 @@ class UVCal(UVBase):
             "antenna_positions",
             description=desc,
             form=("Nants_telescope", 3),
-            expected_type=np.float,
+            expected_type=float,
             tols=1e-3,  # 1 mm
             required=False,
         )
@@ -172,13 +172,13 @@ class UVCal(UVBase):
             "freq_array",
             description=desc,
             form=("Nspws", "Nfreqs"),
-            expected_type=np.float,
+            expected_type=float,
             tols=1e-3,
         )  # mHz
 
         desc = "Channel width of of a frequency bin. Units Hz."
         self._channel_width = uvp.UVParameter(
-            "channel_width", description=desc, expected_type=np.float, tols=1e-3
+            "channel_width", description=desc, expected_type=float, tols=1e-3
         )
 
         desc = (
@@ -203,7 +203,7 @@ class UVCal(UVBase):
             "time_array",
             description=desc,
             form=("Ntimes",),
-            expected_type=np.float,
+            expected_type=float,
             tols=1e-3 / (60.0 * 60.0 * 24.0),
         )
 
@@ -215,14 +215,14 @@ class UVCal(UVBase):
             "lst_array",
             description=desc,
             form=("Ntimes",),
-            expected_type=np.float,
+            expected_type=float,
             tols=radian_tol,
             required=False,
         )
 
         desc = "Integration time of a time bin, units seconds."
         self._integration_time = uvp.UVParameter(
-            "integration_time", description=desc, expected_type=np.float, tols=1e-3
+            "integration_time", description=desc, expected_type=float, tols=1e-3
         )  # 1ms
 
         desc = (
@@ -264,7 +264,7 @@ class UVCal(UVBase):
             "quality_array",
             description=desc,
             form=("Nants_data", "Nspws", "Nfreqs", "Ntimes", "Njones"),
-            expected_type=np.float,
+            expected_type=float,
         )
 
         desc = (
@@ -300,7 +300,7 @@ class UVCal(UVBase):
             description=desc,
             required=False,
             form=("Nants_data", "Nspws", "Nfreqs", "Ntimes", "Njones"),
-            expected_type=np.complex,
+            expected_type=complex,
         )
 
         desc = (
@@ -312,7 +312,7 @@ class UVCal(UVBase):
             description=desc,
             required=False,
             form=("Nants_data", "Nspws", 1, "Ntimes", "Njones"),
-            expected_type=np.float,
+            expected_type=float,
         )
 
         desc = (
@@ -366,7 +366,7 @@ class UVCal(UVBase):
 
         desc = "Number of sources used."
         self._Nsources = uvp.UVParameter(
-            "Nsources", required=False, expected_type=np.int, description=desc
+            "Nsources", required=False, expected_type=int, description=desc
         )
 
         desc = "Range of baselines used for calibration."
@@ -374,7 +374,7 @@ class UVCal(UVBase):
             "baseline_range",
             form=2,
             required=False,
-            expected_type=np.float,
+            expected_type=float,
             description=desc,
         )
 
@@ -449,7 +449,7 @@ class UVCal(UVBase):
             "total_quality_array",
             description=desc,
             form=("Nspws", "Nfreqs", "Ntimes", "Njones"),
-            expected_type=np.float,
+            expected_type=float,
             required=False,
         )
 
@@ -871,7 +871,7 @@ class UVCal(UVBase):
             if antnum not in self.ant_array:
                 return False
         if jpol is not None:
-            if isinstance(jpol, (str, np.str)):
+            if isinstance(jpol, (str, np.str_)):
                 jpol = uvutils.jstr2num(jpol, x_orientation=self.x_orientation)
             if jpol not in self.jones_array:
                 return False
@@ -911,7 +911,7 @@ class UVCal(UVBase):
         int
             Antenna polarization index in data arrays
         """
-        if isinstance(jpol, (str, np.str)):
+        if isinstance(jpol, (str, np.str_)):
             jpol = uvutils.jstr2num(jpol, x_orientation=self.x_orientation)
 
         if not self._has_key(jpol=jpol):

--- a/pyuvdata/uvdata/fhd.py
+++ b/pyuvdata/uvdata/fhd.py
@@ -616,8 +616,8 @@ class FHD(UVData):
             )
 
         self._set_phased()
-        self.phase_center_ra_degrees = np.float(obs["OBSRA"][0])
-        self.phase_center_dec_degrees = np.float(obs["OBSDEC"][0])
+        self.phase_center_ra_degrees = float(obs["OBSRA"][0])
+        self.phase_center_dec_degrees = float(obs["OBSDEC"][0])
 
         self.phase_center_epoch = astrometry["EQUINOX"][0]
 
@@ -637,7 +637,7 @@ class FHD(UVData):
             )
 
         # TODO: Spw axis to be collapsed in future release
-        self.freq_array = np.zeros((1, len(bl_info["FREQ"][0])), dtype=np.float_)
+        self.freq_array = np.zeros((1, len(bl_info["FREQ"][0])), dtype=np.float64)
         self.freq_array[0, :] = bl_info["FREQ"][0]
 
         self.channel_width = float(obs["FREQ_RES"][0])
@@ -682,7 +682,7 @@ class FHD(UVData):
             )
             # TODO: Spw axis to be collapsed in future release
             self.nsample_array = np.zeros(
-                (self.Nblts, 1, self.Nfreqs, self.Npols), dtype=np.float_
+                (self.Nblts, 1, self.Nfreqs, self.Npols), dtype=np.float64
             )
             # TODO: Spw axis to be collapsed in future release
             self.flag_array = np.zeros(

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -154,9 +154,9 @@ class Mir(UVData):
             assert len(spw_nchan) == 1
 
             #  Get the data in the right units and dtype
-            spw_fsky = np.float(spw_fsky * 1e9)  # GHz -> Hz
-            spw_fres = np.float(spw_fres * 1e6)  # MHz -> Hz
-            spw_nchan = np.int(spw_nchan)
+            spw_fsky = np.float64(spw_fsky * 1e9)  # GHz -> Hz
+            spw_fres = np.float64(spw_fres * 1e6)  # MHz -> Hz
+            spw_nchan = np.int64(spw_nchan)
 
             # Tally up the number of channels
             Nfreqs += spw_nchan

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -154,9 +154,9 @@ class Mir(UVData):
             assert len(spw_nchan) == 1
 
             #  Get the data in the right units and dtype
-            spw_fsky = np.float64(spw_fsky * 1e9)  # GHz -> Hz
-            spw_fres = np.float64(spw_fres * 1e6)  # MHz -> Hz
-            spw_nchan = np.int64(spw_nchan)
+            spw_fsky = float(spw_fsky * 1e9)  # GHz -> Hz
+            spw_fres = float(spw_fres * 1e6)  # MHz -> Hz
+            spw_nchan = int(spw_nchan)
 
             # Tally up the number of channels
             Nfreqs += spw_nchan

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -133,9 +133,9 @@ class Mir(UVData):
         Nfreqs = 0  # Set to zero to starts for flex_spw
 
         # Initialize some arrays that we'll be appending to
-        flex_spw_id_array = np.array([], dtype=np.int)
-        channel_width = np.array([], dtype=np.float)
-        freq_array = np.array([], dtype=np.float)
+        flex_spw_id_array = np.array([], dtype=np.int64)
+        channel_width = np.array([], dtype=np.float64)
+        freq_array = np.array([], dtype=np.float64)
         for idx in range(len(corrchunk)):
             data_mask = np.logical_and(
                 mir_data.sp_data["corrchunk"] == corrchunk[idx],
@@ -163,12 +163,12 @@ class Mir(UVData):
 
             # Populate the channel width array
             channel_width = np.append(
-                channel_width, abs(spw_fres) + np.zeros(spw_nchan, dtype=np.float)
+                channel_width, abs(spw_fres) + np.zeros(spw_nchan, dtype=np.float64)
             )
 
             # Populate the the spw_id_array
             flex_spw_id_array = np.append(
-                flex_spw_id_array, idx + np.zeros(spw_nchan, dtype=np.int)
+                flex_spw_id_array, idx + np.zeros(spw_nchan, dtype=np.int64)
             )
 
             # So the freq array here is a little weird, because the current fsky

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -750,7 +750,7 @@ class MirParser(object):
         """
         # Gather the needed metadata
         inhid_arr = sp_data["inhid"]
-        nch_arr = sp_data["nch"].astype(np.int)
+        nch_arr = sp_data["nch"].astype(np.int64)
         dataoff_arr = sp_data["dataoff"] // 2
 
         unique_inhid = np.unique(inhid_arr)

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -254,16 +254,16 @@ class MirParser(object):
         self.in_start_dict = self.scan_int_start(filepath)
         self.antpos_data = self.read_antennas(filepath)
 
-        self.use_in = np.ones(self.in_read.shape, dtype=np.bool)
-        self.use_bl = np.ones(self.bl_read.shape, dtype=np.bool)
-        self.use_sp = np.ones(self.sp_read.shape, dtype=np.bool)
+        self.use_in = np.ones(self.in_read.shape, dtype=np.bool_)
+        self.use_bl = np.ones(self.bl_read.shape, dtype=np.bool_)
+        self.use_sp = np.ones(self.sp_read.shape, dtype=np.bool_)
 
-        self.in_filter = np.ones(self.in_read.shape, dtype=np.bool)
-        self.eng_filter = np.ones(self.eng_read.shape, dtype=np.bool)
-        self.bl_filter = np.ones(self.bl_read.shape, dtype=np.bool)
-        self.sp_filter = np.ones(self.sp_read.shape, dtype=np.bool)
-        self.we_filter = np.ones(self.we_read.shape, dtype=np.bool)
-        self.ac_filter = np.ones(self.ac_read.shape, dtype=np.bool)
+        self.in_filter = np.ones(self.in_read.shape, dtype=np.bool_)
+        self.eng_filter = np.ones(self.eng_read.shape, dtype=np.bool_)
+        self.bl_filter = np.ones(self.bl_read.shape, dtype=np.bool_)
+        self.sp_filter = np.ones(self.sp_read.shape, dtype=np.bool_)
+        self.we_filter = np.ones(self.we_read.shape, dtype=np.bool_)
+        self.ac_filter = np.ones(self.ac_read.shape, dtype=np.bool_)
 
         self.in_data = self.in_read
         self.eng_data = self.eng_read

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -170,7 +170,9 @@ class Miriad(UVData):
         # select on ant_str if provided
         if ant_str is not None:
             # type check
-            assert isinstance(ant_str, (str, np.str)), "ant_str must be fed as a string"
+            assert isinstance(
+                ant_str, (str, np.str_)
+            ), "ant_str must be fed as a string"
             assert (
                 antenna_nums is None and bls is None
             ), "ant_str must be None if antenna_nums or bls is not None"
@@ -273,7 +275,7 @@ class Miriad(UVData):
             assert isinstance(time_range, (list, np.ndarray)), err_msg
             assert len(time_range) == 2, err_msg
             assert np.array(
-                [isinstance(t, (float, np.float, np.float64)) for t in time_range]
+                [isinstance(t, (float, np.float_, np.float64)) for t in time_range]
             ).all(), err_msg
 
             # UVData.time_array marks center of integration, while Miriad
@@ -356,7 +358,7 @@ class Miriad(UVData):
             try:
                 cnt = uv["cnt"]
             except (KeyError):
-                cnt = np.ones(d.shape, dtype=np.float)
+                cnt = np.ones(d.shape, dtype=np.float64)
             ra = uv["ra"]
             dec = uv["dec"]
             # NOTE: Using our lst calculator, which uses astropy,
@@ -560,7 +562,7 @@ class Miriad(UVData):
         proc = None
         if self.telescope_location is not None:
             proc = self.set_lsts_from_time_array(background=background_lsts)
-        self.nsample_array = np.ones(self.data_array.shape, dtype=np.float)
+        self.nsample_array = np.ones(self.data_array.shape, dtype=np.float64)
 
         # Temporary arrays to hold polarization axis, which will be collapsed
         ra_pol_list = np.zeros((self.Nblts, self.Npols))
@@ -1084,7 +1086,7 @@ class Miriad(UVData):
 
             # NOTE only writing spw 0, not supporting multiple spws for write
             for polcnt, pol in enumerate(self.polarization_array):
-                uv["pol"] = pol.astype(np.int)
+                uv["pol"] = pol.astype(np.int32)
                 uv["cnt"] = self.nsample_array[viscnt, 0, :, polcnt].astype(np.double)
 
                 data = self.data_array[viscnt, 0, :, polcnt]
@@ -1319,7 +1321,7 @@ class Miriad(UVData):
                     ]
                 )
                 .flatten()
-                .astype(np.float)
+                .astype(np.float64)
             )
             # Now setup frequency array
             # TODO: Spw axis to be collapsed in future release
@@ -1333,7 +1335,7 @@ class Miriad(UVData):
                     ]
                 )
                 .flatten()
-                .astype(np.float),
+                .astype(np.float64),
                 (1, -1),
             )
             # TODO: Fix this to capture unsorted spectra
@@ -1345,13 +1347,13 @@ class Miriad(UVData):
                     ]
                 )
                 .flatten()
-                .astype(np.int)
+                .astype(np.int32)
             )
         else:
             self.freq_array = np.reshape(
                 np.arange(self.Nfreqs) * self.channel_width + uv["sfreq"] * 1e9, (1, -1)
             )
-            self.channel_width = np.float(self.channel_width)
+            self.channel_width = float(self.channel_width)
 
         self.spw_array = np.arange(self.Nspws)
 
@@ -1752,5 +1754,5 @@ class Miriad(UVData):
                 pass
         if self.antenna_diameters is not None:
             self.antenna_diameters = self.antenna_diameters * np.ones(
-                self.Nants_telescope, dtype=np.float
+                self.Nants_telescope, dtype=np.float64
             )

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -552,7 +552,7 @@ class Miriad(UVData):
         self.data_array = np.zeros(
             (self.Nblts, 1, self.Nfreqs, self.Npols), dtype=np.complex64
         )
-        self.flag_array = np.ones(self.data_array.shape, dtype=np.bool)
+        self.flag_array = np.ones(self.data_array.shape, dtype=np.bool_)
         self.uvw_array = np.zeros((self.Nblts, 3))
         # NOTE: Using our lst calculator, which uses astropy,
         # instead of _miriad values which come from pyephem.

--- a/pyuvdata/uvdata/src/miriad_wrap.pyx
+++ b/pyuvdata/uvdata/src/miriad_wrap.pyx
@@ -200,7 +200,7 @@ cpdef hread_init(int item_hdl) except +raise_miriad_error:
   else:
     raise RuntimeError("unknown item type.")
 
-cpdef hwrite(int item_hdl, int offset, val, str type) except +raise_miriad_error:
+cpdef int hwrite(int item_hdl, int offset, val, str type) except *:
   cdef int iostat
   cdef int int_1
   cdef long lg
@@ -222,8 +222,7 @@ cpdef hwrite(int item_hdl, int offset, val, str type) except +raise_miriad_error
     offset = H_BYTE_SIZE * int_1
 
   elif type[0] == "i":
-    if not isinstance(val, (np.int, np.int_, np.intc)):
-      print(type(val))
+    if not isinstance(val, (int, np.int_, np.intc)):
       raise ValueError("expected an int")
     int_1 = <int>val
     hwritei_c(item_hdl, &int_1, offset, H_INT_SIZE, &iostat)
@@ -231,7 +230,7 @@ cpdef hwrite(int item_hdl, int offset, val, str type) except +raise_miriad_error
     offset = H_INT_SIZE
 
   elif type[0] == "j":
-    if not isinstance(val, (np.int, np.int_, np.intc)):
+    if not isinstance(val, (int, np.int_, np.intc)):
       raise ValueError("expected an int")
     sh = <short>val
     hwritej_c(item_hdl, &sh, offset, H_INT2_SIZE, &iostat)
@@ -239,7 +238,7 @@ cpdef hwrite(int item_hdl, int offset, val, str type) except +raise_miriad_error
     offset = H_INT2_SIZE
 
   elif type[0] == "l":
-    if not isinstance(val, (np.int, np.intc, np.int_)):
+    if not isinstance(val, (int, np.intc, np.int_)):
       raise ValueError("expected a  long")
     lg = <long>val
     hwritel_c(item_hdl, &lg, offset, H_INT8_SIZE, &iostat)
@@ -247,7 +246,7 @@ cpdef hwrite(int item_hdl, int offset, val, str type) except +raise_miriad_error
     offset = H_INT8_SIZE
 
   elif type[0] == "r":
-    if not isinstance(val, (np.float, np.float32)):
+    if not isinstance(val, (float, np.float32)):
       raise ValueError("expected a float")
     fl = <float>val
     hwriter_c(item_hdl, &fl, offset, H_REAL_SIZE, &iostat)
@@ -255,7 +254,7 @@ cpdef hwrite(int item_hdl, int offset, val, str type) except +raise_miriad_error
     offset = H_REAL_SIZE
 
   elif type[0] == "d":
-    if not isinstance(val, (np.float, np.float32, np.float_)):
+    if not isinstance(val, (float, np.float32, np.float64, np.float_)):
       raise ValueError("expected a double")
     db = <double>val
     hwrited_c(item_hdl, &db, offset, H_DBLE_SIZE, &iostat)

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -724,7 +724,7 @@ def test_miriad_extra_keywords_errors(
     "kwd_names,kwd_values",
     (
         [["bool", "bool2"], [True, False]],
-        [["int1", "int2"], [np.int(5), 7]],
+        [["int1", "int2"], [np.int64(5), 7]],
         [["float1", "float2"], [np.int64(5.3), 6.9]],
         [["str", "longstr"], ["hello", "this is a very long string " * 1000]],
     ),
@@ -833,7 +833,9 @@ def test_read_write_read_miriad(uv_in_paper):
 def test_miriad_antenna_diameters(uv_in_paper):
     # check that if antenna_diameters is set, it's read back out properly
     uv_in, uv_out, write_file = uv_in_paper
-    uv_in.antenna_diameters = np.zeros((uv_in.Nants_telescope,), dtype=np.float) + 14.0
+    uv_in.antenna_diameters = (
+        np.zeros((uv_in.Nants_telescope,), dtype=np.float32) + 14.0
+    )
     uv_in.write_miriad(write_file, clobber=True)
     uv_out.read(write_file)
     assert uv_in == uv_out

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -1235,7 +1235,7 @@ def test_select_antennas(casa_uvfits):
     # test removing metadata associated with antennas that are no longer present
     # also add (different) antenna_diameters to test downselection
     uv_object.antenna_diameters = 1.0 * np.ones(
-        (uv_object.Nants_telescope,), dtype=np.float
+        (uv_object.Nants_telescope,), dtype=np.float64
     )
     for i in range(uv_object.Nants_telescope):
         uv_object.antenna_diameters += i
@@ -2296,7 +2296,7 @@ def test_reorder_blts(casa_uvfits):
     assert str(cm.value).startswith("If order is an index array, it must")
 
     with pytest.raises(ValueError) as cm:
-        uv3.reorder_blts(order=np.arange(5, dtype=np.float))
+        uv3.reorder_blts(order=np.arange(5, dtype=np.float64))
     assert str(cm.value).startswith("If order is an index array, it must")
 
     with pytest.raises(ValueError) as cm:
@@ -7546,7 +7546,7 @@ def test_resample_in_time_warning():
 def test_frequency_average(uvdata_data):
     """Test averaging in frequency."""
     eq_coeffs = np.tile(
-        np.arange(uvdata_data.uv_object.Nfreqs, dtype=np.float),
+        np.arange(uvdata_data.uv_object.Nfreqs, dtype=np.float64),
         (uvdata_data.uv_object.Nants_telescope, 1),
     )
     uvdata_data.uv_object.eq_coeffs = eq_coeffs
@@ -7911,7 +7911,7 @@ def test_frequency_average_propagate_flags(uvdata_data):
 def test_frequency_average_nsample_precision(uvdata_data):
     """Test averaging in frequency with a half-precision nsample_array."""
     eq_coeffs = np.tile(
-        np.arange(uvdata_data.uv_object.Nfreqs, dtype=np.float),
+        np.arange(uvdata_data.uv_object.Nfreqs, dtype=np.float64),
         (uvdata_data.uv_object.Nants_telescope, 1),
     )
     uvdata_data.uv_object.eq_coeffs = eq_coeffs
@@ -7974,7 +7974,7 @@ def test_remove_eq_coeffs_divide(uvdata_data):
     # give eq_coeffs to the object
     eq_coeffs = np.empty(
         (uvdata_data.uv_object.Nants_telescope, uvdata_data.uv_object.Nfreqs),
-        dtype=np.float,
+        dtype=np.float64,
     )
     for i, ant in enumerate(uvdata_data.uv_object.antenna_numbers):
         eq_coeffs[i, :] = ant + 1
@@ -8001,7 +8001,7 @@ def test_remove_eq_coeffs_multiply(uvdata_data):
     # give eq_coeffs to the object
     eq_coeffs = np.empty(
         (uvdata_data.uv_object.Nants_telescope, uvdata_data.uv_object.Nfreqs),
-        dtype=np.float,
+        dtype=np.float64,
     )
     for i, ant in enumerate(uvdata_data.uv_object.antenna_numbers):
         eq_coeffs[i, :] = ant + 1

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -4004,7 +4004,7 @@ def test_get_flags(casa_uvfits):
     # Check conjugation
     d = uv.get_flags(ant2, ant1, pol)
     assert np.all(dcheck == d)
-    assert d.dtype == np.bool
+    assert d.dtype == np.bool_
 
     # Antpair only
     dcheck = np.squeeze(uv.flag_array[bltind, :, :, :])

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -301,7 +301,9 @@ def test_readwriteread_antenna_diameters(tmp_path, casa_uvfits):
     write_file = str(tmp_path / "outtest_casa.uvfits")
 
     # check that if antenna_diameters is set, it's read back out properly
-    uv_in.antenna_diameters = np.zeros((uv_in.Nants_telescope,), dtype=np.float) + 14.0
+    uv_in.antenna_diameters = (
+        np.zeros((uv_in.Nants_telescope,), dtype=np.float64) + 14.0
+    )
     uv_in.write_uvfits(write_file)
     uv_out.read(write_file)
     assert uv_in == uv_out
@@ -531,7 +533,7 @@ def test_extra_keywords_errors(
     "kwd_names,kwd_values",
     (
         [["bool", "bool2"], [True, False]],
-        [["int1", "int2"], [np.int(5), 7]],
+        [["int1", "int2"], [np.int64(5), 7]],
         [["float1", "float2"], [np.int64(5.3), 6.9]],
         [["complex1", "complex2"], [np.complex64(5.3 + 1.2j), 6.9 + 4.6j]],
         [

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -2698,7 +2698,7 @@ def test_read_slicing(casa_uvfits):
     # dataset shape checking
     # check various kinds of indexing give the right answer
     indices = [slice(0, 10), 0, [0, 1, 2], [0]]
-    dset = np.empty((100, 1, 1024, 2), dtype=np.float)
+    dset = np.empty((100, 1, 1024, 2), dtype=np.float64)
     shape = uvh5._get_dset_shape(dset, indices)
     assert tuple(shape) == (10, 1, 3, 1)
 

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -74,7 +74,7 @@ def initialize_with_zeros(uvd, filename):
     uvd.initialize_uvh5_file(filename, clobber=True)
     data_shape = (uvd.Nblts, 1, uvd.Nfreqs, uvd.Npols)
     data = np.zeros(data_shape, dtype=np.complex64)
-    flags = np.zeros(data_shape, dtype=np.bool)
+    flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     with h5py.File(filename, "r+") as h5f:
         dgrp = h5f["/Data"]
@@ -99,7 +99,7 @@ def initialize_with_zeros_ints(uvd, filename):
     )
     data_shape = (uvd.Nblts, 1, uvd.Nfreqs, uvd.Npols)
     data = np.zeros(data_shape, dtype=np.complex64)
-    flags = np.zeros(data_shape, dtype=np.bool)
+    flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     with h5py.File(filename, "r+") as h5f:
         dgrp = h5f["/Data"]
@@ -935,7 +935,7 @@ def test_uvh5_partial_write_irregular_blt(uv_partial_write, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -985,7 +985,7 @@ def test_uvh5_partial_write_irregular_freq(uv_partial_write, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -1035,7 +1035,7 @@ def test_uvh5_partial_write_irregular_pol(uv_partial_write, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -1090,7 +1090,7 @@ def test_uvh5_partial_write_irregular_multi1(uv_partial_write, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -1100,7 +1100,7 @@ def test_uvh5_partial_write_irregular_multi1(uv_partial_write, tmp_path):
     freq_inds = [0, 2, 3, 4]
     data_shape = (len(blt_inds), 1, len(freq_inds), full_uvh5.Npols)
     data = np.zeros(data_shape, dtype=np.complex64)
-    flags = np.zeros(data_shape, dtype=np.bool)
+    flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for iblt, blt_idx in enumerate(blt_inds):
         for ifreq, freq_idx in enumerate(freq_inds):
@@ -1162,7 +1162,7 @@ def test_uvh5_partial_write_irregular_multi2(uv_partial_write, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -1172,7 +1172,7 @@ def test_uvh5_partial_write_irregular_multi2(uv_partial_write, tmp_path):
     pol_inds = [0, 1, 3]
     data_shape = (full_uvh5.Nblts, 1, len(freq_inds), len(pol_inds))
     data = np.zeros(data_shape, dtype=np.complex64)
-    flags = np.zeros(data_shape, dtype=np.bool)
+    flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for ifreq, freq_idx in enumerate(freq_inds):
         for ipol, pol_idx in enumerate(pol_inds):
@@ -1238,7 +1238,7 @@ def test_uvh5_partial_write_irregular_multi3(uv_partial_write, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -1248,7 +1248,7 @@ def test_uvh5_partial_write_irregular_multi3(uv_partial_write, tmp_path):
     pol_inds = [0, 1, 3]
     data_shape = (len(blt_inds), 1, full_uvh5.Nfreqs, len(pol_inds))
     data = np.zeros(data_shape, dtype=np.complex64)
-    flags = np.zeros(data_shape, dtype=np.bool)
+    flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for iblt, blt_idx in enumerate(blt_inds):
         for ipol, pol_idx in enumerate(pol_inds):
@@ -1305,7 +1305,7 @@ def test_uvh5_partial_write_irregular_multi4(uv_partial_write, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -1316,7 +1316,7 @@ def test_uvh5_partial_write_irregular_multi4(uv_partial_write, tmp_path):
     pol_inds = [0, 1, 3]
     data_shape = (len(blt_inds), 1, len(freq_inds), len(pol_inds))
     data = np.zeros(data_shape, dtype=np.complex64)
-    flags = np.zeros(data_shape, dtype=np.bool)
+    flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for iblt, blt_idx in enumerate(blt_inds):
         for ifreq, freq_idx in enumerate(freq_inds):
@@ -2198,7 +2198,7 @@ def test_uvh5_partial_write_ints_irregular_blt(uv_uvh5, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -2248,7 +2248,7 @@ def test_uvh5_partial_write_ints_irregular_freq(uv_uvh5, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -2298,7 +2298,7 @@ def test_uvh5_partial_write_ints_irregular_pol(uv_uvh5, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -2353,7 +2353,7 @@ def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -2363,7 +2363,7 @@ def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, tmp_path):
     freq_inds = [0, 2, 3, 4]
     data_shape = (len(blt_inds), 1, len(freq_inds), full_uvh5.Npols)
     data = np.zeros(data_shape, dtype=np.complex64)
-    flags = np.zeros(data_shape, dtype=np.bool)
+    flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for iblt, blt_idx in enumerate(blt_inds):
         for ifreq, freq_idx in enumerate(freq_inds):
@@ -2425,7 +2425,7 @@ def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -2435,7 +2435,7 @@ def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, tmp_path):
     pol_inds = [0, 1, 3]
     data_shape = (full_uvh5.Nblts, 1, len(freq_inds), len(pol_inds))
     data = np.zeros(data_shape, dtype=np.complex64)
-    flags = np.zeros(data_shape, dtype=np.bool)
+    flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for ifreq, freq_idx in enumerate(freq_inds):
         for ipol, pol_idx in enumerate(pol_inds):
@@ -2500,7 +2500,7 @@ def test_uvh5_partial_write_ints_irregular_multi3(uv_uvh5, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -2510,7 +2510,7 @@ def test_uvh5_partial_write_ints_irregular_multi3(uv_uvh5, tmp_path):
     pol_inds = [0, 1, 3]
     data_shape = (len(blt_inds), 1, full_uvh5.Nfreqs, len(pol_inds))
     data = np.zeros(data_shape, dtype=np.complex64)
-    flags = np.zeros(data_shape, dtype=np.bool)
+    flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for iblt, blt_idx in enumerate(blt_inds):
         for ipol, pol_idx in enumerate(pol_inds):
@@ -2569,7 +2569,7 @@ def test_uvh5_partial_write_ints_irregular_multi4(uv_uvh5, tmp_path):
 
     # make a mostly empty object in memory to match what we'll write to disk
     partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
-    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool_)
     partial_uvh5.nsample_array = np.zeros_like(
         full_uvh5.nsample_array, dtype=np.float32
     )
@@ -2580,7 +2580,7 @@ def test_uvh5_partial_write_ints_irregular_multi4(uv_uvh5, tmp_path):
     pol_inds = [0, 1, 3]
     data_shape = (len(blt_inds), 1, len(freq_inds), len(pol_inds))
     data = np.zeros(data_shape, dtype=np.complex64)
-    flags = np.zeros(data_shape, dtype=np.bool)
+    flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for iblt, blt_idx in enumerate(blt_inds):
         for ifreq, freq_idx in enumerate(freq_inds):

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -116,7 +116,7 @@ class UVData(UVBase):
             "flag_array",
             description=desc,
             form=("Nblts", 1, "Nfreqs", "Npols"),
-            expected_type=np.bool_,
+            expected_type=bool,
         )
 
         self._Nspws = uvp.UVParameter(
@@ -301,7 +301,7 @@ class UVData(UVBase):
             "varying widths."
         )
         self._flex_spw = uvp.UVParameter(
-            "flex_spw", description=desc, expected_type=np.bool_, value=False,
+            "flex_spw", description=desc, expected_type=bool, value=False,
         )
 
         desc = (

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -836,7 +836,7 @@ class UVData(UVBase):
         formats cannot, so we just consider it forbidden.
         """
         if self.flex_spw:
-            exp_spw_ids = np.arange(self.Nspws, dtype=np.int)
+            exp_spw_ids = np.arange(self.Nspws, dtype=np.int64)
             # This is an internal consistency check to make sure that the indexes match
             # up as expected -- this shouldn't error unless someone is mucking with
             # settings they shouldn't be.
@@ -3131,7 +3131,7 @@ class UVData(UVBase):
             this_inds = np.ravel_multi_index(
                 (
                     this_blts_ind[:, np.newaxis, np.newaxis, np.newaxis],
-                    np.zeros((1, 1, 1, 1), dtype=np.int),
+                    np.zeros((1, 1, 1, 1), dtype=np.int64),
                     this_freq_ind[np.newaxis, np.newaxis, :, np.newaxis],
                     this_pol_ind[np.newaxis, np.newaxis, np.newaxis, :],
                 ),
@@ -3143,7 +3143,7 @@ class UVData(UVBase):
             other_inds = np.ravel_multi_index(
                 (
                     other_blts_ind[:, np.newaxis, np.newaxis, np.newaxis],
-                    np.zeros((1, 1, 1, 1), dtype=np.int),
+                    np.zeros((1, 1, 1, 1), dtype=np.int64),
                     other_freq_ind[np.newaxis, np.newaxis, :, np.newaxis],
                     other_pol_ind[np.newaxis, np.newaxis, np.newaxis, :],
                 ),
@@ -4248,8 +4248,8 @@ class UVData(UVBase):
             else:
                 history_update_string += "antennas"
             n_selects += 1
-            inds1 = np.zeros(0, dtype=np.int)
-            inds2 = np.zeros(0, dtype=np.int)
+            inds1 = np.zeros(0, dtype=np.int64)
+            inds2 = np.zeros(0, dtype=np.int64)
             for ant in antenna_nums:
                 if ant in self.ant_1_array or ant in self.ant_2_array:
                     wh1 = np.where(self.ant_1_array == ant)[0]
@@ -4264,7 +4264,9 @@ class UVData(UVBase):
                         "ant_1_array or ant_2_array".format(a=ant)
                     )
 
-            ant_blt_inds = np.array(list(set(inds1).intersection(inds2)), dtype=np.int)
+            ant_blt_inds = np.array(
+                list(set(inds1).intersection(inds2)), dtype=np.int64
+            )
         else:
             ant_blt_inds = None
 
@@ -4312,7 +4314,7 @@ class UVData(UVBase):
             else:
                 history_update_string += "antenna pairs"
             n_selects += 1
-            bls_blt_inds = np.zeros(0, dtype=np.int)
+            bls_blt_inds = np.zeros(0, dtype=np.int64)
             bl_pols = set()
             for bl in bls:
                 if not (bl[0] in self.ant_1_array or bl[0] in self.ant_2_array):
@@ -4361,7 +4363,7 @@ class UVData(UVBase):
                 # Use intersection (and) to join antenna_names/nums/ant_pairs_nums
                 # with blt_inds
                 blt_inds = np.array(
-                    list(set(blt_inds).intersection(ant_blt_inds)), dtype=np.int
+                    list(set(blt_inds).intersection(ant_blt_inds)), dtype=np.int64
                 )
             else:
                 blt_inds = ant_blt_inds
@@ -4374,7 +4376,7 @@ class UVData(UVBase):
             if np.array(times).ndim > 1:
                 times = np.array(times).flatten()
 
-            time_blt_inds = np.zeros(0, dtype=np.int)
+            time_blt_inds = np.zeros(0, dtype=np.int64)
             for jd in times:
                 if jd in self.time_array:
                     time_blt_inds = np.append(
@@ -4409,7 +4411,7 @@ class UVData(UVBase):
                 # Use intesection (and) to join
                 # antenna_names/nums/ant_pairs_nums/blt_inds with times
                 blt_inds = np.array(
-                    list(set(blt_inds).intersection(time_blt_inds)), dtype=np.int
+                    list(set(blt_inds).intersection(time_blt_inds)), dtype=np.int64
                 )
             else:
                 blt_inds = time_blt_inds
@@ -4446,7 +4448,7 @@ class UVData(UVBase):
                 history_update_string += "frequencies"
             n_selects += 1
 
-            freq_inds = np.zeros(0, dtype=np.int)
+            freq_inds = np.zeros(0, dtype=np.int64)
             # this works because we only allow one SPW. This will have to be
             # reworked when we support more.
             freq_arr_use = self.freq_array[0, :]
@@ -4487,7 +4489,7 @@ class UVData(UVBase):
                 history_update_string += "polarizations"
             n_selects += 1
 
-            pol_inds = np.zeros(0, dtype=np.int)
+            pol_inds = np.zeros(0, dtype=np.int64)
             for p in polarizations:
                 if isinstance(p, str):
                     p_num = uvutils.polstr2num(p, x_orientation=self.x_orientation)
@@ -4910,7 +4912,7 @@ class UVData(UVBase):
 
         temp_Nblts = np.sum(n_new_samples)
 
-        temp_baseline = np.zeros((temp_Nblts,), dtype=np.int)
+        temp_baseline = np.zeros((temp_Nblts,), dtype=np.int64)
         temp_time = np.zeros((temp_Nblts,))
         temp_int_time = np.zeros((temp_Nblts,))
         if self.metadata_only:
@@ -5214,7 +5216,7 @@ class UVData(UVBase):
                 self.phase_to_time(phase_time)
 
         # make temporary arrays
-        temp_baseline = np.zeros((temp_Nblts,), dtype=np.int)
+        temp_baseline = np.zeros((temp_Nblts,), dtype=np.int64)
         temp_time = np.zeros((temp_Nblts,))
         temp_int_time = np.zeros((temp_Nblts,))
         if self.metadata_only:
@@ -5353,7 +5355,7 @@ class UVData(UVBase):
             inds_to_keep = []
             for bl in bls_not_downsampled:
                 inds_to_keep += np.nonzero(self.baseline_array == bl)[0].tolist()
-            inds_to_keep = np.array(inds_to_keep, dtype=np.int)
+            inds_to_keep = np.array(inds_to_keep, dtype=np.int64)
         else:
             inds_to_keep = np.array([], dtype=bool)
         self._harmonize_resample_arrays(
@@ -5777,8 +5779,8 @@ class UVData(UVBase):
                     conj_group_inds.extend(bl_inds)
                     conj_group_times.extend(self.time_array[bl_inds])
 
-                group_inds = np.array(group_inds, dtype=np.int)
-                conj_group_inds = np.array(conj_group_inds, dtype=np.int)
+                group_inds = np.array(group_inds, dtype=np.int64)
+                conj_group_inds = np.array(conj_group_inds, dtype=np.int64)
                 # now we have to figure out which times are the same to a tolerance
                 # so we can average over them.
                 time_inds = np.arange(len(group_times + conj_group_times))
@@ -5822,7 +5824,7 @@ class UVData(UVBase):
                     # so we use that to split them back up.
                     regular_orientation = np.array(
                         [time_ind for time_ind in gp if time_ind < len(group_times)],
-                        dtype=np.int,
+                        dtype=np.int64,
                     )
                     regular_inds = group_inds[np.array(regular_orientation)]
                     conj_orientation = np.array(
@@ -5831,7 +5833,7 @@ class UVData(UVBase):
                             for time_ind in gp
                             if time_ind >= len(group_times)
                         ],
-                        dtype=np.int,
+                        dtype=np.int64,
                     )
                     conj_inds = conj_group_inds[np.array(conj_orientation)]
                     # check that the integration times are all the same

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -116,7 +116,7 @@ class UVData(UVBase):
             "flag_array",
             description=desc,
             form=("Nblts", 1, "Nfreqs", "Npols"),
-            expected_type=np.bool,
+            expected_type=np.bool_,
         )
 
         self._Nspws = uvp.UVParameter(
@@ -301,7 +301,7 @@ class UVData(UVBase):
             "varying widths."
         )
         self._flex_spw = uvp.UVParameter(
-            "flex_spw", description=desc, expected_type=np.bool, value=False,
+            "flex_spw", description=desc, expected_type=np.bool_, value=False,
         )
 
         desc = (
@@ -1226,7 +1226,7 @@ class UVData(UVBase):
                     "antpair2ind must be fed an antpair tuple or "
                     "expand it as arguments"
                 )
-        if not isinstance(ordered, (bool, np.bool)):
+        if not isinstance(ordered, (bool, np.bool_)):
             raise ValueError("ordered must be a boolean")
 
         # if getting auto-corr, ordered must be True
@@ -1721,7 +1721,7 @@ class UVData(UVBase):
         ind1, ind2, indp = self._key2inds(key)
         out = self._smart_slicing(
             self.flag_array, ind1, ind2, indp, squeeze=squeeze, force_copy=force_copy
-        ).astype(np.bool)
+        ).astype(np.bool_)
         return out
 
     def get_nsamples(
@@ -3253,7 +3253,7 @@ class UVData(UVBase):
                 )
                 this.flag_array = np.concatenate(
                     [this.flag_array, 1 - zero_pad], axis=0
-                ).astype(np.bool)
+                ).astype(np.bool_)
             this.uvw_array = np.concatenate(
                 [this.uvw_array, other.uvw_array[bnew_inds, :]], axis=0
             )[blt_order, :]
@@ -3292,7 +3292,7 @@ class UVData(UVBase):
                 )
                 this.flag_array = np.concatenate(
                     [this.flag_array, 1 - zero_pad], axis=2
-                ).astype(np.bool)
+                ).astype(np.bool_)
         if len(pnew_inds) > 0:
             this.polarization_array = np.concatenate(
                 [this.polarization_array, other.polarization_array[pnew_inds]]
@@ -3314,7 +3314,7 @@ class UVData(UVBase):
                 )
                 this.flag_array = np.concatenate(
                     [this.flag_array, 1 - zero_pad], axis=3
-                ).astype(np.bool)
+                ).astype(np.bool_)
 
         # Now populate the data
         pol_t2o = np.nonzero(

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -77,7 +77,7 @@ class UVData(UVBase):
             "data_array",
             description=desc,
             form=("Nblts", 1, "Nfreqs", "Npols"),
-            expected_type=np.complex,
+            expected_type=complex,
         )
 
         desc = 'Visibility units, options are: "uncalib", "Jy" or "K str"'
@@ -108,7 +108,7 @@ class UVData(UVBase):
             "nsample_array",
             description=desc,
             form=("Nblts", 1, "Nfreqs", "Npols"),
-            expected_type=(np.floating),
+            expected_type=float,
         )
 
         desc = "Boolean flag, True is flagged, same shape as data_array."
@@ -132,7 +132,7 @@ class UVData(UVBase):
             "spw_array",
             description="Array of spectral window numbers, shape (Nspws)",
             form=("Nspws",),
-            expected_type=int,
+            expected_type=np.integer,
         )
 
         desc = (
@@ -173,13 +173,13 @@ class UVData(UVBase):
 
         desc = "Array of first antenna indices, shape (Nblts), " "type = int, 0 indexed"
         self._ant_1_array = uvp.UVParameter(
-            "ant_1_array", description=desc, expected_type=int, form=("Nblts",)
+            "ant_1_array", description=desc, expected_type=np.integer, form=("Nblts",)
         )
         desc = (
             "Array of second antenna indices, shape (Nblts), " "type = int, 0 indexed"
         )
         self._ant_2_array = uvp.UVParameter(
-            "ant_2_array", description=desc, expected_type=int, form=("Nblts",)
+            "ant_2_array", description=desc, expected_type=np.integer, form=("Nblts",)
         )
 
         desc = (
@@ -187,7 +187,10 @@ class UVData(UVBase):
             "type = int; baseline = 2048 * (ant1+1) + (ant2+1) + 2^16"
         )
         self._baseline_array = uvp.UVParameter(
-            "baseline_array", description=desc, expected_type=int, form=("Nblts",)
+            "baseline_array",
+            description=desc,
+            expected_type=np.integer,
+            form=("Nblts",),
         )
 
         # this dimensionality of freq_array does not allow for different spws
@@ -218,7 +221,7 @@ class UVData(UVBase):
         self._polarization_array = uvp.UVParameter(
             "polarization_array",
             description=desc,
-            expected_type=int,
+            expected_type=np.integer,
             acceptable_vals=list(np.arange(-8, 0)) + list(np.arange(1, 5)),
             form=("Npols",),
         )
@@ -250,7 +253,7 @@ class UVData(UVBase):
             "(Nfreqs), type = float."
         )
         self._channel_width = uvp.UVParameter(
-            "channel_width", description=desc, expected_type=np.floating, tols=1e-3,
+            "channel_width", description=desc, expected_type=float, tols=1e-3,
         )  # 1 mHz
 
         # --- observation information ---
@@ -313,7 +316,7 @@ class UVData(UVBase):
             "flex_spw_id_array",
             description=desc,
             form=("Nfreqs",),
-            expected_type=np.int,
+            expected_type=np.integer,
             required=False,
         )
 
@@ -336,10 +339,7 @@ class UVData(UVBase):
             "applied to the data (eg 2000.)"
         )
         self._phase_center_epoch = uvp.UVParameter(
-            "phase_center_epoch",
-            required=False,
-            description=desc,
-            expected_type=np.floating,
+            "phase_center_epoch", required=False, description=desc, expected_type=float,
         )
 
         desc = (
@@ -351,7 +351,7 @@ class UVData(UVBase):
             "phase_center_ra",
             required=False,
             description=desc,
-            expected_type=np.floating,
+            expected_type=float,
             tols=radian_tol,
         )
 
@@ -364,7 +364,7 @@ class UVData(UVBase):
             "phase_center_dec",
             required=False,
             description=desc,
-            expected_type=np.floating,
+            expected_type=float,
             tols=radian_tol,
         )
 
@@ -436,7 +436,7 @@ class UVData(UVBase):
             "antenna_positions",
             description=desc,
             form=("Nants_telescope", 3),
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3,  # 1 mm
         )
 
@@ -494,7 +494,7 @@ class UVData(UVBase):
             required=False,
             description=desc,
             form=("Nants_telescope",),
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3,  # 1 mm
         )
 
@@ -506,7 +506,7 @@ class UVData(UVBase):
             required=False,
             description="Greenwich sidereal time at " "midnight on reference date",
             spoof_val=0.0,
-            expected_type=np.floating,
+            expected_type=float,
         )
         self._rdate = uvp.UVParameter(
             "rdate",
@@ -520,14 +520,14 @@ class UVData(UVBase):
             required=False,
             description="Earth's rotation rate " "in degrees per day",
             spoof_val=360.985,
-            expected_type=np.floating,
+            expected_type=float,
         )
         self._dut1 = uvp.UVParameter(
             "dut1",
             required=False,
             description="DUT1 (google it) AIPS 117 " "calls it UT1UTC",
             spoof_val=0.0,
-            expected_type=np.floating,
+            expected_type=float,
         )
         self._timesys = uvp.UVParameter(
             "timesys",
@@ -552,7 +552,7 @@ class UVData(UVBase):
             required=False,
             description=desc,
             form=("Nants_telescope", "Nfreqs"),
-            expected_type=np.floating,
+            expected_type=float,
             spoof_val=1.0,
         )
 
@@ -1912,7 +1912,7 @@ class UVData(UVBase):
             if (
                 np.max(convention) >= self.Nblts
                 or np.min(convention) < 0
-                or convention.dtype not in [int, np.int, np.int32, np.int64]
+                or convention.dtype not in [int, np.int_, np.int32, np.int64]
             ):
                 raise ValueError(
                     "If convention is an index array, it must "
@@ -2050,7 +2050,7 @@ class UVData(UVBase):
             order = np.array(order)
             if (
                 order.size != self.Npols
-                or order.dtype not in [int, np.int, np.int32, np.int64]
+                or order.dtype not in [int, np.int_, np.int32, np.int64]
                 or np.min(order) < 0
                 or np.max(order) >= self.Npols
             ):
@@ -2148,7 +2148,7 @@ class UVData(UVBase):
             order = np.array(order)
             if order.size != self.Nblts or order.dtype not in [
                 int,
-                np.int,
+                np.int_,
                 np.int32,
                 np.int64,
             ]:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -108,7 +108,7 @@ class UVData(UVBase):
             "nsample_array",
             description=desc,
             form=("Nblts", 1, "Nfreqs", "Npols"),
-            expected_type=(np.float),
+            expected_type=(np.floating),
         )
 
         desc = "Boolean flag, True is flagged, same shape as data_array."
@@ -146,7 +146,7 @@ class UVData(UVBase):
             "uvw_array",
             description=desc,
             form=("Nblts", 3),
-            expected_type=np.float,
+            expected_type=np.floating,
             acceptable_range=(0, 1e8),
             tols=1e-3,
         )
@@ -158,7 +158,7 @@ class UVData(UVBase):
             "time_array",
             description=desc,
             form=("Nblts",),
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3 / (60.0 * 60.0 * 24.0),
         )  # 1 ms in days
 
@@ -167,7 +167,7 @@ class UVData(UVBase):
             "lst_array",
             description=desc,
             form=("Nblts",),
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=radian_tol,
         )
 
@@ -201,7 +201,7 @@ class UVData(UVBase):
             "freq_array",
             description=desc,
             form=(1, "Nfreqs"),
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3,
         )  # mHz
 
@@ -240,7 +240,7 @@ class UVData(UVBase):
             "integration_time",
             description=desc,
             form=("Nblts",),
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3,
         )  # 1 ms
 
@@ -250,7 +250,7 @@ class UVData(UVBase):
             "(Nfreqs), type = float."
         )
         self._channel_width = uvp.UVParameter(
-            "channel_width", description=desc, expected_type=np.float, tols=1e-3,
+            "channel_width", description=desc, expected_type=np.floating, tols=1e-3,
         )  # 1 mHz
 
         # --- observation information ---
@@ -339,7 +339,7 @@ class UVData(UVBase):
             "phase_center_epoch",
             required=False,
             description=desc,
-            expected_type=np.float,
+            expected_type=np.floating,
         )
 
         desc = (
@@ -351,7 +351,7 @@ class UVData(UVBase):
             "phase_center_ra",
             required=False,
             description=desc,
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=radian_tol,
         )
 
@@ -364,7 +364,7 @@ class UVData(UVBase):
             "phase_center_dec",
             required=False,
             description=desc,
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=radian_tol,
         )
 
@@ -436,7 +436,7 @@ class UVData(UVBase):
             "antenna_positions",
             description=desc,
             form=("Nants_telescope", 3),
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3,  # 1 mm
         )
 
@@ -494,7 +494,7 @@ class UVData(UVBase):
             required=False,
             description=desc,
             form=("Nants_telescope",),
-            expected_type=np.float,
+            expected_type=np.floating,
             tols=1e-3,  # 1 mm
         )
 
@@ -506,7 +506,7 @@ class UVData(UVBase):
             required=False,
             description="Greenwich sidereal time at " "midnight on reference date",
             spoof_val=0.0,
-            expected_type=np.float,
+            expected_type=np.floating,
         )
         self._rdate = uvp.UVParameter(
             "rdate",
@@ -520,14 +520,14 @@ class UVData(UVBase):
             required=False,
             description="Earth's rotation rate " "in degrees per day",
             spoof_val=360.985,
-            expected_type=np.float,
+            expected_type=np.floating,
         )
         self._dut1 = uvp.UVParameter(
             "dut1",
             required=False,
             description="DUT1 (google it) AIPS 117 " "calls it UT1UTC",
             spoof_val=0.0,
-            expected_type=np.float,
+            expected_type=np.floating,
         )
         self._timesys = uvp.UVParameter(
             "timesys",
@@ -552,7 +552,7 @@ class UVData(UVBase):
             required=False,
             description=desc,
             form=("Nants_telescope", "Nfreqs"),
-            expected_type=np.float,
+            expected_type=np.floating,
             spoof_val=1.0,
         )
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -132,7 +132,7 @@ class UVData(UVBase):
             "spw_array",
             description="Array of spectral window numbers, shape (Nspws)",
             form=("Nspws",),
-            expected_type=np.integer,
+            expected_type=int,
         )
 
         desc = (
@@ -146,7 +146,7 @@ class UVData(UVBase):
             "uvw_array",
             description=desc,
             form=("Nblts", 3),
-            expected_type=np.floating,
+            expected_type=float,
             acceptable_range=(0, 1e8),
             tols=1e-3,
         )
@@ -158,7 +158,7 @@ class UVData(UVBase):
             "time_array",
             description=desc,
             form=("Nblts",),
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3 / (60.0 * 60.0 * 24.0),
         )  # 1 ms in days
 
@@ -167,19 +167,19 @@ class UVData(UVBase):
             "lst_array",
             description=desc,
             form=("Nblts",),
-            expected_type=np.floating,
+            expected_type=float,
             tols=radian_tol,
         )
 
         desc = "Array of first antenna indices, shape (Nblts), " "type = int, 0 indexed"
         self._ant_1_array = uvp.UVParameter(
-            "ant_1_array", description=desc, expected_type=np.integer, form=("Nblts",)
+            "ant_1_array", description=desc, expected_type=int, form=("Nblts",)
         )
         desc = (
             "Array of second antenna indices, shape (Nblts), " "type = int, 0 indexed"
         )
         self._ant_2_array = uvp.UVParameter(
-            "ant_2_array", description=desc, expected_type=np.integer, form=("Nblts",)
+            "ant_2_array", description=desc, expected_type=int, form=("Nblts",)
         )
 
         desc = (
@@ -187,10 +187,7 @@ class UVData(UVBase):
             "type = int; baseline = 2048 * (ant1+1) + (ant2+1) + 2^16"
         )
         self._baseline_array = uvp.UVParameter(
-            "baseline_array",
-            description=desc,
-            expected_type=np.integer,
-            form=("Nblts",),
+            "baseline_array", description=desc, expected_type=int, form=("Nblts",),
         )
 
         # this dimensionality of freq_array does not allow for different spws
@@ -204,7 +201,7 @@ class UVData(UVBase):
             "freq_array",
             description=desc,
             form=(1, "Nfreqs"),
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3,
         )  # mHz
 
@@ -221,7 +218,7 @@ class UVData(UVBase):
         self._polarization_array = uvp.UVParameter(
             "polarization_array",
             description=desc,
-            expected_type=np.integer,
+            expected_type=int,
             acceptable_vals=list(np.arange(-8, 0)) + list(np.arange(1, 5)),
             form=("Npols",),
         )
@@ -243,7 +240,7 @@ class UVData(UVBase):
             "integration_time",
             description=desc,
             form=("Nblts",),
-            expected_type=np.floating,
+            expected_type=float,
             tols=1e-3,
         )  # 1 ms
 
@@ -316,7 +313,7 @@ class UVData(UVBase):
             "flex_spw_id_array",
             description=desc,
             form=("Nfreqs",),
-            expected_type=np.integer,
+            expected_type=int,
             required=False,
         )
 

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -452,15 +452,15 @@ class UVFITS(UVData):
                 )
 
                 # the axis number for phase center depends on if the spw exists
-                self.phase_center_ra_degrees = np.float64(vis_hdr.pop("CRVAL6"))
-                self.phase_center_dec_degrees = np.float64(vis_hdr.pop("CRVAL7"))
+                self.phase_center_ra_degrees = float(vis_hdr.pop("CRVAL6"))
+                self.phase_center_dec_degrees = float(vis_hdr.pop("CRVAL7"))
             else:
                 self.Nspws = 1
                 self.spw_array = np.array([np.int64(0)])
 
                 # the axis number for phase center depends on if the spw exists
-                self.phase_center_ra_degrees = np.float64(vis_hdr.pop("CRVAL5"))
-                self.phase_center_dec_degrees = np.float64(vis_hdr.pop("CRVAL6"))
+                self.phase_center_ra_degrees = float(vis_hdr.pop("CRVAL5"))
+                self.phase_center_dec_degrees = float(vis_hdr.pop("CRVAL6"))
 
             # get shapes
             self.Npols = vis_hdr.pop("NAXIS3")

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -447,14 +447,16 @@ class UVFITS(UVData):
             # check if we have an spw dimension
             if vis_hdr["NAXIS"] == 7:
                 self.Nspws = vis_hdr.pop("NAXIS5")
-                self.spw_array = uvutils._fits_gethduaxis(vis_hdu, 5).astype(np.int) - 1
+                self.spw_array = (
+                    uvutils._fits_gethduaxis(vis_hdu, 5).astype(np.int64) - 1
+                )
 
                 # the axis number for phase center depends on if the spw exists
                 self.phase_center_ra_degrees = np.float64(vis_hdr.pop("CRVAL6"))
                 self.phase_center_dec_degrees = np.float64(vis_hdr.pop("CRVAL7"))
             else:
                 self.Nspws = 1
-                self.spw_array = np.array([np.int(0)])
+                self.spw_array = np.array([np.int64(0)])
 
                 # the axis number for phase center depends on if the spw exists
                 self.phase_center_ra_degrees = np.float64(vis_hdr.pop("CRVAL5"))

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -450,15 +450,15 @@ class UVFITS(UVData):
                 self.spw_array = uvutils._fits_gethduaxis(vis_hdu, 5).astype(np.int) - 1
 
                 # the axis number for phase center depends on if the spw exists
-                self.phase_center_ra_degrees = np.float(vis_hdr.pop("CRVAL6"))
-                self.phase_center_dec_degrees = np.float(vis_hdr.pop("CRVAL7"))
+                self.phase_center_ra_degrees = np.float64(vis_hdr.pop("CRVAL6"))
+                self.phase_center_dec_degrees = np.float64(vis_hdr.pop("CRVAL7"))
             else:
                 self.Nspws = 1
                 self.spw_array = np.array([np.int(0)])
 
                 # the axis number for phase center depends on if the spw exists
-                self.phase_center_ra_degrees = np.float(vis_hdr.pop("CRVAL5"))
-                self.phase_center_dec_degrees = np.float(vis_hdr.pop("CRVAL6"))
+                self.phase_center_ra_degrees = np.float64(vis_hdr.pop("CRVAL5"))
+                self.phase_center_dec_degrees = np.float64(vis_hdr.pop("CRVAL6"))
 
             # get shapes
             self.Npols = vis_hdr.pop("NAXIS3")
@@ -783,11 +783,11 @@ class UVFITS(UVData):
                 ]
 
             start_freq_array = np.reshape(np.array(start_freq_array), (1, -1)).astype(
-                np.float
+                np.float64
             )
 
             delta_freq_array = np.reshape(np.array(delta_freq_array), (1, -1)).astype(
-                np.float
+                np.float64
             )
 
             # We've constructed a couple of lists with relevant values, now time to
@@ -814,7 +814,7 @@ class UVFITS(UVData):
             # other exciting things...
             ref_freq = start_freq_array[0, 0]
         else:
-            delta_freq_array = np.array([[self.channel_width]]).astype(np.float)
+            delta_freq_array = np.array([[self.channel_width]]).astype(np.float64)
             ref_freq = self.freq_array[0, 0]
 
         if self.Npols > 1:

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -578,7 +578,11 @@ def test_read_missing_nants_data(test_outfile):
     with h5py.File(test_outfile, "a") as h5:
         del h5["Header/Nants_data"]
 
-    with uvtest.check_warnings(UserWarning, "Nants_data not available in file,"):
+    # PLP: Temporarily change from uvtest.check_warnings -> pytest.warns.
+    # numpy v1.20 causes h5py to issue warnings. Must keep as is for now to
+    # avoid test failures, can change back later.
+    # with uvtest.check_warnings(UserWarning, "Nants_data not available in file,"):
+    with pytest.warns(UserWarning, match="Nants_data not available in file,"):
         uvf2 = UVFlag(test_outfile)
 
     # make sure this was set to None
@@ -1934,9 +1938,11 @@ def test_missing_nants_telescope(tmp_path):
 
     with h5py.File(testfile, "r+") as f:
         del f["/Header/Nants_telescope"]
-    with uvtest.check_warnings(
-        UserWarning, match="Nants_telescope not available in file"
-    ):
+    # PLP: Temporarily change from uvtest.check_warnings -> pytest.warns.
+    # numpy v1.20 causes h5py to issue warnings. Must keep as is for now to
+    # avoid test failures, can change back later.
+    # with uvtest.check_warnings(
+    with pytest.warns(UserWarning, match="Nants_telescope not available in file"):
         uvf = UVFlag(testfile)
     uvf2 = UVFlag(test_f_file)
     uvf2.Nants_telescope = 2047
@@ -2113,7 +2119,7 @@ def test_flags2waterfall_errors(uvdata_obj):
 
 
 def test_and_rows_cols():
-    d = np.zeros((10, 20), np.bool)
+    d = np.zeros((10, 20), np.bool_)
     d[1, :] = True
     d[:, 2] = True
     d[5, 10:20] = True

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -578,11 +578,7 @@ def test_read_missing_nants_data(test_outfile):
     with h5py.File(test_outfile, "a") as h5:
         del h5["Header/Nants_data"]
 
-    # PLP: Temporarily change from uvtest.check_warnings -> pytest.warns.
-    # numpy v1.20 causes h5py to issue warnings. Must keep as is for now to
-    # avoid test failures, can change back later.
-    # with uvtest.check_warnings(UserWarning, "Nants_data not available in file,"):
-    with pytest.warns(UserWarning, match="Nants_data not available in file,"):
+    with uvtest.check_warnings(UserWarning, "Nants_data not available in file,"):
         uvf2 = UVFlag(test_outfile)
 
     # make sure this was set to None
@@ -1938,11 +1934,9 @@ def test_missing_nants_telescope(tmp_path):
 
     with h5py.File(testfile, "r+") as f:
         del f["/Header/Nants_telescope"]
-    # PLP: Temporarily change from uvtest.check_warnings -> pytest.warns.
-    # numpy v1.20 causes h5py to issue warnings. Must keep as is for now to
-    # avoid test failures, can change back later.
-    # with uvtest.check_warnings(
-    with pytest.warns(UserWarning, match="Nants_telescope not available in file"):
+    with uvtest.check_warnings(
+        UserWarning, match="Nants_telescope not available in file",
+    ):
         uvf = UVFlag(testfile)
     uvf2 = UVFlag(test_f_file)
     uvf2.Nants_telescope = 2047

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -1986,8 +1986,8 @@ class UVFlag(UVBase):
             n_selects += 1
 
             if self.type == "baseline":
-                inds1 = np.zeros(0, dtype=np.int)
-                inds2 = np.zeros(0, dtype=np.int)
+                inds1 = np.zeros(0, dtype=np.int64)
+                inds2 = np.zeros(0, dtype=np.int64)
                 for ant in antenna_nums:
                     if ant in self.ant_1_array or ant in self.ant_2_array:
                         wh1 = np.where(self.ant_1_array == ant)[0]
@@ -2005,7 +2005,7 @@ class UVFlag(UVBase):
 
             if self.type == "antenna":
                 ant_blt_inds = None
-                ant_inds = np.zeros(0, dtype=np.int)
+                ant_inds = np.zeros(0, dtype=np.int64)
                 for ant in antenna_nums:
                     if ant in self.ant_array:
                         wh = np.nonzero(self.ant_array == ant)[0]
@@ -2057,7 +2057,7 @@ class UVFlag(UVBase):
                 history_update_string += "baselines"
 
             n_selects += 1
-            bls_blt_inds = np.zeros(0, dtype=np.int)
+            bls_blt_inds = np.zeros(0, dtype=np.int64)
             bl_pols = set()
             for bl in bls:
                 if not (bl[0] in self.ant_1_array or bl[0] in self.ant_2_array):
@@ -2122,7 +2122,7 @@ class UVFlag(UVBase):
 
             n_selects += 1
 
-            time_blt_inds = np.zeros(0, dtype=np.int)
+            time_blt_inds = np.zeros(0, dtype=np.int64)
             for jd in times:
                 if jd in self.time_array:
                     time_blt_inds = np.append(
@@ -2187,7 +2187,7 @@ class UVFlag(UVBase):
                 history_update_string += "frequencies"
             n_selects += 1
 
-            freq_inds = np.zeros(0, dtype=np.int)
+            freq_inds = np.zeros(0, dtype=np.int64)
             # this works because we only allow one SPW. This will have to be
             # reworked when we support more.
             if self.type != "waterfall":
@@ -2216,7 +2216,7 @@ class UVFlag(UVBase):
                 history_update_string += "polarizations"
             n_selects += 1
 
-            pol_inds = np.zeros(0, dtype=np.int)
+            pol_inds = np.zeros(0, dtype=np.int64)
             for p in polarizations:
                 if isinstance(p, str):
                     p_num = uvutils.polstr2num(p, x_orientation=self.x_orientation)

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -268,7 +268,7 @@ class UVFlag(UVBase):
             "metric_array",
             description=desc,
             form=("Nblts", "Nspws", "Nfreqs", "Npols"),
-            expected_type=np.float,
+            expected_type=float,
             required=False,
         )
 
@@ -280,7 +280,7 @@ class UVFlag(UVBase):
             "flag_array",
             description=desc,
             form=("Nblts", "Nspws", "Nfreqs", "Npols"),
-            expected_type=np.bool_,
+            expected_type=bool,
             required=False,
         )
 
@@ -289,7 +289,7 @@ class UVFlag(UVBase):
             "weights_array",
             description=desc,
             form=("Nblts", "Nspws", "Nfreqs", "Npols"),
-            expected_type=np.float,
+            expected_type=float,
         )
 
         desc = (
@@ -300,7 +300,7 @@ class UVFlag(UVBase):
             "weights_square_array",
             description=desc,
             form=("Nblts", "Nspws", "Nfreqs", "Npols"),
-            expected_type=np.float,
+            expected_type=float,
             required=False,
         )
 
@@ -311,7 +311,7 @@ class UVFlag(UVBase):
             "time_array",
             description=desc,
             form=("Nblts",),
-            expected_type=np.float,
+            expected_type=float,
             tols=1e-3 / (60.0 * 60.0 * 24.0),
         )  # 1 ms in days
 
@@ -320,7 +320,7 @@ class UVFlag(UVBase):
             "lst_array",
             description=desc,
             form=("Nblts",),
-            expected_type=np.float,
+            expected_type=float,
             tols=radian_tol,
         )
 
@@ -367,7 +367,7 @@ class UVFlag(UVBase):
             "freq_array",
             description=desc,
             form=("Nspws", "Nfreqs"),
-            expected_type=np.float,
+            expected_type=float,
             tols=1e-3,
         )  # mHz
 
@@ -1201,8 +1201,8 @@ class UVFlag(UVBase):
                 arr = np.zeros_like(uv.flag_array)
                 sarr = self.flag_array
             elif self.mode == "metric":
-                arr = np.zeros_like(uv.flag_array, dtype=float)
-                warr = np.zeros_like(uv.flag_array, dtype=np.float)
+                arr = np.zeros_like(uv.flag_array, dtype=np.float64)
+                warr = np.zeros_like(uv.flag_array, dtype=np.float64)
                 sarr = self.metric_array
             for i, t in enumerate(np.unique(self.time_array)):
                 ti = np.where(uv.time_array == t)
@@ -1476,7 +1476,7 @@ class UVFlag(UVBase):
         if self.mode == "metric":
             return
         elif self.mode == "flag":
-            self.metric_array = self.flag_array.astype(np.float)
+            self.metric_array = self.flag_array.astype(np.float64)
             self._set_mode_metric()
 
             if convert_wgts:
@@ -2944,7 +2944,7 @@ class UVFlag(UVBase):
                     self.flag_array = np.zeros_like(indata.flag_array)
                 elif self.mode == "metric":
                     self.metric_array = np.zeros_like(indata.flag_array).astype(
-                        np.float
+                        np.float64
                     )
 
         if indata.x_orientation is not None:
@@ -3103,7 +3103,7 @@ class UVFlag(UVBase):
                     self.flag_array = np.zeros_like(indata.flag_array)
                 elif self.mode == "metric":
                     self.metric_array = np.zeros_like(indata.flag_array).astype(
-                        np.float
+                        np.float64
                     )
         if self.mode == "metric":
             self.weights_array = np.ones(self.metric_array.shape)

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -36,7 +36,7 @@ def and_rows_cols(waterfall):
         that were fully flagged are flagged.
 
     """
-    wf = np.zeros_like(waterfall, dtype=np.bool)
+    wf = np.zeros_like(waterfall, dtype=np.bool_)
     Ntimes, Nfreqs = waterfall.shape
     wf[:, (np.sum(waterfall, axis=0) / Ntimes) == 1] = True
     wf[(np.sum(waterfall, axis=1) / Nfreqs) == 1] = True
@@ -280,7 +280,7 @@ class UVFlag(UVBase):
             "flag_array",
             description=desc,
             form=("Nblts", "Nspws", "Nfreqs", "Npols"),
-            expected_type=np.bool,
+            expected_type=np.bool_,
             required=False,
         )
 
@@ -2892,7 +2892,7 @@ class UVFlag(UVBase):
                             len(self.freq_array),
                             len(self.polarization_array),
                         ),
-                        np.bool,
+                        np.bool_,
                     )
                 elif self.mode == "metric":
                     self.metric_array = np.zeros(
@@ -3056,7 +3056,7 @@ class UVFlag(UVBase):
                             len(self.freq_array),
                             len(self.polarization_array),
                         ),
-                        np.bool,
+                        np.bool_,
                     )
                 elif self.mode == "metric":
                     self.metric_array = np.zeros(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As noted in [the release notes for numpy v1.20.0](https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations), several datatypes such as `np.float` have started issuing `DeprecationWarnings`. This PR makes a lot of changes, in both the code and tests, to handle data types more precisely and make the warnings go away.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This PR includes several different changes, which I've tried to summarize here:
* Explicitly using a type such as `np.float64` for array data types when creating new ones or using `asarray` instead of the generic `np.float`. (e.g., `np.zeros(Nvals, dtype=np.float)` -> `np.zeros(Nvals, dtype=np.float64)`). This includes integer types as well.
* Casting scalars with the python builtins `float` and `int` instead of `np.float` and `np.int`.
* Using `np.str_` instead of `np.str` for doing type comparisons with `isinstance`.
* Changing the `expected_type` value for some parameters to make type checks pass.

~This last point is something I'd like to discuss more generally, because it feels like things are a little looser than I'd like. In the past, it seemed that `np.float` would match the class of both `float` and `np.float64` (or maybe it was just how we were doing the checks?), and now we need to be a little more explicit. I just want to make sure everyone is happy how we do them going forward. (I am not wedded to how they are being done right now, as my primary motivation was making the warnings go away rather than doing things The Right Way.)~ There were several changes made to how type checking and handling were done, and now all parameter types use python builtins (e.g., `float`, `int`, etc.). This relies on the generic typing introduced in #965 to handle specific types when specified by the user, and more general types outside of that.

~Potentially unrelated to this, our tests seem to be failing when built using numpy v1.19.x. When we work out a fix for that, we might want to include it as part of this PR. Running locally, this branch passes all tests using numpy v1.20.0 and v1.19.2, so I don't believe we need to change the numpy requirement on the repo.~ This issue was resolved by using the `oldest-supported-numpy` metapackage in the `pyproject.toml` file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

