### PR TITLE
Improve the documentation on redundancy finding, make keywords consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ along with an option to force them to be real-only if non-zero imaginary compone
 - `UVFlag.to_baseline()` uses internal time tolerances (both rtol and atol) stored in the UVParameter
   `_time_array.tols` to check whether times in the UVFlag object and the input UVFlag/UVData object match.
 
+### Deprecated
+- The `with_conjugates` keyword in favor of the `include_conjugates` keyword in the
+`utils.get_baseline_redundancies` function.
+
 ## [2.2.6] - 2022-01-12
 
 ### Added

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1584,7 +1584,7 @@ redundant groups of baselines in an array, either by antenna positions or uvw
 coordinates. Baselines are considered redundant if they are within a specified tolerance
 distance (default is 1 meter).
 
-The default behavior is to use ``uvw_array`` on the object (representing the baselines
+The default behavior is to use the ``uvw_array`` on the object (representing the baselines
 that have data on the object) to find redundancies among the uvw vectors. If the
 ``include_conjugates`` option is set, it will include baselines that are redundant when
 reversed in the same group. In this case, a list of ``conjugates`` is returned as well,
@@ -1595,7 +1595,7 @@ redundancies instead of the ``uvw_array``. This can result in different behavior
 all possible redundant baselines will be returned, not just the ones with data on the
 object. In this case, the baselines are defined in the u>0 convention, so some of the
 baselines may be conjugated relative to the baselines with data on the object. If the
-``conjugate_bls`` keyword is set, it will also update baseline conjugation on the object
+``conjugate_bls`` keyword is set, it will also update the baseline conjugation on the object
 so that the baselines in the returned groups correspond with the baselines listed on the
 object (except for antenna pairs with no associated data).
 

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -2201,14 +2201,17 @@ def test_redundancy_finder():
     # Check with conjugated baseline redundancies returned
     # Ensure at least one baseline has u==0 and v!=0 (for coverage of this case)
     bl_positions[16, 0] = 0
-    (
-        baseline_groups,
-        vec_bin_centers,
-        lens,
-        conjugates,
-    ) = uvutils.get_baseline_redundancies(
-        uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True
-    )
+    with uvtest.check_warnings(
+        DeprecationWarning, "The with_conjugates keyword is deprecated"
+    ):
+        (
+            baseline_groups,
+            vec_bin_centers,
+            lens,
+            conjugates,
+        ) = uvutils.get_baseline_redundancies(
+            uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True
+        )
 
     # restore baseline (16,0) and repeat to get correct groups
     bl_positions = bl_pos_backup
@@ -2218,7 +2221,7 @@ def test_redundancy_finder():
         lens,
         conjugates,
     ) = uvutils.get_baseline_redundancies(
-        uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True
+        uvd.baseline_array, bl_positions, tol=tol, include_conjugates=True
     )
 
     # Apply flips to compare with get_antenna_redundancies().
@@ -2266,7 +2269,7 @@ def test_high_tolerance_redundancy_error():
             lens,
             conjugates,
         ) = uvutils.get_baseline_redundancies(
-            uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True
+            uvd.baseline_array, bl_positions, tol=tol, include_conjugates=True
         )
     assert "Some baselines are falling into" in str(cm.value)
 
@@ -2299,7 +2302,7 @@ def test_redundancy_conjugates():
         if uneg or (uzer and vneg) or (uzer and vzer and wneg):
             expected_conjugates.append(bl_inds[i])
     bl_gps, vecs, lens, conjugates = uvutils.get_baseline_redundancies(
-        bl_inds, bl_vecs, tol=tol, with_conjugates=True
+        bl_inds, bl_vecs, tol=tol, include_conjugates=True
     )
 
     assert sorted(conjugates) == sorted(expected_conjugates)
@@ -2320,7 +2323,7 @@ def test_redundancy_finder_fully_redundant_array():
         lens,
         conjugates,
     ) = uvutils.get_baseline_redundancies(
-        uvd.baseline_array, bl_positions, tol=tol, with_conjugates=True
+        uvd.baseline_array, bl_positions, tol=tol, include_conjugates=True
     )
 
     # Only 1 set of redundant baselines

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -3544,7 +3544,7 @@ def find_clusters(location_ids, location_vectors, tol, strict=False):
 
 
 def get_baseline_redundancies(
-    baselines, baseline_vecs, tol=1.0, with_conjugates=False, include_conjugates=False,
+    baselines, baseline_vecs, tol=1.0, include_conjugates=False, with_conjugates=False
 ):
     """
     Find redundant baseline groups.

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -9857,7 +9857,7 @@ class UVData(UVBase):
         baselines = np.take(self.baseline_array, unique_inds)
 
         return uvutils.get_baseline_redundancies(
-            baselines, baseline_vecs, tol=tol, with_conjugates=include_conjugates
+            baselines, baseline_vecs, tol=tol, include_conjugates=include_conjugates
         )
 
     def compress_by_redundancy(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Deprecate the `with_conjugates` keyword in `utils.get_baseline_redundancies` in favor of `include_conjugates` to match the `UVData.get_redundancies` method.
- Update the tutorial to emphasize the UVData method as preferred over the utility functions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #893

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change (documentation changes only)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Breaking change checklist:
- [x] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to reflect my changes (if appropriate).
- [x] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Documentation change checklist:
- [x] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)
