### PR TITLE
Enable normalizing cross-correlations by autos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added the `normalize_by_autos` method to `UVData`, which allows one to normalize
+cross-correlations (i.e., covert values from arbitrary scale to correlation coefficients)
+if auto-correlations are present in the data.
 - Added the `write` method to `MirParser`, which allows for `MirParser` to write out
 Mir-formatted data to disk.
 - Added the `select` method to `MirParser`, which provides a much simpler interface for

--- a/docs/uvdata_tutorial.rst
+++ b/docs/uvdata_tutorial.rst
@@ -539,7 +539,7 @@ b) Data with a multiple phase centers enabled.
 
 
   >>> # With multi-phase-ctr data sets, one needs to supply a unique name for each
-  >>> # phase center. We are specifing that the type here is "sidereal", which just
+  >>> # phase center. We are specifying that the type here is "sidereal", which just
   >>> # means that the position is represented by a fixed set of coordinates in a
   >>> # sidereal coordinate frame (e.g., ICRS, FK5, etc)
   >>> uvd.phase(5.23368, 0.710940, epoch="J2000", cat_name='target1', cat_type="sidereal")
@@ -891,7 +891,7 @@ e) Select polarizations
 ***********************
 Selecting on polarizations can be done either using the polarization numbers or the
 polarization strings (e.g. "xx" or "yy" for linear polarizations or "rr" or "ll" for
-circular polarizations). If ``x_orientation`` is set on the object, strings represting
+circular polarizations). If ``x_orientation`` is set on the object, strings representing
 the physical orientation of the dipole can also be used (e.g. "nn" or "ee).
 
 .. code-block:: python
@@ -1510,7 +1510,7 @@ The :meth:`pyuvdata.UVData.reorder_blts` method will reorder the baseline-time a
 sorting by ``'time'``, ``'baseline'``, ``'ant1'`` or ``'ant2'`` or according to an order
 preferred for data that have baseline dependent averaging ``'bda'``. A user can also
 just specify a desired order by passing an array of baseline-time indices. There is also
-an option to sort the auto visibilitiess before the cross visibilities (``autos_first``).
+an option to sort the auto visibilities before the cross visibilities (``autos_first``).
 
 .. code-block:: python
 
@@ -1749,7 +1749,7 @@ gain" of the antenna, which typically depend on geometric size and aperture effi
 Note that when normalizing, if the corresponding autocorrelations are not found or are
 otherwise marked as bad in ``flag_array``, then the the cross-correlation will be
 flagged as well (e.g., if all of antenna 1's autos are flagged, then every baseline that
-containts antenna 1 will also be flagged).
+contains antenna 1 will also be flagged).
 
 .. code-block:: python
 

--- a/docs/uvdata_tutorial.rst
+++ b/docs/uvdata_tutorial.rst
@@ -1723,7 +1723,7 @@ in the full data array based on redundancy.
   >>> # Note -- Compressing and inflating changes the baseline order, reorder before comparing.
   >>> uv0.inflate_by_redundancy(tol=tol)
   >>> uv_backup.reorder_blts(conj_convention="u>0", uvw_tol=tol)
-  >>> uv0.reorder_blts()efficiency
+  >>> uv0.reorder_blts()
   >>> np.all(uv0.baseline_array == uv_backup.baseline_array)
   True
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -13446,3 +13446,103 @@ class UVData(UVBase):
             run_check_acceptability=run_check_acceptability,
         )
         del uvh5_obj
+
+
+def normalize_by_autos(self):
+    # We need to match baselines in a single integration, so figure out how to
+    # group the data by time.
+    if np.any(self.time_array[:-1] > self.time_array[1:]):
+        # If the data are not in ascending time order, re-org the time values now
+        blt_idx = np.argsort(self.time_array)
+        ordered_time = self.time_array[blt_idx]
+    else:
+        blt_idx = np.arange(self.Nblts)
+        ordered_time = self.time_array
+
+    # Normally time has a fixed atol, but verify that this is the case
+    time_tol = self._time_array.tols[1]
+    assert self._time_array.tols[0] == 0
+
+    # Start searching through time, keeping in mind that the data are time ordered.
+    time_groups = []
+    start_idx = end_idx = 0
+    while self.Nblts != start_idx:
+        # Search sorted will find where one would insert the value of the current
+        # time + the time tol, which will give us the ending index of the group.
+        end_idx += np.searchsorted(
+            ordered_time[start_idx:],
+            ordered_time[start_idx] + time_tol,
+            "right",
+        )
+        # Create this new grouping of blts
+        time_groups.append(blt_idx[start_idx:end_idx])
+        start_idx = end_idx
+
+    # Now figure out how the different polarizations map to the autos
+    pol_groups = []
+    pol_list = list(self.polarization_array)
+    for pol in pol_list:
+        try:
+            feed_pols = uvutils.POL_TO_FEED_DICT[uvutils.POL_NUM2STR_DICT[pol]]
+            pol_groups.append(
+                [
+                    pol_list.index(uvutils.POL_STR2NUM_DICT[item + item])
+                    for item in feed_pols
+                ]
+            )
+        except KeyError:
+            # If we run into a key error, it means that one of the dicts above does not
+            # have a match to the given polarization, in which case assume that this pol
+            # its it's own auto.
+            pol_groups.append([pol_list.index(pol)])
+        except ValueError as err:
+            # If we have an index error, it means that the pol that _would_ be the auto
+            # is not found in the data, in which case we need to throw an error.
+            raise ValueError(
+                "Cannot normalize %s, matching polarizations for autos not found." % pol
+            ) from err
+
+        # Each pol group contains the index positions for the "auto" polarizations, so
+        # we can grab all of the auto pols by searching for the unique values
+        auto_pols = list(np.unique(pol_groups))
+
+        # Grab references to data and flags, to manipulate later
+        data_arr = self.data_array
+        flag_arr = self.flag_array
+        if not self.future_array_shapes:
+            data_arr = np.squeeze(data_arr, 1)
+            flag_arr = np.squeeze(flag_arr, 1)
+
+        for group in time_groups:
+            # Now start going through the groups
+            ant_1_arr = self.ant_1_array[group]
+            ant_2_arr = self.ant_2_array[group]
+            norm_dict = {}
+            flag_dict = {}
+            for grp_idx, ant1, ant2 in zip(group, ant_1_arr, ant_2_arr):
+                # Tabulate up front the normalization for each auto-correlation
+                # spectrum, which will save some work downstream
+                if ant1 != ant2:
+                    continue
+                norm_dict[ant1] = {}
+                flag_dict[ant1] = {}
+                for pol in auto_pols:
+                    # Autos _should_ be real only
+                    auto_data = data_arr[grp_idx, :, pol].real
+                    auto_flag = flag_arr[grp_idx, :, pol] | (auto_data == 0)
+                    norm_dict[ant1][pol] = np.where(auto_flag, 1, auto_data ** (-0.5))
+                    flag_dict[ant1][pol] = auto_flag
+
+            for grp_idx, ant1, ant2 in zip(group, ant_1_arr, ant_2_arr):
+                try:
+                    for jdx, (pol1, pol2) in enumerate(pol_groups):
+                        # Proceed pol by pol
+                        data_arr[grp_idx, :, jdx] *= (
+                            norm_dict[ant1][pol1] * norm_dict[ant2][pol2]
+                        )
+                        flag_arr[grp_idx, :, jdx] |= (
+                            flag_dict[ant1][pol1] | flag_dict[ant2][pol2]
+                        )
+                except KeyError:
+                    # If no data found for this antenna, then just flag the whole blt
+                    flag_arr[grp_idx] = True

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -13529,10 +13529,13 @@ class UVData(UVBase):
                     for pol in auto_pols:
                         # Autos _should_ be real only
                         auto_data = data_arr[grp_idx, :, pol].real
-                        auto_flag = flag_arr[grp_idx, :, pol] | (auto_data == 0)
-                        norm_dict[ant1][pol] = np.where(
-                            auto_flag, 1, auto_data ** (-0.5)
+                        auto_flag = flag_arr[grp_idx, :, pol] | ~(auto_data > 0)
+                        norm_data = np.zeros_like(auto_data)
+                        norm_data = np.reciprocal(
+                            auto_data, where=~auto_flag, out=norm_data
                         )
+                        norm_data = np.sqrt(auto_data, out=norm_data)
+                        norm_dict[ant1][pol] = norm_data
                         flag_dict[ant1][pol] = auto_flag
 
                 for grp_idx, ant1, ant2 in zip(group, ant_1_arr, ant_2_arr):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a new method to `UVData` called `normalize_by_autos`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This adds the ability to "normalize" the cross-correlations by the geometric mean of the autos for each baseline, which allows one to convert between arbitarily scaled data and correlation coefficients (the latter of which is used by SMA). Correlation coefficients are sometimes used when storing visibilities, as if you have information about the system temperature and the forward gain of your antenna (typically in Jy/K), you can make an easy first-order conversion of the data into flux density (Jy) units.

No issue to link to, although it was an informally requested feature for both ATA and SMA (in the latter case, for potentially undoing this normalization inside the `UVData` object).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
