### PR TITLE
Putting in fix for astroquery/JPL-Horizons related error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- A bug that resulted in coordinate queries via for solar-system objects `utils.lookup_jplhorizons` to throw an error. The workaround temporarily requires the precision for ephemerides to be limited to 0.05 arcseconds.
 - A bug that resulted in a potential error when attempting to write out multi-phase-center data sets into the UVH5 file format.
 
 
 ## [2.2.2] - 2021-9-30
+
 
 ### Added
 - Added the `UVData.write_ms` method, a UVData measurement set writer.

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -2623,7 +2623,9 @@ def lookup_jplhorizons(
     # If not in the major bodies catalog, try the minor bodies list, and if
     # still not found, throw an error.
     try:
-        ephem_data = query_obj.ephemerides(extra_precision=True)
+        # TODO: Investigate as to why setting extra_precision to True seems to
+        # break everything for MacOS 10.15.
+        ephem_data = query_obj.ephemerides(extra_precision=False)
     except ValueError as err:
         query_obj._session.close()
         raise ValueError(


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A small change to the call to the JPL-Horizons online calculator (accessed through `astroquery`), setting `extra_precision=False`. The net result of which is that the maximum accuracy of the ephems will be precision-limited to 0.05 arcsec.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This is a temporary fix to an issue that has risen when using MacOS-10.15 to make calls to JPL-Horizons using `astroquery`. Once the underlying issue is resolved, then presumably this fix can be revered.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible). (N.B., bug was covered w/ existing test, no tests added)
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
