### PR TITLE
fix doctests by requiring recent astroquery, updating tutorial output

### DIFF
--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - astropy>=4.2.1
-  - astroquery
+  - astroquery>=0.4.4
   - h5py
   - astropy-healpix
   - numpy

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -537,7 +537,7 @@ b) Data with a multiple phase centers enabled.
      ID     Cat Entry       Type      Az/Lon/RA    El/Lat/Dec  Frame    Epoch        Ephem Range        Dist   V_rad
       #          Name                       deg           deg                  Start-MJD    End-MJD       pc    km/s
   -------------------------------------------------------------------------------------------------------------------
-      0           Sun      ephem    94:52:10.20  +23:21:44.63   icrs  J2000.0   58660.25   58661.00  1.0e+00  0.2157
+      0           Sun      ephem    94:52:10.21  +23:21:44.63   icrs  J2000.0   58660.25   58661.00  1.0e+00  0.2157
       1        zenith  driftscan     0:00:00.00  +90:00:00.00  altaz  J2000.0
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -537,7 +537,7 @@ b) Data with a multiple phase centers enabled.
      ID     Cat Entry       Type      Az/Lon/RA    El/Lat/Dec  Frame    Epoch        Ephem Range        Dist   V_rad
       #          Name                       deg           deg                  Start-MJD    End-MJD       pc    km/s
   -------------------------------------------------------------------------------------------------------------------
-      0           Sun      ephem    94:52:10.20  +23:21:44.64   icrs  J2000.0   58660.25   58661.00  1.0e+00  0.2157
+      0           Sun      ephem    94:52:10.20  +23:21:44.63   icrs  J2000.0   58660.25   58661.00  1.0e+00  0.2157
       1        zenith  driftscan     0:00:00.00  +90:00:00.00  altaz  J2000.0
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -519,7 +519,7 @@ b) Data with a multiple phase centers enabled.
      ID     Cat Entry       Type     Az/Lon/RA    El/Lat/Dec  Frame    Epoch        Ephem Range        Dist   V_rad
       #          Name                    hours           deg                  Start-MJD    End-MJD       pc    km/s
   ------------------------------------------------------------------------------------------------------------------
-      0           Sun      ephem    6:19:28.68  +23:21:44.64   icrs  J2000.0   58660.25   58661.00  1.0e+00  0.2157
+      0           Sun      ephem    6:19:28.68  +23:21:44.63   icrs  J2000.0   58660.25   58661.00  1.0e+00  0.2157
 
   >>> # Finally, we can use a selection mask to only phase part of the data at a time,
   >>> # like only the data belonging to the first integration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update our test yaml to require astroquery>=0.4.4 and update the tutorial output to match what we get with that version of astroquery.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
A new astroquery version (0.4.4) just came out which fixes the problem addressed in #1069. We want to leave the try/except handling introduced in that PR because it is more robust and allows us to support more versions of astroquery. But in order for the doctests to pass we need some version certainty.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
