### PR TITLE
Fixing add for flex-spw datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ array rather than an array of spw numbers, making it match the other reorder met
 - Dropped support for python 3.7
 
 ### Fixed
+- A bug in `UVData.__add__` where flexible spectral window datasets were not combined
+correctly if they contained overlapping frequencies in different spectral windows.
 - A bug in `UVData.print_phase_center_info` that occasionally resulted in incorrect values being reported for RA/Az/Longitudinal coordinates.
 - A bug in `UVData.select` that could cause `UVData.check` to fail if `UVData._scan_number_array` was set.
 - A bug in `UVBeam.select` where after selecting down to only auto polarization power


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug when adding flex-spw datasets.

## Description
<!--- Describe your changes in detail -->
Changes `UVData.__add__` to account for spectral window number in flex-spw objects when deciding whether or not frequency channels between objects overlap.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes an issue where the `__add__` method would not correctly combine `UVData` objects. When `flex_spw=True` (which is the case for all multi-spectral window datasets), different spectral windows are allowed to have overlapping frequency values within a single object. The aforementioned bug caused a crash when using `__add__` where two such flex-spw objects had overlapping frequencies in different spectral windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
