### PR TITLE
Add option to `reorder_blts` to sort autos first 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- An option to `UVData.reorder_blts` to sort the autos before the crosses.
 - Added new functionality to `UVData.check` to verify that auto-correlations are real-only,
 along with an option to force them to be real-only if non-zero imaginary components are detected.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1469,7 +1469,8 @@ b) Sorting along the baseline-time axis
 The :meth:`~pyuvdata.UVData.reorder_blts` method will reorder the baseline-time axis by
 sorting by ``'time'``, ``'baseline'``, ``'ant1'`` or ``'ant2'`` or according to an order
 preferred for data that have baseline dependent averaging ``'bda'``. A user can also
-just specify a desired order by passing an array of baseline-time indices.
+just specify a desired order by passing an array of baseline-time indices. There is also
+an option to sort the auto visibilitiess before the cross visibilities (``autos_first``).
 
 .. code-block:: python
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add an option to `reorder_blts` to sort the auto visibilities before the cross visibilities.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #824 
closes #911 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
