### PR TITLE
Fix a bug in write_calfits when time_range is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ calls to JPL Horizons.
 - Improved readability, functionality, and memory usage in `read_mwa_corr_fits`.
 
 ### Fixed
+- A bug in writing calfits files when the optional `time_range` parameter is not set.
 - A bug where the `TIME_CENTROID` field was not being filled in data sets written by
   `UVData.write_ms`, which caused odd behavior in some CASA routines (e.g., `gaincal`).
 - A bug in reading in uvfits files with baseline coordinates that have suffixes of

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -160,7 +160,9 @@ class CALFITS(UVCal):
             prihdr["FRQRANGE"] = ",".join(map(str, self.freq_range))
         elif self.freq_range is not None:
             prihdr["FRQRANGE"] = ",".join(map(str, self.freq_range))
-        prihdr["TMERANGE"] = ",".join(map(str, self.time_range))
+
+        if self.time_range is not None:
+            prihdr["TMERANGE"] = ",".join(map(str, self.time_range))
 
         if self.observer:
             prihdr["OBSERVER"] = self.observer
@@ -495,7 +497,9 @@ class CALFITS(UVCal):
 
                 self.history += self.pyuvdata_version_str
 
-            self.time_range = list(map(float, hdr.pop("TMERANGE").split(",")))
+            time_range = hdr.pop("TMERANGE", None)
+            if time_range is not None:
+                self.time_range = list(map(float, time_range.split(",")))
             self.gain_convention = hdr.pop("GNCONVEN")
             self.gain_scale = hdr.pop("GNSCALE", None)
             self.x_orientation = hdr.pop("XORIENT")

--- a/pyuvdata/uvcal/tests/test_calfits.py
+++ b/pyuvdata/uvcal/tests/test_calfits.py
@@ -69,6 +69,22 @@ def test_readwriteread_no_freq_range(tmp_path):
     return
 
 
+def test_readwriteread_no_time_range(tmp_path):
+    # test without time_range parameter
+    cal_in = UVCal()
+    cal_out = UVCal()
+    testfile = os.path.join(DATA_PATH, "zen.2457698.40355.xx.gain.calfits")
+    write_file = str(tmp_path / "outtest_omnical.fits")
+
+    cal_in.read_calfits(testfile)
+    cal_in.time_range = None
+    cal_in.write_calfits(write_file, clobber=True)
+    cal_out.read_calfits(write_file)
+    assert cal_in == cal_out
+
+    return
+
+
 def test_error_unknown_cal_type(tmp_path):
     """
     Test an error is raised when writing an unknown cal type.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a bug in `write_calfits` when the optional `time_range` is not set.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #1115 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
