### PR TITLE
Fix uvh5 reader to check for `phase_center_catalog` not `multi_phase_center`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- A bug in `UVData.read_uvh5` where `multi_phase_center` was being used to imply the
+existence of the `phase_center_catalog` header item, rather than checking for the
+presence of that item. This conflicted with the uvh5 memo.
+
 ## [2.2.10] - 2022-10-20
 
 ### Added

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -287,14 +287,13 @@ class UVH5(UVData):
             self.flex_spw_id_array = header["flex_spw_id_array"][:]
         if "flex_spw_polarization_array" in header:
             self.flex_spw_polarization_array = header["flex_spw_polarization_array"][:]
-        if "multi_phase_center" in header:
-            if bool(header["multi_phase_center"][()]):
-                self._set_phased()
-                self._set_multi_phase_center(preserve_phase_center_info=False)
 
         # Here is where we start handing phase center information.  If we have a
         # multi phase center dataset, we need to get different header items
-        if self.multi_phase_center:
+        if "phase_center_catalog" in header:
+            self._set_phased()
+            self._set_multi_phase_center(preserve_phase_center_info=False)
+
             self.Nphase = int(header["Nphase"][()])
             self.phase_center_id_array = header["phase_center_id_array"][:]
 
@@ -1133,7 +1132,6 @@ class UVH5(UVData):
         header["ant_2_array"] = self.ant_2_array
         header["antenna_positions"] = self.antenna_positions
         header["flex_spw"] = self.flex_spw
-        header["multi_phase_center"] = self.multi_phase_center
         # handle antenna_names; works for lists or arrays
         header["antenna_names"] = np.asarray(self.antenna_names, dtype="bytes")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a mismatch between the reader and the documentation where the reader was looking for a boolean (`multi_phase_center`) to indicate that the phase_center_catalog was present rather than just looking for that
header item.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #1224 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
