### PR TITLE
Fixing conjugation issue in `compress_by_redundancy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 - Added `time_range`, `lsts`, and `lst_range` kwargs from UVH5.write_uvh5_part() to UVData.write_uvh5_part().
 
 ### Fixed
+- Fixed a bug where `UVData.compress_by_redundancy` sometimes produced incorrectly
+  conjugated visibilities.
 - Fixed a bug where `lsts` and `lst_range` got ignored when doing partial i/o with multiple files.
 
 ## [2.2.5] - 2021-12-21

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -6286,8 +6286,13 @@ def test_redundancy_contract_expand(
         for bl in gp:
             inds = np.where(bl == uv0.baseline_array)
             uv0.data_array[inds] *= 0
-            uv0.data_array[inds] += complex(gp_ind)
+            # Make this data complex so that we can track phase issues
+            uv0.data_array[inds] += complex(1 + gp_ind, 1 - gp_ind)
         index_bls.append(gp[0])
+
+    # Data in the conjugated list, make sure that we manually conjugate here
+    conj_mask = np.isin(uv0.baseline_array, conjugates)
+    uv0.data_array[conj_mask] = np.conj(uv0.data_array[conj_mask])
 
     if flagging_level == "none":
         assert np.all(~uv0.flag_array)

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -9614,6 +9614,12 @@ class UVData(UVBase):
             new_obj.select(bls=bl_ants, keep_all_metadata=keep_all_metadata)
 
             if not self.metadata_only:
+                # If the baseline is in the "conjugated" list, we will need to
+                # fix the conjugation on assignment (since the visibilities are
+                # tabulated assuming that the baseline position is on the opposite
+                # side of the uvw origin).
+                fix_conj = np.isin(new_obj.baseline_array, conjugates)
+
                 # initalize the data like arrays
                 if new_obj.future_array_shapes:
                     temp_data_array = np.zeros(
@@ -9767,8 +9773,14 @@ class UVData(UVBase):
                         )
                         avg_nsample = np.sum(nsample_to_avg, axis=0)
                         avg_flag = np.all(flags_to_avg, axis=0)
-
                         temp_data_array[this_obj_ind] = avg_vis
+
+                        # If we need to flip the conjugation, to that on the
+                        # value assignment here.
+                        if fix_conj[this_obj_ind]:
+                            temp_data_array[this_obj_ind] = np.conj(avg_vis)
+                        else:
+                            temp_data_array[this_obj_ind] = avg_vis
                         temp_nsample_array[this_obj_ind] = avg_nsample
                         temp_flag_array[this_obj_ind] = avg_flag
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Bugfix for `compress_by_redundancy`.

## Description
<!--- Describe your changes in detail -->
- The UVData method `compress_by_redundancy` now checks to see if, after compression, a given baseline lands on the "conjugate" side of the uv-plane (basically u < 0).
- The test `test_redundancy_contract_expand` now uses complex visibility data (with non-zero imaginary components) for testing.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This PR fixes a bug that caused `compress_by_redundancy` to sometimes return incorrectly conjugated data. The root issue at play was that when averaging data together, the method assumes that the given baseline lands on the u>0 side of the uv-plane, which would give problems if after grouping the "lead" baseline landed on the opposite side (u < 0). Earlier test coverage missed this in part because the tests were using real-only data.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).