### PR TITLE
fix mwa_corr_fits bscale handing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `mwa_corr_fits` handing of the `BSCALE` keyword in gpubox files.
+
 ## [2.2.8] - 2022-2-15
 
 ### Added

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -1080,6 +1080,7 @@ def test_deprecated_keywords():
 
 @pytest.mark.filterwarnings("ignore:some coarse channel files were not submitted")
 @pytest.mark.filterwarnings("ignore:cable length correction is now defaulted to True")
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only")
 def test_bscale(tmp_path):
     """Test that bscale is saved correctly"""
     # some data does not have bscale in the zeroth hdu


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`mwa_corr_fits` will look for the `BSCALE` keyword in the first hdu of MWA gpubox files instead of the zeroth hdu. It will only look for this keyword if data is from the legacy correlator.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Closes #1149. Some MWA gpubox files have `BSCALE` in every hdu but some do not have `BSCALE` in the zeroth hdu. `mwa_corr_fits` has been looking for `BSCALE` in the zeroth hdu and so is not finding `BSCALE` for every case.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
