### PR TITLE
MS-related bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added a warning when using `UVData.write_uvfits` when the `vis_units` attribute is
+anything other than `Jy`.
 - Added a warning when using `UVData.write_uvfits` if a UVData object has > 256 antennas,
 recommending use of `UVData.write_ms` if intending to import the data into CASA.
 - Reading writing of scan numbers for MS files as `UVData.scan_number_array`.
@@ -16,6 +18,11 @@ a non-MS file) and is used when writing to an MS file.
 - Flexible spectral windows to `read_mwa_corr_fits`.
 
 ### Changed
+- Changed the defaults by which the `UVData.antenna_names` attribute is set when reading
+measurement sets (used to default to station names, now uses antenna names if available
+and the MS file was not written using the CASA `importuvfits` routine).
+- Fixed a bug where `UVData.x_orientation` and `UVData.vis_units` were not being written
+ to / read from measurement sets.
 - Updated the astroquery requirement to >= 0.4.4, due to changes in the API handling for
 calls to JPL Horizons.
 - Assumes uvfits files are in ITRF frame unless explicitly stated otherwise. Consistent with AIPS 117.

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1958,11 +1958,11 @@ class MS(UVData):
         # importuvfits measurement sets store antenna names in the STATION column.
         # cotter measurement sets store antenna names in the NAME column, which is
         # inline with the MS definition doc. In that case all the station names are
-        # the same.
-        # TODO: Potentially flip which is the default -- use ant_names if filled and
-        # unique. This does seem to fail though on "day2_TDEM0003_10s_norx_1src_1spw".
-        # See the test "test_read_ms_read_uvfits".
-        if len(station_names) != len(np.unique(station_names)):
+        # the same. Default to using what the MS definition doc specifies, unless
+        # we read importuvfits in the history, of the antenna column is not filled
+        if ("importuvfits" not in self.history) and (
+            len(ant_names) == len(np.unique(ant_names)) and ("" not in ant_names)
+        ):
             self.antenna_names = ant_names
         else:
             self.antenna_names = station_names

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1965,7 +1965,7 @@ class MS(UVData):
         # cotter measurement sets store antenna names in the NAME column, which is
         # inline with the MS definition doc. In that case all the station names are
         # the same. Default to using what the MS definition doc specifies, unless
-        # we read importuvfits in the history, of the antenna column is not filled
+        # we read importuvfits in the history, or if the antenna column is not filled.
         if ("importuvfits" not in self.history) and (
             len(ant_names) == len(np.unique(ant_names)) and ("" not in ant_names)
         ):

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1189,6 +1189,9 @@ class MS(UVData):
         if len(self.extra_keywords) != 0:
             ms.putkeyword("pyuvdata_extra", self.extra_keywords)
 
+        if self.x_orientation is not None:
+            ms.putkeyword("pyuvdata_xorient", self.x_orientation)
+
         ms.done()
 
         self._write_ms_antenna(filepath)
@@ -1378,6 +1381,9 @@ class MS(UVData):
         main_keywords = tb_main.getkeywords()
         if "pyuvdata_extra" in main_keywords.keys():
             self.extra_keywords = main_keywords["pyuvdata_extra"]
+
+        if "pyuvdata_xorient" in main_keywords.keys():
+            self.x_orientation = main_keywords["pyuvdata_xorient"]
 
         default_vis_units = {"DATA": "uncalib", "CORRECTED_DATA": "Jy", "MODEL": "Jy"}
 

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -164,6 +164,7 @@ def test_read_mir_write_uvfits(uv_in_uvfits, future_shapes):
     assert mir_uv == uvfits_uv
 
 
+@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 @pytest.mark.filterwarnings("ignore:LST values stored in this file are not ")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_read_mir_write_ms(uv_in_ms, future_shapes):

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -199,6 +199,7 @@ def test_read_write_read_carma(tmp_path):
 @pytest.mark.filterwarnings("ignore:bfmask in extra_keywords is a list, array or dict")
 @pytest.mark.filterwarnings("ignore:LST values stored in this file are not ")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 def test_read_carma_miriad_write_ms(tmp_path):
     """
     Check a roundtrip between CARMA-MIRIAD and MS formats.

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -243,7 +243,20 @@ def test_read_carma_miriad_write_ms(tmp_path):
     # the MS format requires recalculating apparent coords after read in, we'll
     # calculate them here just to verify that everything matches.
     uv_in._set_app_coords_helper()
-    uv_in.write_ms(testfile, clobber=True)
+    with uvtest.check_warnings(
+        UserWarning,
+        [
+            "The uvw_array does not match the expected values given the antenna ",
+            "pamatten in extra_keywords is a list, array or dict",
+            "psys in extra_keywords is a list, array or dict",
+            "psysattn in extra_keywords is a list, array or dict",
+            "ambpsys in extra_keywords is a list, array or dict",
+            "bfmask in extra_keywords is a list, array or dict",
+            "Writing in the MS file that the units of the data are",
+        ],
+    ):
+        uv_in.write_ms(testfile, clobber=True)
+
     uv_out.read(testfile)
 
     # Make sure the MS extra keywords are as expected

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -98,7 +98,15 @@ def test_read_nrao_loopback(tmp_path, nrao_uv):
 
     testfile = os.path.join(tmp_path, "ms_testfile.ms")
 
-    uvobj.write_ms(testfile)
+    with uvtest.check_warnings(
+        UserWarning,
+        match=[
+            "Writing in the MS file that the units of the data are",
+            "The uvw_array does not match the expected values",
+        ],
+    ):
+        uvobj.write_ms(testfile)
+
     uvobj2 = UVData()
     uvobj2.read_ms(testfile)
 
@@ -753,7 +761,10 @@ def test_antenna_diameter_handling(hera_uvh5, tmp_path):
     uv_obj.antenna_diameters = np.asarray(uv_obj.antenna_diameters, dtype=">f4")
 
     test_file = os.path.join(tmp_path, "dish_diameter_out.ms")
-    uv_obj.write_ms(test_file, force_phase=True)
+    with uvtest.check_warnings(
+        UserWarning, match="Writing in the MS file that the units of the data are"
+    ):
+        uv_obj.write_ms(test_file, force_phase=True)
 
     uv_obj2 = UVData.from_file(test_file)
 

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -413,6 +413,7 @@ def test_parse_pyuvdata_frame_ref_errors(check_warning, frame, epoch, msg):
         assert str(cm.value).startswith(msg)
 
 
+@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 def test_ms_history_lesson(mir_uv, tmp_path):
     """
     Test that the MS reader/writer can parse complex history
@@ -455,6 +456,7 @@ def test_ms_history_lesson(mir_uv, tmp_path):
     assert ms_uv.history.startswith("  Read/written with pyuvdata version:")
 
 
+@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 def test_ms_no_ref_dir_source(mir_uv, tmp_path):
     """
     Test that the MS writer/reader appropriately reads in a single-source data set
@@ -477,6 +479,7 @@ def test_ms_no_ref_dir_source(mir_uv, tmp_path):
     assert ms_uv.phase_center_catalog == mir_uv.phase_center_catalog
 
 
+@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 def test_ms_multi_spw_data_variation(mir_uv, tmp_path):
     """
     Test that the MS writer/reader appropriately reads in a single-source data set
@@ -506,6 +509,7 @@ def test_ms_multi_spw_data_variation(mir_uv, tmp_path):
     assert np.all(ms_uv.integration_time == np.array([1.0]))
 
 
+@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_ms_phasing(mir_uv, tmp_path):
     """
@@ -530,6 +534,7 @@ def test_ms_phasing(mir_uv, tmp_path):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 def test_ms_single_chan(mir_uv, tmp_path):
     """
     Make sure that single channel writing/reading work as expected
@@ -573,6 +578,14 @@ def test_ms_single_chan(mir_uv, tmp_path):
     assert ms_uv == mir_uv
 
 
+@pytest.mark.filterwarnings("ignore:pamatten in extra_keywords is a list, array")
+@pytest.mark.filterwarnings("ignore:psys in extra_keywords is a list, array or dict")
+@pytest.mark.filterwarnings("ignore:psysattn in extra_keywords is a list, array or")
+@pytest.mark.filterwarnings("ignore:ambpsys in extra_keywords is a list, array or dict")
+@pytest.mark.filterwarnings("ignore:bfmask in extra_keywords is a list, array or dict")
+@pytest.mark.filterwarnings("ignore:LST values stored in this file are not ")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 def test_ms_scannumber_multiphasecenter(tmp_path):
     """
     Make sure that single channel writing/reading work as expected
@@ -632,6 +645,7 @@ def test_ms_scannumber_multiphasecenter(tmp_path):
     assert ((miriad_uv.phase_center_id_array == (ms_uv.scan_number_array - 1))).all()
 
 
+@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 def test_ms_extra_data_descrip(mir_uv, tmp_path):
     """
     Make sure that data sets can be read even if the main table doesn't have data
@@ -678,6 +692,7 @@ def test_ms_extra_data_descrip(mir_uv, tmp_path):
     assert ms_uv == mir_uv
 
 
+@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 def test_ms_weights(mir_uv, tmp_path):
     """
     Test that the MS writer/reader appropriately handles data when the
@@ -707,6 +722,7 @@ def test_ms_weights(mir_uv, tmp_path):
     assert np.all(ms_uv.nsample_array == 1.0)
 
 
+@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 @pytest.mark.parametrize(
     "badcol,badval,errtype,msg",
     (

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -772,10 +772,4 @@ def test_antenna_diameter_handling(hera_uvh5, tmp_path):
     uv_obj2.history = uv_obj.history
     uv_obj2.extra_keywords = uv_obj.extra_keywords
 
-    # Uh oh, we're losing x_orientation in the ms write/read round trip.
-    # That's a problem. Documented in issue #1083.
-    assert uv_obj.x_orientation is not None
-    assert uv_obj2.x_orientation is None
-    uv_obj2.x_orientation = uv_obj.x_orientation
-
     assert uv_obj2.__eq__(uv_obj, allowed_failures=allowed_failures)

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -960,6 +960,7 @@ def test_remove_flagged_ants(tmp_path):
 
 @pytest.mark.filterwarnings("ignore:telescope_location is not set. ")
 @pytest.mark.filterwarnings("ignore:some coarse channel files were not submitted")
+@pytest.mark.filterwarnings("ignore:.*values are being corrected with the van vleck")
 def test_small_sigs(tmp_path):
     """Test flag_small_auto_ants."""
     small_sigs = str(tmp_path / "small_sigs07_02.fits")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes a couple of outstanding issues related to CASA MS read/write

## Description
<!--- Describe your changes in detail -->
- Fixed a bug by which `UVData.x_orientation` and `UVData.vis_units` were not being propogated by the `write_ms` method.
- Changed the default scheme by which antenna names are imported in `UVData.read_ms`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This PR addresses two open issues, the first of which being some missing meta-information that was not being written when writing out data sets in measurement set format. As part of that, a warning message has been added when writing out data sets where the units are the visibilities are something other than Jy, since 1) CASA procedures will sometimes by default assume that the data are given in Jy, and 2) CASA has no knowledge of what `uncalib` and `K Jy` units are.

The second issue addressed is a change in how antenna names are imported from measurement sets. This had been intended to be included in #995, but it caused an error that I didn't understand at the time. Turns out it was just related to usage `importuvfits`, which was an easy thing to capture for looking at the file history.

Closes #1083.
Closes #1063.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).