### PR TITLE
Checking that `UVBase` attributes match their expected names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ real-only if non-zero imaginary components are detected.
 and `reorder_jones`.
 
 ### Changed
+- `UVBase` object now require that individual attribute names match that given in
+`UVParameter._name`.
 - `UVData.fix_phase` now raises a warning when called.
 - Changed `UVData.write_uvfits` to allow for one to write out datasets in UVFITS format
 without "spoofing" (via setting `spoof_nonessential=True`) UVFITS-specific values.

--- a/pyuvdata/tests/test_uvbase.py
+++ b/pyuvdata/tests/test_uvbase.py
@@ -352,3 +352,10 @@ def test_check_ignore_unset():
     test_obj._unset_int1.required = True
     pytest.raises(ValueError, test_obj.check)
     assert test_obj.check(ignore_requirements=True)
+
+
+def test_name_error():
+    test_obj = UVTest()
+    test_obj._location.name = "place"
+    with pytest.raises(ValueError, match="UVParameter _location does not follow the"):
+        test_obj.check()

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -355,6 +355,12 @@ class UVBase(object):
 
         for p in p_check:
             param = getattr(self, p)
+            if p != ("_" + param.name):
+                raise ValueError(
+                    "UVParameter %s does not follow the required naming convention"
+                    "(expected be %s)." % ((p, "_" + param.name))
+                )
+
             # Check required parameter exists
             if param.value is None:
                 if ignore_requirements:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a check in `UVBase.check` to verify that attribute names match the "expected" convention of `"_" + UVParameter.name`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

Closes #1049.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
