### PR TITLE
Use pytest < 7 because of conflict with pytest-cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ To compile the binary extension modules such that you can successfully run
 If you want to do development on pyuvdata, in addition to the other dependencies
 you will need the following packages:
 
-* pytest >= 6.2
+* pytest >= 6.2,<7.0
 * pytest-cases >= 3
 * pytest-xdist
 * pytest-cov

--- a/ci/azure-piplines.yml
+++ b/ci/azure-piplines.yml
@@ -22,7 +22,7 @@ jobs:
       cd hera_cal
       pip install --no-deps .
       mkdir test-reports
-      python -m pytest hera_cal --junitxml=test-reports/xunit.xml
+      python -m pytest hera_cal -n auto --junitxml=test-reports/xunit.xml
     displayName: run hera_cal tests
 
 - job: hera_qm
@@ -48,5 +48,5 @@ jobs:
       cd hera_qm
       pip install --no-deps .
       mkdir test-reports
-      python -m pytest hera_qm --junitxml=test-reports/xunit.xml
+      python -m pytest hera_qm -n auto --junitxml=test-reports/xunit.xml
     displayName: run hera_qm tests

--- a/ci/hera_cal.yml
+++ b/ci/hera_cal.yml
@@ -26,3 +26,4 @@ dependencies:
     - git+https://github.com/HERA-Team/hera_sim.git
     - pyuvsim
     - pyradiosky
+    - pytest-xdist

--- a/ci/hera_qm.yml
+++ b/ci/hera_qm.yml
@@ -20,3 +20,4 @@ dependencies:
     - git+https://github.com/HERA-Team/omnical.git
     - git+https://github.com/HERA-Team/uvtools.git
     - git+https://github.com/HERA-Team/hera_cal.git
+    - pytest-xdist

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -9,7 +9,7 @@ dependencies:
   - h5py>=3.0
   - pyerfa>=2.0
   - coverage
-  - pytest>=6.2.0
+  - pytest>=6.2.0,<7.0
   - pytest-cov
   - cython
   - setuptools_scm

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -14,7 +14,7 @@ dependencies:
   - scipy
   - six  # added for now because sometimes an old python-casacore build (before 3.3.1) is used that omits this dependency
   - coverage
-  - pytest>=6.2.0
+  - pytest>=6.2.0,<7.0
   - pytest-cov
   - cython
   - setuptools_scm

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -13,7 +13,7 @@ dependencies:
   - pyyaml
   - scipy
   - coverage
-  - pytest>=6.2.0
+  - pytest>=6.2.0,<7.0
   - pytest-cov
   - cython
   - setuptools_scm

--- a/environment.yaml
+++ b/environment.yaml
@@ -18,7 +18,7 @@ dependencies:
   - setuptools_scm
   - sphinx
   - coverage
-  - pytest>=6.2.0
+  - pytest>=6.2.0,<7.0
   - pytest-cov
   - cython>=0.23
   - pip

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ test_reqs = (
     + novas_reqs
     + cst_reqs
     + [
-        "pytest>=6.2",
+        "pytest>=6.2,<7.0",
         "pytest-xdist",
         "pytest-cases>=3",
         "pytest-cov",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pin pytest < 7. This is a temporary fix for pytest-cases not being compatible with pytest 7.

I also added pytest-xdist for the external tests because they are now a limiting factor. Turns out it didn't help much, so I can remove it or leave it 🤷‍♀️ .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The conflict is being tracked here: https://github.com/smarie/python-pytest-cases/issues/251
When it's fixed, we should require a newer version of pytest-cases and remove this pytest pin.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
