### PR TITLE
Use environment variable to fix circleci version on forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ jobs:
       PYTHON: << parameters.python_version >>
       ENV_NAME: << parameters.env_name >>
       OS: "linux"
+      # Circleci builds fail on forks because the version gets munged. (see #1029)
+      SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.1"
     steps:
       - checkout
       - restore_cache:
@@ -45,6 +47,8 @@ jobs:
       ENV_NAME: << parameters.env_name >>
       WITH_SUDO: true
       OS: "linux"
+      # Circleci builds fail on forks because the version gets munged. (see #1029)
+      SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.1"
     steps:
       - checkout
       - restore_cache:
@@ -98,6 +102,8 @@ jobs:
       PYTHON: << parameters.python_version >>
       ENV_NAME: << parameters.env_name >>
       OS: "linux"
+      # Circleci builds fail on forks because the version gets munged. (see #1029)
+      SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.1"
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use an environment variable to spoof the version on CircleCI builds. This fixes a bug with fork builds.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #1029 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
