### PR TITLE
Add LocationParameter.frame

### DIFF
--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -680,6 +680,8 @@ class LocationParameter(UVParameter):
         This is not an attribute of required UVParameters.
     description : str
         Description of the data or metadata in the object.
+    frame : str, optional
+        Coordinate frame. Valid options are "itrs" (default) or "mcmf".
     acceptable_vals : list, optional
         List giving allowed values for elements of value.
     acceptable_range: 2-tuple, optional
@@ -711,6 +713,8 @@ class LocationParameter(UVParameter):
        Always set to 3.
     description : str
         Description of the data or metadata in the object.
+    frame : str, optional
+        Coordinate frame. Valid options are "itrs" (default) or "mcmf".
     expected_type
         Always set to float.
     acceptable_vals : list, optional
@@ -735,11 +739,13 @@ class LocationParameter(UVParameter):
         spoof_val=None,
         description="",
         frame="itrs",
-        acceptable_range=(6.35e6, 6.39e6),
+        acceptable_range=None,
         tols=1e-3,
     ):
-        if frame == "mcmf":
-            acceptable_range = (1717100.0, 1757100.0)
+        if acceptable_range is None:
+            acceptable_range = (
+                (6.35e6, 6.39e6) if frame == "itrs" else (1717100.0, 1757100.0)
+            )
         super(LocationParameter, self).__init__(
             name,
             required=required,

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -734,9 +734,12 @@ class LocationParameter(UVParameter):
         value=None,
         spoof_val=None,
         description="",
+        frame="itrs",
         acceptable_range=(6.35e6, 6.39e6),
         tols=1e-3,
     ):
+        if frame == "mcmf":
+            acceptable_range = (1717100.0, 1757100.0)
         super(LocationParameter, self).__init__(
             name,
             required=required,
@@ -748,6 +751,7 @@ class LocationParameter(UVParameter):
             acceptable_range=acceptable_range,
             tols=tols,
         )
+        self.frame = frame
 
     def lat_lon_alt(self):
         """Get value in (latitude, longitude, altitude) tuple in radians."""
@@ -755,7 +759,9 @@ class LocationParameter(UVParameter):
             return None
         else:
             # check defaults to False b/c exposed check kwarg exists in UVData
-            return utils.LatLonAlt_from_XYZ(self.value, check_acceptability=False)
+            return utils.LatLonAlt_from_XYZ(
+                self.value, check_acceptability=False, frame=self.frame
+            )
 
     def set_lat_lon_alt(self, lat_lon_alt):
         """
@@ -771,7 +777,10 @@ class LocationParameter(UVParameter):
             self.value = None
         else:
             self.value = utils.XYZ_from_LatLonAlt(
-                lat_lon_alt[0], lat_lon_alt[1], lat_lon_alt[2]
+                lat_lon_alt[0],
+                lat_lon_alt[1],
+                lat_lon_alt[2],
+                frame=self.frame,
             )
 
     def lat_lon_alt_degrees(self):
@@ -798,7 +807,10 @@ class LocationParameter(UVParameter):
         else:
             latitude, longitude, altitude = lat_lon_alt_degree
             self.value = utils.XYZ_from_LatLonAlt(
-                latitude * np.pi / 180.0, longitude * np.pi / 180.0, altitude
+                latitude * np.pi / 180.0,
+                longitude * np.pi / 180.0,
+                altitude,
+                frame=self.frame,
             )
 
     def check_acceptability(self):

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -739,14 +739,16 @@ class LocationParameter(UVParameter):
         spoof_val=None,
         description="",
         frame="itrs",
-        acceptable_range=None,
+        acceptable_range=-1,
         tols=1e-3,
     ):
-        if acceptable_range is None:
+        if acceptable_range == -1:
             if frame == "itrs":
                 acceptable_range = (6.35e6, 6.39e6)
             elif frame == "mcmf":
                 acceptable_range = (1717100.0, 1757100.0)
+            else:
+                acceptable_range = None
 
         super(LocationParameter, self).__init__(
             name,

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -658,7 +658,7 @@ class AngleParameter(UVParameter):
 
 class LocationParameter(UVParameter):
     """
-    Subclass of UVParameter for Earth location type parameters.
+    Subclass of UVParameter for location type parameters.
 
     Adds extra methods for conversion to & from lat/lon/alt in radians or
     degrees (used by UVBase objects for _lat_lon_alt and _lat_lon_alt_degrees
@@ -743,9 +743,11 @@ class LocationParameter(UVParameter):
         tols=1e-3,
     ):
         if acceptable_range is None:
-            acceptable_range = (
-                (6.35e6, 6.39e6) if frame == "itrs" else (1717100.0, 1757100.0)
-            )
+            if frame == "itrs":
+                acceptable_range = (6.35e6, 6.39e6)
+            elif frame == "mcmf":
+                acceptable_range = (1717100.0, 1757100.0)
+
         super(LocationParameter, self).__init__(
             name,
             required=required,

--- a/pyuvdata/tests/test_parameter.py
+++ b/pyuvdata/tests/test_parameter.py
@@ -268,6 +268,13 @@ def test_location_acceptable_none():
 
     assert param1.check_acceptability()
 
+    # For undefined frame, acceptable_range should remain None
+    param1 = uvp.LocationParameter(
+        name="p2", value=1, acceptable_range=None, frame="undef"
+    )
+    assert param1.acceptable_range is None
+    assert param1.check_acceptability()
+
 
 def test_location_mcmf_acceptability():
     loc = np.array([171720.0, 0.0, 0.0])

--- a/pyuvdata/tests/test_parameter.py
+++ b/pyuvdata/tests/test_parameter.py
@@ -268,10 +268,8 @@ def test_location_acceptable_none():
 
     assert param1.check_acceptability()
 
-    # For undefined frame, acceptable_range should remain None
-    param1 = uvp.LocationParameter(
-        name="p2", value=1, acceptable_range=None, frame="undef"
-    )
+    # For undefined frame, acceptable_range should default to None
+    param1 = uvp.LocationParameter(name="p2", value=1, frame="undef")
     assert param1.acceptable_range is None
     assert param1.check_acceptability()
 

--- a/pyuvdata/tests/test_parameter.py
+++ b/pyuvdata/tests/test_parameter.py
@@ -269,6 +269,12 @@ def test_location_acceptable_none():
     assert param1.check_acceptability()
 
 
+def test_location_mcmf_acceptability():
+    loc = np.array([171720.0, 0.0, 0.0])
+    param1 = uvp.LocationParameter(name="p2", value=loc, frame="mcmf")
+    assert param1.check_acceptability()
+
+
 @pytest.mark.parametrize(
     "sky2",
     [

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -52,7 +52,6 @@ def uvdata_props():
         "telescope_name",
         "instrument",
         "telescope_location",
-        "telescope_frame",
         "history",
         "vis_units",
         "Nants_data",

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -373,17 +373,8 @@ class UVData(UVBase):
             expected_type=str,
         )
 
-        self._telescope_frame = uvp.UVParameter(
-            "telescope_frame",
-            description='Coordinate frame of the telescope_location. Default is "itrs"',
-            form="str",
-            value="itrs",
-            expected_type=str,
-            acceptable_vals=["itrs", "mcmf"],
-        )
-
         desc = (
-            "Telescope location: xyz in ITRF (earth-centered frame). "
+            "Telescope location: xyz position in specified frame (default ITRS). "
             "Can also be accessed using telescope_location_lat_lon_alt or "
             "telescope_location_lat_lon_alt_degrees properties."
         )
@@ -391,6 +382,7 @@ class UVData(UVBase):
             "telescope_location",
             description=desc,
             acceptable_range=(6.35e6, 6.39e6),
+            frame="itrs",
             tols=1e-3,
         )
 
@@ -2454,6 +2446,7 @@ class UVData(UVBase):
             latitude,
             longitude,
             altitude,
+            frame=self._telescope_location.frame,
         )
         self.lst_array = unique_lst_array[inverse_inds]
         return
@@ -4250,7 +4243,7 @@ class UVData(UVBase):
         antpos = uvutils.ENU_from_ECEF(
             (self.antenna_positions + self.telescope_location),
             *self.telescope_location_lat_lon_alt,
-            frame=self.telescope_frame,
+            frame=self._telescope_location.frame,
         )
         ants = self.antenna_numbers
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes the telescope_frame UVParameter and instead makes `frame` an attribute of the `LocationParameter` class. Default behavior is still to assume everything is ITRS unless otherwise specified.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Coordinate transformations need to be aware of the frame XYZ coordinates are defined in. Several internal automated transformations (like XYZ to spherical) implicitly assumed ITRS coordinates. To provide support for lunar surface positions, these changes make the LocationParameter more general.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Breaking change checklist:
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
