### PR TITLE
Adding a warning to `fix_phase`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ real-only if non-zero imaginary components are detected.
 and `reorder_jones`.
 
 ### Changed
+- `UVData.fix_phase` now raises a warning when called.
 - Changed `UVData.write_uvfits` to allow for one to write out datasets in UVFITS format
 without "spoofing" (via setting `spoof_nonessential=True`) UVFITS-specific values.
 - Methods that ensure that attributes are set up properly on `UVBeam` are now called in

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -1755,7 +1755,8 @@ def test_fix_phase(tmp_path):
     uv_in_bad_ant.write_miriad(
         writepath, clobber=True, run_check=False, check_extra=False
     )
-    uv_out.read(writepath, fix_old_proj=True, fix_use_ant_pos=True)
+    with uvtest.check_warnings(UserWarning, "Fixing phases using antenna positions."):
+        uv_out.read(writepath, fix_old_proj=True, fix_use_ant_pos=True)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["zen.2456865.60537.xy.uvcRREAA"]
@@ -1770,7 +1771,10 @@ def test_fix_phase(tmp_path):
     uv_in_bad_base.write_miriad(
         writepath, clobber=True, run_check=False, check_extra=False
     )
-    uv_out.read(writepath, fix_old_proj=True, fix_use_ant_pos=False)
+    with uvtest.check_warnings(
+        UserWarning, "Attempting to fix residual phasing errors from the old `phase`"
+    ):
+        uv_out.read(writepath, fix_old_proj=True, fix_use_ant_pos=False)
     # We have to handle this case a little carefully, because since the old
     # unphase_to_drift was _mostly_ accurate, although it does seem to intoduce errors
     # on the order of a part in 1e5, which translates to about a tenth of a degree phase

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -393,9 +393,12 @@ def uv_phase_comp_main():
     # checkwarnings to capture the warning about non-real autos
     with uvtest.check_warnings(
         UserWarning,
-        nwarnings=2,
-        match="Fixing auto-correlations to be be real-only, after some imaginary "
-        "values were detected in data_array.",
+        match=[
+            "Fixing auto-correlations to be be real-only, after some imaginary "
+            "values were detected in data_array.",
+            "Fixing phases using antenna positions.",
+        ]
+        * 2,
     ):
         uvd1.read_uvfits(file1, fix_old_proj=True)
         uvd2.read_uvfits(file2, fix_old_proj=True)
@@ -10766,7 +10769,14 @@ def test_fix_phase(hera_uvh5, future_shapes, use_ant_pos):
     # calculated from the antenna positions. Using fix phase here should be "perfect",
     # since the uvws are completely recalculated from scratch.
     uv_in_bad.phase(phase_ra, phase_dec, use_old_proj=True, use_ant_pos=use_ant_pos)
-    uv_in_bad.fix_phase(use_ant_pos=use_ant_pos)
+
+    if use_ant_pos:
+        warn_msg = "Fixing phases using antenna positions."
+    else:
+        warn_msg = "Attempting to fix residual phasing errors from the old `phase`"
+
+    with uvtest.check_warnings(UserWarning, warn_msg):
+        uv_in_bad.fix_phase(use_ant_pos=use_ant_pos)
 
     # We have to handle this case a little carefully, because since the old
     # unphase_to_drift was _mostly_ accurate, although it does seem to intoduce errors

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3237,7 +3237,14 @@ def test_fix_phase(tmp_path):
     filepath = os.path.join(DATA_PATH, "1133866760.uvfits")
     writepath = os.path.join(tmp_path, "phasetest.uvh5")
 
-    uv_in.read(filepath, fix_old_proj=True)
+    with uvtest.check_warnings(
+        UserWarning,
+        [
+            "Fixing phases using antenna positions.",
+            "Fixing auto-correlations to be be real-only, after some imaginary values",
+        ],
+    ):
+        uv_in.read(filepath, fix_old_proj=True)
 
     # Make some copies of the data
     uv_in_bad_ant = uv_in.copy()
@@ -3257,7 +3264,8 @@ def test_fix_phase(tmp_path):
     uv_in_bad_ant.write_uvh5(
         writepath, clobber=True, run_check=False, check_extra=False
     )
-    uv_out.read(writepath, fix_old_proj=True, fix_use_ant_pos=True)
+    with uvtest.check_warnings(UserWarning, "Fixing phases using antenna positions."):
+        uv_out.read(writepath, fix_old_proj=True, fix_use_ant_pos=True)
 
     # make sure filename is what we expect
     assert uv_in.filename == ["1133866760.uvfits"]
@@ -3276,7 +3284,10 @@ def test_fix_phase(tmp_path):
     uv_in_bad_base.write_uvh5(
         writepath, clobber=True, run_check=False, check_extra=False
     )
-    uv_out.read(writepath, fix_old_proj=True, fix_use_ant_pos=False)
+    with uvtest.check_warnings(
+        UserWarning, "Attempting to fix residual phasing errors from the old `phase`"
+    ):
+        uv_out.read(writepath, fix_old_proj=True, fix_use_ant_pos=False)
     # We have to handle this case a little carefully, because since the old
     # unphase_to_drift was _mostly_ accurate, although it does seem to intoduce errors
     # on the order of a part in 1e5, which translates to about a tenth of a degree phase

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -5964,6 +5964,12 @@ class UVData(UVBase):
         use_ant_pos : bool
             Use the antenna positions for determining UVW coordinates. Default is True.
         """
+        if self.multi_phase_center:
+            raise ValueError(
+                "Cannot run fix_phase on a mutli-phase-ctr dataset without using the "
+                "antenna positions. Please set use_ant_pos=True."
+            )
+
         # If we are missing apparent coordinates, we should calculate those now
         if (self.phase_center_app_ra is None) or (self.phase_center_app_dec is None):
             self._set_app_coords_helper()
@@ -5972,16 +5978,19 @@ class UVData(UVBase):
         # anything, since the new baseline vectors will be unaffected by the prior
         # phasing method, and the delta_w values already get correctly corrected for.
         if use_ant_pos:
+            warnings.warn("Fixing phases using antenna positions.")
+
             self.set_uvws_from_antenna_positions(
                 allow_phasing=True,
                 use_old_proj=False,
             )
-        elif self.multi_phase_center:
-            raise ValueError(
-                "Cannot run fix_phase on a mutli-phase-ctr dataset without using the "
-                "antenna positions. Please set use_ant_pos=True."
-            )
         else:
+            warnings.warn(
+                "Attempting to fix residual phasing errors from the old `phase` method "
+                "using the `unphase_to_drift` with use_old_proj set to True. This "
+                "can result in closure errors if the data were not actually phased "
+                "using the old method -- caution is advised."
+            )
             # Record the old values
             phase_center_ra = self.phase_center_ra
             phase_center_dec = self.phase_center_dec


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds a warning to `fix_phase`.

## Description
<!--- Describe your changes in detail -->
Two new warning messages have been added for when users call the `fix_phase` method -- one of which will be shown based on user-provided arguments.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This warning is intended to alert users when `fix_phase` is being called, particularly as part of other method calls like `read`. The severity of the warning depends on what arguments are supplied by the user.

Closes #1136.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

N.b., this isn't exactly a _bug fix_, per se, but it seems a better choice than my second best fit "documentation change".

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

