### PR TITLE
Fixes and performance improvements to the measurement set writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ a non-MS file) and is used when writing to an MS file.
 - Flexible spectral windows to `read_mwa_corr_fits`.
 
 ### Changed
+- Changed the `UVData.write_ms` to reduce processing time and memory footprint.
+- Changed the order in which data are written in Measurement Set format via the method
+  `UVData.write_ms`, where data are now first grouped together by `scan_number_array`.
 - Changed the defaults by which the `UVData.antenna_names` attribute is set when reading
 measurement sets (used to default to station names, now uses antenna names if available
 and the MS file was not written using the CASA `importuvfits` routine).
@@ -30,6 +33,8 @@ calls to JPL Horizons.
 - Improved readability, functionality, and memory usage in `read_mwa_corr_fits`.
 
 ### Fixed
+- A bug that could cause some routines in CASA to fail when using data sets written by
+  `UVData.write_ms`.
 - A bug that could have resulted in `UVData.__add__` combining objects together incorrectly
   when containing overlapping time-baselines/polarization/frequency channels together
   that were ordered differently for the two `UVData` objects.

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -141,7 +141,7 @@ class MS(UVData):
         ms_desc["FLAG_CATEGORY"].update(
             dataManagerType="TiledShapeStMan",
             dataManagerGroup="TiledFlagCategory",
-            keywords={"CATEGORY": []},
+            keywords={"CATEGORY": np.array("baddata")},
         )
         ms_desc["WEIGHT"].update(
             dataManagerType="TiledShapeStMan", dataManagerGroup="TiledWgt",
@@ -697,7 +697,7 @@ class MS(UVData):
                 ch_mask = self.flex_spw_id_array == spw_id
             else:
                 ch_mask = np.ones(freq_array.shape, dtype=bool)
-
+            print(np.min(ch_width))
             sw_table.addrows()
             sw_table.putcell("NUM_CHAN", idx, np.sum(ch_mask))
             sw_table.putcell("NAME", idx, "SPW%d" % spw_id)
@@ -706,6 +706,7 @@ class MS(UVData):
             sw_table.putcell("CHAN_FREQ", idx, freq_array[ch_mask])
             sw_table.putcell("CHAN_WIDTH", idx, ch_width[ch_mask])
             sw_table.putcell("EFFECTIVE_BW", idx, ch_width[ch_mask])
+            sw_table.putcell("TOTAL_BANDWIDTH", idx, np.sum(ch_width[ch_mask]))
             sw_table.putcell("RESOLUTION", idx, ch_width[ch_mask])
             # TODO: These are placeholders for now, but should be replaced with
             # actual frequency reference info (once UVData handles that)

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -511,10 +511,14 @@ def test_ms_multi_spw_data_variation(mir_uv, tmp_path):
 
 @pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_ms_phasing(mir_uv, tmp_path):
+@pytest.mark.parametrize("future_shapes", [True, False])
+def test_ms_phasing(mir_uv, future_shapes, tmp_path):
     """
     Test that the MS writer can appropriately handle unphased data sets.
     """
+    if future_shapes:
+        mir_uv.use_future_array_shapes()
+
     ms_uv = UVData()
     testfile = os.path.join(tmp_path, "out_ms_phasing.ms")
 
@@ -535,10 +539,14 @@ def test_ms_phasing(mir_uv, tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
-def test_ms_single_chan(mir_uv, tmp_path):
+@pytest.mark.parametrize("future_shapes", [True, False])
+def test_ms_single_chan(mir_uv, future_shapes, tmp_path):
     """
     Make sure that single channel writing/reading work as expected
     """
+    if future_shapes:
+        mir_uv.use_future_array_shapes()
+
     ms_uv = UVData()
     testfile = os.path.join(tmp_path, "out_ms_single_chan.ms")
 
@@ -564,6 +572,9 @@ def test_ms_single_chan(mir_uv, tmp_path):
     ms_uv._set_flex_spw()
     ms_uv.channel_width = np.array([ms_uv.channel_width])
     ms_uv.flex_spw_id_array = ms_uv.spw_array.copy()
+
+    if future_shapes:
+        ms_uv.use_future_array_shapes()
 
     # Finally, take care of the odds and ends
     ms_uv.extra_keywords = {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
_On the twelfth day of git-mas, my PR gave to me..._

## Description
<!--- Describe your changes in detail -->
- `UVData.write_ms` has been overhauled to operate more efficiently, dropping the casacore method `putvarcol` in favor of `putcol`.
- Slightly changes the order in which data are written out into the MS format, to better conform to the ordering that various CASA routines appear to prefer (based on some small test data sets).
- Fixes a bug where an incorrectly formed keyword (`CATEGORY`) was used in the primary table, which resulted in crashes when using particular routines (e.g., `concat`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The primary motivation for this PR is that it drastically improves the speed at which `write_ms` operates and significantly reduce the memory footprint of the operation, the latter of which is an impediment to working with larger `UVData` objects (as reported in #1111). In bench testing with a ~1 GB test MS data set, the new `write_ms` operates about 2-3 times faster (10 seconds on my laptop) and has a memory footprint of < 100 MB while running (was > 2 GB). This new rewrite also slightly changes the ordering in which data are written in the MS format, where baseline-times are grouped together based on `scan_number_array`, to better conform to other example data sets from ALMA and VLA. Note that this ordering change currently only affects data sets with multiple phase centers _and_ multiple spectral windows, and does not affect ordering within the `UVData` object on read or write. Finally, a small bug related to a keyword was fixed, where the wrong `dtype` was being provided inside the main MS table, which resulted in the `CATALOG` key being malformed.

Closes #1103
Closes #1111

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

