### PR TITLE
Improved handling of MIR Data + flexible polarization for UVData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ functions. Also added `use_current_array_shapes` to revert to the standard shape
 - Added support for wide-band gain calibrations via the `wide_band` attribute on the
 `UVCal` class, which can be set using the new `_set_wide_band` method.
 - Added `time_range`, `lsts`, and `lst_range` kwargs from UVH5.write_uvh5_part() to UVData.write_uvh5_part().
+- A new attribute to `UVData` called `flex_spw_polarization_array`, of type=int and shape=(`Nspws`,),
+  which allows for individual spectral windows to carry different polarization data.
+- Added the `_make_flex_pol` and `remove_flex_pol` methods to `UVData`, which allows for
+  one to convert a standard `UVData` object to one with "flexible-polarization".
+- Added a new method to `MirParser` called `_apply_tsys`, which will convert MIR visibility data
+  from correlation coefficiencts to pseudo-Jy.
+- Added a method to `Mir` called `_init_from_mir_parser`, which allows for one to pass
+  a `MirParser` object to be coverted into a UVData object (rather than reading from
+  a file on disk).
+
+## Changed
+- General performance improvements in the `read_mir` method.
+- Enabled `read_mir` to read in dual- and full-polarization data.
 
 ### Fixed
 - Fixed a bug where `UVData.compress_by_redundancy` sometimes produced incorrectly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- A new attribute to `UVData` called `flex_spw_polarization_array`, of type=int and shape=(`Nspws`,),
+  which allows for individual spectral windows to carry different polarization data.
+- Added the `_make_flex_pol` and `remove_flex_pol` methods to `UVData`, which allows for
+  one to convert a standard `UVData` object to one with "flexible-polarization".
+- Added a new method to `MirParser` called `_apply_tsys`, which will convert MIR visibility data
+  from correlation coefficiencts to pseudo-Jy.
+- Added a method to `Mir` called `_init_from_mir_parser`, which allows for one to pass
+  a `MirParser` object to be coverted into a UVData object (rather than reading from
+  a file on disk).
 - Added the `flex_spw` attribute to the `UVCal` class, which can be set to True by using
 the new `_set_flex_spw` method.
 - Added the optional `flex_spw_id_array` attribute to UVCal class, of type=int and
@@ -15,15 +24,7 @@ functions. Also added `use_current_array_shapes` to revert to the standard shape
 - Added support for wide-band gain calibrations via the `wide_band` attribute on the
 `UVCal` class, which can be set using the new `_set_wide_band` method.
 - Added `time_range`, `lsts`, and `lst_range` kwargs from UVH5.write_uvh5_part() to UVData.write_uvh5_part().
-- A new attribute to `UVData` called `flex_spw_polarization_array`, of type=int and shape=(`Nspws`,),
-  which allows for individual spectral windows to carry different polarization data.
-- Added the `_make_flex_pol` and `remove_flex_pol` methods to `UVData`, which allows for
-  one to convert a standard `UVData` object to one with "flexible-polarization".
-- Added a new method to `MirParser` called `_apply_tsys`, which will convert MIR visibility data
-  from correlation coefficiencts to pseudo-Jy.
-- Added a method to `Mir` called `_init_from_mir_parser`, which allows for one to pass
-  a `MirParser` object to be coverted into a UVData object (rather than reading from
-  a file on disk).
+- Added `time_range`, `lsts`, and `lst_range` kwargs from UVH5.write_uvh5_part() to UVData.write_uvh5_part().
 
 ## Changed
 - General performance improvements in the `read_mir` method.

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -65,7 +65,9 @@ __all__ = [
 POL_STR2NUM_DICT = {"pI": 1, "pQ": 2, "pU": 3, "pV": 4,
                     "I": 1, "Q": 2, "U": 3, "V": 4,  # support straight stokes names
                     "rr": -1, "ll": -2, "rl": -3, "lr": -4,
-                    "xx": -5, "yy": -6, "xy": -7, "yx": -8}
+                    "xx": -5, "yy": -6, "xy": -7, "yx": -8,
+                    "hh": -5, "vv": -6, "hv": -7, "vh": -8}
+
 # maps polarization integers to polarization strings
 POL_NUM2STR_DICT = {1: "pI", 2: "pQ", 3: "pU", 4: "pV",
                     -1: "rr", -2: "ll", -3: "rl", -4: "lr",

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -289,6 +289,7 @@ class Mir(UVData):
         # Load up the visibilities into the MirParser object.
         vis_data = np.zeros((Nblts, Npols, Nfreqs), dtype=np.complex64)
         mir_data.load_data(load_vis=True)
+        mir_data._apply_tsys()
 
         for sp_rec, window, vis_rec in zip(
             mir_data.sp_data, spdx_list, mir_data.vis_data
@@ -436,8 +437,7 @@ class Mir(UVData):
         # standard a2-a1 that uvdata expects
         self.uvw_array = (-1.0) * uvw_array
 
-        # todo: Raw data is in correlation coefficients, we may want to convert to Jy.
-        self.vis_units = "uncalib"
+        self.vis_units = "Jy"
 
         sou_list = mir_data.codes_data[mir_data.codes_data["v_name"] == b"source"]
         isource = np.unique(mir_data.in_data["isource"])

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -173,13 +173,20 @@ class Mir(UVData):
         for code in mir_data.codes_read[mir_data.codes_read["v_name"] == b"pol"]:
             pol_code_dict[code["icode"]] = code["code"].decode("UTF-8").lower()
 
-        Npols = len(set(pol_dict.values()))
-        polarization_array = np.zeros(Npols, dtype=int)
+        if pol_split_tuning:
+            # Encode polarization array to be pseudo Stokes I, since that is effectively
+            # how these values are going to be treated.
+            Npols = 1
+            polarization_array = np.array([1])
+            # TODO: Add split tuning handing here
+        else:
+            Npols = len(set(pol_dict.values()))
+            polarization_array = np.zeros(Npols, dtype=int)
 
-        for key in pol_dict.keys():
-            polarization_array[pol_dict[key]] = uvutils.POL_STR2NUM_DICT[
-                pol_code_dict[key]
-            ]
+            for key in pol_dict.keys():
+                polarization_array[pol_dict[key]] = uvutils.POL_STR2NUM_DICT[
+                    pol_code_dict[key]
+                ]
 
         blt_list = [
             (intid, ant1, ant2)

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -453,17 +453,19 @@ class MirParser(object):
         if self.auto_data is not None:
             self.auto_data = None
 
-    def tsys_calibrate_data(
+    def _tsys_calibrate_data(
         self, interp_rxa_ants=None, interp_rxb_ants=None, jypk=130.0
     ):
         """
         Apply Tsys calibration to the visibilities.
 
         SMA MIR data are recorded as correlation coefficients. This allows one to apply
-        system temperature information to the data to get values in units of Jy.
+        system temperature information to the data to get values in units of Jy. This
+        method is not meant to be called by users, but is instead meant to be called
+        by data read methods.
         """
         tsys_dict = {
-            (idx, jdx, 0): tsys
+            (idx, jdx, 0): tsys ** 0.5
             for idx, jdx, tsys in zip(
                 self.eng_data["inhid"],
                 self.eng_data["antennaNumber"],
@@ -472,7 +474,7 @@ class MirParser(object):
         }
         tsys_dict.update(
             {
-                (idx, jdx, 1): tsys
+                (idx, jdx, 1): tsys ** 0.5
                 for idx, jdx, tsys in zip(
                     self.eng_data["inhid"],
                     self.eng_data["antennaNumber"],
@@ -482,8 +484,8 @@ class MirParser(object):
         )
 
         normal_dict = {
-            blhid: (2 * jypk)
-            * (tsys_dict[(idx, jdx, kdx)] * tsys_dict[(idx, ldx, mdx)]) ** 0.5
+            blhid: (2.0 * jypk)
+            * (tsys_dict[(idx, jdx, kdx)] * tsys_dict[(idx, ldx, mdx)])
             for blhid, idx, jdx, kdx, ldx, mdx in zip(
                 self.bl_data["blhid"],
                 self.bl_data["inhid"],

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -13,7 +13,8 @@ import copy
 
 __all__ = ["MirParser"]
 
-# MIR structure definitions.
+# MIR structure definitions. Note that because these are all binaries, we need to
+# specify the endianness so that we don't potentially muck that on different machines
 in_dtype = np.dtype(
     [
         ("traid", np.int32),
@@ -58,7 +59,7 @@ in_dtype = np.dtype(
         ("adec", np.float64),
         ("mjd", np.float64),
     ]
-)
+).newbyteorder("little")
 
 eng_dtype = np.dtype(
     [
@@ -91,7 +92,7 @@ eng_dtype = np.dtype(
         ("tsys_rx2", np.float64),
         ("ambient_load_temperature", np.float64),
     ]
-)
+).newbyteorder("little")
 
 bl_dtype = np.dtype(
     [
@@ -133,7 +134,7 @@ bl_dtype = np.dtype(
         ("sparedbl5", np.float64),
         ("sparedbl6", np.float64),
     ]
-)
+).newbyteorder("little")
 
 sp_dtype = np.dtype(
     [
@@ -176,11 +177,11 @@ sp_dtype = np.dtype(
         ("sparedbl5", np.float64),
         ("sparedbl6", np.float64),
     ]
-)
+).newbyteorder("little")
 
 codes_dtype = np.dtype(
     [("v_name", "S12"), ("icode", np.int16), ("code", "S26"), ("ncode", np.int16)]
-)
+).newbyteorder("little")
 
 we_dtype = np.dtype(
     [
@@ -194,7 +195,7 @@ we_dtype = np.dtype(
         ("windDir", np.float32, 11),
         ("h2o", np.float32, 11),
     ]
-)
+).newbyteorder("little")
 
 ac_read_dtype = np.dtype(
     [
@@ -206,7 +207,7 @@ ac_read_dtype = np.dtype(
         ("dataoff", np.int64),
         ("dhrs", np.float64),
     ]
-)
+).newbyteorder("little")
 
 antpos_dtype = np.dtype([("antenna", np.int16), ("xyz_pos", np.float64, 3)])
 

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -924,7 +924,7 @@ class MirParser(object):
                 for idx, jdx, tsys in zip(
                     self.eng_data["inhid"],
                     self.eng_data["antennaNumber"],
-                    self.eng_data["tsys"],
+                    self.eng_data["tsys_rx2"],
                 )
             }
         )

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -908,7 +908,7 @@ class MirParser(object):
         """
         # Create a dictionary here to map antenna pair + integration time step with
         # a sqrt(tsys) value. Note that the last index here is the receiver number,
-        # which techically has a diffenret keyword under which the system temperatures
+        # which techically has a different keyword under which the system temperatures
         # are stored.
         tsys_dict = {
             (idx, jdx, 0): tsys ** 0.5

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -453,9 +453,7 @@ class MirParser(object):
         if self.auto_data is not None:
             self.auto_data = None
 
-    def _tsys_calibrate_data(
-        self, interp_rxa_ants=None, interp_rxb_ants=None, jypk=130.0
-    ):
+    def _apply_tsys(self, interp_rxa_ants=None, interp_rxb_ants=None, jypk=130.0):
         """
         Apply Tsys calibration to the visibilities.
 

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -588,7 +588,7 @@ class MS(UVData):
         # per-timestamp, per-antenna entry
         times = np.asarray(
             [
-                Time(t, format="jd", scale="utc").mjd * 3600.0 * 24.0
+                Time(t, format="jd", scale="utc").mjd * 86400.0
                 for t in np.unique(self.time_array)
             ]
         )
@@ -1143,7 +1143,7 @@ class MS(UVData):
         # is MJD UTC seconds, versus JD UTC days for UVData.
         time_array, time_ind = np.unique(self.time_array, return_inverse=True)
         # TODO: Verify this should actually be UTC, and not some other scale
-        time_array = (Time(time_array, format="jd", scale="utc").mjd * 3600.0 * 24.0)[
+        time_array = (Time(time_array, format="jd", scale="utc").mjd * 86400.0)[
             time_ind
         ]
 

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -393,7 +393,7 @@ class MS(UVData):
 
         field_table = tables.table(filepath + "::FIELD", ack=False, readonly=False)
         time_val = (
-            Time(np.median(self.time_array), format="jd", scale="utc").tai.mjd * 86400.0
+            Time(np.median(self.time_array), format="jd", scale="utc").mjd * 86400.0
         )
         n_poly = 0
 
@@ -510,7 +510,7 @@ class MS(UVData):
         )
 
         time_val = (
-            Time(np.median(self.time_array), format="jd", scale="utc").tai.mjd * 86400.0
+            Time(np.median(self.time_array), format="jd", scale="utc").mjd * 86400.0
         )
         int_val = np.finfo(float).max
 
@@ -587,7 +587,7 @@ class MS(UVData):
         # per-timestamp, per-antenna entry
         times = np.asarray(
             [
-                Time(t, format="jd", scale="utc").tai.mjd * 3600.0 * 24.0
+                Time(t, format="jd", scale="utc").mjd * 3600.0 * 24.0
                 for t in np.unique(self.time_array)
             ]
         )
@@ -1141,7 +1141,10 @@ class MS(UVData):
         # this date conversion as few times as possible. Note that the default for MS
         # is MJD UTC seconds, versus JD UTC days for UVData.
         time_array, time_ind = np.unique(self.time_array, return_inverse=True)
-        time_array = (Time(time_array, format="jd").mjd * 3600.0 * 24.0)[time_ind]
+        # TODO: Verify this should actually be UTC, and not some other scale
+        time_array = (Time(time_array, format="jd", scale="utc").mjd * 3600.0 * 24.0)[
+            time_ind
+        ]
 
         # Add all the rows we need up front, which will allow us to fill the
         # columns all in one shot.

--- a/pyuvdata/uvdata/tests/conftest.py
+++ b/pyuvdata/uvdata/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 
 from pyuvdata.data import DATA_PATH
 from pyuvdata import UVData
-from pyuvdata.uvdata.mir import mir_parser
+from pyuvdata.uvdata.mir_parser import MirParser
 import pyuvdata.tests as uvtest
 
 casa_tutorial_uvfits = os.path.join(
@@ -47,6 +47,23 @@ def casa_uvfits(casa_uvfits_main):
     del casa_uvfits
 
     return
+
+
+@pytest.fixture(scope="session")
+def mir_data_main():
+    testfile = os.path.join(DATA_PATH, "sma_test.mir")
+    mir_data = MirParser(
+        testfile, load_vis=True, load_raw=True, load_auto=True, has_auto=True,
+    )
+
+    yield mir_data
+
+
+@pytest.fixture(scope="function")
+def mir_data(mir_data_main):
+    mir_data = mir_data_main.copy()
+
+    yield mir_data
 
 
 @pytest.fixture(scope="session")
@@ -104,7 +121,7 @@ def mir_data_object(request):
     """Make MIR data object for tests. Param to read autocorr data."""
     has_auto = request.param
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    mir_data = mir_parser.MirParser(
+    mir_data = MirParser(
         testfile, load_vis=True, load_raw=True, load_auto=True, has_auto=has_auto
     )
 

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -591,15 +591,19 @@ def test_flex_pol_add_errs(sma_mir_filt, make_flex, err_msg):
 
 def test_flex_pol_add(sma_mir_filt):
     """Test that the add method works correctly with flex-pol data"""
+    # Grab two copies of the data before we start to manipulate it
     sma_xx_copy = sma_mir_filt.copy()
     sma_yy_copy = sma_mir_filt.copy()
     sma_mir_filt._make_flex_pol()
 
+    # In both copies, isolate out the relevant polarization data.
     sma_xx_copy.select(polarizations=["xx"], freq_chans=[4, 5, 6, 7])
     sma_xx_copy._make_flex_pol()
     sma_yy_copy.select(polarizations=["yy"], freq_chans=[0, 1, 2, 3])
     sma_yy_copy._make_flex_pol()
 
+    # Add the two back together here, and make sure we can the same value out,
+    # modulo the history.
     sma_check = sma_yy_copy + sma_xx_copy
 
     assert sma_check.history != sma_mir_filt.history
@@ -612,8 +616,10 @@ def test_flex_pol_spw_all_flag(sma_mir_filt):
     """
     Test that if one spw is totally flagged, the polarization gets filled correctly.
     """
-    print(sma_mir_filt.polarization_array)
+    # Flag all of the data where we have y-pol data
     sma_mir_filt.flag_array[:, :, : sma_mir_filt.Nfreqs // 2, :] = True
     sma_mir_filt._make_flex_pol()
 
+    # Since all of the y-pol data is flagged, the flex-pol data should only contain
+    # xx visibilities (as recorded in flex_spw_polarization_array).t
     assert np.all(sma_mir_filt.flex_spw_polarization_array == -5)

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -13,8 +13,8 @@ import os
 
 import pytest
 import numpy as np
-import pyuvdata.tests as uvtest
 
+from ... import tests as uvtest
 from ... import UVData
 from ...data import DATA_PATH
 from ...uvdata.mir_parser import MirParser

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -461,7 +461,7 @@ def test_inconsistent_sp_records(mir_data, uv_in_ms):
     sma_mir, _, _ = uv_in_ms
 
     mir_data.use_sp = mir_data.sp_read["iband"] != 0
-    mir_data.sp_read["flags"][1] = True
+    mir_data.sp_read["ipq"][1] = 0
     mir_data.load_data()
 
     with uvtest.check_warnings(UserWarning, "Per-spectral window metadata differ."):

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -55,7 +55,7 @@ def uv_in_uvfits(tmp_path):
     write_file = os.path.join(tmp_path, "outtest_mir.uvfits")
 
     # Currently only one source is supported.
-    uv_in.read(testfile, pseudo_cont=True)
+    uv_in.read(testfile, pseudo_cont=False)
     uv_out = UVData()
 
     yield uv_in, uv_out, write_file
@@ -292,17 +292,17 @@ def test_read_mir_no_records():
     """
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
     uv_in = UVData()
-    with pytest.raises(IndexError, match="No valid sources selected!"):
+    with pytest.raises(ValueError, match="No valid sources selected!"):
         uv_in.read_mir(testfile, isource=-1)
 
-    with pytest.raises(IndexError, match="No valid records matching those selections!"):
+    with pytest.raises(ValueError, match="No valid receivers selected!"):
         uv_in.read_mir(testfile, irec=-1)
 
-    with pytest.raises(IndexError, match="No valid sidebands selected!"):
-        uv_in.read_mir(testfile, isb=[])
+    with pytest.raises(ValueError, match="No valid sidebands selected!"):
+        uv_in.read_mir(testfile, isb=-156)
 
-    with pytest.raises(IndexError, match="isb values contain invalid entries"):
-        uv_in.read_mir(testfile, isb=[-156])
+    with pytest.raises(ValueError, match="No valid spectral bands selected!"):
+        uv_in.read_mir(testfile, corrchunk=999)
 
 
 def test_read_mir_sideband_select():

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -12,15 +12,13 @@ data.
 import numpy as np
 
 
-def test_mir_parser_index_uniqueness(mir_data_object):
+def test_mir_parser_index_uniqueness(mir_data):
     """
     Mir index uniqueness check
 
     Make sure that there are no duplicate indicies for things that are primary keys
     for the various table-like structures that are used in MIR
     """
-    mir_data = mir_data_object
-
     inhid_list = mir_data.in_read["inhid"]
     assert np.all(np.unique(inhid_list) == sorted(inhid_list))
 
@@ -31,14 +29,12 @@ def test_mir_parser_index_uniqueness(mir_data_object):
     assert np.all(np.unique(sphid_list) == sorted(sphid_list))
 
 
-def test_mir_parser_index_valid(mir_data_object):
+def test_mir_parser_index_valid(mir_data):
     """
     Mir index validity check
 
     Make sure that all indexes are non-negative
     """
-    mir_data = mir_data_object
-
     assert np.all(mir_data.in_read["inhid"] >= 0)
 
     assert np.all(mir_data.bl_read["blhid"] >= 0)
@@ -46,13 +42,12 @@ def test_mir_parser_index_valid(mir_data_object):
     assert np.all(mir_data.sp_read["sphid"] >= 0)
 
 
-def test_mir_parser_index_linked(mir_data_object):
+def test_mir_parser_index_linked(mir_data):
     """
     Mir index link check
 
     Make sure that all referenced indicies have matching pairs in their parent tables
     """
-    mir_data = mir_data_object
     inhid_set = set(np.unique(mir_data.in_read["inhid"]))
 
     # Should not exist is has_auto=False
@@ -74,3 +69,321 @@ def test_mir_parser_index_linked(mir_data_object):
     blhid_set = set(np.unique(mir_data.bl_read["blhid"]))
 
     assert set(np.unique(mir_data.sp_read["blhid"])).issubset(blhid_set)
+
+
+def test_mir_parser_unload_data(mir_data):
+    """
+    Check that the unload_data function works as expected
+    """
+    attr_list = ["vis_data", "raw_data", "auto_data", "raw_scale_fac"]
+
+    for attr in attr_list:
+        assert getattr(mir_data, attr) is not None
+
+    mir_data.unload_data()
+
+    for attr in attr_list:
+        assert getattr(mir_data, attr) is None
+
+
+# Below are a series of checks that are designed to check to make sure that the
+# MirParser class is able to produce consistent values from an engineering data
+# set (originally stored in /data/engineering/mir_data/200724_16:35:14), to make
+# sure that we haven't broken the ability of the reader to handle the data. Since
+# this file is the basis for the above checks, we've put this here rather than in
+# test_mir_parser.py
+
+
+def test_mir_remember_me_record_lengths(mir_data):
+    """
+    Mir record length checker
+
+    Make sure the test file containts the right number of records
+    """
+    # Check to make sure we've got the right number of records everywhere
+
+    # ac_read only exists if has_auto=True
+    if mir_data.ac_read is not None:
+        assert len(mir_data.ac_read) == 2
+    else:
+        # This should only occur when has_auto=False
+        assert not mir_data._has_auto
+
+    assert len(mir_data.bl_read) == 4
+
+    assert len(mir_data.codes_read) == 99
+
+    assert len(mir_data.eng_read) == 2
+
+    assert len(mir_data.in_read) == 1
+
+    assert len(mir_data.raw_data) == 20
+
+    assert len(mir_data.raw_scale_fac) == 20
+
+    assert len(mir_data.sp_read) == 20
+
+    assert len(mir_data.vis_data) == 20
+
+    assert len(mir_data.we_read) == 1
+
+
+def test_mir_remember_me_codes_read(mir_data):
+    """
+    Mir codes_read checker.
+
+    Make sure that certain values in the codes_read file of the test data set match
+    whatwe know to be 'true' at the time of observations.
+    """
+    assert mir_data.codes_read[0][0] == b"filever"
+
+    assert mir_data.codes_read[0][2] == b"3"
+
+    assert mir_data.codes_read[90][0] == b"ref_time"
+
+    assert mir_data.codes_read[90][1] == 0
+
+    assert mir_data.codes_read[90][2] == b"Jul 24, 2020"
+
+    assert mir_data.codes_read[90][3] == 0
+
+    assert mir_data.codes_read[91][0] == b"ut"
+
+    assert mir_data.codes_read[91][1] == 1
+
+    assert mir_data.codes_read[91][2] == b"Jul 24 2020  4:34:39.00PM"
+
+    assert mir_data.codes_read[91][3] == 0
+
+    assert mir_data.codes_read[93][0] == b"source"
+
+    assert mir_data.codes_read[93][2] == b"3c84"
+
+    assert mir_data.codes_read[97][0] == b"ra"
+
+    assert mir_data.codes_read[97][2] == b"03:19:48.15"
+
+    assert mir_data.codes_read[98][0] == b"dec"
+
+    assert mir_data.codes_read[98][2] == b"+41:30:42.1"
+
+
+def test_mir_remember_me_in_read(mir_data):
+    """
+    Mir in_read checker.
+
+    Make sure that certain values in the in_read file of the test data set match what
+    we know to be 'true' at the time of observations, including that spare values are
+    stored as zero.
+    """
+    # Check to make sure that things seem right in in_read
+    assert np.all(mir_data.in_read["traid"] == 484)
+
+    assert np.all(mir_data.in_read["proid"] == 484)
+
+    assert np.all(mir_data.in_read["inhid"] == 1)
+
+    assert np.all(mir_data.in_read["ints"] == 1)
+
+    assert np.all(mir_data.in_read["souid"] == 1)
+
+    assert np.all(mir_data.in_read["isource"] == 1)
+
+    assert np.all(mir_data.in_read["ivrad"] == 1)
+
+    assert np.all(mir_data.in_read["ira"] == 1)
+
+    assert np.all(mir_data.in_read["idec"] == 1)
+
+    assert np.all(mir_data.in_read["epoch"] == 2000.0)
+
+    assert np.all(mir_data.in_read["tile"] == 0)
+
+    assert np.all(mir_data.in_read["obsflag"] == 0)
+
+    assert np.all(mir_data.in_read["obsmode"] == 0)
+
+    assert np.all(np.round(mir_data.in_read["mjd"]) == 59055)
+
+    assert np.all(mir_data.in_read["spareshort"] == 0)
+
+    assert np.all(mir_data.in_read["spareint6"] == 0)
+
+
+def test_mir_remember_me_bl_read(mir_data):
+    """
+    Mir bl_read checker.
+
+    Make sure that certain values in the bl_read file of the test data set match what
+    we know to be 'true' at the time of observations, including that spare values are
+    stored as zero.
+    """
+    # Now check bl_read
+    assert np.all(mir_data.bl_read["blhid"] == np.arange(1, 5))
+
+    assert np.all(mir_data.bl_read["isb"] == [0, 0, 1, 1])
+
+    assert np.all(mir_data.bl_read["ipol"] == [0, 0, 0, 0])
+
+    assert np.all(mir_data.bl_read["ant1rx"] == [0, 1, 0, 1])
+
+    assert np.all(mir_data.bl_read["ant2rx"] == [0, 1, 0, 1])
+
+    assert np.all(mir_data.bl_read["pointing"] == 0)
+
+    assert np.all(mir_data.bl_read["irec"] == [0, 3, 0, 3])
+
+    assert np.all(mir_data.bl_read["iant1"] == 1)
+
+    assert np.all(mir_data.bl_read["iant2"] == 4)
+
+    assert np.all(mir_data.bl_read["iblcd"] == 2)
+
+    assert np.all(mir_data.bl_read["spareint1"] == 0)
+
+    assert np.all(mir_data.bl_read["spareint2"] == 0)
+
+    assert np.all(mir_data.bl_read["spareint3"] == 0)
+
+    assert np.all(mir_data.bl_read["spareint4"] == 0)
+
+    assert np.all(mir_data.bl_read["spareint5"] == 0)
+
+    assert np.all(mir_data.bl_read["spareint6"] == 0)
+
+    assert np.all(mir_data.bl_read["sparedbl3"] == 0.0)
+
+    assert np.all(mir_data.bl_read["sparedbl4"] == 0.0)
+
+    assert np.all(mir_data.bl_read["sparedbl5"] == 0.0)
+
+    assert np.all(mir_data.bl_read["sparedbl6"] == 0.0)
+
+
+def test_mir_remember_me_eng_read(mir_data):
+    """
+    Mir bl_read checker.
+
+    Make sure that certain values in the eng_read file of the test data set match what
+    we know to be 'true' at the time of observations.
+    """
+    # Now check eng_read
+    assert np.all(mir_data.eng_read["antennaNumber"] == [1, 4])
+
+    assert np.all(mir_data.eng_read["padNumber"] == [5, 8])
+
+    assert np.all(mir_data.eng_read["trackStatus"] == 1)
+
+    assert np.all(mir_data.eng_read["commStatus"] == 1)
+
+    assert np.all(mir_data.eng_read["inhid"] == 1)
+
+
+def test_mir_remember_me_ac_read(mir_data):
+    """
+    Mir bl_read checker.
+
+    Make sure that certain values in the autoCorrelations file of the test data set
+    match what we know to be 'true' at the time of observations.
+    """
+    # Now check ac_read
+
+    # ac_read only exists if has_auto=True
+    if mir_data.ac_read is not None:
+
+        assert np.all(mir_data.ac_read["inhid"] == 1)
+
+        assert np.all(mir_data.ac_read["achid"] == np.arange(1, 3))
+
+        assert np.all(mir_data.ac_read["antenna"] == [1, 4])
+
+        assert np.all(mir_data.ac_read["nchunks"] == 8)
+
+        assert np.all(mir_data.ac_read["datasize"] == 1048596)
+
+        assert np.all(mir_data.we_read["scanNumber"] == 1)
+
+        assert np.all(mir_data.we_read["flags"] == 0)
+
+    else:
+        # This should only occur when has_auto=False
+        assert not mir_data._has_auto
+
+
+def test_mir_remember_me_sp_read(mir_data):
+    """
+    Mir sp_read checker.
+
+    Make sure that certain values in the sp_read file of the test data set match what
+    we know to be 'true' at the time of observations, including that spare values are
+    stored as zero.
+    """
+    # Now check sp_read
+    assert np.all(mir_data.sp_read["sphid"] == np.arange(1, 21))
+
+    assert np.all(mir_data.sp_read["sphid"] == np.arange(1, 21))
+
+    assert np.all(mir_data.sp_read["igq"] == 0)
+
+    assert np.all(mir_data.sp_read["ipq"] == 1)
+
+    assert np.all(mir_data.sp_read["igq"] == 0)
+
+    assert np.all(mir_data.sp_read["iband"] == [0, 1, 2, 3, 4] * 4)
+
+    assert np.all(mir_data.sp_read["ipstate"] == 0)
+
+    assert np.all(mir_data.sp_read["tau0"] == 0.0)
+
+    assert np.all(mir_data.sp_read["cabinLO"] == 0.0)
+
+    assert np.all(mir_data.sp_read["corrLO1"] == 0.0)
+
+    assert np.all(mir_data.sp_read["vradcat"] == 0.0)
+
+    assert np.all(mir_data.sp_read["nch"] == [4, 16384, 16384, 16384, 16384] * 4)
+
+    assert np.all(mir_data.sp_read["corrblock"] == [0, 1, 1, 1, 1] * 4)
+
+    assert np.all(mir_data.sp_read["corrchunk"] == [0, 1, 2, 3, 4] * 4)
+
+    assert np.all(mir_data.sp_read["correlator"] == 1)
+
+    assert np.all(mir_data.sp_read["spareint2"] == 0)
+
+    assert np.all(mir_data.sp_read["spareint3"] == 0)
+
+    assert np.all(mir_data.sp_read["spareint4"] == 0)
+
+    assert np.all(mir_data.sp_read["spareint5"] == 0)
+
+    assert np.all(mir_data.sp_read["spareint6"] == 0)
+
+    assert np.all(mir_data.sp_read["sparedbl1"] == 0.0)
+
+    assert np.all(mir_data.sp_read["sparedbl2"] == 0.0)
+
+    assert np.all(mir_data.sp_read["sparedbl3"] == 0.0)
+
+    assert np.all(mir_data.sp_read["sparedbl4"] == 0.0)
+
+    assert np.all(mir_data.sp_read["sparedbl5"] == 0.0)
+
+    assert np.all(mir_data.sp_read["sparedbl6"] == 0.0)
+
+
+def test_mir_remember_me_sch_read(mir_data):
+    """
+    Mir sch_read checker.
+
+    Make sure that certain values in the sch_read file of the test data set match what
+    we know to be 'true' at the time of observations.
+    """
+    # Now check sch_read related values. Thanks to a glitch in the data recorder,
+    # all of the pseudo-cont values are the same
+    assert np.all(mir_data.raw_scale_fac[0::5] == [-26] * 4)
+
+    assert (
+        np.array(mir_data.raw_data[0::5]).flatten().tolist()
+        == [-4302, -20291, -5261, -21128, -4192, -19634, -4999, -16346] * 4
+    )

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -10,6 +10,7 @@ python, not neccessarily how pyuvdata (by way of the UVData class) interacts wit
 data.
 """
 import numpy as np
+import pytest
 
 
 def test_mir_parser_index_uniqueness(mir_data):
@@ -84,6 +85,19 @@ def test_mir_parser_unload_data(mir_data):
 
     for attr in attr_list:
         assert getattr(mir_data, attr) is None
+
+
+@pytest.mark.parametrize("filter_type", ["use_in", "use_bl", "use_sp"])
+def test_mir_parser_update_filter(mir_data, filter_type):
+    """
+    Verify that filtering operations work as expected.
+    """
+    getattr(mir_data, filter_type)[:] = False
+    mir_data._update_filter()
+
+    attr_list = ["in_data", "bl_data", "eng_data", "sp_data", "ac_data"]
+    for attr in attr_list:
+        assert len(getattr(mir_data, attr)) == 0
 
 
 # Below are a series of checks that are designed to check to make sure that the

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -112,7 +112,7 @@ def test_mir_remember_me_record_lengths(mir_data):
     """
     Mir record length checker
 
-    Make sure the test file containts the right number of records
+    Make sure the test file contains the right number of records
     """
     # Check to make sure we've got the right number of records everywhere
 

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -714,9 +714,9 @@ def test_ms_weights(mir_uv, tmp_path):
     ms_uv = UVData()
     testfile = os.path.join(tmp_path, "out_ms_weights.ms")
 
-    mir_uv.nsample_array[0, 0, :, 0] = np.tile(
-        np.arange(mir_uv.Nfreqs / mir_uv.Nspws), mir_uv.Nspws,
-    )
+    mir_uv.nsample_array[0, 0, :, :] = np.tile(
+        np.arange(mir_uv.Nfreqs / mir_uv.Nspws), (mir_uv.Npols, mir_uv.Nspws)
+    ).T
     mir_uv.write_ms(testfile, clobber=True)
 
     tb_main = tables.table(testfile, readonly=False, ack=False)

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -94,6 +94,7 @@ def uvdata_props():
         "eq_coeffs",
         "eq_coeffs_convention",
         "flex_spw_id_array",
+        "flex_spw_polarization_array",
         "filename",
     ]
     extra_parameters = ["_" + prop for prop in extra_properties]

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -11332,3 +11332,24 @@ def test_add_pol_sorting_bl(casa_uvfits, add_type, sort_type, future_array_shape
 
     # Finally, make sure everything else lines up
     assert uv3 == casa_uvfits
+
+
+@pytest.mark.parametrize(
+    "pol_sel,err_msg",
+    [
+        [None, "Npols must be equal to 1 if flex_spw_polarization_array is set."],
+        [-5, "polarization_array must all be equal to 0 if flex_spw_polarization"],
+    ],
+)
+def test_flex_pol_errs(sma_mir, pol_sel, err_msg):
+    """
+    Test that appropriate errors are thrown when flex_spw_polarization_array is set
+    incorrectly.
+    """
+    sma_mir.select(polarizations=pol_sel)
+    sma_mir.flex_spw_polarization_array = sma_mir.spw_array
+
+    with pytest.raises(ValueError) as cm:
+        sma_mir.check()
+
+    assert str(cm.value).startswith(err_msg)

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3331,27 +3331,3 @@ def test_none_extra_keywords(uv_uvh5, tmp_path):
         assert h5f["Header/extra_keywords/foo"].shape is None
 
     return
-
-
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_flex_pol_roundtrip(sma_mir, future_shapes, tmp_path):
-    """Test that we can round-trip flex-pol data sets"""
-    sma_mir.flag_array[:, :, : sma_mir.Nfreqs // 2, 0] = True
-    sma_mir.flag_array[:, :, sma_mir.Nfreqs // 2 :, 1] = True
-    testfile = os.path.join(tmp_path, "flex_pol_roundtrip.uvh5")
-
-    if future_shapes:
-        sma_mir.use_future_array_shapes()
-
-    sma_mir._make_flex_pol()
-    sma_mir.write_uvh5(testfile)
-
-    test_uvh5 = UVData.from_file(testfile)
-
-    if future_shapes:
-        test_uvh5.use_future_array_shapes()
-
-    assert sma_mir.history != test_uvh5.history
-    sma_mir.history = test_uvh5.history = None
-
-    assert sma_mir == test_uvh5

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -62,24 +62,6 @@ def uv_partial_write(casa_uvfits, tmp_path):
     return
 
 
-@pytest.fixture(scope="session")
-def sma_mir_main():
-    # read in test file for the resampling in time functions
-    uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    uv_object.read(testfile)
-
-    yield uv_object
-
-
-@pytest.fixture(scope="function")
-def sma_mir(sma_mir_main):
-    # read in test file for the resampling in time functions
-    uv_object = sma_mir_main.copy()
-
-    yield uv_object
-
-
 def initialize_with_zeros(uvd, filename):
     """
     Make a uvh5 file with all zero values for data-sized arrays.

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2384,11 +2384,11 @@ class UVData(UVBase):
         """
         Convert a flex-pol UVData object into one with a standard polarization axis.
 
-        This is an internal helper function, which is not designed to be called by
-        users, but rather individual read/write functions for the UVData object.
         This will convert a flexible-polarization dataset into one with standard
-        polarization handling. Note that depending on how it is used, this can inflate
-        the size of data-like parameters by a factor of Nspws.
+        polarization handling, which is required for some operations or writing in
+        certain filetypes. Note that depending on how it is used, this can inflate
+        the size of data-like parameters by up to a factor of Nspws (the true value
+        depends on the number of unique entiries in `flex_spw_polarization_array`).
         """
         if self.flex_spw_polarization_array is None:
             # There isn't anything to do, so just move along
@@ -2439,7 +2439,28 @@ class UVData(UVBase):
         self.flex_spw_polarization_array = None
 
     def _make_flex_pol(self, raise_error=False, raise_warning=True):
-        """Convert a regular UVData object into one with flex-polarization enabled."""
+        """
+        Convert a regular UVData object into one with flex-polarization enabled.
+
+        This is an internal helper function, which is not designed to be called by
+        users, but rather individual read/write functions for the UVData object.
+        This will convert a regulat UVData object into one that uses flexible
+        polarization, which allows for each spectral window to have its own unique
+        polarization code, useful for storing data more compactly when different
+        windows have different polarizations recorded. Note that at this time,
+        only one polarization code per-spw is allowed -- if more than one polarization
+        is found to have unflagged data in a given spectral window, then the object
+        will not be converted.
+
+        Parameters
+        ----------
+        raise_error : bool
+            If an object cannot be converted to flex-pol, then raise a ValueError.
+            Default is False.
+        raise_warning : bool
+            If an object cannot be converted to flex-pol, and `raise_error=False`, then
+            raise a warning that the conversion failed. Default is True.
+        """
         if not self.flex_spw:
             msg = "Cannot make a flex-pol UVData object if flex_spw=False."
             if raise_error:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -382,6 +382,7 @@ class UVData(UVBase):
             description=desc,
             form=("Nspws",),
             expected_type=int,
+            acceptable_vals=list(np.arange(-8, 0)) + list(np.arange(1, 5)),
             required=False,
         )
 
@@ -2458,10 +2459,16 @@ class UVData(UVBase):
 
         # Check that usage of flex_spw_polarization_array follows the rule that each
         # window only has a single polarization per spectral window.
-        if self.Npols != 1 and self.flex_spw_polarization_array is not None:
-            raise ValueError(
-                "Npols must be equal to 1 if flex_spw_polarization_array is set."
-            )
+        if self.flex_spw_polarization_array is not None:
+            if self.Npols != 1:
+                raise ValueError(
+                    "Npols must be equal to 1 if flex_spw_polarization_array is set."
+                )
+            if np.any(self.polarization_array != 1):
+                raise ValueError(
+                    "polarization_array must all be equal to 1 if "
+                    "flex_spw_polarization_array is set."
+                )
 
         # require that all entries in ant_1_array and ant_2_array exist in
         # antenna_numbers

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2413,7 +2413,7 @@ class UVData(UVBase):
             if self.future_array_shapes:
                 del new_shape[1]
 
-            # Use fill here, since we want zeros if we are working with nsample_array
+            # Use full here, since we want zeros if we are working with nsample_array
             # or data_array, otherwise we want True if working w/ flag_array.
             new_param = np.full(new_shape, name == "flag_array", dtype=param.dtype)
 
@@ -2444,7 +2444,7 @@ class UVData(UVBase):
 
         This is an internal helper function, which is not designed to be called by
         users, but rather individual read/write functions for the UVData object.
-        This will convert a regulat UVData object into one that uses flexible
+        This will convert a regular UVData object into one that uses flexible
         polarization, which allows for each spectral window to have its own unique
         polarization code, useful for storing data more compactly when different
         windows have different polarizations recorded. Note that at this time,
@@ -2482,6 +2482,9 @@ class UVData(UVBase):
         for idx, spw in enumerate(self.spw_array):
             spw_screen = self.flex_spw_id_array == spw
 
+            # For each window, we want to check that there is only one poalrization with
+            # any unflagged data, which we can do by seeing if not all of the flags
+            # are set across the non-polarization axes (hence the ~np.all()).
             if self.future_array_shapes:
                 pol_check = ~np.all(self.flag_array[:, spw_screen], axis=(0, 1))
             else:
@@ -2522,8 +2525,9 @@ class UVData(UVBase):
 
         # Now go through one-by-one with data-like parameters and update
         for name, param in zip(self._data_params, self.data_like_parameters):
-            # Use fill here, since we want zeros if we are working with nsample_array
-            # or data_array, otherwise we want True if working w/ flag_array.
+            # We can use empty here, since we know that we will be filling all
+            # values of his array (and empty allows us to forgo the extra overhead
+            # of setting all the elements to a particular value).
             new_param = np.empty(new_shape, dtype=param.dtype)
 
             # Now we have to iterate through each spectral window

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -11516,7 +11516,7 @@ class UVData(UVBase):
             "flexible polarization", which compresses the polarization-axis of various
             attributes to be of length 1, sets the `flex_spw_polarization_array`
             attribute to define the polarization per spectral window. Only applicable
-            for MIR and MS filetypes, otherwise this argument is ignord. Default is
+            for MIR and MS filetypes, otherwise this argument is ignored. Default is
             True.
 
         Raises
@@ -12465,7 +12465,7 @@ class UVData(UVBase):
             "flexible polarization", which compresses the polarization-axis of various
             attributes to be of length 1, sets the `flex_spw_polarization_array`
             attribute to define the polarization per spectral window. Only applicable
-            for MIR and MS filetypes, otherwise this argument is ignord. Default is
+            for MIR and MS filetypes, otherwise this argument is ignored. Default is
             True.
 
         Raises

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -6349,7 +6349,7 @@ class UVData(UVBase):
                 raise ValueError(
                     "Cannot add a flex-pol and non-flex-pol UVData objects. Use "
                     "the `remove_flex_pol` method to convert the objects to "
-                    "have a regular polariztion axis."
+                    "have a regular polarization axis."
                 )
             elif this.flex_spw_polarization_array is not None:
                 this_flexpol_dict = {
@@ -10237,25 +10237,26 @@ class UVData(UVBase):
         """
         Read in data from an SMA MIR file.
 
-        Note that with the exception of filepath, the reset of the parameters are
-        used to sub-select a range of data that matches the limitations of the current
-        instantiation of pyuvdata  -- namely 1 spectral window, 1 source. These could
-        be dropped in the future, as pyuvdata capabilities grow.
+        Note that with the exception of filepath, the rest of the parameters are
+        used to sub-select a range of data.
 
         Parameters
         ----------
         filepath : str
              The file path to the MIR folder to read from.
         isource : int
-            Source code for MIR dataset
+            Source code for MIR dataset. The default is None, which selects all sources.
         irec : int
-            Receiver code for MIR dataset
+            Receiver code for MIR dataset. The default is None, which selects all
+            receivers.
         isb : int
-            Sideband code for MIR dataset
+            Sideband code for MIR dataset. The default is None, which selects both
+            sidebands.
         corrchunk : int
-            Correlator chunk code for MIR dataset
+            Correlator chunk code for MIR dataset. The default is None, which selects
+            all chunks.
         pseudo_cont : boolean
-            Read in only pseudo-continuuum values. Default is false.
+            Read in only the pseudo-continuuum values. Default is False.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after after reading in the file (the default is True,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -371,6 +371,20 @@ class UVData(UVBase):
             required=False,
         )
 
+        desc = (
+            "Optional, only used if flex_spw = True. Allows for labeling individual "
+            "spectral windows with different polarizations. If set, Npols must be set "
+            "to 1 (i.e., only one polarization per spectral window allowed). Shape "
+            "(Nspws), type = int."
+        )
+        self._flex_spw_polarization_array = uvp.UVParameter(
+            "flex_spw_polarization_array",
+            description=desc,
+            form=("Nspws",),
+            expected_type=int,
+            required=False,
+        )
+
         desc = "Flag indicating that this object is using the future array shapes."
         self._future_array_shapes = uvp.UVParameter(
             "future_array_shapes", description=desc, expected_type=bool, value=False,
@@ -2440,6 +2454,13 @@ class UVData(UVBase):
             raise ValueError(
                 "Ntimes must be equal to the number of unique "
                 "times in the time_array"
+            )
+
+        # Check that usage of flex_spw_polarization_array follows the rule that each
+        # window only has a single polarization per spectral window.
+        if self.Npols != 1 and self.flex_spw_polarization_array is not None:
+            raise ValueError(
+                "Npols must be equal to 1 if flex_spw_polarization_array is set."
             )
 
         # require that all entries in ant_1_array and ant_2_array exist in

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -8374,14 +8374,7 @@ class UVData(UVBase):
                         "polarization_array".format(p=p)
                     )
 
-            if len(pol_inds) > 2:
-                if not uvutils._test_array_constant_spacing(pol_inds):
-                    warnings.warn(
-                        "Selected polarization values are not evenly spaced. This "
-                        "will make it impossible to write this data out to "
-                        "some file types"
-                    )
-            elif len(spw_inds) > 0:
+            if len(spw_inds) > 0:
                 # Since this is a flex-pol data set, we need to filter on the freq
                 # axis instead of the pol axis
                 pol_inds = None
@@ -8415,6 +8408,16 @@ class UVData(UVBase):
                         "will make it impossible to write this data out to "
                         "some file types"
                     )
+            else:
+                pol_inds = np.unique(pol_inds)
+                if len(pol_inds) > 2:
+                    if not uvutils._test_array_constant_spacing(pol_inds):
+                        warnings.warn(
+                            "Selected polarization values are not evenly spaced. This "
+                            "will make it impossible to write this data out to "
+                            "some file types"
+                        )
+                pol_inds = pol_inds.tolist()
         else:
             pol_inds = None
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -226,7 +226,7 @@ class UVData(UVBase):
             "polarization_array",
             description=desc,
             expected_type=int,
-            acceptable_vals=list(np.arange(-8, 0)) + list(np.arange(1, 5)),
+            acceptable_vals=list(np.arange(-8, 5)),
             form=("Npols",),
         )
 
@@ -2464,9 +2464,9 @@ class UVData(UVBase):
                 raise ValueError(
                     "Npols must be equal to 1 if flex_spw_polarization_array is set."
                 )
-            if np.any(self.polarization_array != 1):
+            if np.any(self.polarization_array != 0):
                 raise ValueError(
-                    "polarization_array must all be equal to 1 if "
+                    "polarization_array must all be equal to 0 if "
                     "flex_spw_polarization_array is set."
                 )
 
@@ -9964,6 +9964,11 @@ class UVData(UVBase):
         isb=None,
         corrchunk=None,
         pseudo_cont=False,
+        run_check=True,
+        check_extra=True,
+        run_check_acceptability=True,
+        strict_uvw_antpos_check=False,
+        allow_flex_pol=True,
     ):
         """
         Read in data from an SMA MIR file.
@@ -9987,6 +9992,27 @@ class UVData(UVBase):
             Correlator chunk code for MIR dataset
         pseudo_cont : boolean
             Read in only pseudo-continuuum values. Default is false.
+        run_check : bool
+            Option to check for the existence and proper shapes of parameters
+            after after reading in the file (the default is True,
+            meaning the check will be run). Ignored if read_data is False.
+        check_extra : bool
+            Option to check optional parameters as well as required ones (the
+            default is True, meaning the optional parameters will be checked).
+            Ignored if read_data is False.
+        run_check_acceptability : bool
+            Option to check acceptable range of the values of parameters after
+            reading in the file (the default is True, meaning the acceptable
+            range check will be done). Ignored if read_data is False.
+        strict_uvw_antpos_check : bool
+            Option to raise an error rather than a warning if the check that
+            uvws match antenna positions does not pass.
+        allow_flex_pol : bool
+            If only one polarization per spectral window is read (and the polarization
+            differs from window to window), allow for the `UVData` object to use
+            "flexible polarization", which compresses the polarization-axis of various
+            attributes to be of length 1, sets the `flex_spw_polarization_array`
+            attribute to define the polarization per spectral window.  Default is True.
         """
         from . import mir
 
@@ -9998,6 +10024,11 @@ class UVData(UVBase):
             isb=isb,
             corrchunk=corrchunk,
             pseudo_cont=pseudo_cont,
+            run_check=run_check,
+            check_extra=check_extra,
+            run_check_acceptability=run_check_acceptability,
+            strict_uvw_antpos_check=strict_uvw_antpos_check,
+            allow_flex_pol=allow_flex_pol,
         )
         self._convert_from_filetype(mir_obj)
         del mir_obj
@@ -10165,6 +10196,7 @@ class UVData(UVBase):
         ignore_single_chan=True,
         raise_error=True,
         read_weights=True,
+        allow_flex_pol=True,
     ):
         """
         Read in data from a measurement set.
@@ -10221,6 +10253,12 @@ class UVData(UVBase):
         read_weights : bool
             Read in the weights from the MS file, default is True. If false, the method
             will set the `nsamples_array` to the same uniform value (namely 1.0).
+        allow_flex_pol : bool
+            If only one polarization per spectral window is read (and the polarization
+            differs from window to window), allow for the `UVData` object to use
+            "flexible polarization", which compresses the polarization-axis of various
+            attributes to be of length 1, sets the `flex_spw_polarization_array`
+            attribute to define the polarization per spectral window.  Default is True.
 
         Raises
         ------
@@ -10255,6 +10293,7 @@ class UVData(UVBase):
             ignore_single_chan=ignore_single_chan,
             raise_error=raise_error,
             read_weights=read_weights,
+            allow_flex_pol=allow_flex_pol,
         )
         self._convert_from_filetype(ms_obj)
         del ms_obj
@@ -10922,6 +10961,7 @@ class UVData(UVBase):
         fix_use_ant_pos=True,
         make_multi_phase=False,
         ignore_name=False,
+        allow_flex_pol=True,
     ):
         """
         Read a generic file into a UVData object.
@@ -11201,6 +11241,14 @@ class UVData(UVBase):
             combining multiple files, which would otherwise result in an error being
             raised because of attributes not matching. Doing so effectively adopts the
             name found in the first file read in. Default is False.
+        allow_flex_pol : bool
+            If only one polarization per spectral window is read (and the polarization
+            differs from window to window), allow for the `UVData` object to use
+            "flexible polarization", which compresses the polarization-axis of various
+            attributes to be of length 1, sets the `flex_spw_polarization_array`
+            attribute to define the polarization per spectral window. Only applicable
+            for MIR and MS filetypes, otherwise this argument is ignord. Default is
+            True.
 
         Raises
         ------
@@ -11336,6 +11384,7 @@ class UVData(UVBase):
                         fix_old_proj=fix_old_proj,
                         fix_use_ant_pos=fix_use_ant_pos,
                         make_multi_phase=make_multi_phase,
+                        allow_flex_pol=allow_flex_pol,
                     )
                     unread = False
                 except KeyError as err:
@@ -11419,6 +11468,7 @@ class UVData(UVBase):
                             fix_old_proj=fix_old_proj,
                             fix_use_ant_pos=fix_use_ant_pos,
                             make_multi_phase=make_multi_phase,
+                            allow_flex_pol=allow_flex_pol,
                         )
                         uv_list.append(uv2)
                     except KeyError as err:
@@ -11616,6 +11666,11 @@ class UVData(UVBase):
                     isb=isb,
                     corrchunk=corrchunk,
                     pseudo_cont=pseudo_cont,
+                    run_check=run_check,
+                    check_extra=check_extra,
+                    run_check_acceptability=run_check_acceptability,
+                    strict_uvw_antpos_check=strict_uvw_antpos_check,
+                    allow_flex_pol=allow_flex_pol,
                 )
                 select = False
 
@@ -11692,6 +11747,7 @@ class UVData(UVBase):
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability,
                     strict_uvw_antpos_check=strict_uvw_antpos_check,
+                    allow_flex_pol=allow_flex_pol,
                 )
 
             elif file_type == "uvh5":
@@ -11854,6 +11910,7 @@ class UVData(UVBase):
         fix_use_ant_pos=True,
         make_multi_phase=False,
         ignore_name=False,
+        allow_flex_pol=True,
     ):
         """
         Initialize a new UVData object by reading the input file.
@@ -12133,6 +12190,14 @@ class UVData(UVBase):
             combining multiple files, which would otherwise result in an error being
             raised because of attributes not matching. Doing so effectively adopts the
             name found in the first file read in. Default is False.
+        allow_flex_pol : bool
+            If only one polarization per spectral window is read (and the polarization
+            differs from window to window), allow for the `UVData` object to use
+            "flexible polarization", which compresses the polarization-axis of various
+            attributes to be of length 1, sets the `flex_spw_polarization_array`
+            attribute to define the polarization per spectral window. Only applicable
+            for MIR and MS filetypes, otherwise this argument is ignord. Default is
+            True.
 
         Raises
         ------
@@ -12213,6 +12278,7 @@ class UVData(UVBase):
             fix_use_ant_pos=fix_use_ant_pos,
             make_multi_phase=make_multi_phase,
             ignore_name=ignore_name,
+            allow_flex_pol=allow_flex_pol,
         )
         return uvd
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -232,6 +232,8 @@ class UVH5(UVData):
                 self._set_flex_spw()
         if "flex_spw_id_array" in header:
             self.flex_spw_id_array = header["flex_spw_id_array"][:]
+        if "flex_spw_polarization_array" in header:
+            self.flex_spw_polarization_array = header["flex_spw_polarization_array"][:]
         if "multi_phase_center" in header:
             if bool(header["multi_phase_center"][()]):
                 self._set_phased()
@@ -1065,6 +1067,8 @@ class UVH5(UVData):
             header["eq_coeffs_convention"] = np.string_(self.eq_coeffs_convention)
         if self.flex_spw_id_array is not None:
             header["flex_spw_id_array"] = self.flex_spw_id_array
+        if self.flex_spw_polarization_array is not None:
+            header["flex_spw_polarization_array"] = self.flex_spw_polarization_array
         if self.phase_center_id_array is not None:
             header["phase_center_id_array"] = self.phase_center_id_array
         if self.Nphase is not None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added a new feature, which I've termed "flexible polarization handling", has been added to the `UVData` object. This new feature leverages a new, optional attribute called `flex_spw_polarization_array`, which enables one to encode a different polarization type for each spectral window. When this value is set to something other than `None`, `polarization_array` is set to be equal to `[0]`.
- Added New methods `_make_flex_pol` and `remove_flex_pol` have been added to allow one to convert back/forth from "flex-pol" to "regular" `UVData` objects, when needed.
- Overhauled the `mir` and `mir_parser` objects, allowing them to process much faster and enabling one to read in multiple polarization types simultaneously (currently only one polarization type supported on each read), and enabling first-order flux calibration (moving `vis_units` from "uncalib" to "Jy").

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
After some discussion within the SMA user community, we determined that some changes were needed with the way that pyuvdata handles MIR data in order to enable "full" handling of SMA data for science users (i.e., moving MIR support from "beta" to v1.0). This PR covers approximately one-third of the desired functionality, which we expect should be sufficient for end-to-end handling of continuum data (a subsequent PR will deal with what's required for spectral line observations). 

**Changes to `mir` and `mir_parser`**

Beyond a reorganization of internal functions, the most significant addition to `mir_parser` is the addition of the `_apply_tsys` method, which will convert visibilities (normally recorded in correlator coefficients) from uncalibrated units to Jy units. As currently written, `_apply_tsys` will be called when working with the "normal"/floating-point visibility values, but not the "raw"/compressed/integer values. `mir` has had a significant rewrite to improve both the speed at which a `MirParser` object is converted into a `UVData` object, and to enable more than one polarization mode to be passed at any given time. Additionally, `mir` has been modified so that one can instantiate a `UVData` object from _either_ a file name or a `MirParser` object.

**Changes to `UVData`**

The most significant addition to `UVData` has been the addition of "flexible-polarization" handling, which allows for different spectral windows to have different polarizations (currently only one polarization allowed per-window). The primary benefit of allowing this is that one can more efficiently store data when different windows sparsely populate the polarization axis (as is the case for SMA, which can separately tune its X- and Y-polarization receivers). These per-window polarization values are stored in a new, optional attribute called `flex_spw_polarization_array` (which would also nominally be added to the UVH5 format). I have attempted to implement flex-pol in such a way that it ought to be seamless for most users to use -- the only current method that might require a user to "remove" this new feature is the `__add__` method, which does not nominally allow for "flex-pol" and "regular" data sets to be added together.

Closes #1076

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
