### PR TITLE
Add methods to enable sorting along the various axes in UVCal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 and `reorder_jones`.
 
 ## Changed
+- The `spw_order` parameter for the `UVData.reorder_freqs` method now accepts an index
+array rather than an array of spw numbers, making it match the other reorder methods.
 - Updated the astropy requirement to >= 5.0.4
 - Dropped support for python 3.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Reordering methods for UVCal: `reorder_antennas`, `reorder_freqs`, `reorder_times`
+and `reorder_jones`.
 
 ## Changed
 - Updated the astropy requirement to >= 5.0.4

--- a/docs/uvdata_tutorial.rst
+++ b/docs/uvdata_tutorial.rst
@@ -1548,7 +1548,8 @@ c) Sorting along the frequency axis
 The :meth:`pyuvdata.UVData.reorder_freqs` method will reorder the frequency axis by
 sorting by spectral windows or channels (or even just the channels within specific
 spectral windows). Spectral windows or channels can be sorted by ascending or descending
-number or in an order specified by passing an array of spectral window or channel numbers.
+number or in an order specified by passing an index array for spectral window or
+channels.
 
 .. code-block:: python
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -644,6 +644,7 @@ def _sort_freq_helper(
                 "The spw_order argument is ignored when providing an "
                 "array_like of int for channel_order"
             )
+        channel_order = np.asarray(channel_order)
         if not channel_order.size == Nfreqs or not np.all(
             np.sort(channel_order) == np.arange(Nfreqs)
         ):
@@ -681,6 +682,7 @@ def _sort_freq_helper(
                 sort_spw = {idx: idx == select_spw for idx in spw_array}
         elif spw_order is not None:
             if isinstance(spw_order, (np.ndarray, list, tuple)):
+                spw_order = np.asarray(spw_order)
                 if not spw_order.size == Nspws or not np.all(
                     np.sort(spw_order) == np.sort(spw_array)
                 ):

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -949,8 +949,8 @@ def jstr2num(jstr, x_orientation=None):
 
     Parameters
     ----------
-    jstr : str
-        antenna (jones) polarization string
+    jstr : str or array_like of str
+        antenna (jones) polarization string(s) to convert.
     x_orientation : str, optional
         Orientation of the physical dipole corresponding to what is
         labelled as the x polarization ("east" or "north") to allow for
@@ -959,8 +959,8 @@ def jstr2num(jstr, x_orientation=None):
 
     Returns
     -------
-    int
-        antenna (jones) polarization number corresponding to string
+    int or list of int
+        antenna (jones) polarization number(s) corresponding to the input string(s)
 
     Raises
     ------
@@ -1001,8 +1001,8 @@ def jnum2str(jnum, x_orientation=None):
 
     Parameters
     ----------
-    num : int
-        antenna (jones) polarization number
+    num : int or array_like of int
+        antenna (jones) polarization number(s) to convert to strings
     x_orientation : str, optional
         Orientation of the physical dipole corresponding to what is
         labelled as the x polarization ("east" or "north") to convert to
@@ -1010,8 +1010,8 @@ def jnum2str(jnum, x_orientation=None):
 
     Returns
     -------
-    str
-        antenna (jones) polarization string corresponding to number
+    str or list of str
+        antenna (jones) polarization string(s) corresponding to number
 
     Raises
     ------

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -644,7 +644,9 @@ def _sort_freq_helper(
                 "The spw_order argument is ignored when providing an "
                 "array_like of int for channel_order"
             )
-        if not np.all(np.sort(channel_order) == np.arange(Nfreqs)):
+        if not channel_order.size == Nfreqs or not np.all(
+            np.sort(channel_order) == np.arange(Nfreqs)
+        ):
             raise ValueError(
                 "Index array for channel_order must contain all indicies for "
                 "the frequency axis, without duplicates."
@@ -679,7 +681,9 @@ def _sort_freq_helper(
                 sort_spw = {idx: idx == select_spw for idx in spw_array}
         elif spw_order is not None:
             if isinstance(spw_order, (np.ndarray, list, tuple)):
-                if not np.all(np.sort(spw_order) == np.sort(spw_array)):
+                if not spw_order.size == Nspws or not np.all(
+                    np.sort(spw_order) == np.sort(spw_array)
+                ):
                     raise ValueError(
                         "Index array for spw_order must contain all indicies for "
                         "the frequency axis, without duplicates."

--- a/pyuvdata/uvcal/tests/test_uvcal.py
+++ b/pyuvdata/uvcal/tests/test_uvcal.py
@@ -1675,7 +1675,7 @@ def test_reorder_ants(
         calobj = calobj2.copy()
 
     # this is a no-op because it's already sorted this way
-    calobj2.reorder_antennas("number")
+    calobj2.reorder_antennas()
     ant_num_diff = np.diff(calobj2.ant_array)
     assert np.all(ant_num_diff > 0)
 
@@ -1904,7 +1904,7 @@ def test_reorder_times(
         calobj = calobj2.copy()
 
     # this should be a no-op
-    calobj.reorder_times(order="time")
+    calobj.reorder_times()
     assert calobj == calobj2
 
     calobj2.reorder_times(order="-time")
@@ -2008,7 +2008,8 @@ def test_reorder_jones(
             total_quality_diff = np.diff(calobj2.total_quality_array, axis=3)
         assert np.all(total_quality_diff < 0)
 
-    calobj2.reorder_jones("name")
+    # the default order is "name"
+    calobj2.reorder_jones()
     name_array = np.asarray(
         uvutils.jnum2str(calobj2.jones_array, x_orientation=calobj2.x_orientation)
     )

--- a/pyuvdata/uvcal/tests/test_uvcal.py
+++ b/pyuvdata/uvcal/tests/test_uvcal.py
@@ -1709,21 +1709,21 @@ def test_reorder_ants_errors(gain_data):
         match="order must be one of 'number', 'name', '-number', '-name' or an "
         "index array of length Nants_data",
     ):
-        gain_data.reorder_antennas("foo")
+        gain_data.reorder_antennas(order="foo")
 
     with pytest.raises(
         ValueError,
-        match="If order is an index array, it must contain integers and be length "
-        "Nants_data.",
+        match="If order is an index array, it must contain all indicies for the"
+        "ant_array, without duplicates.",
     ):
-        gain_data.reorder_antennas(gain_data.antenna_numbers.astype(float))
+        gain_data.reorder_antennas(order=gain_data.antenna_numbers.astype(float))
 
     with pytest.raises(
         ValueError,
-        match="If order is an index array, it must contain integers and be length "
-        "Nants_data.",
+        match="If order is an index array, it must contain all indicies for the"
+        "ant_array, without duplicates.",
     ):
-        gain_data.reorder_antennas(gain_data.antenna_numbers[:8])
+        gain_data.reorder_antennas(order=gain_data.antenna_numbers[:8])
 
 
 @pytest.mark.parametrize("future_shapes", [True, False])
@@ -1734,8 +1734,6 @@ def test_reorder_freqs(
     caltype,
     metadata_only,
     gain_data,
-    multi_spw_gain,
-    multi_spw_delay,
     delay_data_inputflag,
     delay_data_inputflag_future,
 ):
@@ -1763,14 +1761,15 @@ def test_reorder_freqs(
         assert calobj == calobj2
     else:
         calobj2.reorder_freqs(channel_order="-freq")
-        ant_num_diff = np.diff(calobj2.freq_array)
-        assert np.all(ant_num_diff < 0)
+        freq_diff = np.diff(calobj2.freq_array)
+        assert np.all(freq_diff < 0)
+
+        calobj.reorder_freqs(channel_order=np.flip(np.arange(calobj.Nfreqs)))
+        assert calobj == calobj2
 
 
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
-def test_reorder_freqs_multi_spw(
-    caltype, multi_spw_gain, multi_spw_delay,
-):
+def test_reorder_freqs_multi_spw(caltype, multi_spw_gain, multi_spw_delay):
     if caltype == "gain":
         calobj = multi_spw_gain
     else:

--- a/pyuvdata/uvcal/tests/test_uvcal.py
+++ b/pyuvdata/uvcal/tests/test_uvcal.py
@@ -1817,7 +1817,7 @@ def test_reorder_freqs_multi_spw(caltype, multi_spw_gain, multi_spw_delay):
     spw_diff = np.diff(calobj.spw_array)
     assert np.all(spw_diff < 0)
 
-    calobj2.reorder_freqs(spw_order=np.flip(calobj2.spw_array))
+    calobj2.reorder_freqs(spw_order=np.flip(np.arange(calobj2.Nspws)))
     assert calobj2 == calobj
 
     calobj.reorder_freqs(spw_order="freq")
@@ -1829,20 +1829,20 @@ def test_reorder_freqs_errors(gain_data, multi_spw_delay):
     with pytest.raises(
         ValueError,
         match="spw_order can only be one of 'number', '-number', "
-        "'freq', '-freq', None or an integer array of length Nspws",
+        "'freq', '-freq', None or an index array of length Nspws",
     ):
         gain_data.reorder_freqs(spw_order="foo")
 
     with pytest.raises(
         ValueError,
         match="spw_order can only be one of 'number', '-number', "
-        "'freq', '-freq', None or an integer array of length Nspws",
+        "'freq', '-freq', None or an index array of length Nspws",
     ):
         multi_spw_delay.reorder_freqs(spw_order="foo")
 
     with pytest.raises(
         ValueError,
-        match="If spw_order is an array, it must contain all spw numbers in "
+        match="If spw_order is an array, it must contain all indicies for "
         "the spw_array, without duplicates.",
     ):
         multi_spw_delay.reorder_freqs(spw_order=[0, 1])

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -1802,7 +1802,7 @@ class UVCal(UVBase):
 
     def reorder_jones(
         self,
-        order="time",
+        order="name",
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -1621,7 +1621,7 @@ class UVCal(UVBase):
                     "channel_order and select_spws are ignored for wide-band "
                     "calibration solutions"
                 )
-                flip_spws = spw_order[0] == "-"
+            flip_spws = spw_order[0] == "-"
 
             if "number" in spw_order:
                 index_array = np.argsort(self.spw_array)

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -1578,10 +1578,10 @@ class UVCal(UVBase):
             number) and `freq` (sort on median frequency). A '-' can be prepended
             to signify descending order instead of the default ascending order,
             e.g., if you have SPW #1 and 2, and wanted them ordered as [2, 1],
-            you would specify `-number`. Alternatively, one can supply an array
-            of length Nspws that specifies the new order, with values matched to
-            the specral window number given in `spw_array`. Default is to apply no
-            sorting of spectral windows.
+            you would specify `-number`. Alternatively, one can supply an index array
+            of length Nspws that specifies how to shuffle the spws (this is not the
+            desired final spw order). Default is to apply nos orting of spectral
+            windows.
         channel_order : str or array_like of int
             A string describing the desired order of frequency channels within a
             spectral window. Allowed strings are "freq" and "-freq", which will sort
@@ -1626,20 +1626,23 @@ class UVCal(UVBase):
             if isinstance(spw_order, (np.ndarray, list, tuple)):
                 spw_order = np.asarray(spw_order)
                 if not spw_order.size == self.Nspws or not np.all(
-                    np.sort(spw_order) == np.sort(self.spw_array)
+                    np.sort(spw_order) == np.arange(self.Nspws)
                 ):
                     raise ValueError(
-                        "If spw_order is an array, it must contain all spw numbers in "
+                        "If spw_order is an array, it must contain all indicies for "
                         "the spw_array, without duplicates."
                     )
                 index_array = np.asarray(
-                    [np.nonzero(self.spw_array == spw)[0][0] for spw in spw_order]
+                    [
+                        np.nonzero(self.spw_array == spw)[0][0]
+                        for spw in self.spw_array[spw_order]
+                    ]
                 )
             else:
                 if spw_order not in ["number", "freq", "-number", "-freq", None]:
                     raise ValueError(
                         "spw_order can only be one of 'number', '-number', "
-                        "'freq', '-freq', None or an integer array of length Nspws"
+                        "'freq', '-freq', None or an index array of length Nspws"
                     )
                 if "number" in spw_order:
                     index_array = np.argsort(self.spw_array)

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -1623,12 +1623,7 @@ class UVCal(UVBase):
                 )
             flip_spws = spw_order[0] == "-"
 
-            if "number" in spw_order:
-                index_array = np.argsort(self.spw_array)
-            elif "freq" in spw_order:
-                mean_freq = np.mean(self.freq_range, axis=1)
-                index_array = np.argsort(mean_freq)
-            else:
+            if isinstance(spw_order, (np.ndarray, list, tuple)):
                 spw_order = np.asarray(spw_order)
                 if not spw_order.size == self.Nspws or not np.all(
                     np.sort(spw_order) == np.sort(self.spw_array)
@@ -1640,6 +1635,18 @@ class UVCal(UVBase):
                 index_array = np.asarray(
                     [np.nonzero(self.spw_array == spw)[0][0] for spw in spw_order]
                 )
+            else:
+                if spw_order not in ["number", "freq", "-number", "-freq", None]:
+                    raise ValueError(
+                        "spw_order can only be one of 'number', '-number', "
+                        "'freq', '-freq', None or an integer array of length Nspws"
+                    )
+                if "number" in spw_order:
+                    index_array = np.argsort(self.spw_array)
+                elif "freq" in spw_order:
+                    mean_freq = np.mean(self.freq_range, axis=1)
+                    index_array = np.argsort(mean_freq)
+
             if flip_spws:
                 index_array = np.flip(index_array)
 

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -1629,6 +1629,7 @@ class UVCal(UVBase):
                 mean_freq = np.mean(self.freq_range, axis=1)
                 index_array = np.argsort(mean_freq)
             else:
+                spw_order = np.asarray(spw_order)
                 if not spw_order.size == self.Nspws or not np.all(
                     np.sort(spw_order) == np.sort(self.spw_array)
                 ):

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -1515,8 +1515,8 @@ class UVCal(UVBase):
                 np.int64,
             ]:
                 raise ValueError(
-                    "If order is an index array, it must "
-                    "contain integers and be length Nants_data."
+                    "If order is an index array, it must contain all indicies for the"
+                    "ant_array, without duplicates."
                 )
             index_array = order
         else:

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -3214,15 +3214,20 @@ def test_reorder_freqs_flipped(sma_mir, future_shapes):
     assert np.all(np.flip(sma_mir.data_array, axis=-2) == sma_mir_copy.data_array)
 
 
-def test_reorder_freqs_eq_coeffs(sma_mir):
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_reorder_freqs_eq_coeffs(casa_uvfits):
     # No test datasets to examine this with, so let's generate some mock data,
     # with a pre-determined order that we can flip
-    sma_mir.reorder_freqs(spw_order="-number", channel_order="-freq")
-    sma_mir.eq_coeffs = np.tile(
-        np.arange(sma_mir.Nfreqs, dtype=float), (sma_mir.Nants_telescope, 1)
+    casa_uvfits.use_future_array_shapes()
+    casa_uvfits.reorder_freqs(channel_order="-freq")
+    casa_uvfits.eq_coeffs = np.tile(
+        np.arange(casa_uvfits.Nfreqs, dtype=float), (casa_uvfits.Nants_telescope, 1)
     )
-    sma_mir.reorder_freqs(spw_order="number", channel_order="freq")
-    assert np.all(np.diff(sma_mir.eq_coeffs, axis=1) == -1)
+    # modify the channel widths so we can check them too
+    casa_uvfits.channel_width += np.arange(casa_uvfits.Nfreqs, dtype=float)
+    casa_uvfits.reorder_freqs(channel_order="freq")
+    assert np.all(np.diff(casa_uvfits.eq_coeffs, axis=1) == -1)
+    assert np.all(np.diff(casa_uvfits.channel_width) == -1)
 
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -4057,8 +4057,10 @@ def test_flex_spw_add_concat(sma_mir, future_shapes, add_method, screen1, screen
         sma_mir.select(freq_chans=np.where(np.logical_or(screen1, screen2)))
 
     # Make sure the two datasets are in the same frequency order
-    uv_recomb.reorder_freqs(spw_order=sma_mir.spw_array, channel_order="freq")
-    sma_mir.reorder_freqs(spw_order=sma_mir.spw_array, channel_order="freq")
+    uv_recomb.reorder_freqs(
+        spw_order=np.argsort(uv_recomb.spw_array), channel_order="freq"
+    )
+    sma_mir.reorder_freqs(spw_order=np.argsort(sma_mir.spw_array), channel_order="freq")
 
     # Check the history first
     assert uv_recomb.history.startswith(sma_mir.history)

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -4104,7 +4104,7 @@ class UVData(UVBase):
         strict_uvw_antpos_check=False,
     ):
         """
-        Rearrange polarizations in the event they are not uvfits compatible.
+        Arrange polarization axis according to desired order.
 
         Parameters
         ----------
@@ -4437,7 +4437,7 @@ class UVData(UVBase):
         spw_order : str or array_like of int
             A string describing the desired order of spectral windows along the
             frequecy axis. Allowed strings include `number` (sort on spectral window
-            number) and `freq` (sort on median frequency). A '-' can be appended
+            number) and `freq` (sort on median frequency). A '-' can be prepended
             to signify descending order instead of the default ascending order,
             e.g., if you have SPW #1 and 2, and wanted them ordered as [2, 1],
             you would specify `-number`. Alternatively, one can supply an array
@@ -4447,7 +4447,7 @@ class UVData(UVBase):
         channel_order : str or array_like of int
             A string describing the desired order of frequency channels within a
             spectral window. Allowed strings include `freq`, which will sort channels
-            within a spectral window by frequency. A '-' can be optionally appended
+            within a spectral window by frequency. A '-' can be optionally prepended
             to signify descending order instead of the default ascending order.
             Alternatively, one can supply an index array of length Nfreqs that
             specifies the new order. Default is to apply no sorting of channels
@@ -7983,7 +7983,7 @@ class UVData(UVBase):
             indicators 'l' and 'r' or 'x' and 'y'.  Minus signs can also be used
             in front of an antenna number or baseline to exclude it from being
             output in ant_pairs_nums. If ant_str has a minus sign as the first
-            character, 'all,' will be appended to the beginning of the string.
+            character, 'all,' will be added to the beginning of the string.
             See the tutorial for examples of valid strings and their behavior.
         print_toggle : bool
             Boolean for printing parsed baselines for a visual user check.

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -4446,11 +4446,10 @@ class UVData(UVBase):
             sorting of spectral windows.
         channel_order : str or array_like of int
             A string describing the desired order of frequency channels within a
-            spectral window. Allowed strings include `freq`, which will sort channels
-            within a spectral window by frequency. A '-' can be optionally prepended
-            to signify descending order instead of the default ascending order.
-            Alternatively, one can supply an index array of length Nfreqs that
-            specifies the new order. Default is to apply no sorting of channels
+            spectral window. Allowed strings are "freq" and "-freq", which will sort
+            channels within a spectral window by ascending or descending frequency
+            respectively. Alternatively, one can supply an index array of length Nfreqs
+            that specifies the new order. Default is to apply no sorting of channels
             within a single spectral window. Note that proving an array_like of ints
             will cause the values given to `spw_order` and `select_spw` to be ignored.
         select_spw : int or array_like of int
@@ -4521,6 +4520,8 @@ class UVData(UVBase):
                 np.unique(self.flex_spw_id_array, return_index=True)[1]
             )
             self.spw_array = self.flex_spw_id_array[unique_index]
+        elif self.future_array_shapes:
+            self.channel_width = self.channel_width[index_array]
 
         if self.eq_coeffs is not None:
             self.eq_coeffs = self.eq_coeffs[:, index_array]

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -4476,130 +4476,28 @@ class UVData(UVBase):
         Raises
         ------
         UserWarning
-            Raised if providing arguments to select_spw and freq_screen (the latter
+            Raised if providing arguments to select_spw and channel_order (the latter
             overrides the former).
         ValueError
-            Raised if select_spw contains values not in spw_array, or if freq_screen
+            Raised if select_spw contains values not in spw_array, or if channel_order
             is not the same length as freq_array.
 
         """
-        if (spw_order is None) and (channel_order is None):
-            warnings.warn(
-                "Not specifying either spw_order or channel_order causes "
-                "no sorting actions to be applied. Returning object unchanged."
-            )
-            return
+        index_array = uvutils._sort_freq_helper(
+            self.Nfreqs,
+            self.freq_array,
+            self.Nspws,
+            self.spw_array,
+            self.flex_spw,
+            self.flex_spw_id_array,
+            self.future_array_shapes,
+            spw_order,
+            channel_order,
+            select_spw,
+        )
 
-        # Check to see if there are arguments we should be ignoring
-        if isinstance(channel_order, (np.ndarray, list, tuple)):
-            if select_spw is not None:
-                warnings.warn(
-                    "The select_spw argument is ignored when providing an "
-                    "array_like of int for channel_order"
-                )
-            if spw_order is not None:
-                warnings.warn(
-                    "The spw_order argument is ignored when providing an "
-                    "array_like of int for channel_order"
-                )
-            if not np.all(np.sort(channel_order) == np.arange(self.Nfreqs)):
-                raise ValueError(
-                    "Index array for channel_order must contain all indicies for "
-                    "the frequency axis, without duplicates."
-                )
-            index_array = channel_order
-        else:
-            index_array = np.arange(self.Nfreqs)
-            # Multipy by 1.0 here to make a cheap copy of the array to manipulate
-            temp_freqs = 1.0 * (
-                self.freq_array if self.future_array_shapes else self.freq_array[0, :]
-            )
-            # Same trick for ints -- add 0 to make a cheap copy
-            temp_spws = 0 + (
-                self.flex_spw_id_array
-                if self.flex_spw
-                else (np.zeros(self.Nfreqs) + self.spw_array)
-            )
-
-            # Check whether or not we need to sort the channels in individual windows
-            sort_spw = {idx: channel_order is not None for idx in self.spw_array}
-            if select_spw is not None:
-                if spw_order is not None:
-                    warnings.warn(
-                        "The spw_order argument is ignored when providing an "
-                        "argument for select_spw"
-                    )
-                if channel_order is None:
-                    warnings.warn(
-                        "Specifying select_spw without providing channel_order causes "
-                        "no sorting actions to be applied. Returning object unchanged."
-                    )
-                    return
-                if isinstance(select_spw, (np.ndarray, list, tuple)):
-                    sort_spw = {idx: idx in select_spw for idx in self.spw_array}
-                else:
-                    sort_spw = {idx: idx == select_spw for idx in self.spw_array}
-            elif spw_order is not None:
-                if isinstance(spw_order, (np.ndarray, list, tuple)):
-                    if not np.all(np.sort(spw_order) == np.sort(self.spw_array)):
-                        raise ValueError(
-                            "Index array for spw_order must contain all indicies for "
-                            "the frequency axis, without duplicates."
-                        )
-                elif spw_order not in ["number", "freq", "-number", "-freq", None]:
-                    raise ValueError(
-                        "spw_order can only be one of 'number', '-number', "
-                        "'freq', '-freq', or None"
-                    )
-                elif self.Nspws > 1:
-                    # Only need to do this step if we actually have multiple spws.
-
-                    # If the string starts with a '-', then we will flip the order at
-                    # the end of the operation
-                    flip_spws = spw_order[0] == "-"
-
-                    if "number" in spw_order:
-                        spw_order = np.sort(self.spw_array)
-                    elif "freq" in spw_order:
-                        spw_order = self.spw_array[
-                            np.argsort(
-                                [
-                                    np.median(temp_freqs[temp_spws == idx])
-                                    for idx in self.spw_array
-                                ]
-                            )
-                        ]
-                    if flip_spws:
-                        spw_order = np.flip(spw_order)
-                else:
-                    spw_order = self.spw_array
-                # Now that we know the spw order, we can apply the first sort
-                index_array = np.concatenate(
-                    [index_array[temp_spws == idx] for idx in spw_order]
-                )
-                temp_freqs = temp_freqs[index_array]
-                temp_spws = temp_spws[index_array]
-            # Spectral windows are assumed sorted at this point
-            if channel_order is not None:
-                if channel_order not in ["freq", "-freq"]:
-                    raise ValueError(
-                        "channel_order can only be one of 'freq' or '-freq'"
-                    )
-                for idx in self.spw_array:
-                    if sort_spw[idx]:
-                        select_mask = temp_spws == idx
-                        subsort_order = index_array[select_mask]
-                        subsort_order = subsort_order[
-                            np.argsort(temp_freqs[select_mask])
-                        ]
-                        index_array[select_mask] = (
-                            np.flip(subsort_order)
-                            if channel_order[0] == "-"
-                            else subsort_order
-                        )
-
-        if np.all(index_array[1:] > index_array[:-1]):
-            # Nothing to do - the data are already sorted!
+        if index_array is None:
+            # This only happens if no sorting is needed
             return
 
         # Now update all of the arrays.

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -4440,10 +4440,10 @@ class UVData(UVBase):
             number) and `freq` (sort on median frequency). A '-' can be prepended
             to signify descending order instead of the default ascending order,
             e.g., if you have SPW #1 and 2, and wanted them ordered as [2, 1],
-            you would specify `-number`. Alternatively, one can supply an array
-            of length Nspws that specifies the new order, with values matched to
-            the specral window number given in `spw_array`. Default is to apply no
-            sorting of spectral windows.
+            you would specify `-number`. Alternatively, one can supply an index array
+            of length Nspws that specifies how to shuffle the spws (this is not the
+            desired final spw order). Default is to apply no sorting of spectral
+            windows.
         channel_order : str or array_like of int
             A string describing the desired order of frequency channels within a
             spectral window. Allowed strings are "freq" and "-freq", which will sort

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -914,7 +914,7 @@ class UVFlag(UVBase):
             indicators 'l' and 'r' or 'x' and 'y'.  Minus signs can also be used
             in front of an antenna number or baseline to exclude it from being
             output in ant_pairs_nums. If ant_str has a minus sign as the first
-            character, 'all,' will be appended to the beginning of the string.
+            character, 'all,' will be added to the beginning of the string.
             See the tutorial for examples of valid strings and their behavior.
         print_toggle : bool
             Boolean for printing parsed baselines for a visual user check.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add `reorder_antennas`, `reorder_freqs`, `reorder_times` and `reorder_jones` methods to UVCal to allow for sorting along all the axes of UVCal objects.
- Change the meaning of passing an integer array to the `spw_order` of `UVData.reorder_freqs` to be an index array rather than an array of spw numbers giving the final desired order of spws. This is makes it similar to all the other reorder methods, but it is a breaking change. When we discussed this, we felt that almost no-one was using this yet, but we wanted to check with @kartographer about this belief. I can add some backwards compatibility if needed.

These were based on the following discussion and notes:
**There is a question I'd like to discuss**: Should the integer arrays passed to the various `order` parameters always be index arrays, or should they be arrays specifying the final desired order if the thing being sorted has an integer representation? There's conflicting behavior in the UVData methods on this front -- it's treated as an index array for everything except spw_order. 

We discussed this on 3/17 and leaned towards making them all be index arrays, but didn't have a quorum. We decided on 3/31 that they should all be index arrays.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The similar methods on UVData are broadly useful and these methods enable testing for the bug described in #1107.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
