### PR TITLE
Handle `None` values in `extra_keywords` in UVH5 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 - Improved readability, functionality, and memory usage in `read_mwa_corr_fits`.
 
 ### Fixed
+- A bug that prevented `extra_keywords` keys with a value of `None` from being
+  saved to UVH5 files.
 - A bug that resulted in the wrong expected shapes for data-like arrays when metadata
 only UVData objects were set to use future array shapes.
 - A bug that caused an error when writing non-double antenna diameters to measurement set files

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3298,3 +3298,22 @@ def test_cast_to_multiphase(uv_uvh5, tmp_path):
     test_uvh5.read(testfile)
 
     assert test_uvh5 == uv_uvh5
+
+
+def test_none_extra_keywords(uv_uvh5, tmp_path):
+    """Test that we can round-trip None values in extra_keywords"""
+    test_uvh5 = UVData()
+    testfile = os.path.join(tmp_path, "none_extra_keywords.uvh5")
+
+    uv_uvh5.extra_keywords["foo"] = None
+
+    uv_uvh5.write_uvh5(testfile)
+    test_uvh5.read(testfile)
+
+    assert test_uvh5 == uv_uvh5
+
+    # also confirm dataset is empty/null
+    with h5py.File(testfile, "r") as h5f:
+        assert h5f["Header/extra_keywords/foo"].shape is None
+
+    return

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -388,7 +388,11 @@ class UVH5(UVData):
                         header["extra_keywords"][key][()]
                     ).decode("utf8")
                 else:
-                    self.extra_keywords[key] = header["extra_keywords"][key][()]
+                    # special handling for empty datasets == python `None` type
+                    if header["extra_keywords"][key].shape is None:
+                        self.extra_keywords[key] = None
+                    else:
+                        self.extra_keywords[key] = header["extra_keywords"][key][()]
 
         if proc is not None:
             # if lsts are in the background wait for them to return
@@ -1073,6 +1077,9 @@ class UVH5(UVData):
             for k in self.extra_keywords.keys():
                 if isinstance(self.extra_keywords[k], str):
                     extra_keywords[k] = np.string_(self.extra_keywords[k])
+                elif self.extra_keywords[k] is None:
+                    # save as empty/null dataset
+                    extra_keywords[k] = h5py.Empty("f")
                 else:
                     extra_keywords[k] = self.extra_keywords[k]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the ability to round-trip `None` values in the `extra_keywords` dictionary for UVH5 files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
In detail, this is done by creating an [empty dataset](https://docs.h5py.org/en/stable/high/dataset.html#creating-and-reading-empty-or-null-datasets-and-attributes) in the HDF5 file with a name corresponding to the key of the `extra_keywords`. To me, this approach is more precise than, e.g., saving a string like `"None"` because it's clear that this is a null-like data object, but I am open to hearing what others think.

Fixes #1081.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

