### PR TITLE
Write scan number for MS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Added a `filename` attribute to UVCal, UVBeam and UVFlag objects.
-- Support for reading MWAX/birli uvfits files.
-- Flexible spectral windows to `read_mwa_corr_fits`.
 - Reading writing of scan numbers for MS files as `UVData.scan_number_array`.
 - Grouping of contiguous integrations for a phase center into "scan numbers" in `UVData._set_scan_numbers`.
 This grouping defines `UVData.scan_number_array` when not originally present in the data (e.g. reading in
 a non-MS file) and is used when writing to an MS file.
+- Added a `filename` attribute to UVCal, UVBeam and UVFlag objects.
+- Support for reading MWAX/birli uvfits files.
+- Flexible spectral windows to `read_mwa_corr_fits`.
 
 ### Changed
 - Assumes uvfits files are in ITRF frame unless explicitly stated otherwise. Consistent with AIPS 117.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 - Added a `filename` attribute to UVCal, UVBeam and UVFlag objects.
 - Support for reading MWAX/birli uvfits files.
 - Flexible spectral windows to `read_mwa_corr_fits`.
+- Reading writing of scan numbers for MS files as `UVData.scan_number_array`.
+- Grouping of contiguous integrations for a phase center into "scan numbers" in `UVData._set_scan_numbers`.
+This grouping defines `UVData.scan_number_array` when not originally present in the data (e.g. reading in
+a non-MS file) and is used when writing to an MS file.
 
 ### Changed
 - Assumes uvfits files are in ITRF frame unless explicitly stated otherwise. Consistent with AIPS 117.

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1170,7 +1170,7 @@ class MS(UVData):
         if self.scan_number_array is None:
             self._set_scan_numbers()
 
-        if self.multi_phase_center:
+        if self.Nspws > 1:
             scan_array_tiled = np.repeat(self.scan_number_array, self.Nspws)
             ms.putcol("SCAN_NUMBER", scan_array_tiled)
         else:

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1196,6 +1196,10 @@ class MS(UVData):
 
             ms.putcol("SCAN_NUMBER", scan_array_tiled)
 
+        else:
+            if self.scan_number_array is not None:
+                ms.putcol("SCAN_NUMBER", self.scan_number_array)
+
         if len(self.extra_keywords) != 0:
             ms.putkeyword("pyuvdata_extra", self.extra_keywords)
 

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1174,8 +1174,7 @@ class MS(UVData):
             scan_array_tiled = np.repeat(self.scan_number_array, self.Nspws)
             ms.putcol("SCAN_NUMBER", scan_array_tiled)
         else:
-            if self.scan_number_array is not None:
-                ms.putcol("SCAN_NUMBER", self.scan_number_array)
+            ms.putcol("SCAN_NUMBER", self.scan_number_array)
 
         if len(self.extra_keywords) != 0:
             ms.putkeyword("pyuvdata_extra", self.extra_keywords)

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1187,7 +1187,7 @@ class MS(UVData):
                 # slice_list_ord
                 scan_array = np.zeros_like(self.phase_center_id_array)
                 for ii, slice_scan in enumerate(slice_list_ord):
-                    scan_array[slice_scan] = ii
+                    scan_array[slice_scan] = ii + 1
 
                 scan_array_tiled = np.repeat(scan_array, self.Nspws)
 

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -17,7 +17,6 @@ import numpy as np
 from ... import UVData
 from ...data import DATA_PATH
 from ...uvdata.mir import mir_parser
-from .test_ms import allowed_failures_with_ms
 
 
 @pytest.fixture
@@ -222,7 +221,7 @@ def test_read_mir_write_ms(uv_in_ms, future_shapes):
     mir_uv.filename = ms_uv.filename = None
 
     # Finally, with all exceptions handled, check for equality.
-    assert ms_uv.__eq__(mir_uv, allowed_failures=allowed_failures_with_ms)
+    assert ms_uv.__eq__(mir_uv, allowed_failures=["filename"])
 
 
 @pytest.mark.filterwarnings("ignore:LST values stored ")

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -183,6 +183,10 @@ def test_read_mir_write_ms(uv_in_ms, future_shapes):
     mir_uv.write_ms(testfile, clobber=True)
     ms_uv.read(testfile)
 
+    # Single integration with 1 phase center = single scan number
+    # output in the MS
+    assert ms_uv.scan_number_array == np.array([1])
+
     if future_shapes:
         ms_uv.use_future_array_shapes()
 

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -17,6 +17,7 @@ import numpy as np
 from ... import UVData
 from ...data import DATA_PATH
 from ...uvdata.mir import mir_parser
+from .test_ms import allowed_failures_with_ms
 
 
 @pytest.fixture
@@ -217,7 +218,7 @@ def test_read_mir_write_ms(uv_in_ms, future_shapes):
     mir_uv.filename = ms_uv.filename = None
 
     # Finally, with all exceptions handled, check for equality.
-    assert ms_uv == mir_uv
+    assert ms_uv.__eq__(mir_uv, allowed_failures=allowed_failures_with_ms)
 
 
 @pytest.mark.filterwarnings("ignore:LST values stored ")

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -32,7 +32,6 @@ from ..miriad import Miriad
 import pyuvdata.utils as uvutils
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH
-from .test_ms import allowed_failures_with_ms
 
 aipy_extracts = pytest.importorskip("pyuvdata.uvdata.aipy_extracts")
 
@@ -263,7 +262,7 @@ def test_read_carma_miriad_write_ms(tmp_path):
     uv_in.history = uv_out.history
 
     # Final equality check
-    assert uv_in.__eq__(uv_out, allowed_failures=allowed_failures_with_ms)
+    assert uv_in.__eq__(uv_out, allowed_failures=["filename"])
 
     # Manipulate the table so that all fields have the same name (as is permitted
     # for MS files), and wipe out the source_ID information
@@ -288,7 +287,7 @@ def test_read_carma_miriad_write_ms(tmp_path):
     )
 
     # Final equality check
-    assert uv_in.__eq__(uv_out, allowed_failures=allowed_failures_with_ms)
+    assert uv_in.__eq__(uv_out, allowed_failures=["filename"])
 
     # Last but not least, change the coord system so that the catalog frames are the
     # same as phase_center_frame
@@ -302,7 +301,7 @@ def test_read_carma_miriad_write_ms(tmp_path):
     # Do one last read/write/check for equality
     uv_in.write_ms(testfile, clobber=True)
     uv_out.read(testfile)
-    assert uv_in.__eq__(uv_out, allowed_failures=allowed_failures_with_ms)
+    assert uv_in.__eq__(uv_out, allowed_failures=["filename"])
 
 
 @pytest.mark.filterwarnings("ignore:LST values stored in this file are not ")

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -32,6 +32,7 @@ from ..miriad import Miriad
 import pyuvdata.utils as uvutils
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH
+from .test_ms import allowed_failures_with_ms
 
 aipy_extracts = pytest.importorskip("pyuvdata.uvdata.aipy_extracts")
 
@@ -262,7 +263,7 @@ def test_read_carma_miriad_write_ms(tmp_path):
     uv_in.history = uv_out.history
 
     # Final equality check
-    assert uv_in == uv_out
+    assert uv_in.__eq__(uv_out, allowed_failures=allowed_failures_with_ms)
 
     # Manipulate the table so that all fields have the same name (as is permitted
     # for MS files), and wipe out the source_ID information
@@ -287,7 +288,7 @@ def test_read_carma_miriad_write_ms(tmp_path):
     )
 
     # Final equality check
-    assert uv_in == uv_out
+    assert uv_in.__eq__(uv_out, allowed_failures=allowed_failures_with_ms)
 
     # Last but not least, change the coord system so that the catalog frames are the
     # same as phase_center_frame
@@ -301,7 +302,7 @@ def test_read_carma_miriad_write_ms(tmp_path):
     # Do one last read/write/check for equality
     uv_in.write_ms(testfile, clobber=True)
     uv_out.read(testfile)
-    assert uv_in == uv_out
+    assert uv_in.__eq__(uv_out, allowed_failures=allowed_failures_with_ms)
 
 
 @pytest.mark.filterwarnings("ignore:LST values stored in this file are not ")
@@ -1484,6 +1485,9 @@ def test_read_ms_write_miriad_casa_history(tmp_path):
     assert miriad_uv.filename == ["outtest_miriad"]
     assert ms_uv.filename == ["day2_TDEM0003_10s_norx_1src_1spw.ms"]
     miriad_uv.filename = ms_uv.filename
+
+    # propagate scan numbers to the uvfits, ONLY for comparison
+    miriad_uv.scan_number_array = ms_uv.scan_number_array
 
     assert miriad_uv == ms_uv
 

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -105,6 +105,9 @@ def test_read_nrao_loopback(tmp_path, nrao_uv):
     assert uvobj2.filename == ["ms_testfile.ms"]
     uvobj.filename = uvobj2.filename
 
+    # Test that the scan numbers are equal
+    assert uvobj.scan_number_array == uvobj2.scan_number_array
+
     assert uvobj == uvobj2
 
 

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -106,7 +106,7 @@ def test_read_nrao_loopback(tmp_path, nrao_uv):
     uvobj.filename = uvobj2.filename
 
     # Test that the scan numbers are equal
-    assert uvobj.scan_number_array == uvobj2.scan_number_array
+    assert (uvobj.scan_number_array == uvobj2.scan_number_array).all()
 
     assert uvobj == uvobj2
 

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -18,9 +18,7 @@ from ..uvfits import UVFITS
 
 pytest.importorskip("casacore")
 
-# Only MSs have `scan_number_array` defined.
-# Skip for eq or neq comparisons as needed.
-allowed_failures_with_ms = ("filename", "scan_number_array")
+allowed_failures = "filename"
 
 
 @pytest.fixture(scope="session")
@@ -205,9 +203,7 @@ def test_read_ms_read_uvfits(nrao_uv, casa_uvfits):
     uvfits_uv.integration_time = ms_uv.integration_time
     # they are equal if only required parameters are checked:
     # scan numbers only defined for the MS
-    assert uvfits_uv.__eq__(
-        ms_uv, check_extra=False, allowed_failures=allowed_failures_with_ms
-    )
+    assert uvfits_uv.__eq__(ms_uv, check_extra=False, allowed_failures=allowed_failures)
 
     # set those parameters to none to check that the rest of the objects match
     ms_uv.antenna_diameters = None
@@ -296,6 +292,9 @@ def test_multi_files(casa_uvfits, axis):
     """
     uv_full = casa_uvfits.copy()
 
+    # Ensure the scan numbers are defined for the comparison
+    uv_full._set_scan_numbers()
+
     uv_multi = UVData()
     testfile1 = os.path.join(DATA_PATH, "multi_1.ms")
     testfile2 = os.path.join(DATA_PATH, "multi_2.ms")
@@ -342,7 +341,7 @@ def test_multi_files(casa_uvfits, axis):
     uv_multi.filename = uv_full.filename
     uv_multi._filename.form = (1,)
 
-    assert uv_multi.__eq__(uv_full, allowed_failures=allowed_failures_with_ms)
+    assert uv_multi.__eq__(uv_full, allowed_failures=allowed_failures)
     del uv_full
     del uv_multi
 
@@ -768,4 +767,4 @@ def test_antenna_diameter_handling(hera_uvh5, tmp_path):
     assert uv_obj2.x_orientation is None
     uv_obj2.x_orientation = uv_obj.x_orientation
 
-    assert uv_obj2.__eq__(uv_obj, allowed_failures=allowed_failures_with_ms)
+    assert uv_obj2.__eq__(uv_obj, allowed_failures=allowed_failures)

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -90,6 +90,7 @@ def uvdata_props():
         "Nphase",
         "phase_center_catalog",
         "phase_center_id_array",
+        "scan_number_array",
         "eq_coeffs",
         "eq_coeffs_convention",
         "flex_spw_id_array",

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -17,7 +17,6 @@ from pyuvdata import UVData
 import pyuvdata.utils as uvutils
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH
-from .test_ms import allowed_failures_with_ms
 
 casa_tutorial_uvfits = os.path.join(
     DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits"
@@ -114,7 +113,7 @@ def test_time_precision(tmp_path):
         atol=uvd2._lst_array.tols[1],
     )
 
-    assert uvd2.__eq__(uvd, allowed_failures=allowed_failures_with_ms)
+    assert uvd2.__eq__(uvd, allowed_failures=["filename", "scan_number_array"])
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -17,6 +17,7 @@ from pyuvdata import UVData
 import pyuvdata.utils as uvutils
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH
+from .test_ms import allowed_failures_with_ms
 
 casa_tutorial_uvfits = os.path.join(
     DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits"
@@ -113,7 +114,7 @@ def test_time_precision(tmp_path):
         atol=uvd2._lst_array.tols[1],
     )
 
-    assert uvd2 == uvd
+    assert uvd2.__eq__(uvd, allowed_failures=allowed_failures_with_ms)
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
@@ -1259,6 +1260,9 @@ def test_read_ms_write_uvfits_casa_history(tmp_path):
     assert ms_uv.filename == ["day2_TDEM0003_10s_norx_1src_1spw.ms"]
     assert uvfits_uv.filename == ["outtest.uvfits"]
     ms_uv.filename = uvfits_uv.filename
+
+    # propagate scan numbers to the uvfits, ONLY for comparison
+    uvfits_uv.scan_number_array = ms_uv.scan_number_array
 
     assert ms_uv == uvfits_uv
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -497,6 +497,18 @@ class UVData(UVBase):
             required=False,
         )
 
+        desc = (
+            "Optional if multi_phase_center = True when reading an MS. Retains the "
+            "scan number when reading an MS. Shape (Nblts), type = int."
+        )
+        self._scan_number_array = uvp.UVParameter(
+            "scan_number_array",
+            description=desc,
+            form=("Nblts",),
+            expected_type=int,
+            required=False,
+        )
+
         # --- antenna information ----
         desc = (
             "Number of antennas with data present (i.e. number of unique "

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -739,7 +739,7 @@ class UVData(UVBase):
             # If this isn't defined, we cannot define scan numbers in this way
             # and default to a single "scan".
             if self.phase_center_catalog is None:
-                self.scan_number_array = np.zeros((self.Nblts,), dtype=int)
+                self.scan_number_array = np.ones((self.Nblts,), dtype=int)
 
             else:
                 sou_list = list(self.phase_center_catalog.keys())

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -498,8 +498,8 @@ class UVData(UVBase):
         )
 
         desc = (
-            "Optional if multi_phase_center = True when reading an MS. Retains the "
-            "scan number when reading an MS. Shape (Nblts), type = int."
+            "Optional when reading a MS. Retains the  scan number when reading a MS."
+            " Shape (Nblts), type = int."
         )
         self._scan_number_array = uvp.UVParameter(
             "scan_number_array",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds setting scan numbers when writing MS files.

## Description
<!--- Describe your changes in detail -->

 For data with multi-phase centers, the scan numbers in the MS should bet set (somehow) to match the usual format in CASA. The SMA will need this for converting MIR to MS (@kartographer).

I've added grouping by phase centers, incrementally increasing whenever the data switches between phase centers (e.g., between the target and gain calibrator) based on `UVData.phase_center_id_array`. I _think_ this is a good grouping definition when scans are not already defined, for example in MIR data.

To-dos and questions:
* [x] Is this grouping on fields from `UVData.phase_center_id_array` reasonable?
* [x] Read in scan numbers from an MS. Add a new attribute `UVData.scan_numbers_array` that is defined only when reading in a MS.
* [x] Add a read and write test for scan numbers. Checks for the scan numbers added to round trip tests with reading/writing a MS; added read/write MS test for multi-phase centers using the CARMA MIRIAD 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.


New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).


