### PR TITLE
added warning to uvcalibrate under x_orientation mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Warning to `utils.uvcalibrate` when data and cal x_orientation are mismatched.
 - Better re-initialization of UVParameters on UVBase objects when using pickle. Improves compatibility of UVBase objects with MPI.
 - Added option to apply a Van Vleck correction to mwa_corr_fits files.
 

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -2024,6 +2024,15 @@ def test_uvcalibrate_feedpol_mismatch(uvcalibrate_data):
         uvd.get_data(key) / (uvc.get_gains(ant1) * uvc.get_gains(ant2).conj()).T,
     )
 
+    # check x_orientation warning
+    uvd.x_orientation = 'north'
+    uvc.x_orientation = 'east'
+    with pytest.warns(
+        UserWarning,
+        match="Data and calibration x_orientation do not match!",
+    ):
+        uvdcal = uvutils.uvcalibrate(uvd, uvc, inplace=False)
+
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_apply_uvflag():

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1857,6 +1857,13 @@ def uvcalibrate(
         if len(uvcal_freqs_to_keep) < uvcal.Nfreqs:
             downselect_cal_freq = True
 
+    # raise warning if x_orientation doesn't match
+    if uvdata.x_orientation != uvcal.x_orientation:
+        warnings.warn(
+            "Data and calibration x_orientation do not match!",
+            UserWarning,
+        )
+
     uvdata_pol_strs = polnum2str(
         uvdata.polarization_array, x_orientation=uvdata.x_orientation
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When calibrating a uvd with a uvcal that has a mismatched x_orientation, `utils.uvcalibrate` silently exits. Here, I've added a warning to tell the user that x_orientation is mismatched

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [ x] My code follows the code style of this project.

Bug fix checklist:
- [x ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x ] All new and existing tests pass.
- [ x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Breaking change checklist:
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
