### PR TITLE
require recent RTD theme to fix bullet points on RTD docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx>=1.3
-sphinx_rtd_theme>=1.0.0
+# >= 1.0.0rc1 for https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
+sphinx-rtd-theme >= 1.0.0rc1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx>=1.3
-# >= 1.0.0rc1 for https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
-sphinx-rtd-theme >= 1.0.0rc1
+# sphinx-rtd-theme and docutils pinned for https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
+sphinx-rtd-theme >= 1.0.0
+docutils=0.16

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinx>=1.3
+sphinx_rtd_theme>=1.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Require a recent RTD sphinx theme.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The RTD docs are not properly rendering bullets in bulleted lists. This is an issue in the RTD default theme (https://github.com/readthedocs/sphinx_rtd_theme/issues/1115)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
