### PR TITLE
Add support for baseline coordinate suffixes in uvfits files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ calls to JPL Horizons.
 - Improved readability, functionality, and memory usage in `read_mwa_corr_fits`.
 
 ### Fixed
+- A bug in reading in uvfits files with baseline coordinates that have suffixes of
+'---SIN' or '---NCP' which are allowed in uvfits files.
 - A bug that could cause some routines in CASA to fail when using data sets written by
   `UVData.write_ms`.
 - A bug that could have resulted in `UVData.__add__` combining objects together incorrectly

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -496,12 +496,22 @@ def test_uvw_coordinate_suffixes(casa_uvfits, tmp_path, uvw_suffix):
         hdulist.writeto(write_file2, overwrite=True)
         hdulist.close()
 
-    uv2 = UVData.from_file(write_file2)
-
     if uvw_suffix == "---NCP":
+        with uvtest.check_warnings(
+            UserWarning,
+            match=[
+                "Telescope EVLA is not in known_telescopes.",
+                "The baseline coordinates (uvws) in this file are specified in the "
+                "---NCP coordinate system",
+                "The uvw_array does not match the expected values",
+            ],
+        ):
+            uv2 = UVData.from_file(write_file2)
         uv2.uvw_array = uvutils._rotate_one_axis(
             uv2.uvw_array[:, :, None], -1 * (uv2.phase_center_app_dec - np.pi / 2), 0
         )[:, :, 0]
+    else:
+        uv2 = UVData.from_file(write_file2)
 
     assert uv2 == uv_in
 

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -496,19 +496,12 @@ def test_uvw_coordinate_suffixes(casa_uvfits, tmp_path, uvw_suffix):
         hdulist.writeto(write_file2, overwrite=True)
         hdulist.close()
 
+    uv2 = UVData.from_file(write_file2)
+
     if uvw_suffix == "---NCP":
-        with uvtest.check_warnings(
-            UserWarning,
-            match=[
-                "Telescope EVLA is not in known_telescopes.",
-                "The baseline coordinates (uvws) in this file are specified in the "
-                "---NCP coordinate system",
-                "The uvw_array does not match the expected values given the antenna ",
-            ],
-        ):
-            uv2 = UVData.from_file(write_file2)
-    else:
-        uv2 = UVData.from_file(write_file2)
+        uv2.uvw_array = uvutils._rotate_one_axis(
+            uv2.uvw_array[:, :, None], -1 * (uv2.phase_center_app_dec - np.pi / 2), 0
+        )[:, :, 0]
 
     assert uv2 == uv_in
 

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -154,6 +154,12 @@ class UVFITS(UVData):
             and "WW---NCP" in vis_hdu.data.parnames
         ):
             uvw_names = ["UU---NCP", "VV---NCP", "WW---NCP"]
+            warnings.warn(
+                "The baseline coordinates (uvws) in this file are specified in the "
+                "---NCP coordinate system, which is does not agree with our baseline "
+                "coordinate conventions. Rotating the uvws to match our convention "
+                "(Note that this rotation has not been widely tested)."
+            )
         else:
             raise ValueError(
                 "There is no consistent set of baseline coordinates in this file. "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for the `---SIN` and `---NCP` suffixes that can optionally appear on the uvw coordinate parameter names in uvfits files. Note that the absence of a suffix indicates the same baseline coordinate system as the `---SIN` suffix. The `---NCP` suffix indicates a different baseline coordinate system that does not agree with our conventions. For files of that type, the uvws are rotated to match our convention.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #1104

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
