### PR TITLE
Fix how setuptools_scm requirements are specified

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = ["setuptools>=30.3.0",
             "wheel",
-            "setuptools_scm<7.0|>=7.0.3",
+            "setuptools_scm!=7.0.0,!=7.0.1,!=7.0.2",
             "oldest-supported-numpy",
             "cython>=0.23"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ setup_args = {
         "numpy>=1.19",
         "pyerfa>=2.0",
         "scipy>=1.3",
-        "setuptools_scm<7.0|>=7.0.3",
+        "setuptools_scm!=7.0.0,!=7.0.1,!=7.0.2",
     ],
     "extras_require": {
         "astroquery": astroquery_reqs,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes the `setuptools_scm` version specification from #1189. Evidently only conda understands the `|` operator as "OR", and pip/setuptools does not. Instead, we need to explicitly exclude versions, and add them together with `,` (which _does_ act as "AND").

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [x] Packaging change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.