### PR TITLE
Fix h5py deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Note that as of v2.2, `pyuvdata` is only supported on python 3.7+.
 Required:
 
 * astropy >= 4.2.1
-* h5py
+* h5py >= 3.0
 * numpy >= 1.18
 * pyerfa >= 2.0
 * scipy

--- a/ci/hera_cal.yml
+++ b/ci/hera_cal.yml
@@ -7,7 +7,7 @@ dependencies:
   - astropy>=4.2.1
   - astropy-healpix
   - cached-property
-  - h5py
+  - h5py>=3.0
   - pyerfa>=2.0
   - matplotlib
   - numpy

--- a/ci/hera_qm.yml
+++ b/ci/hera_qm.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - astropy>=4.2.1
   - astropy-healpix
-  - h5py
+  - h5py>=3.0
   - numpy
   - matplotlib
   - pip

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -6,7 +6,7 @@ dependencies:
   - astropy
   - numpy
   - scipy
-  - h5py
+  - h5py>=3.0
   - pyerfa>=2.0
   - coverage
   - pytest>=6.2.0

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - astropy>=4.2.1
   - astroquery>=0.4.4
-  - h5py
+  - h5py>=3.0
   - astropy-healpix
   - numpy
   - pyerfa>=2.0

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - astropy
-  - h5py
+  - h5py>=3.0
   - hdf5>=1.12.0
   - astropy-healpix
   - numpy

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -106,13 +106,12 @@ def initialize_with_zeros_ints(uvd, filename):
         data_dset = dgrp["visdata"]
         flags_dset = dgrp["flags"]
         nsample_dset = dgrp["nsamples"]
-        with data_dset.astype(uvh5._hera_corr_dtype):
-            if uvd.future_array_shapes:
-                data_dset[:, :, :, "r"] = data.real
-                data_dset[:, :, :, "i"] = data.imag
-            else:
-                data_dset[:, :, :, :, "r"] = data.real
-                data_dset[:, :, :, :, "i"] = data.imag
+        if uvd.future_array_shapes:
+            data_dset[:, :, :, "r"] = data.real
+            data_dset[:, :, :, "i"] = data.imag
+        else:
+            data_dset[:, :, :, :, "r"] = data.real
+            data_dset[:, :, :, :, "i"] = data.imag
         flags_dset = flags  # noqa
         nsample_dset = nsamples  # noqa
     return
@@ -2456,9 +2455,8 @@ def test_read_complex_astype(tmp_path):
         dset = dgrp.create_dataset(
             "testdata", test_data_shape, dtype=uvh5._hera_corr_dtype
         )
-        with dset.astype(uvh5._hera_corr_dtype):
-            dset[:, :, :, :, "r"] = test_data.real
-            dset[:, :, :, :, "i"] = test_data.imag
+        dset[:, :, :, :, "r"] = test_data.real
+        dset[:, :, :, :, "i"] = test_data.imag
 
     # test that reading the data back in works as expected
     indices = (np.s_[:], np.s_[:], np.s_[:], np.s_[:])
@@ -2486,9 +2484,8 @@ def test_read_complex_astype_errors(tmp_path):
         dset = dgrp.create_dataset(
             "testdata", test_data_shape, dtype=uvh5._hera_corr_dtype
         )
-        with dset.astype(uvh5._hera_corr_dtype):
-            dset[:, :, :, :, "r"] = test_data.real
-            dset[:, :, :, :, "i"] = test_data.imag
+        dset[:, :, :, :, "r"] = test_data.real
+        dset[:, :, :, :, "i"] = test_data.imag
 
     # test passing in a forbidden output datatype
     indices = (np.s_[:], np.s_[:], np.s_[:], np.s_[:])
@@ -2523,9 +2520,8 @@ def test_write_complex_astype(tmp_path):
     with h5py.File(test_file, "r") as h5f:
         dset = h5f["Data/testdata"]
         file_data = np.zeros(test_data_shape, dtype=np.complex64)
-        with dset.astype(uvh5._hera_corr_dtype):
-            file_data.real = dset["r"][:, :, :, :]
-            file_data.imag = dset["i"][:, :, :, :]
+        file_data.real = dset.astype(uvh5._hera_corr_dtype)["r"][:, :, :, :]
+        file_data.imag = dset.astype(uvh5._hera_corr_dtype)["i"][:, :, :, :]
 
     assert np.allclose(file_data, test_data)
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -93,10 +93,9 @@ def _read_complex_astype(dset, indices, dtype_out=np.complex64):
     dset_shape, indices = uvutils._get_dset_shape(dset, indices)
     output_array = np.empty(dset_shape, dtype=dtype_out)
     dtype_in = dset.dtype
-    with dset.astype(dtype_in):
-        # dset is indexed in native dtype, but is upcast upon assignment
-        output_array.real = uvutils._index_dset(dset["r"], indices)
-        output_array.imag = uvutils._index_dset(dset["i"], indices)
+    # dset is indexed in native dtype, but is upcast upon assignment
+    output_array.real = uvutils._index_dset(dset.astype(dtype_in)["r"], indices)
+    output_array.imag = uvutils._index_dset(dset.astype(dtype_in)["i"], indices)
 
     return output_array
 
@@ -129,13 +128,11 @@ def _write_complex_astype(data, dset, indices):
     _check_uvh5_dtype(dtype_out)
     if len(dset.shape) == 3:
         # this is the future array shape
-        with dset.astype(dtype_out):
-            dset[indices[0], indices[1], indices[2], "r"] = data.real
-            dset[indices[0], indices[1], indices[2], "i"] = data.imag
+        dset[indices[0], indices[1], indices[2], "r"] = data.real
+        dset[indices[0], indices[1], indices[2], "i"] = data.imag
     else:
-        with dset.astype(dtype_out):
-            dset[indices[0], np.s_[:], indices[1], indices[2], "r"] = data.real
-            dset[indices[0], np.s_[:], indices[1], indices[2], "i"] = data.imag
+        dset[indices[0], np.s_[:], indices[1], indices[2], "r"] = data.real
+        dset[indices[0], np.s_[:], indices[1], indices[2], "i"] = data.imag
     return
 
 

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup_args = {
     "include_package_data": True,
     "install_requires": [
         "astropy>=4.2.1",
-        "h5py",
+        "h5py>=3.0",
         "numpy>=1.18",
         "pyerfa>=2.0",
         "scipy",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With the release of h5py version 3.6.0, [using a context manager to switch datatypes on the fly](https://docs.h5py.org/en/stable/high/dataset.html#h5py.Dataset.astype) is officially deprecated. This PR uses the new syntax, and adds a version requirement for h5py >= 3.0, when the new method was introduced. (Previously, we did not have a version requirement.)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

Fixes broken tests (not an official issue, just something we noticed).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).