### PR TITLE
Warn rather than error if the integration time is missing in uvfits

### DIFF
--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -551,21 +551,26 @@ def test_readwriteread_error_single_time(tmp_path, casa_uvfits):
         hdulist = fits.HDUList(hdus=[vis_hdu, ant_hdu])
         hdulist.writeto(write_file2, overwrite=True)
 
-    with pytest.raises(ValueError) as cm:
+    with pytest.raises(
+        ValueError, match="Required UVParameter _integration_time has not been set"
+    ):
         with uvtest.check_warnings(
-            [UserWarning, erfa.core.ErfaWarning, erfa.core.ErfaWarning, UserWarning],
+            [
+                UserWarning,
+                erfa.core.ErfaWarning,
+                erfa.core.ErfaWarning,
+                UserWarning,
+                UserWarning,
+            ],
             [
                 "Telescope EVLA is not",
-                'ERFA function "utcut1" yielded 1 of "dubious year (Note 3)"',
-                'ERFA function "utctai" yielded 1 of "dubious year (Note 3)"',
+                "ERFA function 'utcut1' yielded 1 of 'dubious year (Note 3)'",
+                "ERFA function 'utctai' yielded 1 of 'dubious year (Note 3)'",
                 "LST values stored in this file are not self-consistent",
+                "The integration time is not specified and only one time",
             ],
         ):
             uv_out.read(write_file2),
-
-    assert str(cm.value).startswith(
-        "integration time not specified and only one time present"
-    )
 
     return
 

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -161,8 +161,13 @@ class UVFITS(UVData):
                     np.ones_like(self.time_array, dtype=np.float64) * int_time
                 )
             else:
-                raise ValueError(
-                    "integration time not specified and only one time present"
+                warnings.warn(
+                    "The integration time is not specified and only one time is "
+                    "present so it cannot be calculated from the difference between "
+                    "integration times. Setting to None which will cause the check to "
+                    "error. Set `run_check` to False to read in the file without "
+                    "checking. Then set the integration_time (to an array of length "
+                    "Nblts) directly on the object to allow futher processing."
                 )
 
         if proc is not None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Warn rather than error if the integration time is missing in uvfits. This allows users to read the file into UVData if they set run_check=False.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #1057

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
