### PR TITLE
Fixing automatically generated catalog IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- A bug that resulted in a potential error when attempting to write out multi-phase-center data sets into the UVH5 file format.
+
+
 ## [2.2.2] - 2021-9-30
 
 ### Added

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3282,3 +3282,19 @@ def test_fix_phase(tmp_path):
         "This data appears to have been phased-up using the old `phase` method,",
     ):
         uv_out.read(writepath, fix_old_proj=False)
+
+
+def test_cast_to_multiphase(uv_uvh5, tmp_path):
+    """
+    Test that round-tripping a UVH5 dataset after turning a single-phase-ctr
+    data set into a multi-phase-ctr writes out correctly
+    """
+    test_uvh5 = UVData()
+    testfile = os.path.join(tmp_path, "out_cast_to_multiphase.uvh5")
+
+    uv_uvh5._set_multi_phase_center(preserve_phase_center_info=True)
+
+    uv_uvh5.write_uvh5(testfile)
+    test_uvh5.read(testfile)
+
+    assert test_uvh5 == uv_uvh5

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -1142,9 +1142,11 @@ class UVData(UVBase):
         if force_update and (cat_name in self.phase_center_catalog.keys()):
             cat_id = self.phase_center_catalog[cat_name]["cat_id"]
         elif cat_id is None:
-            cat_id = np.arange(self.Nphase + 1)[
-                ~np.isin(np.arange(self.Nphase + 1), list(used_cat_ids.keys()))
-            ][0]
+            cat_id = int(
+                np.arange(self.Nphase + 1)[
+                    ~np.isin(np.arange(self.Nphase + 1), list(used_cat_ids.keys()))
+                ][0]
+            )
         elif cat_id in used_cat_ids.keys():
             raise ValueError(
                 "Provided cat_id belongs to another source (%s)." % used_cat_ids[cat_id]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes an issue with the `cat_id` attribute in multi-phase-center data sets that caused an error when attempting to write out in the UVH5 format.

## Description
<!--- Describe your changes in detail -->
A explicit cast to `int` for the `cat_id` keys in `phase_center_catalog` has been added to the method `_add_phase_center`. Previously, the method would return a value of type `np.int64`, which is not supported for conversion into a JSON string. This is of relevance to the UVH5 file format, which converts the individual entries of `phase_center_catalog` into JSON strings before being written to disk.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Closes #1056

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
