### PR TITLE
Add support for parameters that can be ignored in __eq__ methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+
+## [Unreleased]
+
+### Changed
+- The `__eq__` method on UVBase objects (and subclasses) now supports an
+`allowed_failures` keyword for parameters which are allowed to be unequal
+without failing the check.
+
+
 ## [2.2.0] - 2021-6-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - The `__eq__` method on UVBase objects (and subclasses) now supports an
 `allowed_failures` keyword for parameters which are allowed to be unequal
-without failing the check.
+without failing the check. This includes the `filename` parameter of
+`UVData` objects by default.
 
 
 ## [2.2.0] - 2021-6-26

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -279,12 +279,13 @@ class UVBase(object):
                 p_check = self_required
 
             if allowed_failures is not None:
-                for p in allowed_failures:
-                    if not p.startswith("_"):
-                        p = "_" + p
-                    if p not in self_required:
-                        if p in p_check:
-                            p_check.remove(p)
+                for i, param in enumerate(allowed_failures):
+                    if not param.startswith("_"):
+                        param = "_" + param
+                        allowed_failures[i] = param
+                    if param not in self_required:
+                        if param in p_check:
+                            p_check.remove(param)
 
             p_equal = True
             for p in p_check:
@@ -300,7 +301,7 @@ class UVBase(object):
             if allowed_failures is not None:
                 for p in allowed_failures:
                     self_param = getattr(self, p)
-                    other_param = getattr(self, p)
+                    other_param = getattr(other, p)
                     if self_param != other_param:
                         print(
                             f"parameter {p} does not match. Left is {self_param.value},"

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -234,7 +234,7 @@ class UVBase(object):
         check_extra : bool
             Option to specify whether to include all parameters, or just the
             required ones. Default is True.
-        allowed_failues : list of str, optional
+        allowed_failures : list of str, optional
             List of parameter names that are allowed to fail while still passing
             an overall equality check. These should only include optional
             parameters.

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -234,10 +234,10 @@ class UVBase(object):
         check_extra : bool
             Option to specify whether to include all parameters, or just the
             required ones. Default is True.
-        allowed_failures : list of str, optional
-            List of parameter names that are allowed to fail while still passing
-            an overall equality check. These should only include optional
-            parameters.
+        allowed_failures : iterable of str, optional
+            List or tuple of parameter names that are allowed to fail while
+            still passing an overall equality check. These should only include
+            optional parameters.
 
         Returns
         -------
@@ -248,10 +248,10 @@ class UVBase(object):
             # only check that required parameters are identical
             self_required = []
             other_required = []
-            for p in self.required():
-                self_required.append(p)
-            for p in other.required():
-                other_required.append(p)
+            for param in self.required():
+                self_required.append(param)
+            for param in other.required():
+                other_required.append(param)
             if set(self_required) != set(other_required):
                 print(
                     "Sets of required parameters do not match. "
@@ -263,10 +263,10 @@ class UVBase(object):
             if check_extra:
                 self_extra = []
                 other_extra = []
-                for p in self.extra():
-                    self_extra.append(p)
-                for p in other.extra():
-                    other_extra.append(p)
+                for param in self.extra():
+                    self_extra.append(param)
+                for param in other.extra():
+                    other_extra.append(param)
                 if set(self_extra) != set(other_extra):
                     print(
                         "Sets of extra parameters do not match. "
@@ -279,6 +279,13 @@ class UVBase(object):
                 p_check = self_required
 
             if allowed_failures is not None:
+                if isinstance(allowed_failures, str):
+                    # convert a single string into a length-1 list
+                    allowed_failures = [allowed_failures]
+                if isinstance(allowed_failures, tuple):
+                    # convert a tuple into a list
+                    allowed_failures = list(allowed_failures)
+
                 for i, param in enumerate(allowed_failures):
                     if not param.startswith("_"):
                         param = "_" + param
@@ -288,24 +295,25 @@ class UVBase(object):
                             p_check.remove(param)
 
             p_equal = True
-            for p in p_check:
-                self_param = getattr(self, p)
-                other_param = getattr(other, p)
+            for param in p_check:
+                self_param = getattr(self, param)
+                other_param = getattr(other, param)
                 if self_param != other_param:
                     print(
-                        f"parameter {p} does not match. Left is {self_param.value},"
-                        f" right is {other_param.value}."
+                        f"parameter {param} does not match. Left is "
+                        f"{self_param.value}, right is {other_param.value}."
                     )
                     p_equal = False
 
             if allowed_failures is not None:
-                for p in allowed_failures:
-                    self_param = getattr(self, p)
-                    other_param = getattr(other, p)
+                for param in allowed_failures:
+                    self_param = getattr(self, param)
+                    other_param = getattr(other, param)
                     if self_param != other_param:
                         print(
-                            f"parameter {p} does not match. Left is {self_param.value},"
-                            f" right is {other_param.value}."
+                            f"parameter {param} does not match, but is not required "
+                            f"to for equality. Left is {self_param.value}, "
+                            f"right is {other_param.value}."
                         )
 
             return p_equal

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -6827,7 +6827,6 @@ def test_redundancy_missing_groups(method, pyuvsim_redundant, tmp_path):
     # check that filenames are what we expect
     assert uv0.filename == ["fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits"]
     assert uv1.filename == ["temp_hera19_missingreds.uvfits"]
-    uv0.filename = uv1.filename
 
     assert uv0 == uv1  # Check that writing compressed files causes no issues.
 

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -10950,3 +10950,50 @@ def test_multi_phase_downselect(hera_uvh5_split, future_shapes):
         assert uvtemp.history in uvdata.history
         uvtemp.history = uvdata.history
         assert uvtemp == uvdata
+
+
+@pytest.mark.filterwarnings("ignore:Unknown phase types are no longer supported")
+@pytest.mark.filterwarnings("ignore:Telescope mock-HERA is not in known_telescopes")
+def test_eq_allowed_failures(bda_test_file, capsys):
+    """
+    Test that the allowed_failures keyword on the __eq__ method works as intended.
+    """
+    uv1 = bda_test_file
+    uv2 = uv1.copy()
+
+    # adjust optional parameters to be different
+    uv1.x_orientation = "NORTH"
+    uv2.x_orientation = "EAST"
+    assert uv1.__eq__(uv2, check_extra=True, allowed_failures=["x_orientation"])
+    captured = capsys.readouterr()
+    assert captured.out == (
+        "x_orientation parameter value is a string, values are different\n"
+        "parameter _x_orientation does not match. Left is NORTH, right is EAST.\n"
+    )
+
+    # make sure that objects are not equal without specifying allowed_failures
+    assert uv1 != uv2
+
+    return
+
+
+@pytest.mark.filterwarnings("ignore:Unknown phase types are no longer supported")
+@pytest.mark.filterwarnings("ignore:Telescope mock-HERA is not in known_telescopes")
+def test_eq_allowed_failures_filename(bda_test_file, capsys):
+    """
+    Test that the `filename` parameter does not trip up the __eq__ method.
+    """
+    uv1 = bda_test_file
+    uv2 = uv1.copy()
+
+    uv1.filename = ["foo.uvh5"]
+    uv2.filename = ["bar.uvh5"]
+    assert uv1 == uv2
+    captured = capsys.readouterr()
+    assert captured.out == (
+        "filename parameter value is a list of strings, values are different\n"
+        "parameter _filename does not match. Left is ['foo.uvh5'], right is "
+        "['bar.uvh5'].\n"
+    )
+
+    return

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -10968,7 +10968,8 @@ def test_eq_allowed_failures(bda_test_file, capsys):
     captured = capsys.readouterr()
     assert captured.out == (
         "x_orientation parameter value is a string, values are different\n"
-        "parameter _x_orientation does not match. Left is NORTH, right is EAST.\n"
+        "parameter _x_orientation does not match, but is not required to for equality. "
+        "Left is NORTH, right is EAST.\n"
     )
 
     # make sure that objects are not equal without specifying allowed_failures
@@ -10992,8 +10993,30 @@ def test_eq_allowed_failures_filename(bda_test_file, capsys):
     captured = capsys.readouterr()
     assert captured.out == (
         "filename parameter value is a list of strings, values are different\n"
-        "parameter _filename does not match. Left is ['foo.uvh5'], right is "
-        "['bar.uvh5'].\n"
+        "parameter _filename does not match, but is not required to for equality. "
+        "Left is ['foo.uvh5'], right is ['bar.uvh5'].\n"
+    )
+
+    return
+
+
+@pytest.mark.filterwarnings("ignore:Unknown phase types are no longer supported")
+@pytest.mark.filterwarnings("ignore:Telescope mock-HERA is not in known_telescopes")
+def test_eq_allowed_failures_filename_string(bda_test_file, capsys):
+    """
+    Try passing a string to the __eq__ method instead of an iterable.
+    """
+    uv1 = bda_test_file
+    uv2 = uv1.copy()
+
+    uv1.filename = ["foo.uvh5"]
+    uv2.filename = ["bar.uvh5"]
+    assert uv1.__eq__(uv2, allowed_failures="filename")
+    captured = capsys.readouterr()
+    assert captured.out == (
+        "filename parameter value is a list of strings, values are different\n"
+        "parameter _filename does not match, but is not required to for equality. "
+        "Left is ['foo.uvh5'], right is ['bar.uvh5'].\n"
     )
 
     return

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2578,11 +2578,6 @@ class UVData(UVBase):
         """
         Test for equality between two objects.
 
-        By default, this will add the `filename` attribute to the list of
-        parameters allowed to be not equal while passing an overall equality
-        check. The user is permitted to add other attributes to this list with
-        the `allowed_failures` keyword argument.
-
         Parameters
         ----------
         other : UVData object instance

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2581,7 +2581,7 @@ class UVData(UVBase):
         By default, this will add the `filename` attribute to the list of
         parameters allowed to be not equal while passing an overall equality
         check. The user is permitted to add other attributes to this list with
-        the `allowed_failiures` keyword argument.
+        the `allowed_failures` keyword argument.
 
         Parameters
         ----------
@@ -2590,7 +2590,7 @@ class UVData(UVBase):
         check_extra : bool
             Option to specify whether to include all parameters, or just the
             required ones. Default is True.
-        allowed_failues : list of str, optional
+        allowed_failures : list of str, optional
             List of parameter names that are allowed to fail while still passing
             an overall equality check. These should only include optional
             parameters.

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2574,7 +2574,7 @@ class UVData(UVBase):
 
         return True
 
-    def __eq__(self, other, check_extra=True, allowed_failures=None):
+    def __eq__(self, other, check_extra=True, allowed_failures=("filename",)):
         """
         Test for equality between two objects.
 
@@ -2590,20 +2590,17 @@ class UVData(UVBase):
         check_extra : bool
             Option to specify whether to include all parameters, or just the
             required ones. Default is True.
-        allowed_failures : list of str, optional
-            List of parameter names that are allowed to fail while still passing
-            an overall equality check. These should only include optional
-            parameters.
+        allowed_failures : iterable of str, optional
+            List or tuple of parameter names that are allowed to fail while
+            still passing an overall equality check. These should only include
+            optional parameters. By default, the `filename` parameter will be
+            ignored.
 
         Returns
         -------
         bool
             Whether the two instances are equivalent.
         """
-        if allowed_failures is None:
-            allowed_failures = ["filename"]
-        else:
-            allowed_failures = list(set(allowed_failures).union({"filename"}))
         return super(UVData, self).__eq__(
             other, check_extra=check_extra, allowed_failures=allowed_failures
         )

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2574,6 +2574,40 @@ class UVData(UVBase):
 
         return True
 
+    def __eq__(self, other, check_extra=True, allowed_failures=None):
+        """
+        Test for equality between two objects.
+
+        By default, this will add the `filename` attribute to the list of
+        parameters allowed to be not equal while passing an overall equality
+        check. The user is permitted to add other attributes to this list with
+        the `allowed_failiures` keyword argument.
+
+        Parameters
+        ----------
+        other : UVData object instance
+            UVData instance to check
+        check_extra : bool
+            Option to specify whether to include all parameters, or just the
+            required ones. Default is True.
+        allowed_failues : list of str, optional
+            List of parameter names that are allowed to fail while still passing
+            an overall equality check. These should only include optional
+            parameters.
+
+        Returns
+        -------
+        bool
+            Whether the two instances are equivalent.
+        """
+        if allowed_failures is None:
+            allowed_failures = ["filename"]
+        else:
+            allowed_failures = list(set(allowed_failures).union({"filename"}))
+        return super(UVData, self).__eq__(
+            other, check_extra=check_extra, allowed_failures=allowed_failures
+        )
+
     def copy(self, metadata_only=False):
         """
         Make and return a copy of the UVData object.


### PR DESCRIPTION
## Description
This PR adds an `allowed_failures` keyword argument to the `__eq__` method of UVBase objects (and subclasses) which allows the user to specify optional parameters that are allowed to be different in equality checks. It also adds the `filename` parameter automatically for UVData objects, which avoids recent test failures inadvertently introduced with the new parameter.

## Motivation and Context
We wanted to make the `filename` attribute optional-ish for equality checks. Now if the attribute is different between two objects, the user will be notified with a printed message, but the equality check will not fail.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
