### PR TITLE
Measurement set `TIME_CENTROID` field fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ calls to JPL Horizons.
 - Improved readability, functionality, and memory usage in `read_mwa_corr_fits`.
 
 ### Fixed
+- A bug where the `TIME_CENTROID` field was not being filled in data sets written by
+  `UVData.write_ms`, which caused odd behavior in some CASA routines (e.g., `gaincal`).
 - A bug in reading in uvfits files with baseline coordinates that have suffixes of
 '---SIN' or '---NCP' which are allowed in uvfits files.
 - A bug that could cause some routines in CASA to fail when using data sets written by

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1236,6 +1236,7 @@ class MS(UVData):
         ms.putcol("DATA_DESC_ID", data_desc_array)
         ms.putcol("SCAN_NUMBER", scan_number_array)
         ms.putcol("TIME", time_array)
+        ms.putcol("TIME_CENTROID", time_array)
 
         # FITS uvw direction convention is opposite ours and Miriad's.
         # CASA's convention is unclear: the docs contradict themselves,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Updates `UVData.write_ms` to fill in the field `TIME_CENTROID` in the main table, which some routines in CASA use (in lieu of `TIME`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The above is a minor fix to an issue in CASA, where some routines -- namely those related to gains calibration -- use a different column for marking time than the routines that we had tested thusfar (e.g., `tclean`).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
