### PR TITLE
Fix bug with using yamls to describe CST beams with only one file & frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- A bug in `UVBeam.read_cst_beam` when specifying beams with a single file using a yaml.
+
 ## [2.1.5] - 2021-4-02
 
 ### Added

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -3157,6 +3157,10 @@ class UVBeam(UVBase):
 
         if not isinstance(filename, (list, tuple)) and filename.endswith("yaml"):
             settings_dict = self._read_cst_beam_yaml(filename)
+            if not isinstance(settings_dict["filenames"], list):
+                raise ValueError("filenames in yaml file must be a list.")
+            if not isinstance(settings_dict["frequencies"], list):
+                raise ValueError("frequencies in yaml file must be a list.")
             yaml_dir = os.path.dirname(filename)
             cst_filename = [
                 os.path.join(yaml_dir, f) for f in settings_dict["filenames"]
@@ -3380,7 +3384,8 @@ class UVBeam(UVBase):
                     run_check_acceptability=run_check_acceptability,
                 )
                 self += beam2
-            del beam2
+            if len(cst_filename) > 1:
+                del beam2
         else:
             if isinstance(frequency, (list, tuple)):
                 raise ValueError("Too many frequencies specified")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a bug when a CST yaml only has one filename & frequency, provide better error message if lists are not used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes #1001 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
