### PR TITLE
Remove distutils calls that are throwing deprecation warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ import platform
 from setuptools import setup, Extension, find_namespace_packages
 
 import numpy
-from distutils.sysconfig import get_config_var
-from distutils.version import LooseVersion
+from sysconfig import get_config_var
+from packaging.version import parse
 from Cython.Build import cythonize
 
 # add pyuvdata to our path in order to use the branch_scheme function
@@ -38,9 +38,9 @@ def is_platform_windows():
 # implementation based on pandas, see https://github.com/pandas-dev/pandas/issues/23424
 if is_platform_mac():
     if "MACOSX_DEPLOYMENT_TARGET" not in os.environ:
-        current_system = LooseVersion(platform.mac_ver()[0])
-        python_target = LooseVersion(get_config_var("MACOSX_DEPLOYMENT_TARGET"))
-        if python_target < "10.9" and current_system >= "10.9":
+        current_system = parse(platform.mac_ver()[0])
+        python_target = parse(get_config_var("MACOSX_DEPLOYMENT_TARGET"))
+        if python_target < parse("10.9") and current_system >= parse("10.9"):
             os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
 
 # define the cython compile args, depending on platform


### PR DESCRIPTION
Distutils is being deprecated, see https://www.python.org/dev/peps/pep-0632/

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace distutils calls in setup.py with the recommended replacements.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Distutils is being deprecated, see https://www.python.org/dev/peps/pep-0632/
New deprecation warnings are breaking PRs on pyuvsim (e.g. https://github.com/RadioAstronomySoftwareGroup/pyuvsim/pull/379)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
