### PR TITLE
Increase version requirement for pytest-cases, unpin pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ To compile the binary extension modules such that you can successfully run
 If you want to do development on pyuvdata, in addition to the other dependencies
 you will need the following packages:
 
-* pytest >= 6.2,<7.0
-* pytest-cases >= 3
+* pytest >= 6.2
+* pytest-cases >= 3.6.9
 * pytest-xdist
 * pytest-cov
 * cython >=0.23  (This is necessary for coverage reporting of cython extensions)

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -9,11 +9,11 @@ dependencies:
   - h5py>=3.0
   - pyerfa>=2.0
   - coverage
-  - pytest>=6.2.0,<7.0
+  - pytest>=6.2.0
   - pytest-cov
   - cython
   - setuptools_scm
   - pip
   - pip:
-     - pytest-cases>=3
+     - pytest-cases>=3.6.9
      - pytest-xdist

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -14,13 +14,13 @@ dependencies:
   - scipy
   - six  # added for now because sometimes an old python-casacore build (before 3.3.1) is used that omits this dependency
   - coverage
-  - pytest>=6.2.0,<7.0
+  - pytest>=6.2.0
   - pytest-cov
   - cython
   - setuptools_scm
   - pip
   - pip:
-      - pytest-cases>=3
+      - pytest-cases>=3.6.9
       - pytest-xdist
       - novas
       - novas_de405

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -13,11 +13,11 @@ dependencies:
   - pyyaml
   - scipy
   - coverage
-  - pytest>=6.2.0,<7.0
+  - pytest>=6.2.0
   - pytest-cov
   - cython
   - setuptools_scm
   - pip
   - pip:
-      - pytest-cases>=3
+      - pytest-cases>=3.6.9
       - pytest-xdist

--- a/environment.yaml
+++ b/environment.yaml
@@ -18,12 +18,12 @@ dependencies:
   - setuptools_scm
   - sphinx
   - coverage
-  - pytest>=6.2.0,<7.0
+  - pytest>=6.2.0
   - pytest-cov
   - cython>=0.23
   - pip
   - pip:
-      - pytest-cases>=3
+      - pytest-cases>=3.6.9
       - pytest-xdist
       - novas
       - novas_de405

--- a/pyuvdata/uvcal/fhd_cal.py
+++ b/pyuvdata/uvcal/fhd_cal.py
@@ -6,7 +6,7 @@
 import os
 import numpy as np
 import warnings
-from scipy.io.idl import readsav
+from scipy.io import readsav
 
 from .uvcal import UVCal
 from .. import utils as uvutils

--- a/pyuvdata/uvdata/fhd.py
+++ b/pyuvdata/uvdata/fhd.py
@@ -6,7 +6,7 @@
 import os
 import numpy as np
 import warnings
-from scipy.io.idl import readsav
+from scipy.io import readsav
 from astropy import constants as const
 
 from .uvdata import UVData

--- a/setup.py
+++ b/setup.py
@@ -109,9 +109,9 @@ test_reqs = (
     + novas_reqs
     + cst_reqs
     + [
-        "pytest>=6.2,<7.0",
+        "pytest>=6.2",
         "pytest-xdist",
-        "pytest-cases>=3",
+        "pytest-cases>=3.6.9",
         "pytest-cov",
         "cython",
         "coverage",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Require a higher version of pytest-cases to fix an incompatibility with pytest>=7. Undo the pinning of pytest done in #1138.

Also fix the import of `readsav` from scipy to address new DeprecationWarning.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
see #1138.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
