### PR TITLE
Streamlining the `select` method in `UVData`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ array rather than an array of spw numbers, making it match the other reorder met
 - Dropped support for python 3.7
 
 ### Fixed
+- A bug in `UVData.print_phase_center_info` that occasionally resulted in incorrect values being reported for RA/Az/Longitudinal coordinates.
+- A bug in `UVData.select` that could cause `UVData.check` to fail if `UVData._scan_number_array` was set.
 - A bug in `UVBeam.select` where after selecting down to only auto polarization power
 beams the `UVBeam.data_array` remained complex instead of real.
 - A bug in `UVBeam.__add__` where adding an object with cross pol power beams to an

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -405,7 +405,6 @@ def _check_flex_spw_contiguous(spw_array, flex_spw_id_array):
             "frequency axis. Most file formats do not support such "
             "non-grouping of data."
         )
-    return True
 
 
 def _check_freq_spacing(

--- a/pyuvdata/uvcal/tests/test_uvcal.py
+++ b/pyuvdata/uvcal/tests/test_uvcal.py
@@ -572,7 +572,7 @@ def test_flexible_spw(gain_data):
     calobj = gain_data
 
     # check that this check passes on non-flex_spw objects
-    assert calobj._check_flex_spw_contiguous()
+    calobj._check_flex_spw_contiguous()
 
     # first just make one spw and check that object still passes check
     calobj._set_flex_spw()

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -1082,11 +1082,6 @@ class UVCal(UVBase):
         """
         if self.flex_spw:
             uvutils._check_flex_spw_contiguous(self.spw_array, self.flex_spw_id_array)
-        else:
-            # If this isn't a flex_spw data set, then there is only 1 spectral window,
-            # which means that the check always passes
-            pass
-        return True
 
     def _check_freq_spacing(self, raise_errors=True):
         """

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -2459,6 +2459,9 @@ def test_select(casa_uvfits, future_shapes):
     # now test selecting along all axes at once
     uv_object = casa_uvfits
 
+    # Set the scan numbers so that we can check to make sure they are selected correctly
+    uv_object._set_scan_numbers()
+
     if future_shapes:
         uv_object.use_future_array_shapes()
 
@@ -6691,6 +6694,10 @@ def test_redundancy_contract_expand_nblts_not_nbls_times_ntimes(method, casa_uvf
         with uvtest.check_warnings(
             UserWarning,
             [
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ]
+            + [
                 "Index baseline in the redundant group does not have all the "
                 "times, compressed object will be missing those times."
             ]
@@ -9831,8 +9838,8 @@ def test_print_object_full(sma_mir):
     _ = sma_mir._add_phase_center(
         "3c84",
         cat_type="sidereal",
-        cat_lat=sma_mir.phase_center_catalog["3c84"]["cat_lat"],
-        cat_lon=sma_mir.phase_center_catalog["3c84"]["cat_lon"],
+        cat_lat=-1.0,
+        cat_lon=-1.0,
         cat_dist=0.0,
         cat_vrad=0.0,
         cat_pm_ra=0.0,
@@ -9848,8 +9855,8 @@ def test_print_object_full(sma_mir):
         "           deg                  mas/yr  mas/yr       pc    km/s \n"
         "--------------------------------------------"
         "----------------------------------------------------------------\n"
-        "    1          3c84   sidereal    3:19:48.16"
-        "  +41:30:42.11    fk5  J2000.0       0       0  0.0e+00       0 \n"
+        "    1          3c84   sidereal   20:10:49.01"
+        "  -57:17:44.81    fk5  J2000.0       0       0  0.0e+00       0 \n"
     )
     table_str = sma_mir.print_phase_center_info(print_table=False, return_str=True)
     assert table_str == check_str

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -6694,10 +6694,6 @@ def test_redundancy_contract_expand_nblts_not_nbls_times_ntimes(method, casa_uvf
         with uvtest.check_warnings(
             UserWarning,
             [
-                "The uvw_array does not match the expected values given the antenna "
-                "positions."
-            ]
-            + [
                 "Index baseline in the redundant group does not have all the "
                 "times, compressed object will be missing those times."
             ]
@@ -6705,7 +6701,8 @@ def test_redundancy_contract_expand_nblts_not_nbls_times_ntimes(method, casa_uvf
             + [
                 "The uvw_array does not match the expected values given the antenna "
                 "positions."
-            ],
+            ]
+            * 2,
         ):
             uv2 = uv0.compress_by_redundancy(method=method, tol=tol, inplace=False)
     else:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -546,7 +546,7 @@ class UVData(UVBase):
         )
 
         desc = (
-            "Optional when reading a MS. Retains the  scan number when reading a MS."
+            "Optional when reading a MS. Retains the scan number when reading a MS."
             " Shape (Nblts), type = int."
         )
         self._scan_number_array = uvp.UVParameter(
@@ -8560,7 +8560,11 @@ class UVData(UVBase):
                         attr.value = attr.value.take(ind_arr, axis=sel_axis)
                     elif isinstance(attr.value, list):
                         # If this is a list, it _should_ always have 1-dimension.
-                        assert sel_axis == 0
+                        assert sel_axis == 0, (
+                            "Something is wrong, sel_axis != 0 when selecting on a "
+                            "list, which should not be possible. Please file an issue "
+                            "in our GitHub issue log so that we can fix it."
+                        )
                         attr.value = [attr.value[idx] for idx in ind_arr]
 
             if key == "Nblts":

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -291,7 +291,7 @@ class UVFITS(UVData):
         else:
             # do select operations on everything except data_array, flag_array
             # and nsample_array
-            self._select_metadata(
+            self._select_by_index(
                 blt_inds, freq_inds, pol_inds, history_update_string, keep_all_metadata
             )
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -527,7 +527,7 @@ class UVH5(UVData):
         else:
             # do select operations on everything except data_array, flag_array
             # and nsample_array
-            self._select_metadata(
+            self._select_by_index(
                 blt_inds, freq_inds, pol_inds, history_update_string, keep_all_metadata
             )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Simplifies the code in `UVData.select` to make it easier to maintain.

## Description
<!--- Describe your changes in detail -->
The code in `select` has been generalized such that it no longer operates on individual `UVData` parameters, but instead will look at the attributes of these parameters, namely `UVParameter.form` to decide which selection criteria to apply. The method `UVData. _select_metadata` has been replaced with `UVData._select_by_index`, which will handle both metadata-only and "regular" `UVData` objects, and acts as a drop-in replacement where it is called elsewhere in the code.

Also, two other minor changes: a wrapping bug in `UVData.print_phase_center_ info` has been fixed, and some superfluous code in `_check_flex_spw_contiguous` has been removed (since the function raises an error if there's a problem, there did not seem to be a need for it to return a value if no error was raised).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The changes to `select` where primarily motivated by #1159, which was caused by the addition of a new parameter to `UVData` (namely `_scan_number_array`), which was added in part to help support of MS dataset writing. In the original PR that introduced it, nothing was added to `_select_metadata` that told it to explicitly filter on that parameter. Given that there may be other changes/additions to parameters in the not to distant future, this seemed like a good opportunity to "future-proof" the select command, by using `UVParameter.form` to figure out which -- if any --  axes of a given array of values needed to be selected, without needing to explicitly code for individual parameter names. 

Closes #1159.
Closes #1130.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
