### PR TITLE
Pin version of setuptools_scm for installation and CI jobs

### DIFF
--- a/.github/workflows/macosx_windows_ci.yaml
+++ b/.github/workflows/macosx_windows_ci.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@main
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Set ENV NAME
         run: |

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -12,7 +12,7 @@ dependencies:
   - pytest>=6.2.0
   - pytest-cov
   - cython
-  - setuptools_scm
+  - setuptools_scm<7.0
   - pip
   - pip:
      - pytest-cases>=3.6.9

--- a/ci/pyuvdata_min_versions_tests.yml
+++ b/ci/pyuvdata_min_versions_tests.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytest==6.2.0
   - pytest-cov
   - cython
-  - setuptools_scm
+  - setuptools_scm<7.0
   - pip
   - pip:
       - pytest-cases==3.6.9

--- a/ci/pyuvdata_publish.yml
+++ b/ci/pyuvdata_publish.yml
@@ -9,7 +9,7 @@ dependencies:
   - h5py>=3.0
   - pyerfa>=2.0
   - cython
-  - setuptools_scm
+  - setuptools_scm<7.0
   - pip
   - pip:
      - pep517

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytest>=6.2.0
   - pytest-cov
   - cython
-  - setuptools_scm
+  - setuptools_scm<7.0
   - pip
   - pip:
       - pytest-cases>=3.6.9

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytest>=6.2.0
   - pytest-cov
   - cython
-  - setuptools_scm
+  - setuptools_scm<7.0
   - pip
   - pip:
       - pytest-cases>=3.6.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = ["setuptools>=30.3.0",
             "wheel",
-            "setuptools_scm",
+            "setuptools_scm<7.0",
             "oldest-supported-numpy",
             "cython>=0.23"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [flake8]
 ignore = W503, E203, N806

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ setup_args = {
         "numpy>=1.19",
         "pyerfa>=2.0",
         "scipy>=1.3",
-        "setuptools_scm",
+        "setuptools_scm<7.0",
     ],
     "extras_require": {
         "astroquery": astroquery_reqs,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As noted in #1187, there is a known issue in v7.0 of `setuptools_scm` that mangles the branch name reported by setuptools. This in turn breaks the `branch_version` scheme in pyuvdata, which is holding up CI. Local testing also suggests that command-line installs are also broken.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This is a stop-gap solution where we pin to a particular version of `setuptools_scm`. We will want to remove these pins (and probably instead list ranges of the package to avoid) when the problem has been fixed upstream.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.