### PR TITLE
Fix for metadata only read of FHD cal files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 an astropy dependency).
 
 ### Fixed
+- Provide a more useful error message if `UVCal.read_fhd_cal` is called with
+`read_data=False` and a settings file is not provided.
+- Fixed a bug in `UVCal.read_fhd_cal` where the reader crashed on a metadata only read
+if the settings file had an empty field for the diffuse model.
 - Fixed a bug in `UVBeam.efield_to_power` where a the `data_array` remained complex
 rather than real because the tolerance was too low in the numpy `real_if_close` call.
 

--- a/pyuvdata/data/fhd_cal_data/1061316296_nodiffuse_settings.txt
+++ b/pyuvdata/data/fhd_cal_data/1061316296_nodiffuse_settings.txt
@@ -1,0 +1,306 @@
+##MAIN	##		
+Calling program	FHD_VERSIONS_RLB 	
+Machine	ip-172-31-124-209	
+User	ubuntu	
+Date	Fri Mar 19 21:35:49 2021	
+##COMMAND_LINE	##	
+VERSION	rlb_perfreq_cal_Feb2021  	
+##OBS	##	
+CODE_VERSION	v3.5-1440-g2aaede9  	
+INSTRUMENT	mwa  	
+OBSNAME	1061316296  	
+DIMENSION	 2048.00  	
+ELEMENTS	 2048.00  	
+NBASELINES	 8128  	
+DFT_THRESHOLD	 0.00000  	
+DOUBLE_PRECISION	 0  	
+KPIX	 0.500000  	
+DEGPIX	 0.0559529  	
+OBSAZ	 263.676  	
+OBSALT	 89.9999  	
+OBSRA	 359.849  	
+OBSDEC	 -26.7836  	
+ZENRA	 359.850  	
+ZENDEC	 -26.7836  	
+OBSX	 1024.00  	
+OBSY	 1024.00  	
+ZENX	 1024.00  	
+ZENY	 1024.00  	
+PHASERA	 359.849  	
+PHASEDEC	 -26.7836  	
+ORIG_PHASERA	 359.849  	
+ORIG_PHASEDEC	 -26.7836  	
+N_POL	 2  	
+N_TILE	 128  	
+N_TILE_FLAG	 4  	
+N_FREQ	 384  	
+N_FREQ_FLAG	 48  	
+N_TIME	 56  	
+N_TIME_FLAG	 0.00000  	
+N_VIS	 104528464  	
+N_VIS_IN	 147425696  	
+N_VIS_RAW	 174784512  	
+NF_VIS	Long Integer array (384 elements)	
+PRIMARY_BEAM_AREA	Pointer array (4 elements)	
+PRIMARY_BEAM_SQ_AREA	Pointer array (4 elements)	
+POL_NAMES	XX  YY  XY  YX  I  Q  U  V  	
+JD0	 2456528.3  	
+MAX_BASELINE	 723.930  	
+MIN_BASELINE	 4.30430  	
+DELAYS	Null pointer	
+LON	 116.671  	
+LAT	 -26.7033  	
+ALT	 377.827  	
+FREQ_CENTER	 1.82435e+08  	
+FREQ_RES	 80000.0  	
+TIME_RES	 2.00071  	
+ASTR	Structure (20 tags)	
+  NAXIS	 2048.00   2048.00  	
+  CD	 1.00000   0.00000   0.00000   1.00000  	
+  CDELT	 0.0559529   0.0559529  	
+  CRPIX	 1025.00   1025.00  	
+  CRVAL	 359.84940   -26.783640  	
+  CTYPE	RA---SIN  DEC--SIN  	
+  LONGPOLE	 180.00000  	
+  LATPOLE	 0.0000000  	
+  PV2	 1.9216962e-06   -1.7952835e-07  	
+  PV1	 0.0000000   0.0000000   90.000000   180.00000   0.0000000  	
+  AXES	 1   2  	
+  REVERSE	  	
+  COORD_SYS	C  	
+  PROJECTION	SIN  	
+  KNOWN	  	
+  RADECSYS	FK5  	
+  EQUINOX	 2000.0000  	
+  DATEOBS	2013-08-23T18:04:40.00  	
+  MJDOBS	 56527.753  	
+  X0Y0	 0.0000000   0.0000000  	
+ALPHA	 -0.800000  	
+RESIDUAL	 0  	
+VIS_NOISE	Pointer	
+  ->	Double array (2 x 384 elements)	
+BASELINE_INFO	Pointer	
+  ->	Structure (12 tags)	
+    TILE_A	Long Integer array (455168 elements)	
+    TILE_B	Long Integer array (455168 elements)	
+    BIN_OFFSET	 0   8128   16256   24384   32512   40640   48768   56896   65024   73152   81280   89408   97536   105664   113792   121920   130048   138176   146304   154432   162560   170688   178816   186944   195072   203200   211328   219456   227584   235712   243840   251968   260096   268224   276352   284480   292608   300736   308864   316992   325120   333248   341376   349504   357632   365760   373888   382016   390144   398272   406400   414528   422656   430784   438912   447040  	
+    JDATE	 2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3   2456528.3  	
+    FREQ	Double array (384 elements)	
+    FBIN_I	Long Integer array (384 elements)	
+    FREQ_USE	Integer array (384 elements)	
+    TILE_USE	 1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   0   1   1   1   0   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   0   1   0   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1  	
+    TIME_USE	 1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1   1  	
+    TILE_NAMES	 1   2   3   4   5   6   7   8   9   10   11   12   13   14   15   16   17   18   19   20   21   22   23   24   25   26   27   28   29   30   31   32   33   34   35   36   37   38   39   40   41   42   43   44   45   46   47   48   49   50   51   52   53   54   55   56   57   58   59   60   61   62   63   64   65   66   67   68   69   70   71   72   73   74   75   76   77   78   79   80   81   82   83   84   85   86   87   88   89   90   91   92   93   94   95   96   97   98   99   100   101   102   103   104   105   106   107   108   109   110   111   112   113   114   115   116   117   118   119   120   121   122   123   124   125   126   127   128  	
+    TILE_HEIGHT	 0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000  	
+    TILE_FLAG	Pointer array (4 elements)	
+META_DATA	Null pointer	
+META_HDR	Null pointer	
+DEGRID_SPECTRAL_TERMS	 0  	
+GRID_SPECTRAL_TERMS	 0  	
+GRID_INFO	Null pointer	
+HEALPIX	Structure (4 tags)	
+  NSIDE	 0  	
+  IND_LIST	EoR0_high_healpix_inds.idlsave  	
+  N_PIX	 0  	
+  N_ZERO	 -1  	
+##LAYOUT	##	
+ARRAY_CENTER	 -2559453.3   5095371.7   -2849056.8  	
+COORDINATE_FRAME	ITRF  	
+GST0	 -1  	
+EARTH_DEGPD	 360.985  	
+REF_DATE	2013-08-23T00:00:00.0  	
+TIME_SYSTEM	UTC   	
+DUT1	 0.00000  	
+DIFF_UTC	 0.00000  	
+NLEAP_SEC	 33.0000  	
+POL_TYPE	X-Y LIN  	
+N_POL_CAL_PARAMS	 3  	
+N_ANTENNA	 128  	
+ANTENNA_NAMES	Tile011   Tile012   Tile013   Tile014   Tile015   Tile016   Tile017   Tile018   Tile021   Tile022   Tile023   Tile024   Tile025   Tile026   Tile027   Tile028   Tile031   Tile032   Tile033   Tile034   Tile035   Tile036   Tile037   Tile038   Tile041   Tile042   Tile043   Tile044   Tile045   Tile046   Tile047   Tile048   Tile051   Tile052   Tile053   Tile054   Tile055   Tile056   Tile057   Tile058   Tile061   Tile062   Tile063   Tile064   Tile065   Tile066   Tile067   Tile068   Tile071   Tile072   Tile073   Tile074   Tile075   Tile076   Tile077   Tile078   Tile081   Tile082   Tile083   Tile084   Tile085   Tile086   Tile087   Tile088   Tile091   Tile092   Tile093   Tile094   Tile095   Tile096   Tile097   Tile098   Tile101   Tile102   Tile103   Tile104   Tile105   Tile106   Tile107   Tile108   Tile111   Tile112   Tile113   Tile114   Tile115   Tile116   Tile117   Tile118   Tile121   Tile122   Tile123   Tile124   Tile125   Tile126   Tile127   Tile128   Tile131   Tile132   Tile133   Tile134   Tile135   Tile136   Tile137   Tile138   Tile141   Tile142   Tile143   Tile144   Tile145   Tile146   Tile147   Tile148   Tile151   Tile152   Tile153   Tile154   Tile155   Tile156   Tile157   Tile158   Tile161   Tile162   Tile163   Tile164   Tile165   Tile166   Tile167   Tile168   	
+ANTENNA_NUMBERS	 1   2   3   4   5   6   7   8   9   10   11   12   13   14   15   16   17   18   19   20   21   22   23   24   25   26   27   28   29   30   31   32   33   34   35   36   37   38   39   40   41   42   43   44   45   46   47   48   49   50   51   52   53   54   55   56   57   58   59   60   61   62   63   64   65   66   67   68   69   70   71   72   73   74   75   76   77   78   79   80   81   82   83   84   85   86   87   88   89   90   91   92   93   94   95   96   97   98   99   100   101   102   103   104   105   106   107   108   109   110   111   112   113   114   115   116   117   118   119   120   121   122   123   124   125   126   127   128  	
+ANTENNA_COORDS	Double array (3 x 128 elements)	
+MOUNT_TYPE	 0  	
+AXIS_OFFSET	 0.00000  	
+POLA	X  	
+POLA_ORIENTATION	 0.00000  	
+POLA_CAL_PARAMS	 0.00000   0.00000   0.00000  	
+POLB	Y  	
+POLB_ORIENTATION	 90.0000  	
+POLB_CAL_PARAMS	 0.00000   0.00000   0.00000  	
+##ANTENNA	##	
+N_POL	 2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2  	
+ANTENNA_TYPE	mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  mwa  	
+NAMES	Long Integer array (127 x 128 elements)	
+MODEL_VERSION	 2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2   2  	
+FREQ	Float array (24 x 128 elements)	
+NFREQ_BIN	 24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24   24  	
+N_ANT_ELEMENTS	 16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16   16  	
+JONES	Pointer array (2 x 2 x 24 x 128 elements)	
+COUPLING	Pointer array (2 x 24 x 128 elements)	
+GAIN	Pointer array (2 x 128 elements)	
+COORDS	Pointer array (3 x 128 elements)	
+DELAYS	Pointer array (128 elements)	
+SIZE_METERS	 5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000   5.00000  	
+HEIGHT	 0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000   0.290000  	
+RESPONSE	Pointer array (2 x 24 x 128 elements)	
+GROUP_ID	Long Integer array (2 x 128 elements)	
+PIX_WINDOW	Pointer array (128 elements)	
+PIX_USE	Pointer array (128 elements)	
+PSF_IMAGE_DIM	 1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00   1400.00  	
+##PSF	##	
+BEAM_PTR	Pointer	
+  ->	Pointer array (2 x 24 x 8128 elements)	
+XVALS	Pointer array (100 x 100 elements)	
+YVALS	Pointer array (100 x 100 elements)	
+PNORM	 1.00000   1.00000  	
+FNORM	 1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000   1.00000  	
+ID	Long Integer array (2 x 24 x 8128 elements)	
+FBIN_I	Long Integer array (384 elements)	
+RESOLUTION	 100  	
+DIM	 14  	
+COMPLEX_FLAG	 1  	
+N_POL	 2  	
+N_FREQ	 24  	
+FREQ	 1.67715e+08   1.68995e+08   1.70275e+08   1.71555e+08   1.72835e+08   1.74115e+08   1.75395e+08   1.76675e+08   1.77955e+08   1.79235e+08   1.80515e+08   1.81795e+08   1.83075e+08   1.84355e+08   1.85635e+08   1.86915e+08   1.88195e+08   1.89475e+08   1.90755e+08   1.92035e+08   1.93315e+08   1.94595e+08   1.95875e+08   1.97155e+08  	
+INTERPOLATE_KERNEL	 1  	
+BEAM_MASK_THRESHOLD	 100.000  	
+IMAGE_INFO	Pointer	
+  ->	Structure (5 tags)	
+    IMAGE_POWER_BEAM_ARR	Null pointer	
+    RA_ARR	Double array (1400 x 1400 elements)	
+    DEC_ARR	Double array (1400 x 1400 elements)	
+    PSF_IMAGE_RESOLUTION	 10.0000  	
+    PSF_IMAGE_DIM	 1400.00  	
+##CAL	##	
+N_POL	 2  	
+N_FREQ	 384  	
+N_TILE	 128  	
+N_TIME	 56  	
+UU	Double array (455168 elements)	
+VV	Double array (455168 elements)	
+AUTO_INITIALIZE	 1  	
+MAX_ITER	 100  	
+PHASE_ITER	 4  	
+TILE_A	Long Integer array (455168 elements)	
+TILE_B	Long Integer array (455168 elements)	
+TILE_NAMES	 1   2   3   4   5   6   7   8   9   10   11   12   13   14   15   16   17   18   19   20   21   22   23   24   25   26   27   28   29   30   31   32   33   34   35   36   37   38   39   40   41   42   43   44   45   46   47   48   49   50   51   52   53   54   55   56   57   58   59   60   61   62   63   64   65   66   67   68   69   70   71   72   73   74   75   76   77   78   79   80   81   82   83   84   85   86   87   88   89   90   91   92   93   94   95   96   97   98   99   100   101   102   103   104   105   106   107   108   109   110   111   112   113   114   115   116   117   118   119   120   121   122   123   124   125   126   127   128  	
+BIN_OFFSET	 0   8128   16256   24384   32512   40640   48768   56896   65024   73152   81280   89408   97536   105664   113792   121920   130048   138176   146304   154432   162560   170688   178816   186944   195072   203200   211328   219456   227584   235712   243840   251968   260096   268224   276352   284480   292608   300736   308864   316992   325120   333248   341376   349504   357632   365760   373888   382016   390144   398272   406400   414528   422656   430784   438912   447040  	
+FREQ	Double array (384 elements)	
+GAIN	Pointer array (2 elements)	
+ADAPTIVE_GAIN	 0  	
+BASE_GAIN	 0.750000  	
+GAIN_RESIDUAL	Pointer array (2 elements)	
+AUTO_SCALE	 0.287587   0.287674  	
+AUTO_PARAMS	Pointer array (2 elements)	
+CROSS_PHASE	 0.00000  	
+STOKES_MIX_PHASE	 0.00000  	
+MIN_CAL_BASELINE	 50.0000  	
+MAX_CAL_BASELINE	 723.930  	
+N_VIS_CAL	 1660905  	
+TIME_AVG	 1  	
+MIN_SOLNS	 5  	
+REF_ANTENNA	 1  	
+REF_ANTENNA_NAME	 2  	
+CONV_THRESH	 1.00000e-07  	
+CONVERGENCE	Pointer array (2 elements)	
+N_CONVERGED	 336   336  	
+CONV_ITER	Pointer array (2 elements)	
+POLYFIT	 1  	
+AMP_DEGREE	 2  	
+PHASE_DEGREE	 1  	
+AMP_PARAMS	Pointer array (2 x 128 elements)	
+PHASE_PARAMS	Pointer array (2 x 128 elements)	
+MEAN_GAIN	 1.62670   1.71194  	
+MEAN_GAIN_RESIDUAL	 0.00000   0.00000  	
+MEAN_GAIN_RESTRICT	 0.00000   0.00000  	
+STDDEV_GAIN_RESIDUAL	 0.00000   0.00000  	
+BANDPASS	 1  	
+MODE_FIT	 1.00000  	
+MODE_PARAMS	Pointer array (2 x 128 elements)	
+CAL_ORIGIN	1061316296  	
+SKYMODEL	Structure (8 tags)	
+  INCLUDE_CALIBRATION	 1  	
+  N_SOURCES	 53766  	
+  SOURCE_LIST	Structure (14 tags)	
+    ID	Long Integer array (53766 elements)	
+    X	Float array (53766 elements)	
+    Y	Float array (53766 elements)	
+    RA	Float array (53766 elements)	
+    DEC	Float array (53766 elements)	
+    STON	Float array (53766 elements)	
+    FREQ	Float array (53766 elements)	
+    ALPHA	Float array (53766 elements)	
+    GAIN	Float array (53766 elements)	
+    FLAG	Integer array (53766 elements)	
+    EXTEND	Pointer array (53766 elements)	
+    FLUX	Structure (8 tags)	
+      XX	Float array (53766 elements)	
+      YY	Float array (53766 elements)	
+      XY	Complex array (53766 elements)	
+      YX	Complex array (53766 elements)	
+      I	Float array (53766 elements)	
+      Q	Float array (53766 elements)	
+      U	Float array (53766 elements)	
+      V	Float array (53766 elements)	
+    SHAPE	Structure (3 tags)	
+      X	Float array (53766 elements)	
+      Y	Float array (53766 elements)	
+      ANGLE	Float array (53766 elements)	
+    BEAM	Structure (8 tags)	
+      XX	Float array (53766 elements)	
+      YY	Float array (53766 elements)	
+      XY	Complex array (53766 elements)	
+      YX	Complex array (53766 elements)	
+      I	Float array (53766 elements)	
+      Q	Float array (53766 elements)	
+      U	Float array (53766 elements)	
+      V	Float array (53766 elements)	
+  CATALOG_NAME	GLEAM_v2_plus_rlb2019  	
+  GALAXY_MODEL	 0  	
+  GALAXY_SPECTRAL_INDEX	 NaN  	
+  DIFFUSE_MODEL	  	
+  DIFFUSE_SPECTRAL_INDEX	 NaN  	
+##SKYMODEL	##	
+INCLUDE_CALIBRATION	 1  	
+N_SOURCES	 53766  	
+SOURCE_LIST	Structure (14 tags)	
+  ID	Long Integer array (53766 elements)	
+  X	Float array (53766 elements)	
+  Y	Float array (53766 elements)	
+  RA	Float array (53766 elements)	
+  DEC	Float array (53766 elements)	
+  STON	Float array (53766 elements)	
+  FREQ	Float array (53766 elements)	
+  ALPHA	Float array (53766 elements)	
+  GAIN	Float array (53766 elements)	
+  FLAG	Integer array (53766 elements)	
+  EXTEND	Pointer array (53766 elements)	
+  FLUX	Structure (8 tags)	
+    XX	Float array (53766 elements)	
+    YY	Float array (53766 elements)	
+    XY	Complex array (53766 elements)	
+    YX	Complex array (53766 elements)	
+    I	Float array (53766 elements)	
+    Q	Float array (53766 elements)	
+    U	Float array (53766 elements)	
+    V	Float array (53766 elements)	
+  SHAPE	Structure (3 tags)	
+    X	Float array (53766 elements)	
+    Y	Float array (53766 elements)	
+    ANGLE	Float array (53766 elements)	
+  BEAM	Structure (8 tags)	
+    XX	Float array (53766 elements)	
+    YY	Float array (53766 elements)	
+    XY	Complex array (53766 elements)	
+    YX	Complex array (53766 elements)	
+    I	Float array (53766 elements)	
+    Q	Float array (53766 elements)	
+    U	Float array (53766 elements)	
+    V	Float array (53766 elements)	
+CATALOG_NAME	GLEAM_v2_plus_rlb2019  	
+GALAXY_MODEL	 0  	
+GALAXY_SPECTRAL_INDEX	 NaN  	
+DIFFUSE_MODEL	  	
+DIFFUSE_SPECTRAL_INDEX	 NaN  	
+##FHD	##	
+##END	##	

--- a/pyuvdata/uvcal/fhd_cal.py
+++ b/pyuvdata/uvcal/fhd_cal.py
@@ -274,7 +274,10 @@ class FHDCal(UVCal):
                 float(settings_lines["max_cal_baseline"][0]),
             ]
             galaxy_model = int(settings_lines["galaxy_model"][0])
-            diffuse_model = settings_lines["diffuse_model"][0]
+            if len(settings_lines["diffuse_model"]) > 0:
+                diffuse_model = settings_lines["diffuse_model"][0]
+            else:
+                diffuse_model = ""
             auto_scale = settings_lines["auto_scale"]
             n_vis_cal = np.int64(settings_lines["n_vis_cal"][0])
             time_avg = int(settings_lines["time_avg"][0])

--- a/pyuvdata/uvcal/tests/test_fhd_cal.py
+++ b/pyuvdata/uvcal/tests/test_fhd_cal.py
@@ -222,7 +222,13 @@ def test_unknown_telescope():
 def test_break_read_fhdcal(cal_file, obs_file, layout_file, settings_file, nfiles):
     """Try various cases of missing files."""
     fhd_cal = UVCal()
-    pytest.raises(TypeError, fhd_cal.read_fhd_cal, cal_file)  # Missing obs
+    # check useful error message for metadata only read with no settings file
+    with pytest.raises(
+        ValueError, match="A settings_file must be provided if read_data is False."
+    ):
+        fhd_cal.read_fhd_cal(
+            cal_file, obs_file, layout_file=layout_file, read_data=False
+        )
 
     message_list = [
         "No settings file",

--- a/pyuvdata/uvcal/tests/test_fhd_cal.py
+++ b/pyuvdata/uvcal/tests/test_fhd_cal.py
@@ -18,6 +18,9 @@ testfile_prefix = "1061316296_"
 obs_testfile = os.path.join(testdir, testfile_prefix + "obs.sav")
 cal_testfile = os.path.join(testdir, testfile_prefix + "cal.sav")
 settings_testfile = os.path.join(testdir, testfile_prefix + "settings.txt")
+settings_testfile_nodiffuse = os.path.join(
+    testdir, testfile_prefix + "nodiffuse_settings.txt"
+)
 layout_testfile = os.path.join(testdir, testfile_prefix + "layout.sav")
 
 testdir2 = os.path.join(DATA_PATH, "fhd_cal_data/set2")
@@ -89,6 +92,17 @@ def test_read_fhdcal_raw_write_read_calfits(raw, tmp_path):
     ]
 
     assert fhd_cal == calfits_cal2
+
+    fhd_cal.read_fhd_cal(
+        cal_testfile,
+        obs_testfile,
+        layout_file=layout_testfile,
+        settings_file=settings_testfile_nodiffuse,
+        raw=raw,
+        read_data=False,
+    )
+    calfits_cal2.diffuse_model = None
+    fhd_cal == calfits_cal2
 
     return
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added a useful error message for metadata only reads that makes it clear that the settings file is required.
- Added handling for an empty diffuse model in the settings file on a metadata only read

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #1043 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
