### PR TITLE
Improve history handling when combining objects

### DIFF
--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -70,20 +70,25 @@ def test_XYZ_from_LatLonAlt():
     assert np.allclose(ref_xyz, out_xyz, rtol=0, atol=1e-3)
 
     # test error checking
-    pytest.raises(
+    with pytest.raises(
         ValueError,
-        uvutils.XYZ_from_LatLonAlt,
-        ref_latlonalt[0],
-        ref_latlonalt[1],
-        np.array([ref_latlonalt[2], ref_latlonalt[2]]),
-    )
-    pytest.raises(
+        match="latitude, longitude and altitude must all have the same length",
+    ):
+        uvutils.XYZ_from_LatLonAlt(
+            ref_latlonalt[0],
+            ref_latlonalt[1],
+            np.array([ref_latlonalt[2], ref_latlonalt[2]]),
+        )
+
+    with pytest.raises(
         ValueError,
-        uvutils.XYZ_from_LatLonAlt,
-        ref_latlonalt[0],
-        np.array([ref_latlonalt[1], ref_latlonalt[1]]),
-        ref_latlonalt[2],
-    )
+        match="latitude, longitude and altitude must all have the same length",
+    ):
+        uvutils.XYZ_from_LatLonAlt(
+            ref_latlonalt[0],
+            np.array([ref_latlonalt[1], ref_latlonalt[1]]),
+            ref_latlonalt[2],
+        )
 
 
 def test_LatLonAlt_from_XYZ():

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -251,8 +251,27 @@ def _check_histories(history1, history2):
         return False
 
 
-def _combine_histories(history1, history2):
-    """Combine histories with minimal repeats."""
+def _combine_history_addition(history1, history2):
+    """
+    Find extra history to add to have minimal repeats.
+
+    Parameters
+    ----------
+    history1 : str
+        First history.
+    history2 : str
+        Second history
+
+    Returns
+    -------
+    str
+        Extra history to add to first history.
+
+    """
+    # first check if they're the same to avoid more complicated processing.
+    if _check_histories(history1, history2):
+        return None
+
     hist2_words = history2.split(" ")
     add_hist = ""
     test_hist1 = " " + history1 + " "
@@ -270,7 +289,9 @@ def _combine_histories(history1, history2):
                 else:
                     keep_going = False
 
-    return history1 + add_hist
+    if add_hist == "":
+        add_hist = None
+    return add_hist
 
 
 def baseline_to_antnums(baseline, Nants_telescope):

--- a/pyuvdata/uvbeam/tests/test_uvbeam.py
+++ b/pyuvdata/uvbeam/tests/test_uvbeam.py
@@ -2006,7 +2006,7 @@ def test_add(cst_power_1freq, cst_efield_1freq):
         UserWarning,
         "Only one of the UVBeam objects being combined has optional parameter",
     ):
-        beam1.__iadd__(beam2)
+        beam1 += beam2
 
     assert beam1.receiver_temperature_array is None
 
@@ -2018,16 +2018,23 @@ def test_add(cst_power_1freq, cst_efield_1freq):
         polarizations=power_beam.polarization_array[2:4], inplace=False
     )
     beam2.history += " testing the history. Read/written with pyuvdata"
-    beam1 += beam2
+    new_beam = beam1 + beam2
     assert uvutils._check_histories(
-        power_beam.history + "  Downselected to specific polarizations "
-        "using pyuvdata. Combined data along "
-        "polarization axis using pyuvdata. "
-        "testing the history.",
-        beam1.history,
+        power_beam.history + "  Downselected to specific polarizations using pyuvdata. "
+        "Combined data along polarization axis using pyuvdata. Unique part of next "
+        "object history follows.  testing the history.",
+        new_beam.history,
     )
-    beam1.history = power_beam.history
-    assert beam1 == power_beam
+    new_beam.history = power_beam.history
+    assert new_beam == power_beam
+
+    new_beam = beam1.__add__(beam2, verbose_history=True)
+    assert uvutils._check_histories(
+        power_beam.history + "  Downselected to specific polarizations using pyuvdata. "
+        "Combined data along polarization axis using pyuvdata. Next object history "
+        "follows. " + beam2.history,
+        new_beam.history,
+    )
 
     # ------------------------
     # Test failure modes of add function

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -2129,6 +2129,7 @@ class UVBeam(UVBase):
     def __add__(
         self,
         other,
+        verbose_history=False,
         inplace=False,
         run_check=True,
         check_extra=True,
@@ -2147,6 +2148,14 @@ class UVBeam(UVBase):
         inplace : bool
             Option to overwrite self as we go, otherwise create a third object
             as the sum of the two.
+        verbose_history : bool
+            Option to allow more verbose history. If True and if the histories for the
+            two objects are different, the combined object will keep all the history of
+            both input objects (if many objects are combined in succession this can
+            lead to very long histories). If False and if the histories for the two
+            objects are different, the combined object will have the history of the
+            first object and only the parts of the second object history that are unique
+            (this is done word by word and can result in hard to interpret histories).
         run_check : bool
             Option to check for the existence and proper shapes of
             required parameters after combining objects.
@@ -2555,9 +2564,21 @@ class UVBeam(UVBase):
 
         if n_axes > 0:
             history_update_string += " axis using pyuvdata."
-            this.history += history_update_string
+            histories_match = uvutils._check_histories(this.history, other.history)
 
-        this.history = uvutils._combine_histories(this.history, other.history)
+            this.history += history_update_string
+            if not histories_match:
+                if verbose_history:
+                    this.history += " Next object history follows. " + other.history
+                else:
+                    extra_history = uvutils._combine_history_addition(
+                        this.history, other.history
+                    )
+                    if extra_history is not None:
+                        this.history += (
+                            " Unique part of next object history follows. "
+                            + extra_history
+                        )
 
         # Check final object is self-consistent
         if run_check:

--- a/pyuvdata/uvcal/tests/test_uvcal.py
+++ b/pyuvdata/uvcal/tests/test_uvcal.py
@@ -1316,13 +1316,21 @@ def test_add(caltype, gain_data, delay_data):
         calobj2.history = "Some random history string OMNI_RUN:"
     else:
         calobj2.history = "Some random history string firstcal.py"
-    calobj += calobj2
+    new_cal = calobj + calobj2
 
     additional_history = "Some random history string"
     assert uvutils._check_histories(
         calobj_original.history + " Combined data along antenna axis "
-        "using pyuvdata. " + additional_history,
-        calobj.history,
+        "using pyuvdata. Unique part of next object history follows.  "
+        + additional_history,
+        new_cal.history,
+    )
+
+    new_cal = calobj.__add__(calobj2, verbose_history=True)
+    assert uvutils._check_histories(
+        calobj_original.history + " Combined data along antenna axis "
+        "using pyuvdata. Next object history follows.  " + calobj2.history,
+        new_cal.history,
     )
 
 

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -2605,11 +2605,24 @@ def test_sum_vis(casa_uvfits, future_shapes):
 
     uv_half = uv_full.copy()
     uv_half.data_array = uv_full.data_array / 2
-    uv_summed = uv_half.sum_vis(uv_half)
+    uv_half_mod = uv_half.copy()
+    uv_half_mod.history += " testing the history. "
+    uv_summed = uv_half.sum_vis(uv_half_mod)
 
     assert np.array_equal(uv_summed.data_array, uv_full.data_array)
     assert uvutils._check_histories(
-        uv_half.history + " Visibilities summed " "using pyuvdata.", uv_summed.history
+        uv_half.history + " Visibilities summed using pyuvdata. Unique part of second "
+        "object history follows.  testing the history.",
+        uv_summed.history,
+    )
+
+    uv_summed = uv_half.sum_vis(uv_half_mod, verbose_history=True)
+
+    assert np.array_equal(uv_summed.data_array, uv_full.data_array)
+    assert uvutils._check_histories(
+        uv_half.history + " Visibilities summed using pyuvdata. Second object history "
+        "follows. " + uv_half_mod.history,
+        uv_summed.history,
     )
 
     # check diff_vis
@@ -2617,7 +2630,7 @@ def test_sum_vis(casa_uvfits, future_shapes):
 
     assert np.array_equal(uv_diffed.data_array, uv_half.data_array)
     assert uvutils._check_histories(
-        uv_full.history + " Visibilities " "differenced using pyuvdata.",
+        uv_full.history + " Visibilities differenced using pyuvdata.",
         uv_diffed.history,
     )
 
@@ -3034,16 +3047,23 @@ def test_add(casa_uvfits, future_shapes):
     uv1.select(polarizations=uv1.polarization_array[0:2])
     uv2.select(polarizations=uv2.polarization_array[2:4])
     uv2.history += " testing the history. AIPS WTSCAL = 1.0"
-    uv1 += uv2
+    uv_new = uv1 + uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
-        "specific polarizations using pyuvdata. "
-        "Combined data along polarization "
-        "axis using pyuvdata. testing the history.",
-        uv1.history,
+        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
+        "Combined data along polarization axis using pyuvdata. Unique part of next "
+        "object history follows.  testing the history.",
+        uv_new.history,
     )
-    uv1.history = uv_full.history
-    assert uv1 == uv_full
+    uv_new.history = uv_full.history
+    assert uv_new == uv_full
+
+    uv_new = uv1.__add__(uv2, verbose_history=True)
+    assert uvutils._check_histories(
+        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
+        "Combined data along polarization axis using pyuvdata. Next object history "
+        "follows.  " + uv2.history,
+        uv_new.history,
+    )
 
     # test add of autocorr-only and crosscorr-only objects
     uv_full = UVData()
@@ -3297,17 +3317,23 @@ def test_add_drift(casa_uvfits):
     uv1.select(polarizations=uv1.polarization_array[0:2])
     uv2.select(polarizations=uv2.polarization_array[2:4])
     uv2.history += " testing the history. AIPS WTSCAL = 1.0"
-    uv1 += uv2
+    uv_new = uv1 + uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
-        "specific polarizations using pyuvdata. "
-        "Combined data along polarization "
-        "axis using pyuvdata. testing the history.",
-        uv1.history,
+        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
+        "Combined data along polarization axis using pyuvdata.  Unique part of next "
+        "object history follows.  testing the history.",
+        uv_new.history,
     )
-    uv1.history = uv_full.history
-    assert uv1 == uv_full
+    uv_new.history = uv_full.history
+    assert uv_new == uv_full
 
+    uv_new = uv1.__add__(uv2, verbose_history=True)
+    assert uvutils._check_histories(
+        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
+        "Combined data along polarization axis using pyuvdata. Next object history "
+        "follows." + uv2.history,
+        uv_new.history,
+    )
 
 @pytest.mark.filterwarnings("ignore:LST values stored in this file are not ")
 @pytest.mark.parametrize("future_shapes", [True, False])
@@ -4007,16 +4033,23 @@ def test_fast_concat(casa_uvfits, future_shapes):
     uv1.select(polarizations=uv1.polarization_array[0:2])
     uv2.select(polarizations=uv2.polarization_array[2:4])
     uv2.history += " testing the history. AIPS WTSCAL = 1.0"
-    uv1.fast_concat(uv2, "polarization", inplace=True)
+    uv_new = uv1.fast_concat(uv2, "polarization")
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
-        "specific polarizations using pyuvdata. "
-        "Combined data along polarization "
-        "axis using pyuvdata. testing the history.",
-        uv1.history,
+        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
+        "Combined data along polarization axis using pyuvdata. Unique part of next "
+        "object history follows. testing the history.",
+        uv_new.history,
     )
-    uv1.history = uv_full.history
-    assert uv1 == uv_full
+    uv_new.history = uv_full.history
+    assert uv_new == uv_full
+
+    uv_new = uv1.fast_concat(uv2, "polarization", verbose_history=True)
+    assert uvutils._check_histories(
+        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
+        "Combined data along polarization axis using pyuvdata. Next object history "
+        "follows." + uv2.history,
+        uv_new.history,
+    )
 
     # test add of autocorr-only and crosscorr-only objects
     uv_full = UVData()

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -2615,6 +2615,16 @@ def test_sum_vis(casa_uvfits, future_shapes):
         "object history follows.  testing the history.",
         uv_summed.history,
     )
+    # add a test for full coverage of _combine_history_addition function
+    assert (
+        uvutils._combine_history_addition(
+            uv_half.history
+            + " Visibilities summed using pyuvdata. Unique part of second "
+            "object history follows.  testing the history.",
+            uv_summed.history,
+        )
+        is None
+    )
 
     uv_summed = uv_half.sum_vis(uv_half_mod, verbose_history=True)
 
@@ -3334,6 +3344,7 @@ def test_add_drift(casa_uvfits):
         "follows." + uv2.history,
         uv_new.history,
     )
+
 
 @pytest.mark.filterwarnings("ignore:LST values stored in this file are not ")
 @pytest.mark.parametrize("future_shapes", [True, False])

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -162,7 +162,7 @@ class UVFITS(UVData):
                 )
             else:
                 raise ValueError(
-                    "integration time not specified and only " "one time present"
+                    "integration time not specified and only one time present"
                 )
 
         if proc is not None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Improve the way histories are handled when objects are combined.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This came up initially in the context of a pyradiosky PR to add a concat method (https://github.com/RadioAstronomySoftwareGroup/pyradiosky/pull/115) where we realized that the history handling wasn't really ideal.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
