### PR TITLE
Fix mwa_corr_fits start_flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - A bug in reading in the MWA beam that caused the beam to be rotated by 90 degrees.
+- A bug in mwa_corr_fits that didn't round start_flag to the nearest multiple of
+integration time when using goodtime, resulting in an error when reading data
+taken at 2 seconds.
 
 ## [2.1.4] - 2021-2-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ All notable changes to this project will be documented in this file.
 - Added option to apply a Van Vleck correction to mwa_corr_fits files.
 
 ### Fixed
-- A bug in reading in the MWA beam that caused the beam to be rotated by 90 degrees.
 - A bug in mwa_corr_fits that didn't round start_flag to the nearest multiple of
 integration time when using goodtime, resulting in an error when reading data
 taken at 2 seconds.
+- A bug in reading in the MWA beam that caused the beam to be rotated by 90 degrees.
 
 ## [2.1.4] - 2021-2-04
 

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -1034,6 +1034,9 @@ class MWACorrFITS(UVData):
                 try:
                     if meta_hdr["GOODTIME"] > start_time:
                         start_flag = meta_hdr["GOODTIME"] - start_time
+                        # round start_flag up to nearest multiple of int_time
+                        if start_flag % int_time > 0:
+                            start_flag = (1 + int(start_flag / int_time)) * int_time
                     else:
                         start_flag = 0.0
                 except KeyError:

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -788,6 +788,22 @@ def test_start_flag_bad_string():
     assert str(cm.value).startswith("start_flag must be int or float or 'goodtime'")
 
 
+@pytest.mark.filterwarnings("ignore:telescope_location is not set.")
+@pytest.mark.filterwarnings("ignore:some coarse channel files were not submitted")
+def test_start_flag_int_time(tmp_path):
+    """Test goodtime returning a start_flag smaller than integration time."""
+    uv = UVData()
+    new_meta = str(tmp_path / "1131733552_goodtime.metafits")
+    with fits.open(filelist[0]) as meta:
+        meta[0].header["GOODTIME"] = 1447698337.25
+        meta.writeto(new_meta)
+    uv.read(
+        [new_meta, filelist[1]], flag_init=True, start_flag="goodtime",
+    )
+    # goodtime > start_time so all data should be flagged
+    assert np.all(uv.flag_array)
+
+
 def test_input_output_mapping():
     """Test the input_output_mapping function."""
     mapping_dict = {}

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -800,7 +800,8 @@ def test_start_flag_int_time(tmp_path):
     uv.read(
         [new_meta, filelist[1]], flag_init=True, start_flag="goodtime",
     )
-    # goodtime > start_time so all data should be flagged
+    # first integration time should be flagged
+    # data only has one integration time, so all data should be flagged
     assert np.all(uv.flag_array)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update deriving `start_flag` from the 'GOODTIME' metafits field so that `start_flag` is an integer multiple of the integration time.
## Description
<!--- Describe your changes in detail -->
If `start_flag` is not an integer multiple of the integration time, round `start_flag` up to the nearest multiple of the integration time.
## Motivation and Context
Subtracting the 'GOODTIME' field from the first integration time can give a `start_flag` that is not an integer multiple of the integration time, causing the read to fail.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).