### PR TITLE
Support interdependent UVParameters

### DIFF
--- a/pyuvdata/tests/test_uvbase.py
+++ b/pyuvdata/tests/test_uvbase.py
@@ -131,6 +131,15 @@ class UVTest(UVBase):
             form=(),
         )
 
+        self._dependent = uvp.UVParameter(
+            "dependent",
+            description="A parameter that depends on another parameter.",
+            expected_type=str,
+            dependencies={"time": "cur_time"},
+            value="val0",
+            required=False,
+        )
+
         super(UVTest, self).__init__()
 
 
@@ -358,3 +367,10 @@ def test_name_error():
     test_obj._location.name = "place"
     with pytest.raises(ValueError, match="UVParameter _location does not follow the"):
         test_obj.check()
+
+
+def test_param_dependency():
+    test_obj = UVTest()
+    # Need to access the parameter value at least once for the other values to be set
+    assert test_obj.dependent == "val0"
+    assert test_obj._dependent.cur_time == test_obj.time

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -143,6 +143,13 @@ class UVBase(object):
         # Create method to return
         def fget(self):
             this_param = getattr(self, param_name)
+            if this_param.dependencies is not None:
+                for sup_par, attr_name in this_param.dependencies.items():
+                    # Key is the name of parent parameters
+                    # Value is the name to give that attribute in this parameter
+                    sup_val = getattr(self, sup_par)
+                    setattr(this_param, attr_name, sup_val)
+                setattr(self, param_name, this_param)
             return this_param.value
 
         return fget
@@ -166,6 +173,12 @@ class UVBase(object):
         def fset(self, value):
             this_param = getattr(self, param_name)
             this_param.value = value
+            if this_param.dependencies is not None:
+                for sup_par, attr_name in this_param.dependencies.items():
+                    # Key is the name of parent parameters
+                    # Value is the name to give that attribute in this parameter
+                    sup_val = getattr(self, sup_par)
+                    setattr(this_param, attr_name, sup_val)
             setattr(self, param_name, this_param)
 
         return fset

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -383,13 +383,14 @@ class UVData(UVBase):
         )
 
         desc = (
-            "Telescope location: xyz in ITRF (earth-centered frame). "
+            "Telescope location: xyz position in telescope_frame. "
             "Can also be accessed using telescope_location_lat_lon_alt or "
             "telescope_location_lat_lon_alt_degrees properties."
         )
         self._telescope_location = uvp.LocationParameter(
             "telescope_location",
             description=desc,
+            dependencies={"telescope_frame": "frame"},
             acceptable_range=(6.35e6, 6.39e6),
             tols=1e-3,
         )
@@ -2454,6 +2455,7 @@ class UVData(UVBase):
             latitude,
             longitude,
             altitude,
+            frame=self.telescope_frame,
         )
         self.lst_array = unique_lst_array[inverse_inds]
         return


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a keyword "dependencies" to the declaration of UVParameter and its subclasses, which should be a dictionary. The keys are names of other UVParameters in the UVBase-derived object the UVParameter is kept on, and the values are "local" names.

In short -- If a UVParameter "_param" on a UVBase-derived object "base" is initialized with a dependencies dictionary {key: val}, then it will have `_param.val == base.key`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `telescope_location` parameter is interpreted differently depending on the value of the `telescope_frame` attribute. This provides a way for the `telescope_location` parameter to be aware of the telescope_frame.

More specifically, this is needed because `telescope_location_lat_lon_alt` automatically converts between XYZ and LatLonAlt, but explicitly assumes the ITRS frame. The `...lat_lon_alt` attribute is instantiated before the `telescope_frame` might be defined, so it needs to be aware of the current value of `telescope_frame`.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
It's not an open issue, but this makes the telescope_location_lat_lon_alt values to be sensible for lunar coordinates (it was previously giving deeply negative heights and incorrect lat/lon). It also adjusts the acceptable_range for telescope_position for lunar coordinates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).