### PR TITLE
Fix external tests (hera_cal, hera_qm) by pinning scipy versions to <1.8.1

### DIFF
--- a/ci/hera_cal.yml
+++ b/ci/hera_cal.yml
@@ -17,7 +17,7 @@ dependencies:
   - pytest-cov
   - pyyaml
   - scikit-learn
-  - scipy
+  - scipy<1.8.1
   - setuptools_scm
   - pip:
     - git+https://github.com/HERA-Team/linsolve.git

--- a/ci/hera_qm.yml
+++ b/ci/hera_qm.yml
@@ -14,7 +14,7 @@ dependencies:
   - pytest-cov
   - pyyaml
   - scikit-learn
-  - scipy
+  - scipy<1.8.1
   - setuptools_scm
   - pip:
     - git+https://github.com/HERA-Team/omnical.git


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pin the scipy version used in the CI for hera_cal and hera_qm to less than 1.8.1.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The external tests CI is failing on all PRs because of some internal scipy import. Seems to have started when v1.8.1 dropped. Pinning the version to less than that seems to have fixed it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
