### PR TITLE
Some more efficient baselien_to_antnums calls

### DIFF
--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -3109,7 +3109,7 @@ class UVData(UVBase):
         list of tuples of int
             list of unique antpair tuples (ant1, ant2) with data associated with them.
         """
-        return [self.baseline_to_antnums(bl) for bl in self.get_baseline_nums()]
+        return list(zip(*self.baseline_to_antnums(self.get_baseline_nums())))
 
     def get_pols(self):
         """
@@ -7784,7 +7784,7 @@ class UVData(UVBase):
                             "Baseline number {i} is not present in the "
                             "baseline_array".format(i=bl_ind)
                         )
-                bls = [self.baseline_to_antnums(bl) for bl in bls]
+                bls = list(zip(*self.baseline_to_antnums(bls)))
             elif isinstance(bls, tuple) and (len(bls) == 2 or len(bls) == 3):
                 bls = [bls]
             if len(bls) == 0 or not all(isinstance(item, tuple) for item in bls):

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -3434,7 +3434,7 @@ class UVData(UVBase):
         if pick_data_ants:
             data_ants = np.unique(np.concatenate([self.ant_1_array, self.ant_2_array]))
             telescope_ants = self.antenna_numbers
-            select = [x in data_ants for x in telescope_ants]
+            select = np.in1d(telescope_ants, data_ants)
             antpos = antpos[select, :]
             ants = telescope_ants[select]
 

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -852,7 +852,7 @@ class UVFlag(UVBase):
     def get_antpairs(self):
         """Return list of unique antpair tuples (ant1, ant2) in data."""
         assert self.type == "baseline", 'Must be "baseline" type UVFlag object.'
-        return [self.baseline_to_antnums(bl) for bl in self.get_baseline_nums()]
+        return list(zip(*self.baseline_to_antnums(self.get_baseline_nums())))
 
     def get_ants(self):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Found a few places we call baselines_to_antnums on each bl individually. 
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The utility is more efficient if we call it on the entire array, then zip the outputs together.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [x] ?

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

