### PR TITLE
Fix a bug in efield_to_power with only one feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a bug in `UVBeam.efield_to_power` when there is only one feed.
+
 ## [2.2.4] - 2021-10-14
 
 ### Fixed

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -811,6 +811,10 @@ class UVBeam(UVBase):
         if beam_object.beam_type != "efield":
             raise ValueError("beam_type must be efield")
 
+        if beam_object.Nfeeds == 1:
+            # There are no cross pols with one feed. Set this so the power beam is real
+            calc_cross_pols = False
+
         efield_data = beam_object.data_array
         efield_naxes_vec = beam_object.Naxes_vec
 
@@ -820,8 +824,8 @@ class UVBeam(UVBase):
 
         if calc_cross_pols:
             beam_object.Npols = beam_object.Nfeeds ** 2
-            if beam_object.Nfeeds > 1:
-                feed_pol_order.extend([(0, 1), (1, 0)])
+            # to get here we have Nfeeds > 1
+            feed_pol_order.extend([(0, 1), (1, 0)])
         else:
             beam_object.Npols = beam_object.Nfeeds
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed a bug that resulted in the output beam being complex rather than real if Nfeeds=1 unless `calc_cross_pols` was set to `False`, which shouldn't be required. 

Added a new test and made some related tests more atomic

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Noticed in https://github.com/HERA-Team/vis_cpu/pull/29

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
