### PR TITLE
Add time_atol parameter to UVFlag.to_baseline()

### DIFF
--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -1015,7 +1015,6 @@ class UVFlag(UVBase):
         self,
         method="quadmean",
         keep_pol=True,
-        time_atol=0.0,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -1033,10 +1032,6 @@ class UVFlag(UVBase):
             than one polarization, the resulting polarization_array
             will be a single element array with a comma separated string
             encoding the original polarizations.
-        time_atol : float
-            Absolute tolerance in units of time (usually JD) to consider two
-            times to be identical when matching times in this UVFlag object to
-            times in the input uv. Default 0.0 means they must be exactly equal.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after converting to waterfall type.
@@ -1085,7 +1080,7 @@ class UVFlag(UVBase):
             if return_weights_square:
                 ws = np.zeros((Nt, Nf, Np))
             for i, t in enumerate(np.unique(self.time_array)):
-                ind = np.isclose(self.time_array, t, atol=time_atol, rtol=0.0)
+                ind = self.time_array == t
                 if self.mode == "metric":
                     _weights = self.weights_array[ind, :, :]
                 else:

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -1137,6 +1137,7 @@ class UVFlag(UVBase):
         self,
         uv,
         force_pol=False,
+        time_atol=0.0,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -1155,6 +1156,10 @@ class UVFlag(UVBase):
             Otherwise, will require polarizations match.
             For example, this keyword is useful if one flags on all
             pols combined, and wants to broadcast back to individual pols.
+        time_atol : float
+            Absolute tolerance in units of time (usually JD) to consider two
+            times to be identical when matching times in this UVFlag object to
+            times in the input uv. Default 0.0 means they must be exactly equal.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after converting to baseline type.
@@ -1225,7 +1230,7 @@ class UVFlag(UVBase):
                     warr = np.zeros_like(uv.flag_array, dtype=np.float64)
                 sarr = self.metric_array
             for i, t in enumerate(np.unique(self.time_array)):
-                ti = np.where(uv.time_array == t)
+                ti = np.where(np.isclose(uv.time_array, t, atol=time_atol, rtol=0.0))
                 arr[ti, :, :, :] = sarr[i, :, :][np.newaxis, np.newaxis, :, :]
                 if self.mode == "metric":
                     warr[ti, :, :, :] = self.weights_array[i, :, :][
@@ -1261,9 +1266,13 @@ class UVFlag(UVBase):
                 )
 
                 for t_index, bl in enumerate(uv.baseline_array):
-                    uvf_t_index = np.nonzero(uv.time_array[t_index] == self.time_array)[
-                        0
-                    ]
+                    uvf_t_index = np.nonzero(
+                        np.isclose(
+                            uv.time_array[t_index] == self.time_array,
+                            atol=time_atol,
+                            rtol=0.0,
+                        )
+                    )[0]
                     if uvf_t_index.size > 0:
                         # if the time is found in the array
                         # input the or'ed data from each antenna

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -1015,6 +1015,7 @@ class UVFlag(UVBase):
         self,
         method="quadmean",
         keep_pol=True,
+        time_atol=0.0,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -1032,6 +1033,10 @@ class UVFlag(UVBase):
             than one polarization, the resulting polarization_array
             will be a single element array with a comma separated string
             encoding the original polarizations.
+        time_atol : float
+            Absolute tolerance in units of time (usually JD) to consider two
+            times to be identical when matching times in this UVFlag object to
+            times in the input uv. Default 0.0 means they must be exactly equal.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after converting to waterfall type.
@@ -1080,7 +1085,7 @@ class UVFlag(UVBase):
             if return_weights_square:
                 ws = np.zeros((Nt, Nf, Np))
             for i, t in enumerate(np.unique(self.time_array)):
-                ind = self.time_array == t
+                ind = np.isclose(self.time_array, t, atol=time_atol, rtol=0.0)
                 if self.mode == "metric":
                     _weights = self.weights_array[ind, :, :]
                 else:


### PR DESCRIPTION
## Description
This PR add absolute tolerance parameters to UVFlag's functions that transforms the object to baseline type.

## Motivation and Context
Changing a waterfall-type UVFlag tobject to baseline-type is done by providing another UVFlag or UVData object. In `hera_qm.xrfi` we have found an issue where if the UVFlag object was created using a UVCal object read from calfits, the times might be mismatched from the corresponding times in the UVData object by ~1e-10 days due to rounds errors. This causes flags generated from median filters to be inconsistently applied before mean filters, leading to subsequent overflagging that @ele-rath and I tracked down. This PR should not change the default behavior of pyuvdata, but it should allow us to easily fix that with a single extra kwarg.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Breaking change checklist:
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
