### PR TITLE
Astroquery/JPL Horizons deprecation  fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Flexible spectral windows to `read_mwa_corr_fits`.
 
 ### Changed
+- Updated the astroquery requirement to >= 0.4.4, due to changes in the API handling for
+calls to JPL Horizons.
 - Assumes uvfits files are in ITRF frame unless explicitly stated otherwise. Consistent with AIPS 117.
 - Improved readability, functionality, and memory usage in `read_mwa_corr_fits`.
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Optional:
 * astropy-healpix (for working with beams in HEALPix formats)
 * pyyaml (for working with settings files for CST beam files)
 * novas and novas_de405 (for using the NOVAS library for astrometry)
-* astroquery >= 0.4.1 (for enabling lookup functionality with JPL-Horizons)
+* astroquery >= 0.4.4 (for enabling lookup functionality with JPL-Horizons)
 
 The numpy and astropy versions are important, so make sure these are up to date.
 

--- a/ci/pyuvdata_publish.yml
+++ b/ci/pyuvdata_publish.yml
@@ -6,7 +6,7 @@ dependencies:
   - astropy
   - numpy
   - scipy
-  - h5py
+  - h5py>=3.0
   - pyerfa>=2.0
   - cython
   - setuptools_scm

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -3,7 +3,8 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - astropy
+  - astropy>=4.2.1
+  - astroquery>=0.4.4
   - h5py>=3.0
   - hdf5>=1.12.0
   - astropy-healpix

--- a/environment.yaml
+++ b/environment.yaml
@@ -7,7 +7,7 @@ dependencies:
   - astropy>=4.2.1
   - astropy-healpix
   - astroquery>=0.4.4
-  - h5py
+  - h5py>=3.0
   - numpy>=1.18
   - pre-commit
   - pyerfa>=2.0

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python>3.6
   - astropy>=4.2.1
   - astropy-healpix
-  - astroquery
+  - astroquery>=0.4.4
   - h5py
   - numpy>=1.18
   - pre-commit

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -2615,7 +2615,7 @@ def lookup_jplhorizons(
     # not know which to choose).
     if target_name in major_body_dict.keys():
         target_id = major_body_dict[target_name]
-        id_type = "majorbody"
+        id_type = None
 
     query_obj = Horizons(
         id=target_id, location=site_loc, epochs=epoch_list, id_type=id_type,

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ extensions = [corr_fits_extension, utils_extension]
 if not is_platform_windows():
     extensions.append(miriad_extension)
 
-astroquery_reqs = ["astroquery"]
+astroquery_reqs = ["astroquery>=0.4.4"]
 novas_reqs = ["novas", "novas_de405"]
 casa_reqs = ["python-casacore>=3.1.0"]
 healpix_reqs = ["astropy_healpix"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Deals with a pesky deprecation warning from astroquery. 

## Description
<!--- Describe your changes in detail -->
- Updated the required version of astroquery to v0.4.4, following an  API change that was made for handling requests to the JPL Horizons service.
- Dropped the use of `id_type="majorbody"` in favor of `id_type=None`, which is preferred when dealing with major SSBs or ID numbers for targets.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The astroquery API for JPL-Horizons has undergone major revision, and with it has come a new deprecation warning about which keywords are allowed for `id_type`. The changes are not entirely backward-compatible, and as there was no prior version requirement for astroquery, the updated requirement of 0.4.4 requires development against only the updated (v0.? -> v1.0) JPL Horizons API moving foward.

Closes #1098

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Build or continuous integration change

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Build or continuous integration change checklist:
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
