### PR TITLE
Adding a check to verify autos are real-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added new functionality to `UVData.check` to verify that auto-correlations are real-only,
+along with an option to force them to be real-only if non-zero imaginary components are detected.
+
 ## [2.2.6] - 2022-01-12
 
 ### Added

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -2671,7 +2671,7 @@ def test_mean_weights_and_weights_square():
     assert np.allclose(wso, np.sum(1.0 / (np.arange(data.shape[1]) + 1) ** 2))
 
     # Zero weights
-    w = np.ones_like(w)
+    w = np.ones_like(data)
     w[0, :] = 0
     w[:, 0] = 0
     out, wo = uvutils.mean_collapse(data, weights=w, axis=0, return_weights=True)
@@ -2810,6 +2810,7 @@ def test_and_collapse_errors():
     pytest.raises(ValueError, uvutils.and_collapse, data)
 
 
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvcalibrate_apply_gains_oldfiles():
     # read data
@@ -2863,6 +2864,7 @@ def test_uvcalibrate_apply_gains_oldfiles():
 
 
 @pytest.mark.filterwarnings("ignore:When converting a delay-style cal to future array")
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("uvd_future_shapes", [True, False])
 @pytest.mark.parametrize("uvc_future_shapes", [True, False])
@@ -2918,6 +2920,7 @@ def test_uvcalibrate_delay_oldfiles(uvd_future_shapes, uvc_future_shapes):
 
 @pytest.mark.parametrize("uvc_future_shapes", [True, False])
 @pytest.mark.parametrize("uvd_future_shapes", [True, False])
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.parametrize("flip_gain_conj", [False, True])
 @pytest.mark.parametrize("gain_convention", ["divide", "multiply"])
 def test_uvcalibrate(
@@ -3401,6 +3404,7 @@ def test_uvcalibrate_delay_multispw(uvcalibrate_data):
         uvutils.uvcalibrate(uvd, uvc, inplace=False)
 
 
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_apply_uvflag(future_shapes):

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -3366,6 +3366,7 @@ def test_uvcalibrate_wideband_gain(uvcalibrate_data):
         uvutils.uvcalibrate(uvd, uvc, inplace=False)
 
 
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:When converting a delay-style cal to future array")
 @pytest.mark.filterwarnings("ignore:Nfreqs will be required to be 1 for wide_band cals")

--- a/pyuvdata/uvdata/fhd.py
+++ b/pyuvdata/uvdata/fhd.py
@@ -372,11 +372,11 @@ class FHD(UVData):
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
         check_autos : bool
-            Check whether any auto-correlations have imaginary values in them (which
-            should not mathematically exist). Default is True.
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only. Default is False.
+            that they are real-only in data_array. Default is False.
 
         Raises
         ------

--- a/pyuvdata/uvdata/fhd.py
+++ b/pyuvdata/uvdata/fhd.py
@@ -331,6 +331,8 @@ class FHD(UVData):
         check_extra=True,
         run_check_acceptability=True,
         strict_uvw_antpos_check=False,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read in data from a list of FHD files.
@@ -369,6 +371,12 @@ class FHD(UVData):
         strict_uvw_antpos_check : bool
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
+        check_autos : bool
+            Check whether any auto-correlations have imaginary values in them (which
+            should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only. Default is False.
 
         Raises
         ------
@@ -711,4 +719,6 @@ class FHD(UVData):
                 run_check_acceptability=run_check_acceptability,
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
                 allow_flip_conj=True,
+                check_autos=check_autos,
+                fix_autos=fix_autos,
             )

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -83,11 +83,11 @@ class Mir(UVData):
             attributes to be of length 1, sets the `flex_spw_polarization_array`
             attribute to define the polarization per spectral window. Default is True.
         check_autos : bool
-            Check whether any auto-correlations have imaginary values in them (which
-            should not mathematically exist). Default is True.
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only. Default is False.
+            that they are real-only in data_array. Default is False.
         """
         # Use the mir_parser to read in metadata, which can be used to select data.
         mir_data = mir_parser.MirParser(filepath)

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -38,6 +38,8 @@ class Mir(UVData):
         run_check_acceptability=True,
         strict_uvw_antpos_check=False,
         allow_flex_pol=True,
+        check_autos=True,
+        fix_autos=False,
     ):
         """
         Read in data from an SMA MIR file, and map to the UVData model.
@@ -80,6 +82,12 @@ class Mir(UVData):
             "flexible polarization", which compresses the polarization-axis of various
             attributes to be of length 1, sets the `flex_spw_polarization_array`
             attribute to define the polarization per spectral window. Default is True.
+        check_autos : bool
+            Check whether any auto-correlations have imaginary values in them (which
+            should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only. Default is False.
         """
         # Use the mir_parser to read in metadata, which can be used to select data.
         mir_data = mir_parser.MirParser(filepath)
@@ -611,6 +619,16 @@ class Mir(UVData):
         self.data_array = np.transpose(vis_data, (0, 2, 1))[:, np.newaxis, :, :]
         self.flag_array = np.zeros(self.data_array.shape, dtype=bool)
         self.nsample_array = np.ones(self.data_array.shape, dtype=np.float32)
+
+        if run_check:
+            self.check(
+                check_extra=check_extra,
+                run_check_acceptability=run_check_acceptability,
+                strict_uvw_antpos_check=strict_uvw_antpos_check,
+                allow_flip_conj=True,
+                check_autos=check_autos,
+                fix_autos=fix_autos,
+            )
 
     def write_mir(self, filename):
         """

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -620,16 +620,6 @@ class Mir(UVData):
         self.flag_array = np.zeros(self.data_array.shape, dtype=bool)
         self.nsample_array = np.ones(self.data_array.shape, dtype=np.float32)
 
-        if run_check:
-            self.check(
-                check_extra=check_extra,
-                run_check_acceptability=run_check_acceptability,
-                strict_uvw_antpos_check=strict_uvw_antpos_check,
-                allow_flip_conj=True,
-                check_autos=check_autos,
-                fix_autos=fix_autos,
-            )
-
     def write_mir(self, filename):
         """
         Write out the SMA MIR files.

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -730,6 +730,8 @@ class Miriad(UVData):
         calc_lst=True,
         fix_old_proj=False,
         fix_use_ant_pos=True,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read in data from a miriad file.
@@ -808,6 +810,12 @@ class Miriad(UVData):
             If setting `fix_old_proj` to True, use the antenna positions to derive the
             correct uvw-coordinates rather than using the baseline vectors. Default is
             True.
+        check_autos : bool
+            Check whether any auto-correlations have imaginary values in them (which
+            should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only. Default is False.
 
         Raises
         ------
@@ -1569,6 +1577,8 @@ class Miriad(UVData):
                 run_check_acceptability=run_check_acceptability,
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
                 allow_flip_conj=True,
+                check_autos=check_autos,
+                fix_autos=fix_autos,
             )
 
     def write_miriad(
@@ -1581,6 +1591,8 @@ class Miriad(UVData):
         strict_uvw_antpos_check=False,
         no_antnums=False,
         calc_lst=False,
+        check_autos=True,
+        fix_autos=False,
     ):
         """
         Write the data to a miriad file.
@@ -1615,6 +1627,12 @@ class Miriad(UVData):
             marks the midpoint). Default is False, which instead uses a simple formula
             for correcting the LSTs, expected to be accurate to approximately 0.1 µsec
             precision.
+        check_autos : bool
+            Check whether any auto-correlations have imaginary values in them (which
+            should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only. Default is False.
 
         Raises
         ------
@@ -1651,6 +1669,8 @@ class Miriad(UVData):
                 run_check_acceptability=run_check_acceptability,
                 check_freq_spacing=True,
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
+                check_autos=check_autos,
+                fix_autos=fix_autos,
             )
 
         if os.path.exists(filepath):

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -811,11 +811,11 @@ class Miriad(UVData):
             correct uvw-coordinates rather than using the baseline vectors. Default is
             True.
         check_autos : bool
-            Check whether any auto-correlations have imaginary values in them (which
-            should not mathematically exist). Default is True.
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only. Default is False.
+            that they are real-only in data_array. Default is False.
 
         Raises
         ------
@@ -1628,11 +1628,11 @@ class Miriad(UVData):
             for correcting the LSTs, expected to be accurate to approximately 0.1 µsec
             precision.
         check_autos : bool
-            Check whether any auto-correlations have imaginary values in them (which
-            should not mathematically exist). Default is True.
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only. Default is False.
+            that they are real-only in data_array. Default is False.
 
         Raises
         ------

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1081,11 +1081,11 @@ class MS(UVData):
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
         check_autos : bool
-            Check whether any auto-correlations have imaginary values in them (which
-            should not mathematically exist). Default is True.
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only. Default is False.
+            that they are real-only in data_array. Default is False.
         """
         if not casa_present:  # pragma: no cover
             raise ImportError(no_casa_message) from casa_error
@@ -1943,11 +1943,11 @@ class MS(UVData):
             attributes to be of length 1, sets the `flex_spw_polarization_array`
             attribute to define the polarization per spectral window.  Default is True.
         check_autos : bool
-            Check whether any auto-correlations have imaginary values in them (which
-            should not mathematically exist). Default is True.
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only. Default is True.
+            that they are real-only in data_array. Default is True.
 
         Raises
         ------

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1054,6 +1054,8 @@ class MS(UVData):
         check_extra=True,
         run_check_acceptability=True,
         strict_uvw_antpos_check=False,
+        check_autos=True,
+        fix_autos=False,
     ):
         """
         Write a CASA measurement set (MS).
@@ -1078,7 +1080,12 @@ class MS(UVData):
         strict_uvw_antpos_check : bool
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
-
+        check_autos : bool
+            Check whether any auto-correlations have imaginary values in them (which
+            should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only. Default is False.
         """
         if not casa_present:  # pragma: no cover
             raise ImportError(no_casa_message) from casa_error
@@ -1088,6 +1095,8 @@ class MS(UVData):
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
+                check_autos=check_autos,
+                fix_autos=fix_autos,
             )
 
         if os.path.exists(filepath):
@@ -1876,6 +1885,8 @@ class MS(UVData):
         raise_error=True,
         read_weights=True,
         allow_flex_pol=False,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read in a casa measurement set.
@@ -1931,6 +1942,12 @@ class MS(UVData):
             "flexible polarization", which compresses the polarization-axis of various
             attributes to be of length 1, sets the `flex_spw_polarization_array`
             attribute to define the polarization per spectral window.  Default is True.
+        check_autos : bool
+            Check whether any auto-correlations have imaginary values in them (which
+            should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only. Default is True.
 
         Raises
         ------
@@ -2273,4 +2290,6 @@ class MS(UVData):
                 run_check_acceptability=run_check_acceptability,
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
                 allow_flip_conj=True,
+                check_autos=check_autos,
+                fix_autos=fix_autos,
             )

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -1083,6 +1083,8 @@ class MWACorrFITS(UVData):
         check_extra=True,
         run_check_acceptability=True,
         strict_uvw_antpos_check=False,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read in MWA correlator gpu box files.
@@ -1189,6 +1191,12 @@ class MWACorrFITS(UVData):
         strict_uvw_antpos_check : bool
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
+        check_autos : bool
+            Check whether any auto-correlations have imaginary values in them (which
+            should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only. Default is True.
 
 
         Raises
@@ -1820,4 +1828,6 @@ class MWACorrFITS(UVData):
                 run_check_acceptability=run_check_acceptability,
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
                 allow_flip_conj=True,
+                check_autos=check_autos,
+                fix_autos=fix_autos,
             )

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -1192,11 +1192,11 @@ class MWACorrFITS(UVData):
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
         check_autos : bool
-            Check whether any auto-correlations have imaginary values in them (which
-            should not mathematically exist). Default is True.
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only. Default is True.
+            that they are real-only in data_array. Default is True.
 
 
         Raises

--- a/pyuvdata/uvdata/tests/conftest.py
+++ b/pyuvdata/uvdata/tests/conftest.py
@@ -50,23 +50,6 @@ def casa_uvfits(casa_uvfits_main):
 
 
 @pytest.fixture(scope="session")
-def mir_data_main():
-    testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    mir_data = MirParser(
-        testfile, load_vis=True, load_raw=True, load_auto=True, has_auto=True,
-    )
-
-    yield mir_data
-
-
-@pytest.fixture(scope="function")
-def mir_data(mir_data_main):
-    mir_data = mir_data_main.copy()
-
-    yield mir_data
-
-
-@pytest.fixture(scope="session")
 def hera_uvh5_main():
     # read in test file for the resampling in time functions
     uv_object = UVData()
@@ -116,21 +99,7 @@ def paper_miriad(paper_miriad_main):
     del uv_in
 
 
-@pytest.fixture(params=[True, False])
-def mir_data_object(request):
-    """Make MIR data object for tests. Param to read autocorr data."""
-    has_auto = request.param
-    testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    mir_data = MirParser(
-        testfile, load_vis=True, load_raw=True, load_auto=True, has_auto=has_auto
-    )
-
-    yield mir_data
-
-    # cleanup
-    del mir_data
-
-
+@pytest.fixture(scope="session")
 def sma_mir_main():
     # read in test file for the resampling in time functions
     uv_object = UVData()
@@ -146,3 +115,20 @@ def sma_mir(sma_mir_main):
     uv_object = sma_mir_main.copy()
 
     yield uv_object
+
+
+@pytest.fixture(scope="session")
+def mir_data_main():
+    testfile = os.path.join(DATA_PATH, "sma_test.mir")
+    mir_data = MirParser(
+        testfile, load_vis=True, load_raw=True, load_auto=True, has_auto=True,
+    )
+
+    yield mir_data
+
+
+@pytest.fixture(scope="function")
+def mir_data(mir_data_main):
+    mir_data = mir_data_main.copy()
+
+    yield mir_data

--- a/pyuvdata/uvdata/tests/conftest.py
+++ b/pyuvdata/uvdata/tests/conftest.py
@@ -129,3 +129,20 @@ def mir_data_object(request):
 
     # cleanup
     del mir_data
+
+
+def sma_mir_main():
+    # read in test file for the resampling in time functions
+    uv_object = UVData()
+    testfile = os.path.join(DATA_PATH, "sma_test.mir")
+    uv_object.read(testfile)
+
+    yield uv_object
+
+
+@pytest.fixture(scope="function")
+def sma_mir(sma_mir_main):
+    # read in test file for the resampling in time functions
+    uv_object = sma_mir_main.copy()
+
+    yield uv_object

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -280,7 +280,8 @@ def test_read_mir_no_records():
         uv_in.read_mir(testfile, corrchunk=999)
 
 
-def test_read_mir_sideband_select(sma_mir):
+@pytest.mark.parametrize("pseudo_cont", [True, False])
+def test_read_mir_sideband_select(sma_mir, pseudo_cont):
     """
     Mir sideband read check
 
@@ -288,6 +289,8 @@ def test_read_mir_sideband_select(sma_mir):
     stitch them back together as though they were read together from the start.
     """
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
+    if pseudo_cont:
+        sma_mir.read(testfile, pseudo_cont=pseudo_cont)
 
     # Re-order here so that we can more easily compare the two
     sma_mir.reorder_freqs(channel_order="freq", spw_order="freq")
@@ -295,10 +298,10 @@ def test_read_mir_sideband_select(sma_mir):
     sma_mir.history = ""
 
     mir_lsb = UVData()
-    mir_lsb.read(testfile, isb=[0])
+    mir_lsb.read(testfile, isb=[0], pseudo_cont=pseudo_cont)
 
     mir_usb = UVData()
-    mir_usb.read(testfile, isb=[1])
+    mir_usb.read(testfile, isb=[1], pseudo_cont=pseudo_cont)
 
     mir_recomb = mir_lsb + mir_usb
     # Re-order here so that we can more easily compare the two

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -22,109 +22,55 @@ from ...uvdata.mir import Mir
 
 
 @pytest.fixture(scope="session")
-def sma_mir_main():
-    # read in test file for the resampling in time functions
-    uv_object = UVData()
+def mir_data():
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    uv_object.read(testfile)
+    mir_data = MirParser(
+        testfile, load_vis=True, load_raw=True, load_auto=True,
+    )
 
-    yield uv_object
-
-
-@pytest.fixture(scope="function")
-def sma_mir(sma_mir_main):
-    # read in test file for the resampling in time functions
-    uv_object = sma_mir_main.copy()
-
-    yield uv_object
-
-
-@pytest.fixture(scope="session")
-def sma_mir_filt_main():
-    # read in test file for the resampling in time functions
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    uv_object.read(testfile, pseudo_cont=True, corrchunk=0)
-
-    uv_object.flag_array[:, :, : uv_object.Nfreqs // 2, 0] = True
-    uv_object.flag_array[:, :, uv_object.Nfreqs // 2 :, 1] = True
-    uv_object.set_lsts_from_time_array()
-    uv_object._set_app_coords_helper()
-
-    yield uv_object
-
-
-@pytest.fixture(scope="function")
-def sma_mir_filt(sma_mir_filt_main):
-    # read in test file for the resampling in time functions
-    uv_object = sma_mir_filt_main.copy()
-
-    yield uv_object
+    yield mir_data
 
 
 @pytest.fixture
 def uv_in_ms(tmp_path):
-    uv_in = UVData()
-    testfile = os.path.join(DATA_PATH, "sma_test.mir")
     write_file = os.path.join(tmp_path, "outtest_mir.ms")
-
-    # Currently only one source is supported.
-    uv_in.read(testfile)
     uv_out = UVData()
 
-    yield uv_in, uv_out, write_file
-
-    # cleanup
-    del uv_in, uv_out
+    yield uv_out, write_file
 
 
 @pytest.fixture
 def uv_in_uvfits(tmp_path):
-    uv_in = UVData()
-    testfile = os.path.join(DATA_PATH, "sma_test.mir/")
     write_file = os.path.join(tmp_path, "outtest_mir.uvfits")
 
-    # Currently only one source is supported.
-    uv_in.read(testfile, pseudo_cont=False)
     uv_out = UVData()
 
-    yield uv_in, uv_out, write_file
-
-    # cleanup
-    del uv_in, uv_out
+    yield uv_out, write_file
 
 
 @pytest.fixture
 def uv_in_uvh5(tmp_path):
-    uv_in = UVData()
-    testfile = os.path.join(DATA_PATH, "sma_test.mir")
     write_file = os.path.join(tmp_path, "outtest_mir.uvh5")
-
-    # Currently only one source is supported.
-    uv_in.read(testfile)
     uv_out = UVData()
 
-    yield uv_in, uv_out, write_file
-
-    # cleanup
-    del uv_in, uv_out
+    yield uv_out, write_file
 
 
 @pytest.mark.filterwarnings("ignore:LST values stored in this file are not ")
 @pytest.mark.parametrize("future_shapes", [True, False])
-def test_read_mir_write_uvfits(uv_in_uvfits, future_shapes):
+def test_read_mir_write_uvfits(sma_mir, uv_in_uvfits, future_shapes):
     """
     Mir to uvfits loopback test.
 
     Read in Mir files, write out as uvfits, read back in and check for
     object equality.
     """
-    mir_uv, uvfits_uv, testfile = uv_in_uvfits
+    uvfits_uv, testfile = uv_in_uvfits
 
     if future_shapes:
-        mir_uv.use_future_array_shapes()
+        sma_mir.use_future_array_shapes()
 
-    mir_uv.write_uvfits(testfile, spoof_nonessential=True)
+    sma_mir.write_uvfits(testfile, spoof_nonessential=True)
     uvfits_uv.read_uvfits(testfile)
 
     if future_shapes:
@@ -132,72 +78,72 @@ def test_read_mir_write_uvfits(uv_in_uvfits, future_shapes):
 
     # UVFITS doesn't allow for numbering of spectral windows like MIR does, so
     # we need an extra bit of handling here
-    assert len(np.unique(mir_uv.spw_array)) == len(np.unique(uvfits_uv.spw_array))
+    assert len(np.unique(sma_mir.spw_array)) == len(np.unique(uvfits_uv.spw_array))
 
-    spw_dict = {idx: jdx for idx, jdx in zip(uvfits_uv.spw_array, mir_uv.spw_array)}
+    spw_dict = {idx: jdx for idx, jdx in zip(uvfits_uv.spw_array, sma_mir.spw_array)}
 
     assert np.all(
         [
             idx == spw_dict[jdx]
-            for idx, jdx in zip(mir_uv.flex_spw_id_array, uvfits_uv.flex_spw_id_array,)
+            for idx, jdx in zip(sma_mir.flex_spw_id_array, uvfits_uv.flex_spw_id_array,)
         ]
     )
 
     # Now that we've checked, set this things as equivalent
-    uvfits_uv.spw_array = mir_uv.spw_array
-    uvfits_uv.flex_spw_id_array = mir_uv.flex_spw_id_array
+    uvfits_uv.spw_array = sma_mir.spw_array
+    uvfits_uv.flex_spw_id_array = sma_mir.flex_spw_id_array
 
     # Check the history first via find
     assert 0 == uvfits_uv.history.find(
-        mir_uv.history + "  Read/written with pyuvdata version:"
+        sma_mir.history + "  Read/written with pyuvdata version:"
     )
-    mir_uv.history = uvfits_uv.history
+    sma_mir.history = uvfits_uv.history
 
     # We have to do a bit of special handling for the phase_center_catalog, because
     # _very_ small errors (like last bit in the mantissa) creep in when passing through
     # the util function transform_sidereal_coords (for mutli-phase-ctr datasets). Verify
     # the two match up in terms of their coordinates
-    for cat_name in mir_uv.phase_center_catalog.keys():
+    for cat_name in sma_mir.phase_center_catalog.keys():
         assert np.isclose(
-            mir_uv.phase_center_catalog[cat_name]["cat_lat"],
+            sma_mir.phase_center_catalog[cat_name]["cat_lat"],
             uvfits_uv.phase_center_catalog[cat_name]["cat_lat"],
         )
         assert np.isclose(
-            mir_uv.phase_center_catalog[cat_name]["cat_lon"],
+            sma_mir.phase_center_catalog[cat_name]["cat_lon"],
             uvfits_uv.phase_center_catalog[cat_name]["cat_lon"],
         )
-    uvfits_uv.phase_center_catalog = mir_uv.phase_center_catalog
+    uvfits_uv.phase_center_catalog = sma_mir.phase_center_catalog
 
     # There's a minor difference between what SMA calculates online for app coords
     # and what pyuvdata calculates, to the tune of ~1 arcsec. Check those values here,
     # then set them equal to one another.
     assert np.all(
-        np.abs(mir_uv.phase_center_app_ra - uvfits_uv.phase_center_app_ra) < 1e-5
+        np.abs(sma_mir.phase_center_app_ra - uvfits_uv.phase_center_app_ra) < 1e-5
     )
 
     assert np.all(
-        np.abs(mir_uv.phase_center_app_dec - uvfits_uv.phase_center_app_dec) < 1e-5
+        np.abs(sma_mir.phase_center_app_dec - uvfits_uv.phase_center_app_dec) < 1e-5
     )
 
-    mir_uv._set_app_coords_helper()
+    sma_mir._set_app_coords_helper()
     uvfits_uv._set_app_coords_helper()
 
     # make sure filenames are what we expect
-    assert mir_uv.filename == ["sma_test.mir"]
+    assert sma_mir.filename == ["sma_test.mir"]
     assert uvfits_uv.filename == ["outtest_mir.uvfits"]
-    mir_uv.filename = uvfits_uv.filename
-    assert mir_uv == uvfits_uv
+    sma_mir.filename = uvfits_uv.filename
+    assert sma_mir == uvfits_uv
 
     # Since mir is mutli-phase-ctr by default, this should effectively be a no-op
-    mir_uv._set_multi_phase_center()
+    sma_mir._set_multi_phase_center()
 
-    assert mir_uv == uvfits_uv
+    assert sma_mir == uvfits_uv
 
 
 @pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 @pytest.mark.filterwarnings("ignore:LST values stored in this file are not ")
 @pytest.mark.parametrize("future_shapes", [True, False])
-def test_read_mir_write_ms(uv_in_ms, future_shapes):
+def test_read_mir_write_ms(sma_mir, uv_in_ms, future_shapes):
     """
     Mir to uvfits loopback test.
 
@@ -205,12 +151,12 @@ def test_read_mir_write_ms(uv_in_ms, future_shapes):
     object equality.
     """
     pytest.importorskip("casacore")
-    mir_uv, ms_uv, testfile = uv_in_ms
+    ms_uv, testfile = uv_in_ms
 
     if future_shapes:
-        mir_uv.use_future_array_shapes()
+        sma_mir.use_future_array_shapes()
 
-    mir_uv.write_ms(testfile, clobber=True)
+    sma_mir.write_ms(testfile, clobber=True)
     ms_uv.read(testfile)
 
     # Single integration with 1 phase center = single scan number
@@ -223,79 +169,78 @@ def test_read_mir_write_ms(uv_in_ms, future_shapes):
     # There are some minor differences between the values stored by MIR and that
     # calculated by UVData. Since MS format requires these to be calculated on the fly,
     # we calculate them here just to verify that everything is looking okay.
-    mir_uv.set_lsts_from_time_array()
-    mir_uv._set_app_coords_helper()
+    sma_mir.set_lsts_from_time_array()
+    sma_mir._set_app_coords_helper()
 
     # These reorderings just make sure that data from the two formats are lined up
     # correctly.
-    mir_uv.reorder_freqs(spw_order="number")
+    sma_mir.reorder_freqs(spw_order="number")
     ms_uv.reorder_blts()
 
     # MS doesn't have the concept of an "instrument" name like FITS does, and instead
     # defaults to the telescope name. Make sure that checks out here.
-    assert mir_uv.instrument == "SWARM"
+    assert sma_mir.instrument == "SWARM"
     assert ms_uv.instrument == "SMA"
-    mir_uv.instrument = ms_uv.instrument
+    sma_mir.instrument = ms_uv.instrument
 
     # Quick check for history here
-    assert ms_uv.history != mir_uv.history
-    ms_uv.history = mir_uv.history
+    assert ms_uv.history != sma_mir.history
+    ms_uv.history = sma_mir.history
 
     # Only MS has extra keywords, verify those look as expected.
     assert ms_uv.extra_keywords == {"DATA_COL": "DATA", "observer": "SMA"}
-    assert mir_uv.extra_keywords == {}
-    mir_uv.extra_keywords = ms_uv.extra_keywords
+    assert sma_mir.extra_keywords == {}
+    sma_mir.extra_keywords = ms_uv.extra_keywords
 
     # Make sure the filenames line up as expected.
-    assert mir_uv.filename == ["sma_test.mir"]
+    assert sma_mir.filename == ["sma_test.mir"]
     assert ms_uv.filename == ["outtest_mir.ms"]
-    mir_uv.filename = ms_uv.filename = None
+    sma_mir.filename = ms_uv.filename = None
 
     # Finally, with all exceptions handled, check for equality.
-    assert ms_uv.__eq__(mir_uv, allowed_failures=["filename"])
+    assert ms_uv.__eq__(sma_mir, allowed_failures=["filename"])
 
 
 @pytest.mark.filterwarnings("ignore:LST values stored ")
-def test_read_mir_write_uvh5(uv_in_uvh5):
+def test_read_mir_write_uvh5(sma_mir, uv_in_uvh5):
     """
     Mir to uvfits loopback test.
 
     Read in Mir files, write out as uvfits, read back in and check for
     object equality.
     """
-    mir_uv, uvh5_uv, testfile = uv_in_uvh5
+    uvh5_uv, testfile = uv_in_uvh5
 
-    mir_uv.write_uvh5(testfile)
+    sma_mir.write_uvh5(testfile)
     uvh5_uv.read_uvh5(testfile)
 
     # Check the history first via find
     assert 0 == uvh5_uv.history.find(
-        mir_uv.history + "  Read/written with pyuvdata version:"
+        sma_mir.history + "  Read/written with pyuvdata version:"
     )
 
     # test fails because of updated history, so this is our workaround for now.
-    mir_uv.history = uvh5_uv.history
+    sma_mir.history = uvh5_uv.history
 
     # make sure filenames are what we expect
-    assert mir_uv.filename == ["sma_test.mir"]
+    assert sma_mir.filename == ["sma_test.mir"]
     assert uvh5_uv.filename == ["outtest_mir.uvh5"]
-    mir_uv.filename = uvh5_uv.filename
+    sma_mir.filename = uvh5_uv.filename
 
-    assert mir_uv == uvh5_uv
+    assert sma_mir == uvh5_uv
 
 
-def test_write_mir(uv_in_uvfits, err_type=NotImplementedError):
+def test_write_mir(hera_uvh5, err_type=NotImplementedError):
     """
     Mir writer test
 
     Check and make sure that attempts to use the writer return a
     'not implemented' error.
     """
-    mir_uv, uvfits_uv, testfile = uv_in_uvfits
 
     # Check and see if the correct error is raised
     with pytest.raises(err_type):
-        mir_uv.write_mir("dummy.mir")
+        hera_uvh5.write_mir("dummy.mir")
 
 
 def test_multi_nchan_spw_read(tmp_path):
@@ -335,7 +280,7 @@ def test_read_mir_no_records():
         uv_in.read_mir(testfile, corrchunk=999)
 
 
-def test_read_mir_sideband_select():
+def test_read_mir_sideband_select(sma_mir):
     """
     Mir sideband read check
 
@@ -343,12 +288,11 @@ def test_read_mir_sideband_select():
     stitch them back together as though they were read together from the start.
     """
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    mir_dsb = UVData()
-    mir_dsb.read(testfile)
+
     # Re-order here so that we can more easily compare the two
-    mir_dsb.reorder_freqs(channel_order="freq", spw_order="freq")
+    sma_mir.reorder_freqs(channel_order="freq", spw_order="freq")
     # Drop the history
-    mir_dsb.history = ""
+    sma_mir.history = ""
 
     mir_lsb = UVData()
     mir_lsb.read(testfile, isb=[0])
@@ -362,7 +306,7 @@ def test_read_mir_sideband_select():
     # Drop the history
     mir_recomb.history = ""
 
-    assert mir_dsb == mir_recomb
+    assert sma_mir == mir_recomb
 
 
 def test_mir_auto_read(

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -52,7 +52,6 @@ def test_mir_parser_index_linked(mir_data):
     inhid_set = set(np.unique(mir_data.in_read["inhid"]))
 
     # Should not exist is has_auto=False
-    # See `mir_data_object` above.
     if mir_data.ac_read is not None:
         assert set(np.unique(mir_data.ac_read["inhid"])).issubset(inhid_set)
     else:

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -1030,6 +1030,7 @@ def test_miriad_antenna_diameters(uv_in_paper):
     assert uv_in == uv_out
 
 
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_miriad_write_read_diameters(tmp_path):
     uv_in = UVData()
@@ -1660,6 +1661,7 @@ def test_antpos_units(casa_uvfits, tmp_path):
     assert np.allclose(aantpos, uv.antenna_positions)
 
 
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_readmiriad_write_miriad_check_time_format(tmp_path):
     """

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -1000,6 +1000,7 @@ def test_van_vleck_interp(tmp_path):
     ]
     messages = messages * 10
     messages.append("some coarse channel files were not submitted")
+    messages.append("Fixing auto-correlations to be be real-only,")
     uv = UVData()
     with uvtest.check_warnings(UserWarning, messages):
         uv.read(

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -131,6 +131,7 @@ def test_read_mwax_write_uvfits(tmp_path):
     mwax_uv = UVData()
     uvfits_uv = UVData()
     messages = [
+        "Fixing auto-correlations to be be real-only, after some imaginary values",
         "some coarse channel files were not submitted",
     ]
     with uvtest.check_warnings(UserWarning, messages):

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -11393,19 +11393,18 @@ def test_make_flex_pol_errs(sma_mir, err_msg, param, param_val):
     assert sma_copy == sma_mir
 
 
-@pytest.mark.parametrize("dataset", ["hera", "casa"])
+@pytest.mark.parametrize("dataset", ["hera", "mwa"])
 @pytest.mark.parametrize("future_array_shapes", [True, False])
-def test_auto_check(
-    hera_uvh5_main, casa_uvh5_main, future_array_shapes, dataset, tmp_path
-):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_auto_check(hera_uvh5, uv_phase_comp, future_array_shapes, dataset, tmp_path):
     """
     Checks that checking/fixing the autos works correctly, both with dual-pol data
     (supplied by hera_uvh5) and full-pol data (supplied by casa_uvfits).
     """
     if dataset == "hera":
-        uv = hera_uvh5_main.copy()
-    elif dataset == "casa":
-        uv = casa_uvh5_main.copy()
+        uv = hera_uvh5
+    elif dataset == "mwa":
+        uv, _ = uv_phase_comp
 
     if future_array_shapes:
         uv.use_future_array_shapes()

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -11257,10 +11257,10 @@ def test_from_file(filename):
 
 @pytest.mark.parametrize("add_type", ["blt", "freq", "pol"])
 @pytest.mark.parametrize("sort_type", ["blt", "freq", "pol"])
-@pytest.mark.parametrize("future_array_shapes", [True, False])
+@pytest.mark.parametrize("future_shapes", [True, False])
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_add_pol_sorting_bl(casa_uvfits, add_type, sort_type, future_array_shapes):
-    if future_array_shapes:
+def test_add_pol_sorting_bl(casa_uvfits, add_type, sort_type, future_shapes):
+    if future_shapes:
         casa_uvfits.use_future_array_shapes()
 
     if add_type == "pol":
@@ -11394,9 +11394,9 @@ def test_make_flex_pol_errs(sma_mir, err_msg, param, param_val):
 
 
 @pytest.mark.parametrize("dataset", ["hera", "mwa"])
-@pytest.mark.parametrize("future_array_shapes", [True, False])
+@pytest.mark.parametrize("future_shapes", [True, False])
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_auto_check(hera_uvh5, uv_phase_comp, future_array_shapes, dataset, tmp_path):
+def test_auto_check(hera_uvh5, uv_phase_comp, future_shapes, dataset, tmp_path):
     """
     Checks that checking/fixing the autos works correctly, both with dual-pol data
     (supplied by hera_uvh5) and full-pol data (supplied by casa_uvfits).
@@ -11406,7 +11406,7 @@ def test_auto_check(hera_uvh5, uv_phase_comp, future_array_shapes, dataset, tmp_
     elif dataset == "mwa":
         uv, _ = uv_phase_comp
 
-    if future_array_shapes:
+    if future_shapes:
         uv.use_future_array_shapes()
 
     out_file = os.path.join(tmp_path, "auto_check.uvh5")
@@ -11437,7 +11437,7 @@ def test_auto_check(hera_uvh5, uv_phase_comp, future_array_shapes, dataset, tmp_
 
     assert uv1 == uv2
 
-    if future_array_shapes:
+    if future_shapes:
         uv1.use_future_array_shapes()
 
     assert uv == uv1

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -40,24 +40,6 @@ def uvfits_nospw(uvfits_nospw_main):
     return uvfits_nospw_main.copy()
 
 
-@pytest.fixture(scope="session")
-def sma_mir_main():
-    # read in test file for the resampling in time functions
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    uv_object.read(testfile)
-
-    yield uv_object
-
-
-@pytest.fixture(scope="function")
-def sma_mir(sma_mir_main):
-    # read in test file for the resampling in time functions
-    uv_object = sma_mir_main.copy()
-
-    yield uv_object
-
-
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 def test_read_nrao(casa_uvfits):
@@ -77,6 +59,7 @@ def test_read_nrao(casa_uvfits):
     assert uvobj2 == uvobj3
 
 
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.filterwarnings("ignore:ITRF coordinate frame detected")
 @pytest.mark.filterwarnings("ignore:Telescope OVRO_MMA is not")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3212,6 +3212,7 @@ def test_read_metadata(casa_uvfits, tmp_path):
     os.remove(testfile)
 
 
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.filterwarnings("ignore:The original `phase` method is deprecated")
 def test_fix_phase(tmp_path):
     """Test that the fix phase method works"""

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -10204,6 +10204,8 @@ class UVData(UVBase):
         check_extra=True,
         run_check_acceptability=True,
         strict_uvw_antpos_check=False,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read in data from a list of FHD files.
@@ -10274,6 +10276,8 @@ class UVData(UVBase):
             check_extra=check_extra,
             run_check_acceptability=run_check_acceptability,
             strict_uvw_antpos_check=strict_uvw_antpos_check,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         self._convert_from_filetype(fhd_obj)
         del fhd_obj
@@ -10291,6 +10295,8 @@ class UVData(UVBase):
         run_check_acceptability=True,
         strict_uvw_antpos_check=False,
         allow_flex_pol=True,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read in data from an SMA MIR file.
@@ -10352,6 +10358,8 @@ class UVData(UVBase):
             run_check_acceptability=run_check_acceptability,
             strict_uvw_antpos_check=strict_uvw_antpos_check,
             allow_flex_pol=allow_flex_pol,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         self._convert_from_filetype(mir_obj)
         del mir_obj
@@ -10376,6 +10384,8 @@ class UVData(UVBase):
         calc_lst=True,
         fix_old_proj=False,
         fix_use_ant_pos=True,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read in data from a miriad file.
@@ -10501,6 +10511,8 @@ class UVData(UVBase):
             calc_lst=calc_lst,
             fix_old_proj=fix_old_proj,
             fix_use_ant_pos=fix_use_ant_pos,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         self._convert_from_filetype(miriad_obj)
         del miriad_obj
@@ -10520,6 +10532,8 @@ class UVData(UVBase):
         raise_error=True,
         read_weights=True,
         allow_flex_pol=True,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read in data from a measurement set.
@@ -10617,6 +10631,8 @@ class UVData(UVBase):
             raise_error=raise_error,
             read_weights=read_weights,
             allow_flex_pol=allow_flex_pol,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         self._convert_from_filetype(ms_obj)
         del ms_obj
@@ -10650,6 +10666,8 @@ class UVData(UVBase):
         check_extra=True,
         run_check_acceptability=True,
         strict_uvw_antpos_check=False,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read in MWA correlator gpu box files.
@@ -10823,6 +10841,8 @@ class UVData(UVBase):
             check_extra=check_extra,
             run_check_acceptability=run_check_acceptability,
             strict_uvw_antpos_check=strict_uvw_antpos_check,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         self._convert_from_filetype(corr_obj)
         del corr_obj
@@ -10852,6 +10872,8 @@ class UVData(UVBase):
         strict_uvw_antpos_check=False,
         fix_old_proj=None,
         fix_use_ant_pos=True,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read in header, metadata and data from a single uvfits file.
@@ -11011,6 +11033,8 @@ class UVData(UVBase):
             strict_uvw_antpos_check=strict_uvw_antpos_check,
             fix_old_proj=fix_old_proj,
             fix_use_ant_pos=fix_use_ant_pos,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         self._convert_from_filetype(uvfits_obj)
         del uvfits_obj
@@ -11042,6 +11066,8 @@ class UVData(UVBase):
         strict_uvw_antpos_check=False,
         fix_old_proj=None,
         fix_use_ant_pos=True,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read a UVH5 file.
@@ -11213,6 +11239,8 @@ class UVData(UVBase):
             strict_uvw_antpos_check=strict_uvw_antpos_check,
             fix_old_proj=fix_old_proj,
             fix_use_ant_pos=fix_use_ant_pos,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         self._convert_from_filetype(uvh5_obj)
         del uvh5_obj
@@ -11285,6 +11313,8 @@ class UVData(UVBase):
         make_multi_phase=False,
         ignore_name=False,
         allow_flex_pol=True,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read a generic file into a UVData object.
@@ -11708,6 +11738,8 @@ class UVData(UVBase):
                         fix_use_ant_pos=fix_use_ant_pos,
                         make_multi_phase=make_multi_phase,
                         allow_flex_pol=allow_flex_pol,
+                        check_autos=check_autos,
+                        fix_autos=fix_autos,
                     )
                     unread = False
                 except KeyError as err:
@@ -11792,6 +11824,8 @@ class UVData(UVBase):
                             fix_use_ant_pos=fix_use_ant_pos,
                             make_multi_phase=make_multi_phase,
                             allow_flex_pol=allow_flex_pol,
+                            check_autos=check_autos,
+                            fix_autos=fix_autos,
                         )
                         uv_list.append(uv2)
                     except KeyError as err:
@@ -11979,6 +12013,8 @@ class UVData(UVBase):
                     strict_uvw_antpos_check=strict_uvw_antpos_check,
                     fix_old_proj=fix_old_proj,
                     fix_use_ant_pos=fix_use_ant_pos,
+                    check_autos=check_autos,
+                    fix_autos=fix_autos,
                 )
 
             elif file_type == "mir":
@@ -11994,6 +12030,8 @@ class UVData(UVBase):
                     run_check_acceptability=run_check_acceptability,
                     strict_uvw_antpos_check=strict_uvw_antpos_check,
                     allow_flex_pol=allow_flex_pol,
+                    check_autos=check_autos,
+                    fix_autos=fix_autos,
                 )
                 select = False
 
@@ -12016,6 +12054,8 @@ class UVData(UVBase):
                     calc_lst=calc_lst,
                     fix_old_proj=fix_old_proj,
                     fix_use_ant_pos=fix_use_ant_pos,
+                    check_autos=check_autos,
+                    fix_autos=fix_autos,
                 )
 
             elif file_type == "mwa_corr_fits":
@@ -12046,6 +12086,8 @@ class UVData(UVBase):
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability,
                     strict_uvw_antpos_check=strict_uvw_antpos_check,
+                    check_autos=check_autos,
+                    fix_autos=fix_autos,
                 )
 
             elif file_type == "fhd":
@@ -12058,6 +12100,8 @@ class UVData(UVBase):
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability,
                     strict_uvw_antpos_check=strict_uvw_antpos_check,
+                    check_autos=check_autos,
+                    fix_autos=fix_autos,
                 )
 
             elif file_type == "ms":
@@ -12071,6 +12115,8 @@ class UVData(UVBase):
                     run_check_acceptability=run_check_acceptability,
                     strict_uvw_antpos_check=strict_uvw_antpos_check,
                     allow_flex_pol=allow_flex_pol,
+                    check_autos=check_autos,
+                    fix_autos=fix_autos,
                 )
 
             elif file_type == "uvh5":
@@ -12099,6 +12145,8 @@ class UVData(UVBase):
                     strict_uvw_antpos_check=strict_uvw_antpos_check,
                     fix_old_proj=fix_old_proj,
                     fix_use_ant_pos=fix_use_ant_pos,
+                    check_autos=check_autos,
+                    fix_autos=fix_autos,
                 )
                 select = False
 
@@ -12119,6 +12167,8 @@ class UVData(UVBase):
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability,
                     strict_uvw_antpos_check=strict_uvw_antpos_check,
+                    check_autos=check_autos,
+                    fix_autos=fix_autos,
                 )
 
             if make_multi_phase:
@@ -12234,6 +12284,8 @@ class UVData(UVBase):
         make_multi_phase=False,
         ignore_name=False,
         allow_flex_pol=True,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Initialize a new UVData object by reading the input file.
@@ -12602,6 +12654,8 @@ class UVData(UVBase):
             make_multi_phase=make_multi_phase,
             ignore_name=ignore_name,
             allow_flex_pol=allow_flex_pol,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         return uvd
 
@@ -12615,6 +12669,8 @@ class UVData(UVBase):
         strict_uvw_antpos_check=False,
         no_antnums=False,
         calc_lst=False,
+        check_autos=True,
+        fix_autos=False,
     ):
         """
         Write the data to a miriad file.
@@ -12681,6 +12737,8 @@ class UVData(UVBase):
             strict_uvw_antpos_check=strict_uvw_antpos_check,
             no_antnums=no_antnums,
             calc_lst=calc_lst,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         del miriad_obj
 
@@ -12719,6 +12777,8 @@ class UVData(UVBase):
         check_extra=True,
         run_check_acceptability=True,
         strict_uvw_antpos_check=False,
+        check_autos=True,
+        fix_autos=False,
     ):
         """
         Write a CASA measurement set (MS).
@@ -12765,6 +12825,8 @@ class UVData(UVBase):
             check_extra=check_extra,
             run_check_acceptability=run_check_acceptability,
             strict_uvw_antpos_check=strict_uvw_antpos_check,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         del ms_obj
 
@@ -12778,6 +12840,8 @@ class UVData(UVBase):
         check_extra=True,
         run_check_acceptability=True,
         strict_uvw_antpos_check=False,
+        check_autos=True,
+        fix_autos=False,
     ):
         """
         Write the data to a uvfits file.
@@ -12853,6 +12917,8 @@ class UVData(UVBase):
             check_extra=check_extra,
             run_check_acceptability=run_check_acceptability,
             strict_uvw_antpos_check=strict_uvw_antpos_check,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         del uvfits_obj
 
@@ -12869,6 +12935,8 @@ class UVData(UVBase):
         check_extra=True,
         run_check_acceptability=True,
         strict_uvw_antpos_check=False,
+        check_autos=True,
+        fix_autos=False,
     ):
         """
         Write a completely in-memory UVData object to a UVH5 file.
@@ -12937,6 +13005,8 @@ class UVData(UVBase):
             check_extra=check_extra,
             run_check_acceptability=run_check_acceptability,
             strict_uvw_antpos_check=strict_uvw_antpos_check,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         del uvh5_obj
 
@@ -13018,6 +13088,8 @@ class UVData(UVBase):
         blt_inds=None,
         add_to_history=None,
         run_check_acceptability=True,
+        check_autos=True,
+        fix_autos=False,
     ):
         """
         Write data to a UVH5 file that has already been initialized.
@@ -13131,5 +13203,7 @@ class UVData(UVBase):
             blt_inds=blt_inds,
             add_to_history=add_to_history,
             run_check_acceptability=run_check_acceptability,
+            check_autos=check_autos,
+            fix_autos=fix_autos,
         )
         del uvh5_obj

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2551,7 +2551,11 @@ class UVData(UVBase):
 
     def _fix_autos(self):
         """Remove imaginary component of auto-correlations."""
+        # Select out the autos
         auto_screen = self.ant_1_array == self.ant_2_array
+
+        # Only these pols have "true" auto-correlations, that we'd expect
+        # to be real only. Select on only them
         auto_pol_list = ["xx", "yy", "rr", "ll", "pI", "pQ", "pQ", "pV"]
         pol_screen = np.array(
             [
@@ -2560,13 +2564,20 @@ class UVData(UVBase):
             ]
         )
 
-        auto_data = self.data_array[auto_screen]
-        if self.future_array_shapes:
-            auto_data[:, :, pol_screen] = np.abs(auto_data[:, :, pol_screen])
-        else:
-            auto_data[:, :, :, pol_screen] = np.abs(auto_data[:, :, :, pol_screen])
+        # Make sure we actually have work to do here, otherwise skip all of this
+        if np.any(pol_screen) and np.any(auto_screen):
+            # Select out the relevant data. Need to do this because we have two
+            # complex slices we need to do
+            auto_data = self.data_array[auto_screen]
 
-        self.data_array[auto_screen] = auto_data
+            # Set the autos to be real-only by taking the absolute value
+            if self.future_array_shapes:
+                auto_data[:, :, pol_screen] = np.abs(auto_data[:, :, pol_screen])
+            else:
+                auto_data[:, :, :, pol_screen] = np.abs(auto_data[:, :, :, pol_screen])
+
+            # Finally, plug the modified values back into data_array
+            self.data_array[auto_screen] = auto_data
 
     def check(
         self,
@@ -2603,6 +2614,12 @@ class UVData(UVBase):
             the UVWs by -1) resolves  the apparent discrepancy -- and if it does, fix
             the apparent conjugation error in `uvw_array` and `data_array`. Default is
             False.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is False.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is False.
 
         Returns
         -------
@@ -10249,6 +10266,12 @@ class UVData(UVBase):
         strict_uvw_antpos_check : bool
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is True.
 
         Raises
         ------
@@ -10343,6 +10366,12 @@ class UVData(UVBase):
             "flexible polarization", which compresses the polarization-axis of various
             attributes to be of length 1, sets the `flex_spw_polarization_array`
             attribute to define the polarization per spectral window.  Default is True.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is True.
         """
         from . import mir
 
@@ -10470,6 +10499,12 @@ class UVData(UVBase):
             If setting `fix_old_proj` to True, use the antenna positions to derive the
             correct uvw-coordinates rather than using the baseline vectors. Default is
             True.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is True.
 
         Raises
         ------
@@ -10597,6 +10632,12 @@ class UVData(UVBase):
             "flexible polarization", which compresses the polarization-axis of various
             attributes to be of length 1, sets the `flex_spw_polarization_array`
             attribute to define the polarization per spectral window.  Default is True.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is True.
 
         Raises
         ------
@@ -10779,6 +10820,12 @@ class UVData(UVBase):
         strict_uvw_antpos_check : bool
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is True.
 
         Raises
         ------
@@ -10987,6 +11034,12 @@ class UVData(UVBase):
             If setting `fix_old_proj` to True, use the antenna positions to derive the
             correct uvw-coordinates rather than using the baseline vectors. Default is
             True.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is True.
 
         Raises
         ------
@@ -11193,6 +11246,12 @@ class UVData(UVBase):
             If setting `fix_old_proj` to True, use the antenna positions to derive the
             correct uvw-coordinates rather than using the baseline vectors. Default is
             True.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is True.
 
         Raises
         ------
@@ -11614,6 +11673,12 @@ class UVData(UVBase):
             If the data are multi source or have multiple
             spectral windows.
             If phase_center_radec is not None and is not length 2.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is True.
 
         """
         if isinstance(filename, (list, tuple, np.ndarray)):
@@ -12803,6 +12868,12 @@ class UVData(UVBase):
         strict_uvw_antpos_check : bool
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is False.
 
         Raises
         ------
@@ -12877,6 +12948,12 @@ class UVData(UVBase):
         strict_uvw_antpos_check : bool
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is False.
 
         Raises
         ------
@@ -12977,6 +13054,12 @@ class UVData(UVBase):
         strict_uvw_antpos_check : bool
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is False.
 
         Raises
         ------

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -12167,8 +12167,6 @@ class UVData(UVBase):
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability,
                     strict_uvw_antpos_check=strict_uvw_antpos_check,
-                    check_autos=check_autos,
-                    fix_autos=fix_autos,
                 )
 
             if make_multi_phase:
@@ -13088,8 +13086,6 @@ class UVData(UVBase):
         blt_inds=None,
         add_to_history=None,
         run_check_acceptability=True,
-        check_autos=True,
-        fix_autos=False,
     ):
         """
         Write data to a UVH5 file that has already been initialized.
@@ -13203,7 +13199,5 @@ class UVData(UVBase):
             blt_inds=blt_inds,
             add_to_history=add_to_history,
             run_check_acceptability=run_check_acceptability,
-            check_autos=check_autos,
-            fix_autos=fix_autos,
         )
         del uvh5_obj

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -12637,6 +12637,12 @@ class UVData(UVBase):
             attribute to define the polarization per spectral window. Only applicable
             for MIR and MS filetypes, otherwise this argument is ignored. Default is
             True.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is True.
 
         Raises
         ------
@@ -12769,6 +12775,12 @@ class UVData(UVBase):
             marks the midpoint). Default is False, which instead uses a simple formula
             for correcting the LSTs, expected to be accurate to approximately 0.1 µsec
             precision.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is False.
 
         Raises
         ------

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2780,6 +2780,7 @@ class UVData(UVBase):
                     else:
                         raise ValueError(
                             "Some auto-correlations have non-real values in data_array."
+                            " You can attempt to fix this by setting fix_autos=True."
                         )
             if np.any(
                 np.isclose(

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -231,6 +231,8 @@ class UVFITS(UVData):
         strict_uvw_antpos_check,
         fix_old_proj,
         fix_use_ant_pos,
+        check_autos,
+        fix_autos,
     ):
         """
         Read just the visibility and flag data of the uvfits file.
@@ -365,6 +367,8 @@ class UVFITS(UVData):
                 run_check_acceptability=run_check_acceptability,
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
                 allow_flip_conj=True,
+                check_autos=check_autos,
+                fix_autos=fix_autos,
             )
 
     def read_uvfits(
@@ -391,6 +395,8 @@ class UVFITS(UVData):
         strict_uvw_antpos_check=False,
         fix_old_proj=False,
         fix_use_ant_pos=True,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read in header, metadata and data from a uvfits file.
@@ -496,7 +502,12 @@ class UVFITS(UVData):
             If setting `fix_old_proj` to True, use the antenna positions to derive the
             correct uvw-coordinates rather than using the baseline vectors. Default is
             True.
-
+        check_autos : bool
+            Check whether any auto-correlations have imaginary values in them (which
+            should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only. Default is True.
 
         Raises
         ------
@@ -853,6 +864,8 @@ class UVFITS(UVData):
                 strict_uvw_antpos_check,
                 fix_old_proj,
                 fix_use_ant_pos,
+                check_autos,
+                fix_autos,
             )
 
     def write_uvfits(
@@ -865,6 +878,8 @@ class UVFITS(UVData):
         check_extra=True,
         run_check_acceptability=True,
         strict_uvw_antpos_check=False,
+        check_autos=True,
+        fix_autos=False,
     ):
         """
         Write the data to a uvfits file.
@@ -898,6 +913,12 @@ class UVFITS(UVData):
         strict_uvw_antpos_check : bool
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
+        check_autos : bool
+            Check whether any auto-correlations have imaginary values in them (which
+            should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only. Default is False.
 
         Raises
         ------
@@ -920,6 +941,8 @@ class UVFITS(UVData):
                 run_check_acceptability=run_check_acceptability,
                 check_freq_spacing=True,
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
+                check_autos=check_autos,
+                fix_autos=fix_autos,
             )
 
         if self.phase_type == "phased":

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -503,11 +503,11 @@ class UVFITS(UVData):
             correct uvw-coordinates rather than using the baseline vectors. Default is
             True.
         check_autos : bool
-            Check whether any auto-correlations have imaginary values in them (which
-            should not mathematically exist). Default is True.
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only. Default is True.
+            that they are real-only in data_array. Default is True.
 
         Raises
         ------
@@ -914,11 +914,11 @@ class UVFITS(UVData):
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
         check_autos : bool
-            Check whether any auto-correlations have imaginary values in them (which
-            should not mathematically exist). Default is True.
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only. Default is False.
+            that they are real-only in data_array. Default is False.
 
         Raises
         ------

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -890,11 +890,11 @@ class UVH5(UVData):
             correct uvw-coordinates rather than using the baseline vectors. Default is
             True.
         check_autos : bool
-            Check whether any auto-correlations have imaginary values in them (which
-            should not mathematically exist). Default is True.
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only. Default is True.
+            that they are real-only in data_array. Default is True.
 
         Returns
         -------
@@ -1169,11 +1169,11 @@ class UVH5(UVData):
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
         check_autos : bool
-            Check whether any auto-correlations have imaginary values in them (which
-            should not mathematically exist). Default is True.
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only. Default is False.
+            that they are real-only in data_array. Default is False.
 
         Returns
         -------

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -423,6 +423,8 @@ class UVH5(UVData):
         strict_uvw_antpos_check,
         fix_old_proj,
         fix_use_ant_pos,
+        check_autos,
+        fix_autos,
     ):
         """
         Read the data-size arrays (data, flags, nsamples) from a file.
@@ -737,6 +739,8 @@ class UVH5(UVData):
                 run_check_acceptability=run_check_acceptability,
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
                 allow_flip_conj=True,
+                check_autos=check_autos,
+                fix_autos=fix_autos,
             )
 
         return
@@ -767,6 +771,8 @@ class UVH5(UVData):
         strict_uvw_antpos_check=False,
         fix_old_proj=None,
         fix_use_ant_pos=True,
+        check_autos=True,
+        fix_autos=True,
     ):
         """
         Read in data from a UVH5 file.
@@ -883,6 +889,12 @@ class UVH5(UVData):
             If setting `fix_old_proj` to True, use the antenna positions to derive the
             correct uvw-coordinates rather than using the baseline vectors. Default is
             True.
+        check_autos : bool
+            Check whether any auto-correlations have imaginary values in them (which
+            should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only. Default is True.
 
         Returns
         -------
@@ -957,6 +969,8 @@ class UVH5(UVData):
                 strict_uvw_antpos_check,
                 fix_old_proj,
                 fix_use_ant_pos,
+                check_autos,
+                fix_autos,
             )
 
         # For now, always use current shapes when data is read in, even if the file
@@ -1112,6 +1126,8 @@ class UVH5(UVData):
         check_extra=True,
         run_check_acceptability=True,
         strict_uvw_antpos_check=False,
+        check_autos=True,
+        fix_autos=False,
     ):
         """
         Write an in-memory UVData object to a UVH5 file.
@@ -1152,6 +1168,12 @@ class UVH5(UVData):
         strict_uvw_antpos_check : bool
             Option to raise an error rather than a warning if the check that
             uvws match antenna positions does not pass.
+        check_autos : bool
+            Check whether any auto-correlations have imaginary values in them (which
+            should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only. Default is False.
 
         Returns
         -------
@@ -1184,6 +1206,8 @@ class UVH5(UVData):
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
+                check_autos=check_autos,
+                fix_autos=fix_autos,
             )
 
         if os.path.exists(filename):

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -147,6 +147,7 @@ def test_outfile(tmp_path):
     yield str(tmp_path / "outtest_uvflag.h5")
 
 
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_check_flag_array(uvdata_obj):
     uvf = UVFlag()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
_A PR a day keeps the doctor away..._
## Description
<!--- Describe your changes in detail -->
- Added a new method to `UVData` called `_fix_autos`, which will force the auto-correlation data in `data_array` to be real-only.
- Added a new feature to `UVData.check`, which will see whether or not auto-correlation data have non-zero imaginary components in them. If they detected, depending on arguments supplied, `check` can either raise an error or attempt to fix the auto-correlations (via a call to `_fix_autos`).
- Did some minor test fixture cleanup (mostly with the SMA MIR test data set).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
As originally motivated in #1024, and demonstrated in #1102, checking that the autos are real-only is a good way to help verify the health of any given `UVData` object, to make sure that something weird hasn't happened in the handling of the data set. However, since this check is potentially inspecting lots of values in `data_array`, it can be somewhat computationally expensive to run, which seems somewhat antithetical to how `UVData.check` _should_ work -- quoting @bhazelton here from a comment in #1024:

> It'll almost always pass so we want to make sure it's lightweight, but catching this early on a dataset is very useful.
 
To that end, I've set up this new functionality with the following defaults:

- On **read**, if non-zero imaginary components are found in the autocorrelation data, `check` will raise a warning, and will subsequently fix the issue by making those values real-only (using `np.abs` on the autocorrelation data).
- On **write**, if non-zero imaginary components are found in the autocorrelation data, `check` will raise an error.
- On all other operations, no check of the autos is done.

I think the above is a reasonable balance between ease-of-use, speed, and ensuring the integrity of `UVData` objects. FWIW, The addition of `_fix_autos` was motivated in part by the fact that some of the test files so have non-zero imaginary components in their auto-correlation data -- something that I believe is a hangover from the old `phase` method (something I noticed while working on #979).

Closes #1024
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).