### PR TITLE
Fixing an issue with UVData objects being incorrectly added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ calls to JPL Horizons.
 - Improved readability, functionality, and memory usage in `read_mwa_corr_fits`.
 
 ### Fixed
+- A bug that could have resulted in `UVData.__add__` combining objects together incorrectly
+  when containing overlapping time-baselines/polarization/frequency channels together
+  that were ordered differently for the two `UVData` objects.
 - A bug that prevented `extra_keywords` keys with a value of `None` from being
   saved to UVH5 files.
 - A bug that resulted in the wrong expected shapes for data-like arrays when metadata

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6415,6 +6415,8 @@ class UVData(UVBase):
                     )
 
         # Begin manipulating the objects.
+        # First, handle the internal source catalogs, since merging them is kind of a
+        # weird, one-off process (i.e., nothing is cat'd across a particular axis)
         if make_multi_phase and (not this.multi_phase_center):
             this._set_multi_phase_center(preserve_phase_center_info=True)
         if other.multi_phase_center:
@@ -6464,6 +6466,109 @@ class UVData(UVBase):
                 cat_frame=other.phase_center_frame,
                 cat_epoch=other.phase_center_epoch,
             )
+
+        # Next, we want to make sure that the ordering of the _overlapping_ data is
+        # the same, so that things can get plugged together in a sensible way.
+        if len(this_blts_ind) != 0:
+            this_argsort = np.argsort(this_blts_ind)
+            other_argsort = np.argsort(other_blts_ind)
+
+            if np.any(this_argsort != other_argsort):
+                old_ind = this_blts_ind[this_argsort]
+                new_ind = this_blts_ind[other_argsort]
+                this.ant_1_array[old_ind] = this.ant_1_array[new_ind]
+                this.ant_2_array[old_ind] = this.ant_2_array[new_ind]
+                this.baseline_array[old_ind] = this.baseline_array[new_ind]
+                this.lst_array[old_ind] = this.lst_array[new_ind]
+                this.uvw_array[old_ind] = this.uvw_array[new_ind]
+                this.integration_time[old_ind] = this.integration_time[new_ind]
+                this.time_array[old_ind] = this.time_array[new_ind]
+                if this.data_array is not None:
+                    this.data_array[old_ind] = this.data_array[new_ind]
+                if this.flag_array is not None:
+                    this.flag_array[old_ind] = this.flag_array[new_ind]
+                if this.nsample_array is not None:
+                    this.nsample_array[old_ind] = this.nsample_array[new_ind]
+                if this.phase_center_app_ra is not None:
+                    this.phase_center_app_ra[old_ind] = this.phase_center_app_ra[
+                        new_ind
+                    ]
+                    this.phase_center_app_dec[old_ind] = this.phase_center_app_dec[
+                        new_ind
+                    ]
+                    this.phase_center_frame_pa[old_ind] = this.phase_center_frame_pa[
+                        new_ind
+                    ]
+                if this.phase_center_id_array is not None:
+                    this.phase_center_id_array[old_ind] = this.phase_center_id_array[
+                        new_ind
+                    ]
+                if this.scan_number_array is not None:
+                    this.scan_number_array[old_ind] = this.scan_number_array[new_ind]
+
+        if len(this_freq_ind) != 0:
+            this_argsort = np.argsort(this_freq_ind)
+            other_argsort = np.argsort(other_freq_ind)
+            if np.any(this_argsort != other_argsort):
+                old_ind = this_freq_ind[this_argsort]
+                new_ind = this_freq_ind[other_argsort]
+                if this.future_array_shapes:
+                    this.freq_array[old_ind] = this.freq_array[new_ind]
+                    this.channel_width[old_ind] = this.channel_width[new_ind]
+                else:
+                    this.freq_array[:, old_ind] = this.freq_array[:, new_ind]
+                    if self.flex_spw:
+                        this.channel_width[old_ind] = this.channel_width[new_ind]
+                if this.flex_spw_id_array is not None:
+                    this.flex_spw_id_array[old_ind] = this.flex_spw_id_array[new_ind]
+                if this.eq_coeffs is not None:
+                    this.eq_coeffs[:, old_ind] = this.eq_coeffs[:, new_ind]
+                if this.future_array_shapes:
+                    if this.data_array is not None:
+                        this.data_array[:, old_ind] = this.data_array[:, new_ind]
+                    if this.flag_array is not None:
+                        this.flag_array[:, old_ind] = this.flag_array[:, new_ind]
+                    if this.nsample_array is not None:
+                        this.nsample_array[:, old_ind] = this.nsample_array[:, new_ind]
+                else:
+                    if this.data_array is not None:
+                        this.data_array[:, :, old_ind] = this.data_array[:, :, new_ind]
+                    if this.flag_array is not None:
+                        this.flag_array[:, :, old_ind] = this.flag_array[:, :, new_ind]
+                    if this.nsample_array is not None:
+                        this.nsample_array[:, :, old_ind] = this.nsample_array[
+                            :, :, new_ind
+                        ]
+
+        if len(this_pol_ind) != 0:
+            this_argsort = np.argsort(this_pol_ind)
+            other_argsort = np.argsort(other_pol_ind)
+            if np.any(this_argsort != other_argsort):
+                old_ind = this_pol_ind[this_argsort]
+                new_ind = this_pol_ind[other_argsort]
+                this.polarization_array[old_ind] = this.polarization_array[new_ind]
+                if this.future_array_shapes:
+                    if this.data_array is not None:
+                        this.data_array[:, :, old_ind] = this.data_array[:, :, new_ind]
+                    if this.flag_array is not None:
+                        this.flag_array[:, :, old_ind] = this.flag_array[:, :, new_ind]
+                    if this.nsample_array is not None:
+                        this.nsample_array[:, :, old_ind] = this.nsample_array[
+                            :, :, new_ind
+                        ]
+                else:
+                    if this.data_array is not None:
+                        this.data_array[:, :, :, old_ind] = this.data_array[
+                            :, :, :, new_ind
+                        ]
+                    if this.flag_array is not None:
+                        this.flag_array[:, :, old_ind] = this.flag_array[
+                            :, :, :, new_ind
+                        ]
+                    if this.nsample_array is not None:
+                        this.nsample_array[:, :, :, old_ind] = this.nsample_array[
+                            :, :, :, new_ind
+                        ]
 
         # Pad out self to accommodate new data
         if len(bnew_inds) > 0:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6478,7 +6478,7 @@ class UVData(UVBase):
             if np.any(this_argsort != other_argsort):
                 temp_ind = np.arange(this.Nblts)
                 temp_ind[this_blts_ind[this_argsort]] = temp_ind[
-                    this_blts_ind[this_blts_ind[other_argsort]]
+                    this_blts_ind[other_argsort]
                 ]
 
                 this.reorder_blts(temp_ind)
@@ -6489,10 +6489,10 @@ class UVData(UVBase):
             if np.any(this_argsort != other_argsort):
                 temp_ind = np.arange(this.Nfreqs)
                 temp_ind[this_freq_ind[this_argsort]] = temp_ind[
-                    this_freq_ind[this_blts_ind[other_argsort]]
+                    this_freq_ind[other_argsort]
                 ]
 
-                this.reorder_freqs(temp_ind)
+                this.reorder_freqs(channel_order=temp_ind)
 
         if len(this_pol_ind) != 0:
             this_argsort = np.argsort(this_pol_ind)
@@ -6500,7 +6500,7 @@ class UVData(UVBase):
             if np.any(this_argsort != other_argsort):
                 temp_ind = np.arange(this.Npols)
                 temp_ind[this_pol_ind[this_argsort]] = temp_ind[
-                    this_pol_ind[this_blts_ind[other_argsort]]
+                    this_pol_ind[other_argsort]
                 ]
 
                 this.reorder_pols(temp_ind)

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6474,101 +6474,34 @@ class UVData(UVBase):
             other_argsort = np.argsort(other_blts_ind)
 
             if np.any(this_argsort != other_argsort):
-                old_ind = this_blts_ind[this_argsort]
-                new_ind = this_blts_ind[other_argsort]
-                this.ant_1_array[old_ind] = this.ant_1_array[new_ind]
-                this.ant_2_array[old_ind] = this.ant_2_array[new_ind]
-                this.baseline_array[old_ind] = this.baseline_array[new_ind]
-                this.lst_array[old_ind] = this.lst_array[new_ind]
-                this.uvw_array[old_ind] = this.uvw_array[new_ind]
-                this.integration_time[old_ind] = this.integration_time[new_ind]
-                this.time_array[old_ind] = this.time_array[new_ind]
-                if this.data_array is not None:
-                    this.data_array[old_ind] = this.data_array[new_ind]
-                if this.flag_array is not None:
-                    this.flag_array[old_ind] = this.flag_array[new_ind]
-                if this.nsample_array is not None:
-                    this.nsample_array[old_ind] = this.nsample_array[new_ind]
-                if this.phase_center_app_ra is not None:
-                    this.phase_center_app_ra[old_ind] = this.phase_center_app_ra[
-                        new_ind
-                    ]
-                    this.phase_center_app_dec[old_ind] = this.phase_center_app_dec[
-                        new_ind
-                    ]
-                    this.phase_center_frame_pa[old_ind] = this.phase_center_frame_pa[
-                        new_ind
-                    ]
-                if this.phase_center_id_array is not None:
-                    this.phase_center_id_array[old_ind] = this.phase_center_id_array[
-                        new_ind
-                    ]
-                if this.scan_number_array is not None:
-                    this.scan_number_array[old_ind] = this.scan_number_array[new_ind]
+                temp_ind = np.arange(this.Nblts)
+                temp_ind[this_blts_ind[this_argsort]] = temp_ind[
+                    this_blts_ind[this_blts_ind[other_argsort]]
+                ]
+
+                this.reorder_blts(temp_ind)
 
         if len(this_freq_ind) != 0:
             this_argsort = np.argsort(this_freq_ind)
             other_argsort = np.argsort(other_freq_ind)
             if np.any(this_argsort != other_argsort):
-                old_ind = this_freq_ind[this_argsort]
-                new_ind = this_freq_ind[other_argsort]
-                if this.future_array_shapes:
-                    this.freq_array[old_ind] = this.freq_array[new_ind]
-                    this.channel_width[old_ind] = this.channel_width[new_ind]
-                else:
-                    this.freq_array[:, old_ind] = this.freq_array[:, new_ind]
-                    if self.flex_spw:
-                        this.channel_width[old_ind] = this.channel_width[new_ind]
-                if this.flex_spw_id_array is not None:
-                    this.flex_spw_id_array[old_ind] = this.flex_spw_id_array[new_ind]
-                if this.eq_coeffs is not None:
-                    this.eq_coeffs[:, old_ind] = this.eq_coeffs[:, new_ind]
-                if this.future_array_shapes:
-                    if this.data_array is not None:
-                        this.data_array[:, old_ind] = this.data_array[:, new_ind]
-                    if this.flag_array is not None:
-                        this.flag_array[:, old_ind] = this.flag_array[:, new_ind]
-                    if this.nsample_array is not None:
-                        this.nsample_array[:, old_ind] = this.nsample_array[:, new_ind]
-                else:
-                    if this.data_array is not None:
-                        this.data_array[:, :, old_ind] = this.data_array[:, :, new_ind]
-                    if this.flag_array is not None:
-                        this.flag_array[:, :, old_ind] = this.flag_array[:, :, new_ind]
-                    if this.nsample_array is not None:
-                        this.nsample_array[:, :, old_ind] = this.nsample_array[
-                            :, :, new_ind
-                        ]
+                temp_ind = np.arange(this.Nfreqs)
+                temp_ind[this_freq_ind[this_argsort]] = temp_ind[
+                    this_freq_ind[this_blts_ind[other_argsort]]
+                ]
+
+                this.reorder_freqs(temp_ind)
 
         if len(this_pol_ind) != 0:
             this_argsort = np.argsort(this_pol_ind)
             other_argsort = np.argsort(other_pol_ind)
             if np.any(this_argsort != other_argsort):
-                old_ind = this_pol_ind[this_argsort]
-                new_ind = this_pol_ind[other_argsort]
-                this.polarization_array[old_ind] = this.polarization_array[new_ind]
-                if this.future_array_shapes:
-                    if this.data_array is not None:
-                        this.data_array[:, :, old_ind] = this.data_array[:, :, new_ind]
-                    if this.flag_array is not None:
-                        this.flag_array[:, :, old_ind] = this.flag_array[:, :, new_ind]
-                    if this.nsample_array is not None:
-                        this.nsample_array[:, :, old_ind] = this.nsample_array[
-                            :, :, new_ind
-                        ]
-                else:
-                    if this.data_array is not None:
-                        this.data_array[:, :, :, old_ind] = this.data_array[
-                            :, :, :, new_ind
-                        ]
-                    if this.flag_array is not None:
-                        this.flag_array[:, :, old_ind] = this.flag_array[
-                            :, :, :, new_ind
-                        ]
-                    if this.nsample_array is not None:
-                        this.nsample_array[:, :, :, old_ind] = this.nsample_array[
-                            :, :, :, new_ind
-                        ]
+                temp_ind = np.arange(this.Npols)
+                temp_ind[this_pol_ind[this_argsort]] = temp_ind[
+                    this_pol_ind[this_blts_ind[other_argsort]]
+                ]
+
+                this.reorder_pols(temp_ind)
 
         # Pad out self to accommodate new data
         if len(bnew_inds) > 0:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -4329,6 +4329,8 @@ class UVData(UVBase):
                         ]
                     if flip_spws:
                         spw_order = np.flip(spw_order)
+                else:
+                    spw_order = self.spw_array
                 # Now that we know the spw order, we can apply the first sort
                 index_array = np.concatenate(
                     [index_array[temp_spws == idx] for idx in spw_order]


### PR DESCRIPTION
Fixes a bug with `UVData.__add__` when objects are sorted differently.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Made a change to `UVData.__add__` that checks for the ordering of records along time-baseline, polarization, and frequency when two `UVData` objects have "overlap" in these domains. If there is overlap, _but_ the ordering of the data is different, the new code will reorder the (meta-)data of one of the objects so that data are concatenated as expected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes a nasty bug were data could be concatenated incorrectly when the sorting order is different (e.g., #1102). 

Closes #1102.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
