### PR TITLE
Fix mwa_corr_fits memory spike

### DIFF
--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -519,9 +519,10 @@ class MWACorrFITS(UVData):
         # multiplied be the integration time (s)
         nsamples = self.channel_width * self.integration_time[0]
         # cast data to ints
-        self.data_array = np.rint(self.data_array / self.extra_keywords["SCALEFAC"])
+        self.data_array /= self.extra_keywords["SCALEFAC"]
+        np.rint(self.data_array, out=self.data_array)
         # take advantage of circular symmetry! divide by two
-        self.data_array = self.data_array / (nsamples * 2.0)
+        self.data_array /= nsamples * 2.0
         # reshape to (nbls, ntimes, nfreqs, npols)
         self.data_array = np.swapaxes(self.data_array, 0, 1)
         # get indices for autos
@@ -725,9 +726,7 @@ class MWACorrFITS(UVData):
         # reshape to (ntimes, nbls, nfreqs, npols)
         self.data_array = np.swapaxes(self.data_array, 0, 1)
         # rescale the data
-        self.data_array = self.data_array * (
-            self.extra_keywords["SCALEFAC"] * nsamples * 2
-        )
+        self.data_array *= self.extra_keywords["SCALEFAC"] * nsamples * 2
         # return data array to desired precision
         if self.data_array.dtype != data_array_dtype:
             self.data_array = self.data_array.astype(data_array_dtype)
@@ -1312,10 +1311,9 @@ class MWACorrFITS(UVData):
                 # when MWA data is cast to float for the correlator, the division
                 # by 127 introduces small errors that are mitigated when the data
                 # is cast back into integer
-                self.data_array = np.rint(
-                    self.data_array / self.extra_keywords["SCALEFAC"]
-                )
-                self.data_array = self.data_array * self.extra_keywords["SCALEFAC"]
+                self.data_array /= self.extra_keywords["SCALEFAC"]
+                np.rint(self.data_array, out=self.data_array)
+                self.data_array *= self.extra_keywords["SCALEFAC"]
             # combine baseline and time axes
             self.data_array = self.data_array.reshape(
                 (self.Nblts, self.Nfreqs, self.Npols)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Modify the cast of data_array to integer so that memory spike is avoided.
## Description
<!--- Describe your changes in detail -->
Casting the data_array to integer was performed such that the data_array was being copied, causing a memory spike. This modifies the cast, and makes a couple of other calculations inplace.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
