### PR TITLE
Fix expected shapes for data-like arrays on metadata only objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - Improved readability, functionality, and memory usage in `read_mwa_corr_fits`.
 
 ### Fixed
+- A bug that resulted in the wrong expected shapes for data-like arrays when metadata
+only UVData objects were set to use future array shapes.
 - Added a warning in `utils.uvcalibrate` when uvdata x_orientation is not set.
 - Fixed a bug in `UVBeam.efield_to_power` when there is only one feed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - A bug that resulted in the wrong expected shapes for data-like arrays when metadata
 only UVData objects were set to use future array shapes.
+- A bug that caused an error when writing non-double antenna diameters to measurement set files
 - Added a warning in `utils.uvcalibrate` when uvdata x_orientation is not set.
 - Fixed a bug in `UVBeam.efield_to_power` when there is only one feed.
 

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -273,7 +273,7 @@ class MS(UVData):
 
         antenna_table.putcol("POSITION", ant_pos_table)
         if self.antenna_diameters is not None:
-            ant_diam_table = np.zeros((nants_table), dtype=self.antenna_diameters.dtype)
+            ant_diam_table = np.zeros((nants_table), dtype=np.float64)
             # This is here is suppress an error that arises when one has antennas of
             # different diameters (which CASA can't handle), since otherwise the
             # "padded" antennas have zero diameter (as opposed to any real telescope).

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -18,7 +18,7 @@ from .. import utils as uvutils
 __all__ = ["MS"]
 
 no_casa_message = (
-    "casacore is not installed but is required for " "measurement set functionality"
+    "casacore is not installed but is required for measurement set functionality"
 )
 
 casa_present = True

--- a/pyuvdata/uvdata/tests/conftest.py
+++ b/pyuvdata/uvdata/tests/conftest.py
@@ -1,0 +1,39 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright (c) 2021 Radio Astronomy Software Group
+# Licensed under the 2-clause BSD License
+
+"""Testing fixtures for UVData."""
+import os
+
+import pytest
+
+from pyuvdata.data import DATA_PATH
+from pyuvdata import UVData
+
+
+@pytest.fixture(scope="session")
+def hera_uvh5_main():
+    # read in test file for the resampling in time functions
+    uv_object = UVData()
+    testfile = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
+    uv_object.read(testfile)
+
+    yield uv_object
+
+    # cleanup
+    del uv_object
+
+    return
+
+
+@pytest.fixture(scope="function")
+def hera_uvh5(hera_uvh5_main):
+    # read in test file for the resampling in time functions
+    uv_object = hera_uvh5_main.copy()
+
+    yield uv_object
+
+    # cleanup
+    del uv_object
+
+    return

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -679,7 +679,7 @@ def test_antenna_diameter_handling(hera_uvh5, tmp_path):
     uv_obj2.extra_keywords = uv_obj.extra_keywords
 
     # Uh oh, we're losing x_orientation in the ms write/read round trip.
-    # That's a problem.
+    # That's a problem. Documented in issue #1083.
     assert uv_obj.x_orientation is not None
     assert uv_obj2.x_orientation is None
     uv_obj2.x_orientation = uv_obj.x_orientation

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -774,6 +774,18 @@ def test_future_array_shape(casa_uvfits):
 
     assert uvobj == uvobj2
 
+    uvobj2.data_array = None
+    uvobj2.flag_array = None
+    uvobj2.nsample_array = None
+    assert uvobj2.metadata_only
+
+    uvobj2.use_future_array_shapes()
+    assert uvobj2._data_array.expected_shape(uvobj2) == (
+        uvobj2.Nblts,
+        uvobj2.Nfreqs,
+        uvobj2.Npols,
+    )
+
     uvobj.use_future_array_shapes()
     uvobj.channel_width[-1] = uvobj.channel_width[0] * 2.0
     uvobj.check()

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -205,34 +205,6 @@ def uvdata_props():
 
 
 @pytest.fixture(scope="session")
-def hera_uvh5_main():
-    # read in test file for the resampling in time functions
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-    uv_object.read(testfile)
-
-    yield uv_object
-
-    # cleanup
-    del uv_object
-
-    return
-
-
-@pytest.fixture(scope="function")
-def hera_uvh5(hera_uvh5_main):
-    # read in test file for the resampling in time functions
-    uv_object = hera_uvh5_main.copy()
-
-    yield uv_object
-
-    # cleanup
-    del uv_object
-
-    return
-
-
-@pytest.fixture(scope="session")
 def hera_uvh5_split_main(hera_uvh5_main):
     # Get some meta info up from
     unique_times = np.unique(hera_uvh5_main.time_array)

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -1971,9 +1971,8 @@ class UVData(UVBase):
         self.future_array_shapes = True
         self._freq_array.form = ("Nfreqs",)
         self._channel_width.form = ("Nfreqs",)
-        if not self.metadata_only:
-            for param_name in self._data_params:
-                getattr(self, "_" + param_name).form = ("Nblts", "Nfreqs", "Npols")
+        for param_name in self._data_params:
+            getattr(self, "_" + param_name).form = ("Nblts", "Nfreqs", "Npols")
 
     def use_future_array_shapes(self):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Changed `_set_future_array_shapes` method to always update the form of data-like arrays, regardless of whether the object is a metadata only object.
- Explicitly put `antenna_diameters` into measurement sets as doubles.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The form for the data-like arrays were not being updated for the future shapes if the UVData object was a metadata only object. This is a bug and caused problems on pyuvsim, where the object is first created and set to use future shapes and then the metadata and data are added later. The result was that the check errored because the forms hadn't been properly updated for the data-like arrays.

I also found another small bug when adding the option to write measurement sets to pyuvsim. The antenna diameters in a file I was working with had a dtype of `">f4"` and this caused an error in adding the diameters to the measurement set.  @kartographer suggested forcing them to be doubles and that fixed the error, so I added that fix (and a test) to this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
