### PR TITLE
Make reading autocorrelation data in MIR optional

### DIFF
--- a/pyuvdata/conftest.py
+++ b/pyuvdata/conftest.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from pyuvdata.data import DATA_PATH
 from pyuvdata import UVData, UVBeam
+from pyuvdata.uvdata.mir import mir_parser
 
 filenames = ["HERA_NicCST_150MHz.txt", "HERA_NicCST_123MHz.txt"]
 cst_folder = "NicCSTbeams"
@@ -282,3 +283,17 @@ def cst_power_1freq_cut_healpix_main(cst_power_2freq_cut_healpix_main):
 def cst_power_1freq_cut_healpix(cst_power_1freq_cut_healpix_main):
     """Make function level HEALPix cut down single freq power beam."""
     return cst_power_1freq_cut_healpix_main.copy()
+
+
+@pytest.fixture(params=[True, False])
+def mir_data_object(request):
+    has_auto = request.param
+    testfile = os.path.join(DATA_PATH, "sma_test.mir")
+    mir_data = mir_parser.MirParser(
+        testfile, load_vis=True, load_raw=True, load_auto=True, has_auto=has_auto
+    )
+
+    yield mir_data
+
+    # cleanup
+    del mir_data

--- a/pyuvdata/conftest.py
+++ b/pyuvdata/conftest.py
@@ -287,6 +287,7 @@ def cst_power_1freq_cut_healpix(cst_power_1freq_cut_healpix_main):
 
 @pytest.fixture(params=[True, False])
 def mir_data_object(request):
+    """Make MIR data object for tests. Param to read autocorr data."""
     has_auto = request.param
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
     mir_data = mir_parser.MirParser(

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -429,7 +429,7 @@ class MirParser(object):
                 self.filepath, self.in_start_dict, self.sp_data
             )
             self.raw_data_loaded = True
-        if load_auto:
+        if load_auto and self._read_auto:
             # Have to do this because of a strange bug in data recording where
             # we record more autos worth of spectral windows than we actually
             # have online.

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -247,7 +247,6 @@ class MirParser(object):
         load_auto : bool
             flag to load auto-correlations into memory, default is False.
         """
-
         self._has_auto = has_auto
 
         self.filepath = filepath
@@ -640,8 +639,10 @@ class MirParser(object):
         full_filepath = os.path.join(filepath, "autoCorrelations")
 
         if not os.path.exists(full_filepath):
-            raise FileNotFoundError(f"Cannot find file {full_filepath}."  # pragma: no cover
-                                    " Set `has_auto=False` to avoid reading autocorrelations.")
+            raise FileNotFoundError(
+                f"Cannot find file {full_filepath}."  # pragma: no cover
+                " Set `has_auto=False` to avoid reading autocorrelations."
+            )
 
         file_size = os.path.getsize(full_filepath)
         with open(full_filepath, "rb") as auto_file:

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -638,6 +638,11 @@ class MirParser(object):
             Numpy ndarray of custom type ac_read_dtype.
         """
         full_filepath = os.path.join(filepath, "autoCorrelations")
+
+        if not os.path.exists(full_filepath):
+            raise FileNotFoundError(f"Cannot find file {full_filepath}."
+                                    " Set `has_auto=False` to avoid reading autocorrelations.")
+
         file_size = os.path.getsize(full_filepath)
         with open(full_filepath, "rb") as auto_file:
             data_offset = 0

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -225,7 +225,7 @@ class MirParser(object):
     """
 
     def __init__(
-        self, filepath, read_auto=False, load_vis=False, load_raw=False, load_auto=False
+        self, filepath, has_auto=False, load_vis=False, load_raw=False, load_auto=False
     ):
         """
         Read in all files from a mir data set into predefined numpy datatypes.
@@ -238,7 +238,7 @@ class MirParser(object):
         ----------
         filepath : str
             filepath is the path to the folder containing the mir data set.
-        read_auto : bool
+        has_auto : bool
             flag to read auto-correlation data, default is False.
         load_vis : bool
             flag to load visibilities into memory, default is False.
@@ -248,7 +248,7 @@ class MirParser(object):
             flag to load auto-correlations into memory, default is False.
         """
 
-        self._read_auto = read_auto
+        self._has_auto = has_auto
 
         self.filepath = filepath
         self.in_read = self.read_in_data(filepath)
@@ -277,11 +277,15 @@ class MirParser(object):
         self.codes_data = self.codes_read
         self.we_data = self.we_read
 
-        if read_auto:
+        if self._has_auto:
             self.ac_read = self.scan_auto_data(filepath)
             self.ac_filter = np.ones(self.ac_read.shape, dtype=np.bool_)
             self.ac_data = self.ac_read
         else:
+            self.ac_read = None
+            self.ac_filter = None
+            self.ac_data = None
+
             # Check for load_auto=True.
             if load_auto:
                 load_auto = False
@@ -370,7 +374,7 @@ class MirParser(object):
             [inhid_filter_dict[key] for key in self.we_read["scanNumber"]]
         )
 
-        if self._read_auto:
+        if self._has_auto:
             self.ac_filter = np.array(
                 [inhid_filter_dict[key] for key in self.ac_read["inhid"]]
             )
@@ -388,7 +392,7 @@ class MirParser(object):
             self.eng_data = self.eng_read[self.eng_filter]
             self.we_data = self.we_read[self.we_filter]
 
-            if self._read_auto:
+            if self._has_auto:
                 self.ac_data = self.ac_read[self.ac_filter]
 
         # Craft some dictionaries so you know what list position matches
@@ -430,7 +434,7 @@ class MirParser(object):
                 self.filepath, self.in_start_dict, self.sp_data
             )
             self.raw_data_loaded = True
-        if load_auto and self._read_auto:
+        if load_auto and self._has_auto:
             # Have to do this because of a strange bug in data recording where
             # we record more autos worth of spectral windows than we actually
             # have online.

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -224,7 +224,9 @@ class MirParser(object):
     metadata first to check whether or not to load additional data into memory.
     """
 
-    def __init__(self, filepath, read_auto=False, load_vis=False, load_raw=False, load_auto=False):
+    def __init__(
+        self, filepath, read_auto=False, load_vis=False, load_raw=False, load_auto=False
+    ):
         """
         Read in all files from a mir data set into predefined numpy datatypes.
 
@@ -274,7 +276,6 @@ class MirParser(object):
         self.sp_data = self.sp_read
         self.codes_data = self.codes_read
         self.we_data = self.we_read
-
 
         if read_auto:
             self.ac_read = self.scan_auto_data(filepath)

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -640,7 +640,7 @@ class MirParser(object):
         full_filepath = os.path.join(filepath, "autoCorrelations")
 
         if not os.path.exists(full_filepath):
-            raise FileNotFoundError(f"Cannot find file {full_filepath}."
+            raise FileNotFoundError(f"Cannot find file {full_filepath}."  # pragma: no cover
                                     " Set `has_auto=False` to avoid reading autocorrelations.")
 
         file_size = os.path.getsize(full_filepath)

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -18,6 +18,7 @@ from ... import UVData
 from ...data import DATA_PATH
 from ...uvdata.mir import mir_parser
 
+
 @pytest.fixture
 def uv_in_uvfits(tmp_path):
     uv_in = UVData()

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -18,9 +18,6 @@ from ... import UVData
 from ...data import DATA_PATH
 from ...uvdata.mir import mir_parser
 
-from .test_mir_parser import mir_data_object
-
-
 @pytest.fixture
 def uv_in_uvfits(tmp_path):
     uv_in = UVData()

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -285,7 +285,7 @@ def test_mir_remember_me_record_lengths(mir_data_object):
     # Check to make sure we've got the right number of records everywhere
 
     # ac_read only exists if read_auto=True
-    if hasattr(mir_data, 'ac_read'):
+    if hasattr(mir_data, "ac_read"):
         assert len(mir_data.ac_read) == 2
     else:
         # This should only occur when read_auto=False
@@ -481,7 +481,7 @@ def test_mir_remember_me_ac_read(mir_data_object):
     # Now check ac_read
 
     # ac_read only exists if read_auto=True
-    if hasattr(mir_data, 'ac_read'):
+    if hasattr(mir_data, "ac_read"):
 
         assert np.all(mir_data.ac_read["inhid"] == 1)
 
@@ -500,6 +500,7 @@ def test_mir_remember_me_ac_read(mir_data_object):
     else:
         # This should only occur when read_auto=False
         assert not mir_data._read_auto
+
 
 def test_mir_remember_me_sp_read(mir_data_object):
     """

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -246,7 +246,7 @@ def test_mir_auto_read(
     Make sure that Mir autocorrelations are read correctly
     """
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    mir_data = mir_parser.MirParser(testfile, read_auto=True)
+    mir_data = mir_parser.MirParser(testfile, has_auto=True)
     with pytest.raises(err_type, match=err_msg):
         ac_data = mir_data.scan_auto_data(testfile, nchunks=999)
 
@@ -284,12 +284,12 @@ def test_mir_remember_me_record_lengths(mir_data_object):
 
     # Check to make sure we've got the right number of records everywhere
 
-    # ac_read only exists if read_auto=True
-    if mir_data.ac_read is None:
+    # ac_read only exists if has_auto=True
+    if mir_data.ac_read is not None:
         assert len(mir_data.ac_read) == 2
     else:
-        # This should only occur when read_auto=False
-        assert not mir_data._read_auto
+        # This should only occur when has_auto=False
+        assert not mir_data._has_auto
 
     assert len(mir_data.bl_read) == 4
 
@@ -480,8 +480,8 @@ def test_mir_remember_me_ac_read(mir_data_object):
 
     # Now check ac_read
 
-    # ac_read only exists if read_auto=True
-    if mir_data.ac_read is None:
+    # ac_read only exists if has_auto=True
+    if mir_data.ac_read is not None:
 
         assert np.all(mir_data.ac_read["inhid"] == 1)
 
@@ -498,8 +498,8 @@ def test_mir_remember_me_ac_read(mir_data_object):
         assert np.all(mir_data.we_read["flags"] == 0)
 
     else:
-        # This should only occur when read_auto=False
-        assert not mir_data._read_auto
+        # This should only occur when has_auto=False
+        assert not mir_data._has_auto
 
 
 def test_mir_remember_me_sp_read(mir_data_object):

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -18,18 +18,19 @@ from ... import UVData
 from ...data import DATA_PATH
 from ...uvdata.mir import mir_parser
 
+from .test_mir_parser import mir_data_object
 
-@pytest.fixture
-def mir_data_object():
-    testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    mir_data = mir_parser.MirParser(
-        testfile, load_vis=True, load_raw=True, load_auto=True,
-    )
+# @pytest.fixture
+# def mir_data_object():
+#     testfile = os.path.join(DATA_PATH, "sma_test.mir")
+#     mir_data = mir_parser.MirParser(
+#         testfile, load_vis=True, load_raw=True, load_auto=True,
+#     )
 
-    yield mir_data
+#     yield mir_data
 
-    # cleanup
-    del mir_data
+#     # cleanup
+#     del mir_data
 
 
 @pytest.fixture
@@ -257,7 +258,7 @@ def test_mir_auto_read(
     Make sure that Mir autocorrelations are read correctly
     """
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    mir_data = mir_parser.MirParser(testfile)
+    mir_data = mir_parser.MirParser(testfile, read_auto=True)
     with pytest.raises(err_type, match=err_msg):
         ac_data = mir_data.scan_auto_data(testfile, nchunks=999)
 

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -285,7 +285,7 @@ def test_mir_remember_me_record_lengths(mir_data_object):
     # Check to make sure we've got the right number of records everywhere
 
     # ac_read only exists if read_auto=True
-    if hasattr(mir_data, "ac_read"):
+    if mir_data.ac_read is None:
         assert len(mir_data.ac_read) == 2
     else:
         # This should only occur when read_auto=False
@@ -481,7 +481,7 @@ def test_mir_remember_me_ac_read(mir_data_object):
     # Now check ac_read
 
     # ac_read only exists if read_auto=True
-    if hasattr(mir_data, "ac_read"):
+    if mir_data.ac_read is None:
 
         assert np.all(mir_data.ac_read["inhid"] == 1)
 

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -10,7 +10,6 @@ python, not neccessarily how pyuvdata (by way of the UVData class) interacts wit
 data.
 """
 import os
-from attr import has
 
 import pytest
 import numpy as np

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -21,10 +21,10 @@ from ...uvdata.mir import mir_parser
 
 @pytest.fixture(params=[True, False])
 def mir_data_object(request):
-    read_auto = request.param
+    has_auto = request.param
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
     mir_data = mir_parser.MirParser(
-        testfile, load_vis=True, load_raw=True, load_auto=True, read_auto=read_auto
+        testfile, load_vis=True, load_raw=True, load_auto=True, has_auto=has_auto
     )
 
     yield mir_data
@@ -76,13 +76,13 @@ def test_mir_parser_index_linked(mir_data_object):
     mir_data = mir_data_object
     inhid_set = set(np.unique(mir_data.in_read["inhid"]))
 
-    # Should not exist is read_auto=False
+    # Should not exist is has_auto=False
     # See `mir_data_object` above.
-    if mir_data.ac_read is None:
+    if mir_data.ac_read is not None:
         assert set(np.unique(mir_data.ac_read["inhid"])).issubset(inhid_set)
     else:
-        # This should only occur when read_auto=False
-        assert not mir_data._read_auto
+        # This should only occur when has_auto=False
+        assert not mir_data._has_auto
 
     assert set(np.unique(mir_data.bl_read["inhid"])).issubset(inhid_set)
 

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -24,8 +24,7 @@ def mir_data_object(request):
     read_auto = request.param
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
     mir_data = mir_parser.MirParser(
-        testfile, load_vis=True, load_raw=True, load_auto=True,
-        read_auto=read_auto
+        testfile, load_vis=True, load_raw=True, load_auto=True, read_auto=read_auto
     )
 
     yield mir_data
@@ -79,7 +78,7 @@ def test_mir_parser_index_linked(mir_data_object):
 
     # Should not exist is read_auto=False
     # See `mir_data_object` above.
-    if hasattr(mir_data, 'ac_read'):
+    if hasattr(mir_data, "ac_read"):
         assert set(np.unique(mir_data.ac_read["inhid"])).issubset(inhid_set)
     else:
         # This should only occur when read_auto=False

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -81,6 +81,9 @@ def test_mir_parser_index_linked(mir_data_object):
     # See `mir_data_object` above.
     if hasattr(mir_data, 'ac_read'):
         assert set(np.unique(mir_data.ac_read["inhid"])).issubset(inhid_set)
+    else:
+        # This should only occur when read_auto=False
+        assert not mir_data._read_auto
 
     assert set(np.unique(mir_data.bl_read["inhid"])).issubset(inhid_set)
 

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -9,12 +9,7 @@ data in pyuvdata. Tests in this module are specific to the way that MIR is read 
 python, not neccessarily how pyuvdata (by way of the UVData class) interacts with that
 data.
 """
-import os
-
-import pytest
 import numpy as np
-
-from ...data import DATA_PATH
 
 
 def test_mir_parser_index_uniqueness(mir_data_object):

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -78,7 +78,7 @@ def test_mir_parser_index_linked(mir_data_object):
 
     # Should not exist is read_auto=False
     # See `mir_data_object` above.
-    if hasattr(mir_data, "ac_read"):
+    if mir_data.ac_read is None:
         assert set(np.unique(mir_data.ac_read["inhid"])).issubset(inhid_set)
     else:
         # This should only occur when read_auto=False

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -15,21 +15,6 @@ import pytest
 import numpy as np
 
 from ...data import DATA_PATH
-from ...uvdata.mir import mir_parser
-
-
-@pytest.fixture(params=[True, False])
-def mir_data_object(request):
-    has_auto = request.param
-    testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    mir_data = mir_parser.MirParser(
-        testfile, load_vis=True, load_raw=True, load_auto=True, has_auto=has_auto
-    )
-
-    yield mir_data
-
-    # cleanup
-    del mir_data
 
 
 def test_mir_parser_index_uniqueness(mir_data_object):

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -10,6 +10,7 @@ python, not neccessarily how pyuvdata (by way of the UVData class) interacts wit
 data.
 """
 import os
+from attr import has
 
 import pytest
 import numpy as np
@@ -18,11 +19,13 @@ from ...data import DATA_PATH
 from ...uvdata.mir import mir_parser
 
 
-@pytest.fixture
-def mir_data_object():
+@pytest.fixture(params=[True, False])
+def mir_data_object(request):
+    read_auto = request.param
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
     mir_data = mir_parser.MirParser(
         testfile, load_vis=True, load_raw=True, load_auto=True,
+        read_auto=read_auto
     )
 
     yield mir_data
@@ -74,7 +77,10 @@ def test_mir_parser_index_linked(mir_data_object):
     mir_data = mir_data_object
     inhid_set = set(np.unique(mir_data.in_read["inhid"]))
 
-    assert set(np.unique(mir_data.ac_read["inhid"])).issubset(inhid_set)
+    # Should not exist is read_auto=False
+    # See `mir_data_object` above.
+    if hasattr(mir_data, 'ac_read'):
+        assert set(np.unique(mir_data.ac_read["inhid"])).issubset(inhid_set)
 
     assert set(np.unique(mir_data.bl_read["inhid"])).issubset(inhid_set)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
SMA MIR data is often rechunked to reduce the data volume and number of channels. However, the autocorrelation data is not currently included in the rechunked data. This PR makes reading the autocorr data optional in `MirParser` to handle these cases.

## Description
<!--- Describe your changes in detail -->
I've added the ~~`read_auto`~~ `has_auto` flag for `MirParser` and updated the existing tests to against reading/not reading the autocorr data.

Suggestions are most welcome!

cc @kartographer 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.


New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

