### PR TITLE
Improving tolerance to flaky JPL-Horizons tests

### DIFF
--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -17,8 +17,6 @@ from pyuvdata import UVData, UVFlag, UVCal
 import pyuvdata.utils as uvutils
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH
-from ssl import SSLError
-from requests import RequestException
 
 ref_latlonalt = (-26.7 * np.pi / 180.0, 116.7 * np.pi / 180.0, 377.8)
 ref_xyz = (-2562123.42683, 5094215.40141, -2848728.58869)
@@ -1088,6 +1086,10 @@ def test_lookup_jplhorizons_arg_errs(arg_dict, msg):
     """
     # Don't do this test if we don't have astroquery loaded
     pytest.importorskip("astroquery")
+
+    from ssl import SSLError
+    from requests import RequestException
+
     default_args = {
         "targ_name": "Mars",
         "time_array": np.array([0.0, 1000.0]) + 2456789.0,
@@ -1325,6 +1327,9 @@ def test_jphl_lookup():
     slam JPL w/ coordinate requests.
     """
     pytest.importorskip("astroquery")
+
+    from ssl import SSLError
+    from requests import RequestException
 
     # If we can't connect to JPL-Horizons, then skip this test and don't outright fail.
     try:

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -19,8 +19,6 @@ from pyuvdata import UVData, UVCal
 import pyuvdata.utils as uvutils
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH
-from ssl import SSLError
-from requests import RequestException
 
 # needed for multifile read error test
 from pyuvdata.uvdata.tests.test_mwa_corr_fits import filelist as mwa_corr_files
@@ -10427,6 +10425,10 @@ def test_phase_dict_helper_errs(sma_mir, arg_dict, dummy_phase_dict, msg):
     source information.
     """
     pytest.importorskip("astroquery")
+
+    from ssl import SSLError
+    from requests import RequestException
+
     for key in dummy_phase_dict.keys():
         if key not in arg_dict.keys():
             arg_dict[key] = dummy_phase_dict[key]
@@ -10552,6 +10554,10 @@ def test_phase_dict_helper_jpl_lookup_append(sma_mir):
     an old ephem does not cover the newly requested time range
     """
     pytest.importorskip("astroquery")
+
+    from ssl import SSLError
+    from requests import RequestException
+
     # Now see what happens if we attempt to lookup something that JPL actually knows
     obs_time = np.array(2456789.0)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Enables pytest to skip certain tests related to JPL-Horizons (caused by failures external to `pyuvdata`). 

## Description
<!--- Describe your changes in detail -->
Added code to skip several tests when connection issues (either SSL or just "no route to host" related) prevent querying the JPL Horizons service, which is used via the `astroquery` package for grabbing ephemerides for Solar System bodies.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
An infrequent-but-annoyingly-not-rare issue that has popped up in CI testing has been SSL errors that have caused failures in a total of 4 tests. These failures appear stocastic, and unrelated to anything inside of `pyuvdata`, but instead are probably server-side issues either w/ CI services or with JPL Horizons itself. These tests should _mostly_ work, so I've added a bit of wrapping around these tests for force `pytest` to skip them when either an `SSLError` (which is what we were seeing in the test reports) or a `RequestException` (more general connection error that is raised when I locally block any connection to JPL-H) is raised. Since neither of these should come from anything but connection issues, and so I think there's little danger of a problem getting missed by this workaround. In `pytest` reports, these particular failures will show up as 's' -- I think that's reasonanly visable (and of course should be naturally recorded as part of the unit test execution).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
