### PR TITLE
Make handling of types in Miriad extra_keywords more general

### DIFF
--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -1860,20 +1860,6 @@ class Miriad(UVData):
         # vectors.  This is not supported at present!
         # NB: complex numbers *should* be supportable, but are not currently
         # supported due to unexplained errors in _miriad and/or its underlying libraries
-        numpy_types = {
-            np.int8: int,
-            np.int16: int,
-            np.int32: int,
-            np.int64: int,
-            np.uint8: int,
-            np.uint16: int,
-            np.uint32: int,
-            np.uint64: int,
-            np.float16: float,
-            np.float32: float,
-            np.float64: float,
-            np.float128: float,
-        }
         types = {
             str: "a",
             int: "i",
@@ -1881,14 +1867,20 @@ class Miriad(UVData):
             bool: "a",  # booleans are stored as strings and changed back on read
         }
         for key, value in self.extra_keywords.items():
-            if isinstance(value, tuple(numpy_types.keys())):
-                if numpy_types[type(value)] == int:
+            raise_type_error = False
+            if isinstance(value, np.number):
+                if issubclass(value.dtype.type, np.integer):
                     value = int(value)
-                elif numpy_types[type(value)] == float:
+                elif issubclass(value.dtype.type, np.floating):
                     value = float(value)
+                elif issubclass(value.dtype.type, np.complexfloating):
+                    raise_type_error = True
             elif type(value) == bool:
                 value = str(value)
             elif type(value) not in types.keys():
+                raise_type_error = True
+
+            if raise_type_error:
                 raise TypeError(
                     "Extra keyword {keyword} is of {keytype}. "
                     "Only strings and real numbers are "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When deciding how to write out entries in the `extra_keywords` dictionary to Miriad, we were using a dictionary that contained explicitly numpy types in it. This makes the type checking slightly more flexible, and does not rely on explicit enumeration of various types.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Closes #1131.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
