### PR TITLE
Warn about future shapes change on file read for all objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ types.
 - Severe performance hit when calling `polnum2str` and its variants for many baselines.
 
 ### Deprecated
+- Reading files into objects without setting `use_future_array_shapes` now results in
+deprecation warnings.
 - The utility functions `phase_uvw` and `unphase_uvw` associated with the deprecated
 old phasing method.
 - The `flex_spw_id_array` will be required on all UVData and UVFlag and all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ to set several of these new parameters.
 deprecation warnings.
 
 ### Fixed
+- Fixed some bugs related to handling of the `UVCal.time_range` parameter in
+`UVCal.__add__` and other methods. Ensured that it is a list when
+`UVCal.future_array_shapes` is False.
 - Fixed a bug in `UVCal.__add__` when data are sorted differently along any axis or
 interleaved along an axis.
 - Fixed a bug in reading MS files with non-UTC time scales.

--- a/docs/uvbeam_tutorial.rst
+++ b/docs/uvbeam_tutorial.rst
@@ -119,7 +119,6 @@ a) Reading a CST power beam file
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
   >>> import matplotlib.pyplot as plt # doctest: +SKIP
-  >>> beam = UVBeam()
 
   # you can pass several filenames and the objects from each file will be
   # combined across the appropriate axis -- in this case frequency
@@ -132,12 +131,13 @@ a) Reading a CST power beam file
   # You should also specify the polarization that the file represents and you can
   # set rotate_pol to generate the other polarization by rotating by 90 degrees.
   # The feed_pol defaults to 'x' and rotate_pol defaults to True.
-  >>> beam.read(
+  >>> beam = UVBeam.from_file(
   ...   filenames, beam_type='power', frequency=[150e6, 123e6],
   ...   feed_pol='x', rotate_pol=True, telescope_name='HERA',
   ...   feed_name='PAPER_dipole', feed_version='0.1',
   ...   model_name='E-field pattern - Rigging height 4.9m',
-  ...   model_version='1.0'
+  ...   model_version='1.0',
+  ...   use_future_array_shapes=True,
   ... )
   >>> print(beam.beam_type)
   power
@@ -149,7 +149,7 @@ a) Reading a CST power beam file
   >>> # You can also use a yaml settings file.
   >>> # Note that using a yaml file requires that pyyaml is installed.
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam.read(settings_file, beam_type='power')
+  >>> beam = UVBeam.from_file(settings_file, beam_type='power', use_future_array_shapes=True)
   >>> print(beam.beam_type)
   power
   >>> print(beam.pixel_coordinate_system)
@@ -163,7 +163,7 @@ a) Reading a CST power beam file
   >>> print(beam.Nfreqs)
   2
   >>> print(beam.data_array.shape)
-  (1, 1, 2, 2, 181, 360)
+  (1, 2, 2, 181, 360)
 
   >>> # plot zenith angle cut through beam
   >>> plt.plot(beam.axis2_array, beam.data_array[0, 0, 0, 0, :, 0]) # doctest: +SKIP
@@ -180,16 +180,15 @@ b) Reading a CST E-field beam file
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
   >>> import numpy as np
-  >>> beam = UVBeam()
 
   >>> # the same interface as for power beams, just specify beam_type = 'efield'
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam.read(settings_file, beam_type='efield')
+  >>> beam = UVBeam.from_file(settings_file, beam_type='efield', use_future_array_shapes=True)
   >>> print(beam.beam_type)
   efield
 
   >>> # UVBeam also has a `from_file` class method we can call directly.
-  >>> beam3 = UVBeam.from_file(settings_file, beam_type="efield")
+  >>> beam3 = UVBeam.from_file(settings_file, beam_type="efield", use_future_array_shapes=True)
   >>> beam == beam3
   True
 
@@ -213,16 +212,17 @@ c) Reading in the MWA full embedded element beam
   >>> import numpy as np
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
-  >>> beam = UVBeam()
 
   >>> mwa_beam_file = os.path.join(DATA_PATH, 'mwa_full_EE_test.h5')
-  >>> beam.read(mwa_beam_file)
+  >>> beam = UVBeam.from_file(mwa_beam_file, use_future_array_shapes=True)
   >>> print(beam.beam_type)
   efield
 
   >>> delays = np.zeros((2, 16), dtype='int')
   >>> delays[:, 0] = 32
-  >>> beam.read(mwa_beam_file, pixels_per_deg=1, delays=delays)
+  >>> beam = UVBeam.from_file(
+  ...    mwa_beam_file, pixels_per_deg=1, delays=delays, use_future_array_shapes=True
+  ... )
 
 
 d) Writing a regularly gridded beam FITS file
@@ -238,9 +238,15 @@ files and az/za grid.
   >>> import os
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
-  >>> beam = UVBeam()
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam.read(settings_file, beam_type='power', freq_range=(1e8, 1.5e8), za_range=(0, 90.0))
+  >>> beam = UVBeam()
+  >>> beam.read(
+  ...    settings_file,
+  ...    beam_type='power',
+  ...    freq_range=(1e8, 1.5e8),
+  ...    za_range=(0, 90.0),
+  ...    use_future_array_shapes=True,
+  ... )
   >>> write_file = os.path.join('.', 'tutorial.fits')
   >>> beam.write_beamfits(write_file, clobber=True)
 
@@ -254,9 +260,8 @@ See :ref:`uvbeam_to_healpix` for more details on the :meth:`pyuvdata.UVBeam.to_h
   >>> import numpy as np
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
-  >>> beam = UVBeam()
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam.read(settings_file, beam_type='power')
+  >>> beam = UVBeam.from_file(settings_file, beam_type='power', use_future_array_shapes=True)
 
   >>> # note that the `to_healpix` method requires astropy_healpix to be installed
   >>> # this beam file is very large. Let's cut down the size to ease the computation
@@ -284,9 +289,8 @@ a) Selecting a range of Zenith Angles
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
   >>> import matplotlib.pyplot as plt # doctest: +SKIP
-  >>> beam = UVBeam()
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam.read(settings_file, beam_type='power')
+  >>> beam = UVBeam.from_file(settings_file, beam_type='power', use_future_array_shapes=True)
   >>> new_beam = beam.select(axis2_inds=np.arange(0, 20), inplace=False)
 
   >>> # plot zenith angle cut through beams
@@ -316,9 +320,8 @@ or "ee).
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
   >>> import pyuvdata.utils as uvutils
-  >>> uvb = UVBeam()
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> uvb.read(settings_file, beam_type='efield')
+  >>> uvb = UVBeam.from_file(settings_file, beam_type='efield', use_future_array_shapes=True)
 
   >>> # The feeds names can be found in the feed_array
   >>> print(uvb.feed_array)
@@ -400,9 +403,8 @@ extra interpolation errors.
   >>> from matplotlib.colors import LogNorm # doctest: +SKIP
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
-  >>> beam = UVBeam()
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam.read(settings_file, beam_type='power')
+  >>> beam = UVBeam.from_file(settings_file, beam_type='power', use_future_array_shapes=True)
 
   >>> # this beam file is very large. Let's cut down the size to ease the computation
   >>> za_max = np.deg2rad(10.0)
@@ -428,9 +430,8 @@ a) Convert a regularly gridded efield beam to a power beam (leaving original int
   >>> import matplotlib.pyplot as plt # doctest: +SKIP
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
-  >>> beam = UVBeam()
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam.read(settings_file, beam_type='efield')
+  >>> beam = UVBeam.from_file(settings_file, beam_type='efield', use_future_array_shapes=True)
   >>> new_beam = beam.efield_to_power(inplace=False)
 
   >>> # plot zenith angle cut through the beams
@@ -453,9 +454,8 @@ b) Generating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beams
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
   >>> from pyuvdata import utils as uvutils
-  >>> beam = UVBeam()
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam.read(settings_file, beam_type='efield')
+  >>> beam = UVBeam.from_file(settings_file, beam_type='efield', use_future_array_shapes=True)
 
   >>> # this beam file is very large. Let's cut down the size to ease the computation
   >>> za_max = np.deg2rad(10.0)
@@ -489,9 +489,10 @@ a) Calculating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beam area and beam squared
   >>> import numpy as np
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
-  >>> beam = UVBeam()
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam.read(settings_file, beam_type='efield')
+  >>> beam = UVBeam.from_file(
+  ...    settings_file, beam_type='efield', use_future_array_shapes=True
+  ... )
 
   >>> # note that the `to_healpix` method requires astropy_healpix to be installed
   >>> # this beam file is very large. Let's cut down the size to ease the computation
@@ -514,7 +515,7 @@ a) Calculating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beam area and beam squared
   >>> pU_area1, pU_area2 = round(pU_area[0].real, 5), round(pU_area[1].real, 5)
   >>> pV_area1, pV_area2 = round(pV_area[0].real, 5), round(pV_area[1].real, 5)
 
-  >>> print (f'Beam area at {freqs[0][0]*1e-6} MHz for pseudo-stokes\nI: {pI_area1}\nQ: {pQ_area1}\nU: {pU_area1}\nV: {pV_area1}')
+  >>> print (f'Beam area at {freqs[0]*1e-6} MHz for pseudo-stokes\nI: {pI_area1}\nQ: {pQ_area1}\nU: {pU_area1}\nV: {pV_area1}')
   Beam area at 123.0 MHz for pseudo-stokes
   I: 0.04674
   Q: 0.02904
@@ -522,7 +523,7 @@ a) Calculating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beam area and beam squared
   V: 0.0464
 
 
-  >>> print (f'Beam area at {freqs[0][1]*1e-6} MHz for pseudo-stokes\nI: {pI_area2}\nQ: {pQ_area2}\nU: {pU_area2}\nV: {pV_area2}')
+  >>> print (f'Beam area at {freqs[1]*1e-6} MHz for pseudo-stokes\nI: {pI_area2}\nQ: {pQ_area2}\nU: {pU_area2}\nV: {pV_area2}')
   Beam area at 150.0 MHz for pseudo-stokes
   I: 0.03237
   Q: 0.01995
@@ -541,7 +542,7 @@ a) Calculating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beam area and beam squared
   >>> pU_sq_area1, pU_sq_area2 = round(pU_sq_area[0].real, 5), round(pU_sq_area[1].real, 5)
   >>> pV_sq_area1, pV_sq_area2 = round(pV_sq_area[0].real, 5), round(pV_sq_area[1].real, 5)
 
-  >>> print (f'Beam squared area at {freqs[0][0]*1e-6} MHz for pseudo-stokes\nI: {pI_sq_area1}\nQ: {pQ_sq_area1}\nU: {pU_sq_area1}\nV: {pV_sq_area1}')
+  >>> print (f'Beam squared area at {freqs[0]*1e-6} MHz for pseudo-stokes\nI: {pI_sq_area1}\nQ: {pQ_sq_area1}\nU: {pU_sq_area1}\nV: {pV_sq_area1}')
   Beam squared area at 123.0 MHz for pseudo-stokes
   I: 0.02474
   Q: 0.01186
@@ -549,7 +550,7 @@ a) Calculating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beam area and beam squared
   V: 0.0246
 
 
-  >>> print (f'Beam squared area at {freqs[0][1]*1e-6} MHz for pseudo-stokes\nI: {pI_sq_area2}\nQ: {pQ_sq_area2}\nU: {pU_sq_area2}\nV: {pV_sq_area2}')
+  >>> print (f'Beam squared area at {freqs[1]*1e-6} MHz for pseudo-stokes\nI: {pI_sq_area2}\nQ: {pQ_sq_area2}\nU: {pU_sq_area2}\nV: {pV_sq_area2}')
   Beam squared area at 150.0 MHz for pseudo-stokes
   I: 0.01696
   Q: 0.00798

--- a/docs/uvcal_tutorial.rst
+++ b/docs/uvcal_tutorial.rst
@@ -98,7 +98,7 @@ a) Reading a cal fits gain calibration file.
   >>> from pyuvdata.data import DATA_PATH
   >>> cal = UVCal()
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
 
   >>> # Cal type:
   >>> print(cal.cal_type)
@@ -118,7 +118,7 @@ a) Reading a cal fits gain calibration file.
 
   >>> # Shape of the gain_array
   >>> print(cal.gain_array.shape)
-  (19, 1, 10, 5, 1)
+  (19, 10, 5, 1)
 
   >>> # plot abs of all gains for first time and first jones component.
   >>> for ant in range(cal.Nants_data): # doctest: +SKIP
@@ -142,7 +142,11 @@ b) FHD cal to cal fits
 
   >>> fhd_cal = UVCal()
   >>> fhd_cal.read_fhd_cal(
-  ...   cal_testfile, obs_testfile, settings_file=settings_testfile, layout_file=layout_testfile
+  ...    cal_testfile,
+  ...    obs_testfile,
+  ...    settings_file=settings_testfile,
+  ...    layout_file=layout_testfile,
+  ...    use_future_array_shapes=True,
   ... )
   >>> fhd_cal.write_calfits(os.path.join('.', 'tutorial_cal.fits'), clobber=True)
 
@@ -162,7 +166,7 @@ data-like arrays as well, filled with zeros.
   >>> from pyuvdata import UVData, UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> uvd_file = os.path.join(DATA_PATH, "zen.2458098.45361.HH.uvh5_downselected")
-  >>> uvd = UVData.from_file(uvd_file, file_type="uvh5")
+  >>> uvd = UVData.from_file(uvd_file, file_type="uvh5", use_future_array_shapes=True)
   >>> uvc = UVCal.initialize_from_uvdata(uvd, "multiply", "redundant")
   >>> print(uvc.ant_array)
   [ 0  1 11 12 13 23 24 25]
@@ -187,7 +191,7 @@ a) Data for a single antenna and instrumental polarization
   >>> from pyuvdata.data import DATA_PATH
   >>> UVC = UVCal()
   >>> filename = os.path.join(DATA_PATH, 'zen.2457555.42443.HH.uvcA.omni.calfits')
-  >>> UVC.read_calfits(filename)
+  >>> UVC.read_calfits(filename, use_future_array_shapes=True)
   >>> gain = UVC.get_gains(9, 'Jxx')  # gain for ant=9, pol='Jxx'
 
   >>> # One can equivalently make any of these calls with the input wrapped in a tuple.
@@ -214,10 +218,16 @@ a) Calibration of UVData by UVCal
   >>> import os
   >>> from pyuvdata import UVData, UVCal, utils
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
-  >>> uvd.read(os.path.join(DATA_PATH, "zen.2458098.45361.HH.uvh5_downselected"), file_type="uvh5")
+  >>> uvd = UVData.from_file(
+  ...    os.path.join(DATA_PATH, "zen.2458098.45361.HH.uvh5_downselected"),
+  ...    file_type="uvh5",
+  ...    use_future_array_shapes=True
+  ... )
   >>> uvc = UVCal()
-  >>> uvc.read_calfits(os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected"))
+  >>> uvc.read_calfits(
+  ...    os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected"),
+  ...    use_future_array_shapes=True
+  ... )
   >>> # this is an old calfits file which has the wrong antenna names, so we need to fix them first.
   >>> # fix the antenna names in the uvcal object to match the uvdata object
   >>> uvc.antenna_names = np.array(
@@ -245,7 +255,7 @@ a) Select antennas to keep on UVCal object using the antenna number.
   >>> import numpy as np
   >>> cal = UVCal()
   >>> filename = os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
 
   >>> # print all the antennas numbers with data in the original file
   >>> print(cal.ant_array)
@@ -266,14 +276,14 @@ b) Select antennas to keep using the antenna names, also select frequencies to k
   >>> from pyuvdata.data import DATA_PATH
   >>> cal = UVCal()
   >>> filename = os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
 
   >>> # print all the antenna names with data in the original file
   >>> print([cal.antenna_names[np.where(cal.antenna_numbers==a)[0][0]] for a in cal.ant_array])
   ['ant0', 'ant1', 'ant11', 'ant12', 'ant13', 'ant23', 'ant24', 'ant25']
 
   >>> # print the first 10 frequencies in the original file
-  >>> print(cal.freq_array[0, 0:10])
+  >>> print(cal.freq_array[0:10])
   [1.000000e+08 1.015625e+08 1.031250e+08 1.046875e+08 1.062500e+08
    1.078125e+08 1.093750e+08 1.109375e+08 1.125000e+08 1.140625e+08]
   >>> cal.select(antenna_names=['ant11', 'ant13', 'ant25'], freq_chans=np.arange(0, 4))
@@ -284,7 +294,7 @@ b) Select antennas to keep using the antenna names, also select frequencies to k
 
   >>> # print all the frequencies after the select
   >>> print(cal.freq_array)
-  [[1.000000e+08 1.015625e+08 1.031250e+08 1.046875e+08]]
+  [1.000000e+08 1.015625e+08 1.031250e+08 1.046875e+08]
 
 d) Select times
 ***************
@@ -296,7 +306,7 @@ d) Select times
   >>> from pyuvdata.data import DATA_PATH
   >>> cal = UVCal()
   >>> filename = os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
 
   >>> # print all the times in the original file
   >>> print(cal.time_array)
@@ -326,7 +336,7 @@ represting the physical orientation of the dipole can also be used (e.g. "Jnn" o
   >>> import pyuvdata.utils as uvutils
   >>> cal = UVCal()
   >>> filename = os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
 
   >>> # Jones component numbers can be found in the jones_array
   >>> print(cal.jones_array)
@@ -385,7 +395,7 @@ a) Add frequencies.
   >>> from pyuvdata.data import DATA_PATH
   >>> cal1 = UVCal()
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal1.read_calfits(filename)
+  >>> cal1.read_calfits(filename, use_future_array_shapes=True)
   >>> cal2 = cal1.copy()
 
   >>> # Downselect frequencies to recombine
@@ -405,7 +415,7 @@ b) Add times.
   >>> from pyuvdata.data import DATA_PATH
   >>> cal1 = UVCal()
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal1.read_calfits(filename)
+  >>> cal1.read_calfits(filename, use_future_array_shapes=True)
   >>> cal2 = cal1.copy()
 
   >>> # Downselect times to recombine
@@ -429,14 +439,14 @@ directly without creating a third uvcal object.
   >>> from pyuvdata.data import DATA_PATH
   >>> cal1 = UVCal()
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal1.read_calfits(filename)
+  >>> cal1.read_calfits(filename, use_future_array_shapes=True)
   >>> cal2 = cal1.copy()
   >>> times = np.unique(cal1.time_array)
   >>> cal1.select(times=times[0:len(times) // 2])
   >>> cal2.select(times=times[len(times) // 2:])
   >>> cal1.__add__(cal2, inplace=True)
 
-  >>> cal1.read_calfits(filename)
+  >>> cal1.read_calfits(filename, use_future_array_shapes=True)
   >>> cal2 = cal1.copy()
   >>> cal1.select(times=times[0:len(times) // 2])
   >>> cal2.select(times=times[len(times) // 2:])
@@ -456,7 +466,7 @@ each file will be read in succession and added to the previous.
   >>> from pyuvdata.data import DATA_PATH
   >>> cal = UVCal()
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
   >>> cal1 = cal.select(freq_chans=np.arange(0, 2), inplace=False)
   >>> cal2 = cal.select(freq_chans=np.arange(2, 4), inplace=False)
   >>> cal3 = cal.select(freq_chans=np.arange(4, 7), inplace=False)
@@ -465,7 +475,7 @@ each file will be read in succession and added to the previous.
   >>> cal3.write_calfits(os.path.join('.', 'tutorial3.fits'))
   >>> filenames = [os.path.join('.', f) for f
   ...              in ['tutorial1.fits', 'tutorial2.fits', 'tutorial3.fits']]
-  >>> cal.read_calfits(filenames)
+  >>> cal.read_calfits(filenames, use_future_array_shapes=True)
 
   >>> # For FHD cal datasets pass lists for each file type
   >>> fhd_cal = UVCal()
@@ -486,7 +496,11 @@ each file will be read in succession and added to the previous.
   ...   os.path.join(DATA_PATH, 'fhd_cal_data/1061316296_layout.sav'),
   ... ]
   >>> fhd_cal.read_fhd_cal(
-  ...   cal_testfiles, obs_testfiles, settings_file=settings_testfiles, layout_file=layout_testfiles
+  ...    cal_testfiles,
+  ...    obs_testfiles,
+  ...    settings_file=settings_testfiles,
+  ...    layout_file=layout_testfiles,
+  ...    use_future_array_shapes=True,
   ... )
 
 UVCal: Sorting data along various axes
@@ -508,7 +522,7 @@ specified by passing an index array.
   >>> from pyuvdata.data import DATA_PATH
   >>> cal = UVCal()
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
   >>> # Default is to order by antenna number
   >>> cal.reorder_antennas()
   >>> print(np.min(np.diff(cal.ant_array)) >= 0)
@@ -536,7 +550,7 @@ channels.
   >>> from pyuvdata.data import DATA_PATH
   >>> cal = UVCal()
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
   >>> # First create a multi-spectral window UVCal object:
   >>> cal._set_flex_spw()
   >>> cal.channel_width = np.zeros(cal.Nfreqs, dtype=np.float64) + cal.channel_width
@@ -545,7 +559,7 @@ channels.
   >>> cal.spw_array = np.array([1, 2])
   >>> spw2_inds = np.nonzero(cal.flex_spw_id_array == 2)[0]
   >>> spw2_chan_width = cal.channel_width[0] * 2
-  >>> cal.freq_array[0, spw2_inds] = cal.freq_array[0, spw2_inds[0]] + spw2_chan_width * np.arange(spw2_inds.size)
+  >>> cal.freq_array[spw2_inds] = cal.freq_array[spw2_inds[0]] + spw2_chan_width * np.arange(spw2_inds.size)
   >>> cal.channel_width[spw2_inds] = spw2_chan_width
 
   >>> # Sort by spectral window number and by frequency within the spectral window
@@ -555,7 +569,7 @@ channels.
   >>> print(cal.spw_array)
   [1 2]
 
-  >>> print(np.min(np.diff(cal.freq_array[0, np.nonzero(cal.flex_spw_id_array == 1)])) >= 0)
+  >>> print(np.min(np.diff(cal.freq_array[np.nonzero(cal.flex_spw_id_array == 1)])) >= 0)
   True
 
   >>> # Prepend a ``-`` to the sort string to sort in descending order.
@@ -565,17 +579,17 @@ channels.
   >>> print(cal.spw_array)
   [2 1]
 
-  >>> print(np.min(np.diff(cal.freq_array[0, np.nonzero(cal.flex_spw_id_array == 1)])) >= 0)
+  >>> print(np.min(np.diff(cal.freq_array[np.nonzero(cal.flex_spw_id_array == 1)])) >= 0)
   True
 
   >>> # Use the ``select_spw`` keyword to sort only one spectral window.
   >>> # Now the frequencies in spectral window 1 are in descending order but the frequencies
   >>> # in spectral window 2 are in ascending order
   >>> cal.reorder_freqs(select_spw=1, channel_order="-freq")
-  >>> print(np.min(np.diff(cal.freq_array[0, np.nonzero(cal.flex_spw_id_array == 1)])) <= 0)
+  >>> print(np.min(np.diff(cal.freq_array[np.nonzero(cal.flex_spw_id_array == 1)])) <= 0)
   True
 
-  >>> print(np.min(np.diff(cal.freq_array[0, np.nonzero(cal.flex_spw_id_array == 2)])) >= 0)
+  >>> print(np.min(np.diff(cal.freq_array[np.nonzero(cal.flex_spw_id_array == 2)])) >= 0)
   True
 
 c) Sorting along the time axis
@@ -593,7 +607,7 @@ array for the time axis.
   >>> from pyuvdata.data import DATA_PATH
   >>> cal = UVCal()
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
 
   >>> # Default is to order by ascending time
   >>> cal.reorder_times()
@@ -619,7 +633,7 @@ by the Jones component number or name, or by an explicit index ordering set by t
   >>> from pyuvdata.data import DATA_PATH
   >>> cal = UVCal()
   >>> filename = os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
   >>> # Default is to order by Jones component name
   >>> cal.reorder_jones()
   >>> print(cal.jones_array)
@@ -641,14 +655,15 @@ object's ``gain_array`` to an array consistent with its pre-existing ``delay_arr
 
   >>> # This file has a cal_type of 'delay'.
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.delay.calfits')
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
   >>> print(cal.cal_type)
   delay
 
   >>> # But we can convert it to a 'gain' type calibration.
   >>> channel_width = 1e8 # 1 MHz
-  >>> n_freqs = (cal.freq_range[1] - cal.freq_range[0]) / channel_width
+  >>> n_freqs = (cal.freq_range[0, 1] - cal.freq_range[0, 0]) / channel_width
   >>> freq_array = np.arange(n_freqs) * channel_width + cal.freq_range[0]
+  >>> channel_width = np.full(freq_array.size, channel_width, dtype=float) # 1 MHz
   >>> cal.convert_to_gain(freq_array=freq_array, channel_width=channel_width)
   >>> print(cal.cal_type)
   gain
@@ -656,23 +671,23 @@ object's ``gain_array`` to an array consistent with its pre-existing ``delay_arr
   >>> # If we want the calibration to use a positive value in its exponent, rather
   >>> # than the default negative value:
   >>> cal = UVCal()
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
   >>> cal = cal.convert_to_gain(delay_convention='plus', freq_array=freq_array, channel_width=channel_width)
 
   >>> # Convert to gain *without* running the default check that internal arrays are
   >>> # of compatible shapes:
   >>> cal = UVCal()
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
   >>> cal.convert_to_gain(freq_array=freq_array, channel_width=channel_width, run_check=False)
 
   >>> # Convert to gain *without* running the default check that optional parameters
   >>> # are properly shaped and typed:
   >>> cal = UVCal()
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
   >>> cal.convert_to_gain(freq_array=freq_array, channel_width=channel_width, check_extra=False)
 
   >>> # Convert to gain *without* running the default checks on the reasonableness
   >>> # of the resulting calibration's parameters.
   >>> cal = UVCal()
-  >>> cal.read_calfits(filename)
+  >>> cal.read_calfits(filename, use_future_array_shapes=True)
   >>> cal.convert_to_gain(freq_array=freq_array, channel_width=channel_width, run_check_acceptability=False)

--- a/docs/uvdata_tutorial.rst
+++ b/docs/uvdata_tutorial.rst
@@ -72,15 +72,16 @@ array of length ``Nfreqs``.
 
 In order to support an orderly conversion of code and packages that use the ``UVData``
 object to these new parameter shapes, we have created the
-:meth:`pyuvdata.UVData.use_future_array_shapes` method which will change the parameters
-listed above to have their future shapes. Users writing new code that uses ``UVData``
-objects are encouraged to call that method immediately after creating a UVData object
-or reading in data from a file to ensure that the code will be compatible with the
-forthcoming changes. Developers and maintainers of existing code that uses ``UVData``
-objects are encouraged to similarly add that method call and convert their code to use
-the new shapes at their earliest convenience to ensure future compatibility. The method
-will be deprecated but not removed in version 3.0 (it will just become a no-op) so
-that code that calls it will continue to function.
+:meth:`pyuvdata.UVData.use_future_array_shapes` method and option on the read method,
+which will change the parameters listed above to have their future shapes. Users writing
+new code that uses ``UVData`` objects are encouraged to use the option in the read
+methods or call that method immediately after creating a UVData object to ensure that
+the code will be compatible with the forthcoming changes. Developers and maintainers of
+existing code that uses ``UVData`` objects are encouraged to similarly add that option
+or method call and convert their code to use the new shapes at their earliest
+convenience to ensure future compatibility. The method and option will be deprecated
+but not removed in version 3.0 (it will just become a no-op) so that code that calls it
+will continue to function.
 
 
 UVData: File conversion
@@ -96,15 +97,14 @@ a) miriad -> uvfits
   >>> import os
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
 
   >>> # This miriad file is known to be a drift scan.
-  >>> # Use the `read` method, optionally specify the file type. Can also use the
-  >>> # file type specific `read_miriad` method, but only if reading a single file.
+  >>> # Use the `read` or `from_file` method, optionally specify the file type.
   >>> miriad_file = os.path.join(DATA_PATH, 'new.uvA')
-  >>> uvd.read(miriad_file)
-  >>> uvd.read(miriad_file, file_type='miriad')
-  >>> uvd.read_miriad(miriad_file)
+  >>> uvd = UVData.from_file(miriad_file, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(
+  ...    miriad_file, file_type='miriad', use_future_array_shapes=True,
+  ... )
 
   >>> # Write out the uvfits file
   >>> write_file = os.path.join('.', 'tutorial.uvfits')
@@ -119,16 +119,13 @@ b) uvfits -> miriad
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> import shutil
-  >>> uvd = UVData()
   >>> uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
 
-  >>> # Use the `read` method (and by extension `from_file`), optionally specify the file type. Can also use the
-  >>> # file type specific `read_uvfits` method, but only if reading a single file.
-  >>> uvd.read(uvfits_file)
-  >>> uvd.read(uvfits_file, file_type='uvfits')
-  >>> uvd.read_uvfits(uvfits_file)
+  >>> # Use the `read` or `from_file` method, optionally specify the file type.
+  >>> uvd.read(uvfits_file, use_future_array_shapes=True)
+  >>> uvd.read(uvfits_file, file_type='uvfits', use_future_array_shapes=True)
   >>> # Here we use the ``from_file`` class method without needing to initialize a new object.
-  >>> uvd = UVData.from_file(uvfits_file)
+  >>> uvd = UVData.from_file(uvfits_file, use_future_array_shapes=True)
 
   >>> # Write out the miriad file
   >>> write_file = os.path.join('.', 'tutorial.uv')
@@ -154,11 +151,9 @@ When reading FHD format, we need to point to several files for each observation.
   ...                                       'vis_model_YY.sav', 'settings.txt',
   ...                                       'layout.sav']]
 
-  # Use the `read` method, optionally specify the file type. Can also use the
-  # file type specific `read_fhd` method, but only if reading a single observation.
-  >>> uvd.read(fhd_files)
-  >>> uvd.read(fhd_files, file_type='fhd')
-  >>> uvd.read_fhd(fhd_files)
+  # Use the `read` method, optionally specify the file type.
+  >>> uvd = UVData.from_file(fhd_files, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(fhd_files, file_type='fhd', use_future_array_shapes=True)
   >>> write_file = os.path.join('.', 'tutorial.uvfits')
   >>> uvd.write_uvfits(write_file)
 
@@ -171,7 +166,6 @@ d) FHD -> miriad
   >>> from pyuvdata.data import DATA_PATH
   >>> import shutil
   >>> import os
-  >>> uvd = UVData()
 
   >>> # Construct the list of files
   >>> fhd_prefix = os.path.join(DATA_PATH, 'fhd_vis_data/1061316296_')
@@ -179,7 +173,7 @@ d) FHD -> miriad
   ...                                       'vis_YY.sav', 'vis_model_XX.sav',
   ...                                       'vis_model_YY.sav', 'settings.txt',
   ...                                       'layout.sav']]
-  >>> uvd.read(fhd_files)
+  >>> uvd = UVData.from_file(fhd_files, use_future_array_shapes=True)
   >>> write_file = os.path.join('.','tutorial.uv')
   >>> if os.path.exists(write_file):
   ...    shutil.rmtree(write_file)
@@ -192,15 +186,13 @@ e) CASA -> uvfits
   >>> import os
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> ms_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.ms')
 
   >>> # Use the `read` method, optionally specify the file type. Can also use the
   >>> # file type specific `read_ms` method, but only if reading a single file.
   >>> # note that reading CASA measurement sets requires casacore to be installed
-  >>> uvd.read(ms_file)
-  >>> uvd.read(ms_file, file_type='ms')
-  >>> uvd.read_ms(ms_file)
+  >>> uvd = UVData.from_file(ms_file, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(ms_file, file_type='ms', use_future_array_shapes=True)
 
   >>> # Write out uvfits file
   >>> write_file = os.path.join('.', 'tutorial.uvfits')
@@ -215,11 +207,10 @@ f) CASA -> miriad
   >>> from pyuvdata.data import DATA_PATH
   >>> import shutil
   >>> import os
-  >>> uvd = UVData()
   >>> ms_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.ms')
 
   >>> # note that reading CASA measurement sets requires casacore to be installed
-  >>> uvd.read(ms_file)
+  >>> uvd = UVData.from_file(ms_file, use_future_array_shapes=True)
 
   >>> # Write out Miriad file
   >>> write_file = os.path.join('.', 'tutorial.uv')
@@ -234,11 +225,10 @@ g) miriad -> uvh5
   >>> import os
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
 
   >>> # This miriad file is known to be a drift scan.
   >>> miriad_file = os.path.join(DATA_PATH, 'new.uvA')
-  >>> uvd.read(miriad_file)
+  >>> uvd = UVData.from_file(miriad_file, use_future_array_shapes=True)
 
   >>> # Write out the uvh5 file
   >>> uvd.write_uvh5(os.path.join('.', 'tutorial.uvh5'))
@@ -251,9 +241,8 @@ h) uvfits -> uvh5
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> import os
-  >>> uvd = UVData()
   >>> uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(uvfits_file)
+  >>> uvd = UVData.from_file(uvfits_file, use_future_array_shapes=True)
 
   >>> # Write out the uvh5 file
   >>> write_file = os.path.join('.', 'tutorial.uvh5')
@@ -262,11 +251,9 @@ h) uvfits -> uvh5
   >>> uvd.write_uvh5(write_file)
 
   >>> # Read the uvh5 file back in.
-  >>> # Use the `read` method, optionally specify the file type. Can also use the
-  >>> # file type specific `read_uvh5` method, but only if reading a single file.
-  >>> uvd.read(write_file)
-  >>> uvd.read(write_file, file_type='uvh5')
-  >>> uvd.read_uvh5(write_file)
+  >>> # Use the `read` or `from_file` method, optionally specify the file type.
+  >>> uvd = UVData.from_file(write_file, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(write_file, file_type='uvh5', use_future_array_shapes=True)
 
 i) MWA correlator -> uvfits
 ***************************
@@ -293,14 +280,11 @@ approximation, and there is an option to instead use a slower integral implement
   >>> filelist = [data_path + i for i in ['1131733552.metafits',
   ... '1131733552_20151116182537_mini_gpubox01_00.fits']]
 
-  >>> # Use the `read` method, optionally specify the file type. Can also use the
-  >>> # file type specific `read_mwa_corr_fits` method, but only if reading files
-  >>> # from a single observation.
+  >>> # Use the `read` or `from_file` method, optionally specify the file type.
   >>> # Apply cable corrections and phase data before writing to uvfits
   >>> # Skip routine time/frequency flagging - see flag_init and associated keywords in documentation
-  >>> uvd.read(filelist, correct_cable_len=True, phase_to_pointing_center=True, flag_init=False)
-  >>> uvd.read(filelist, file_type='mwa_corr_fits', correct_cable_len=True, phase_to_pointing_center=True, flag_init=False)
-  >>> uvd.read_mwa_corr_fits(filelist, correct_cable_len=True, phase_to_pointing_center=True, flag_init=False)
+  >>> uvd.read(filelist, correct_cable_len=True, phase_to_pointing_center=True, flag_init=False, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filelist, file_type='mwa_corr_fits', correct_cable_len=True, phase_to_pointing_center=True, flag_init=False, use_future_array_shapes=True)
 
   >>> # Write out uvfits file
   >>> write_file = os.path.join('.', 'tutorial.uvfits')
@@ -330,9 +314,8 @@ a) Data for single antenna pair / polarization combination.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
   >>> data = uvd.get_data(1, 2, 'rr')  # data for ant1=1, ant2=2, pol='rr'
   >>> times = uvd.get_times(1, 2)  # times corresponding to 0th axis in data
   >>> print(data.shape)
@@ -352,9 +335,8 @@ b) Flags and nsamples for above data.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> flags = uvd.get_flags(1, 2, 'rr')
   >>> nsamples = uvd.get_nsamples(1, 2, 'rr')
@@ -371,9 +353,8 @@ c) Data for single antenna pair, all polarizations.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> data = uvd.get_data(1, 2)
   >>> print(data.shape)
@@ -392,9 +373,8 @@ d) Data for single polarization, all baselines.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> data = uvd.get_data('rr')
   >>> print(data.shape)
@@ -411,9 +391,8 @@ and :meth:`pyuvdata.UVData.set_nsamples` methods.
   >>> import os
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> data = uvd.get_data(1, 2, "rr", force_copy=True, squeeze="none")
   >>> data *= 2
@@ -427,9 +406,8 @@ f) Iterate over all antenna pair / polarizations.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> for key, data in uvd.antpairpol_iter():
   ...  flags = uvd.get_flags(key)
@@ -445,9 +423,8 @@ g) Convenience functions to ask what antennas, baselines, and pols are in the da
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # Get all unique antennas in data
   >>> print(uvd.get_ants())
@@ -490,9 +467,8 @@ Phasing/unphasing data
   >>> from numpy import pi
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> uvh5_file = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-  >>> uvd.read(uvh5_file)
+  >>> uvd = UVData.from_file(uvh5_file, use_future_array_shapes=True)
 
   >>> # We can get information on the sources in the data set by using the
   >>> # `print_phase_center_info` command. This object is initially unprojected (unphased)
@@ -598,9 +574,8 @@ the data have had baseline-dependent averaging applied.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> datafile = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-  >>> uvd.read(datafile)
+  >>> uvd = UVData.from_file(datafile, use_future_array_shapes=True)
   >>> uvd2 = uvd.copy()
   >>> print("Range of integration times: ", np.amin(uvd.integration_time),
   ...       "-", np.amax(uvd.integration_time))
@@ -634,9 +609,8 @@ b) Upsampling in time
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> datafile = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-  >>> uvd.read(datafile)
+  >>> uvd = UVData.from_file(datafile, use_future_array_shapes=True)
   >>> print("Range of integration times: ", np.amin(uvd.integration_time),
   ...       "-", np.amax(uvd.integration_time))
   Range of integration times:  1.879048192 - 1.879048192
@@ -658,11 +632,11 @@ c) Resampling a BDA dataset in time
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> testfile = os.path.join(DATA_PATH, "simulated_bda_file.uvh5")
-  >>> uvd.read(testfile)
-  >>> print("Range of integration times: ", np.amin(uvd.integration_time),
-  ...       "-", np.amax(uvd.integration_time))
+  >>> uvd = UVData.from_file(testfile, use_future_array_shapes=True)
+  >>> print(
+  ...    "Range of integration times: ", np.amin(uvd.integration_time), "-", np.amax(uvd.integration_time)
+  ... )
   Range of integration times:  2.0 - 16.0
 
   >>> # Resample all baselines to an 8s integration time
@@ -682,16 +656,15 @@ d) Averaging in frequency
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> datafile = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-  >>> uvd.read(datafile)
+  >>> uvd = UVData.from_file(datafile, use_future_array_shapes=True)
   >>> print("Channel width: ", uvd.channel_width)
-  Channel width:  122070.3125
+  Channel width:  [122070.3125 122070.3125 122070.3125 122070.3125]
 
   >>> # Average by a factor of 2 in frequency
   >>> uvd.frequency_average(2)
   >>> print("Channel width after frequency averaging: ", uvd.channel_width)
-  Channel width after frequency averaging:  244140.625
+  Channel width after frequency averaging:  [244140.625 244140.625]
 
 UVData: Plotting
 ----------------
@@ -708,13 +681,12 @@ entire file to plot one waterfall.
   >>> import matplotlib.pyplot as plt # doctest: +SKIP
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # Note that the length of the array along axis=1 is always 1.
   >>> print(uvd.data_array.shape)
-  (1360, 1, 64, 4)
+  (1360, 64, 4)
   >>> print(uvd.Ntimes)
   15
   >>> print(uvd.Nfreqs)
@@ -752,9 +724,8 @@ a) Getting antenna positions in topocentric frame in units of meters
   >>> import os
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> data_file = os.path.join(DATA_PATH, 'new.uvA')
-  >>> uvd.read(data_file)
+  >>> uvd = UVData.from_file(data_file, use_future_array_shapes=True)
   >>> antpos, ants = uvd.get_ENU_antpos()
 
   >>> # using utils
@@ -784,9 +755,8 @@ a) Select 3 antennas to keep using the antenna number.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # print all the antennas numbers with data in the original file
   >>> print(np.unique(uvd.ant_1_array.tolist() + uvd.ant_2_array.tolist()))
@@ -805,9 +775,8 @@ b) Select 3 antennas to keep using the antenna names, also select 5 frequencies 
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # print all the antenna names with data in the original file
   >>> unique_ants = np.unique(uvd.ant_1_array.tolist() + uvd.ant_2_array.tolist())
@@ -817,7 +786,7 @@ b) Select 3 antennas to keep using the antenna names, also select 5 frequencies 
   >>> # print how many frequencies in the original file
   >>> print(uvd.freq_array.size)
   64
-  >>> uvd.select(antenna_names=['N02', 'E09', 'W06'], frequencies=uvd.freq_array[0,0:4])
+  >>> uvd.select(antenna_names=['N02', 'E09', 'W06'], frequencies=uvd.freq_array[0:4])
 
   >>> # print all the antenna names with data after the select
   >>> unique_ants = np.unique(uvd.ant_1_array.tolist() + uvd.ant_2_array.tolist())
@@ -826,7 +795,7 @@ b) Select 3 antennas to keep using the antenna names, also select 5 frequencies 
 
   >>> # print all the frequencies after the select
   >>> print(uvd.freq_array)
-  [[3.6304542e+10 3.6304667e+10 3.6304792e+10 3.6304917e+10]]
+  [3.6304542e+10 3.6304667e+10 3.6304792e+10 3.6304917e+10]
 
 c) Select a few antenna pairs to keep
 *************************************
@@ -835,9 +804,8 @@ c) Select a few antenna pairs to keep
   >>> import os
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # print how many antenna pairs with data in the original file
   >>> print(len(set(zip(uvd.ant_1_array, uvd.ant_2_array))))
@@ -857,9 +825,8 @@ d) Select antenna pairs using baseline numbers
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # baseline numbers can be found in the baseline_array
   >>> print(len(uvd.baseline_array))
@@ -888,9 +855,8 @@ the physical orientation of the dipole can also be used (e.g. "nn" or "ee).
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> import pyuvdata.utils as uvutils
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # polarization numbers can be found in the polarization_array
   >>> print(uvd.polarization_array)
@@ -920,7 +886,7 @@ the physical orientation of the dipole can also be used (e.g. "nn" or "ee).
 
   >>> # read in a file with linear polarizations and an x_orientation
   >>> filename = os.path.join(DATA_PATH, 'zen.2458661.23480.HH.uvh5')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # print polarization numbers and strings
   >>> print(uvd.polarization_array)
@@ -960,9 +926,8 @@ ________________________________
   >>> import os
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # Print the number of antenna pairs in the original file
   >>> print(len(uvd.get_antpairs()))
@@ -988,9 +953,8 @@ ___________________________
   >>> import os
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # Print the number of antenna pairs in the original file
   >>> print(len(uvd.get_antpairs()))
@@ -1023,9 +987,8 @@ all antenna pairs kept in the object will retain data for each specified polariz
   >>> import os
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # Print the number of antennas and polarizations with data in the original file
   >>> print((len(uvd.get_antpairs()), uvd.get_pols()))
@@ -1060,9 +1023,8 @@ If a minus sign is present in front of an antenna number, it will not be kept in
   >>> import os
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # Print the number of antenna pairs in the original file
   >>> print(len(uvd.get_antpairs()))
@@ -1089,9 +1051,8 @@ second, the range is assumed to wrap around LST = 0 = 2*pi.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
 
   >>> # Times can be found in the time_array, which is length Nblts.
   >>> # Use unique to find the unique times
@@ -1139,9 +1100,8 @@ h) Select data and return new object (leaving original intact).
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
   >>> uvd2 = uvd.select(antenna_nums=[1, 12, 21], inplace=False)
 
   >>> # print all the antennas numbers with data in the original file
@@ -1165,9 +1125,8 @@ a) Combine frequencies.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd1 = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd1.read(filename)
+  >>> uvd1 = UVData.from_file(filename, use_future_array_shapes=True)
   >>> uvd2 = uvd1.copy()
 
   >>> # Downselect frequencies to recombine
@@ -1185,9 +1144,8 @@ b) Combine times.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd1 = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd1.read(filename)
+  >>> uvd1 = UVData.from_file(filename, use_future_array_shapes=True)
   >>> uvd2 = uvd1.copy()
 
   >>> # Downselect times to recombine
@@ -1210,15 +1168,14 @@ directly without creating a third uvdata object.
   >>> import os
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd1 = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd1.read(filename)
+  >>> uvd1 = UVData.from_file(filename, use_future_array_shapes=True)
   >>> uvd2 = uvd1.copy()
   >>> uvd1.select(times=times[0:len(times) // 2])
   >>> uvd2.select(times=times[len(times) // 2:])
   >>> uvd1.__add__(uvd2, inplace=True)
 
-  >>> uvd1.read(filename)
+  >>> uvd1 = UVData.from_file(filename, use_future_array_shapes=True)
   >>> uvd2 = uvd1.copy()
   >>> uvd1.select(times=times[0:len(times) // 2])
   >>> uvd2.select(times=times[len(times) // 2:])
@@ -1236,9 +1193,8 @@ and combined with the previous file(s).
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
   >>> uvd1 = uvd.select(freq_chans=np.arange(0, 20), inplace=False)
   >>> uvd2 = uvd.select(freq_chans=np.arange(20, 40), inplace=False)
   >>> uvd3 = uvd.select(freq_chans=np.arange(40, 64), inplace=False)
@@ -1247,7 +1203,7 @@ and combined with the previous file(s).
   >>> uvd3.write_uvfits(os.path.join('.', 'tutorial3.uvfits'))
   >>> filenames = [os.path.join('.', f) for f
   ...             in ['tutorial1.uvfits', 'tutorial2.uvfits', 'tutorial3.uvfits']]
-  >>> uvd.read(filenames, allow_rephase=False)
+  >>> uvd = UVData.from_file(filenames, allow_rephase=False, use_future_array_shapes=True)
 
 e) Fast concatenation
 *********************
@@ -1280,9 +1236,8 @@ stored in the uvh5 format.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename)
+  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
   >>> uvd1 = uvd.select(freq_chans=np.arange(0, 20), inplace=False)
   >>> uvd2 = uvd.select(freq_chans=np.arange(20, 40), inplace=False)
   >>> uvd3 = uvd.select(freq_chans=np.arange(40, 64), inplace=False)
@@ -1291,7 +1246,7 @@ stored in the uvh5 format.
   >>> uvd3.write_uvfits(os.path.join('.', 'tutorial3.uvfits'))
   >>> filenames = [os.path.join('.', f) for f
   ...             in ['tutorial1.uvfits', 'tutorial2.uvfits', 'tutorial3.uvfits']]
-  >>> uvd.read(filenames, axis='freq', allow_rephase=False)
+  >>> uvd = UVData.from_file(filenames, axis='freq', allow_rephase=False, use_future_array_shapes=True)
 
 
 UVData: Summing and differencing visibilities
@@ -1305,8 +1260,7 @@ and :meth:`pyuvdata.UVData.diff_vis` methods.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd1 = UVData()
-  >>> uvd1.read(filename)
+  >>> uvd1 = UVData.from_file(filename, use_future_array_shapes=True)
   >>> uvd2 = uvd1.copy()
 
   >>> # sum visibilities
@@ -1346,11 +1300,10 @@ Measurement set (ms) files do not support reading only the metadata
   >>> import os
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
 
   >>> # read the metadata but not the data
-  >>> uvd.read(filename, read_data=False)
+  >>> uvd = UVData.from_file(filename, read_data=False, use_future_array_shapes=True)
 
   >>> print(uvd.metadata_only)
   True
@@ -1382,34 +1335,33 @@ done after the read, which does not save memory.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(filename, freq_chans=np.arange(32))
+  >>> uvd = UVData.from_file(filename, freq_chans=np.arange(32), use_future_array_shapes=True)
   >>> print(uvd.data_array.shape)
-  (1360, 1, 32, 4)
+  (1360, 32, 4)
 
   >>> # Reading in the metadata can help with specifying what data to read in
-  >>> uvd.read(filename, read_data=False)
+  >>> uvd = UVData.from_file(filename, read_data=False, use_future_array_shapes=True)
   >>> unique_times = np.unique(uvd.time_array)
   >>> print(unique_times.shape)
   (15,)
 
   >>> times_to_keep = unique_times[[0, 2, 4]]
-  >>> uvd.read(filename, times=times_to_keep)
+  >>> uvd = UVData.from_file(filename, times=times_to_keep, use_future_array_shapes=True)
   >>> print(uvd.data_array.shape)
-  (179, 1, 64, 4)
+  (179, 64, 4)
 
   >>> # Select a few baselines from a miriad file
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcA')
-  >>> uvd.read(filename, bls=[(9, 10), (9, 20)])
+  >>> uvd = UVData.from_file(filename, bls=[(9, 10), (9, 20)], use_future_array_shapes=True)
   >>> print(uvd.get_antpairs())
   [(9, 10), (9, 20)]
 
   >>> # Select certain frequencies from a uvh5 file
   >>> filename = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-  >>> uvd.read(filename, freq_chans=np.arange(2))
+  >>> uvd = UVData.from_file(filename, freq_chans=np.arange(2), use_future_array_shapes=True)
   >>> print(uvd.data_array.shape)
-  (200, 1, 2, 2)
+  (200, 2, 2)
 
 c) Writing to a uvh5 file in parts
 **********************************
@@ -1434,9 +1386,8 @@ are written to the appropriate parts of the file on disk.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> filename = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-  >>> uvd.read(filename, read_data=False)
+  >>> uvd = UVData.from_file(filename, read_data=False, use_future_array_shapes=True)
   >>> partfile = os.path.join('.', 'tutorial_partial_io.uvh5')
   >>> uvd.initialize_uvh5_file(partfile, clobber=True)
 
@@ -1446,13 +1397,13 @@ are written to the appropriate parts of the file on disk.
   >>> freq_inds1 = np.arange(Hfreqs)
   >>> freq_inds2 = np.arange(Hfreqs, Nfreqs)
   >>> uvd2 = UVData()
-  >>> uvd2.read(filename, freq_chans=freq_inds1)
+  >>> uvd2 = UVData.from_file(filename, freq_chans=freq_inds1, use_future_array_shapes=True)
   >>> data_array = 0.5 * uvd2.data_array
   >>> flag_array = uvd2.flag_array
   >>> nsample_array = uvd2.nsample_array
   >>> uvd.write_uvh5_part(partfile, data_array, flag_array, nsample_array, freq_chans=freq_inds1)
 
-  >>> uvd2.read(filename, freq_chans=freq_inds2)
+  >>> uvd2 = UVData.from_file(filename, freq_chans=freq_inds2, use_future_array_shapes=True)
   >>> data_array = 2.0 * uvd2.data_array
   >>> flag_array = uvd2.flag_array
   >>> nsample_array = uvd2.nsample_array
@@ -1479,9 +1430,8 @@ various conventions (``'ant1<ant2'``, ``'ant2<ant1'``, ``'u<0'``, ``'u>0'``, ``'
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(uvfits_file)
+  >>> uvd = UVData.from_file(uvfits_file, use_future_array_shapes=True)
   >>> uvd.conjugate_bls('ant1<ant2')
   >>> print(np.min(uvd.ant_2_array - uvd.ant_1_array) >= 0)
   True
@@ -1505,9 +1455,8 @@ an option to sort the auto visibilities before the cross visibilities (``autos_f
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(uvfits_file)
+  >>> uvd = UVData.from_file(uvfits_file, use_future_array_shapes=True)
 
   >>> # The default is to sort first by time, then by baseline
   >>> uvd.reorder_blts()
@@ -1545,9 +1494,8 @@ channels.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uvd = UVData()
   >>> testfile = os.path.join(DATA_PATH, "sma_test.mir")
-  >>> uvd.read(testfile)
+  >>> uvd = UVData.from_file(testfile, use_future_array_shapes=True)
 
   >>> # Sort by spectral window number and by frequency within the spectral window
   >>> # Now the spectral windows are in ascending order and the frequencies in each window
@@ -1556,7 +1504,7 @@ channels.
   >>> print(uvd.spw_array)
   [-4 -3 -2 -1  1  2  3  4]
 
-  >>> print(np.min(np.diff(uvd.freq_array[0, np.nonzero(uvd.flex_spw_id_array == 1)])) >= 0)
+  >>> print(np.min(np.diff(uvd.freq_array[np.nonzero(uvd.flex_spw_id_array == 1)])) >= 0)
   True
 
   >>> # Prepend a ``-`` to the sort string to sort in descending order.
@@ -1566,17 +1514,17 @@ channels.
   >>> print(uvd.spw_array)
   [ 4  3  2  1 -1 -2 -3 -4]
 
-  >>> print(np.min(np.diff(uvd.freq_array[0, np.nonzero(uvd.flex_spw_id_array == 1)])) >= 0)
+  >>> print(np.min(np.diff(uvd.freq_array[np.nonzero(uvd.flex_spw_id_array == 1)])) >= 0)
   True
 
   >>> # Use the ``select_spw`` keyword to sort only one spectral window.
   >>> # Now the frequencies in spectral window 1 are in descending order but the frequencies
   >>> # in spectral window 2 are in ascending order
   >>> uvd.reorder_freqs(select_spw=1, channel_order="-freq")
-  >>> print(np.min(np.diff(uvd.freq_array[0, np.nonzero(uvd.flex_spw_id_array == 1)])) <= 0)
+  >>> print(np.min(np.diff(uvd.freq_array[np.nonzero(uvd.flex_spw_id_array == 1)])) <= 0)
   True
 
-  >>> print(np.min(np.diff(uvd.freq_array[0, np.nonzero(uvd.flex_spw_id_array == 2)])) >= 0)
+  >>> print(np.min(np.diff(uvd.freq_array[np.nonzero(uvd.flex_spw_id_array == 2)])) >= 0)
   True
 
 c) Sorting along the polarization axis
@@ -1592,9 +1540,8 @@ ordering set by the user.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> import pyuvdata.utils as uvutils
-  >>> uvd = UVData()
   >>> uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd.read(uvfits_file)
+  >>> uvd = UVData.from_file(uvfits_file, use_future_array_shapes=True)
   >>> print(uvutils.polnum2str(uvd.polarization_array))
   ['rr', 'll', 'rl', 'lr']
 
@@ -1702,7 +1649,10 @@ object.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
 
-  >>> uvd = UVData.from_file(os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5"))
+  >>> uvd = UVData.from_file(
+  ...    os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5"),
+  ...    use_future_array_shapes=True,
+  ... )
   >>> # make a copy to enable comparisons after converting to and from flex_pol
   >>> uvd_orig = uvd.copy()
   >>> print(uvd.polarization_array)
@@ -1712,7 +1662,7 @@ object.
   >>> print(uvd.flex_spw_polarization_array)
   None
   >>> print(uvd.data_array.shape)
-  (200, 1, 4, 2)
+  (200, 4, 2)
 
   >>> uvd.convert_to_flex_pol()
   >>> print(uvd.polarization_array)
@@ -1722,7 +1672,7 @@ object.
   >>> print(uvd.flex_spw_polarization_array)
   [-5 -6]
   >>> print(uvd.data_array.shape)
-  (200, 1, 8, 1)
+  (200, 8, 1)
 
   >>> uvd.remove_flex_pol()
   >>> print(uvd.polarization_array)
@@ -1732,7 +1682,7 @@ object.
   >>> print(uvd.flex_spw_polarization_array)
   None
   >>> print(uvd.data_array.shape)
-  (200, 1, 4, 2)
+  (200, 4, 2)
 
 
 
@@ -1778,10 +1728,12 @@ the baseline array.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> from pyuvdata import utils as uvutils
-  >>> uvd = UVData()
 
   >>> # This file contains a HERA19 layout.
-  >>> uvd.read(os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'))
+  >>> uvd = UVData.from_file(
+  ...   os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'),
+  ...   use_future_array_shapes=True
+  ... )
   >>> uvd.unproject_phase(use_ant_pos=True)
   >>> tol = 0.05  # Tolerance in meters
 
@@ -1830,8 +1782,10 @@ in the full data array based on redundancy.
   >>> import numpy as np
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
-  >>> uv0 = UVData()
-  >>> uv0.read(os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'))
+  >>> uv0 = UVData.from_file(
+  ...   os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'),
+  ...   use_future_array_shapes=True
+  ... )
   >>> tol = 0.02   # In meters
 
   >>> # Compression can be run in-place or return a separate UVData object.
@@ -1880,7 +1834,9 @@ contains antenna 1 will also be flagged).
   >>> from pyuvdata.data import DATA_PATH
   >>> import numpy as np
 
-  >>> uvd = UVData.from_file(os.path.join(DATA_PATH, 'zen.2458661.23480.HH.uvh5'))
+  >>> uvd = UVData.from_file(
+  ...    os.path.join(DATA_PATH, 'zen.2458661.23480.HH.uvh5'), use_future_array_shapes=True
+  ... )
   >>> # Build a binary mask where the cross-correlations are stored.
   >>> cross_mask = uvd.ant_1_array != uvd.ant_2_array
   >>> # Check to see that all the crosses have amplitudes greater than 1

--- a/pyuvdata/conftest.py
+++ b/pyuvdata/conftest.py
@@ -46,10 +46,12 @@ def uvcalibrate_init_data_main():
     uvdata.read(
         os.path.join(DATA_PATH, "zen.2458098.45361.HH.uvh5_downselected"),
         file_type="uvh5",
+        use_future_array_shapes=True,
     )
     uvcal = UVCal()
     uvcal.read_calfits(
-        os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
+        os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected"),
+        use_future_array_shapes=True,
     )
 
     yield uvdata, uvcal

--- a/pyuvdata/tests/test_telescopes.py
+++ b/pyuvdata/tests/test_telescopes.py
@@ -187,7 +187,9 @@ def test_get_telescope_no_loc():
 def test_hera_loc():
     hera_file = os.path.join(DATA_PATH, "zen.2458098.45361.HH.uvh5_downselected")
     hera_data = UVData()
-    hera_data.read(hera_file, read_data=False, file_type="uvh5")
+    hera_data.read(
+        hera_file, read_data=False, file_type="uvh5", use_future_array_shapes=True
+    )
 
     telescope_obj = pyuvdata.get_telescope("HERA")
 

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -3262,9 +3262,10 @@ def test_uvcalibrate_delay_oldfiles(uvd_future_shapes, uvc_future_shapes):
     assert uvdcal == uvdcal2
 
 
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.parametrize("uvc_future_shapes", [True, False])
 @pytest.mark.parametrize("uvd_future_shapes", [True, False])
-@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.parametrize("flip_gain_conj", [False, True])
 @pytest.mark.parametrize("gain_convention", ["divide", "multiply"])
 def test_uvcalibrate(
@@ -3276,10 +3277,10 @@ def test_uvcalibrate(
 ):
     uvd, uvc = uvcalibrate_data
 
-    if uvd_future_shapes:
-        uvd.use_future_array_shapes()
-    if uvc_future_shapes:
-        uvc.use_future_array_shapes()
+    if not uvd_future_shapes:
+        uvd.use_current_array_shapes()
+    if not uvc_future_shapes:
+        uvc.use_current_array_shapes()
 
     uvc.gain_convention = gain_convention
 
@@ -3348,6 +3349,7 @@ def test_uvcalibrate_dterm_handling(uvcalibrate_data):
         uvutils.uvcalibrate(uvd, uvcDterm, Dterm_cal=True)
 
 
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:Cannot preserve total_quality_array")
 @pytest.mark.parametrize("uvc_future_shapes", [True, False])
 @pytest.mark.parametrize("uvd_future_shapes", [True, False])
@@ -3356,10 +3358,10 @@ def test_uvcalibrate_flag_propagation(
 ):
     uvd, uvc = uvcalibrate_data
 
-    if uvd_future_shapes:
-        uvd.use_future_array_shapes()
-    if uvc_future_shapes:
-        uvc.use_future_array_shapes()
+    if not uvd_future_shapes:
+        uvd.use_current_array_shapes()
+    if not uvc_future_shapes:
+        uvc.use_current_array_shapes()
 
     # test flag propagation
     uvc.flag_array[0] = True
@@ -3476,13 +3478,14 @@ def test_uvcalibrate_extra_cal_antennas(uvcalibrate_data):
     )
 
 
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvcalibrate_antenna_names_mismatch(uvcalibrate_init_data, future_shapes):
     uvd, uvc = uvcalibrate_init_data
 
-    if future_shapes:
-        uvd.use_future_array_shapes()
-        uvc.use_future_array_shapes()
+    if not future_shapes:
+        uvd.use_current_array_shapes()
+        uvc.use_current_array_shapes()
 
     with pytest.raises(
         ValueError,
@@ -3674,7 +3677,6 @@ def test_uvcalibrate_x_orientation_mismatch(uvcalibrate_data):
 def test_uvcalibrate_wideband_gain(uvcalibrate_data):
     uvd, uvc = uvcalibrate_data
 
-    uvc.use_future_array_shapes()
     uvc._set_wide_band()
     uvc.flex_spw_id_array = None
     uvc.spw_array = np.array([1, 2, 3])

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -4622,44 +4622,45 @@ def uvcalibrate(
                 )
 
     downselect_cal_freq = False
-    if uvdata.future_array_shapes:
-        uvdata_freq_arr_use = uvdata.freq_array
-    else:
-        uvdata_freq_arr_use = uvdata.freq_array[0, :]
-    if uvcal.future_array_shapes:
-        uvcal_freq_arr_use = uvcal.freq_array
-    else:
-        uvcal_freq_arr_use = uvcal.freq_array[0, :]
-    try:
-        freq_arr_match = np.allclose(
-            np.sort(uvcal_freq_arr_use),
-            np.sort(uvdata_freq_arr_use),
-            atol=uvdata._freq_array.tols[1],
-            rtol=uvdata._freq_array.tols[0],
-        )
-    except ValueError:
-        freq_arr_match = False
-
-    if freq_arr_match is False:
-        # check more carefully
-        uvcal_freqs_to_keep = []
-        for this_freq in uvdata_freq_arr_use:
-            wh_freq_match = np.nonzero(
-                np.isclose(
-                    uvcal.freq_array - this_freq,
-                    0,
-                    atol=uvdata._freq_array.tols[1],
-                    rtol=uvdata._freq_array.tols[0],
-                )
+    if uvcal.freq_array is not None:
+        if uvdata.future_array_shapes:
+            uvdata_freq_arr_use = uvdata.freq_array
+        else:
+            uvdata_freq_arr_use = uvdata.freq_array[0, :]
+        if uvcal.future_array_shapes:
+            uvcal_freq_arr_use = uvcal.freq_array
+        else:
+            uvcal_freq_arr_use = uvcal.freq_array[0, :]
+        try:
+            freq_arr_match = np.allclose(
+                np.sort(uvcal_freq_arr_use),
+                np.sort(uvdata_freq_arr_use),
+                atol=uvdata._freq_array.tols[1],
+                rtol=uvdata._freq_array.tols[0],
             )
-            if wh_freq_match[0].size > 0:
-                uvcal_freqs_to_keep.append(uvcal.freq_array[wh_freq_match][0])
-            else:
-                raise ValueError(
-                    f"Frequency {this_freq} exists on UVData but not on UVCal."
+        except ValueError:
+            freq_arr_match = False
+
+        if freq_arr_match is False:
+            # check more carefully
+            uvcal_freqs_to_keep = []
+            for this_freq in uvdata_freq_arr_use:
+                wh_freq_match = np.nonzero(
+                    np.isclose(
+                        uvcal.freq_array - this_freq,
+                        0,
+                        atol=uvdata._freq_array.tols[1],
+                        rtol=uvdata._freq_array.tols[0],
+                    )
                 )
-        if len(uvcal_freqs_to_keep) < uvcal.Nfreqs:
-            downselect_cal_freq = True
+                if wh_freq_match[0].size > 0:
+                    uvcal_freqs_to_keep.append(uvcal.freq_array[wh_freq_match][0])
+                else:
+                    raise ValueError(
+                        f"Frequency {this_freq} exists on UVData but not on UVCal."
+                    )
+            if len(uvcal_freqs_to_keep) < uvcal.Nfreqs:
+                downselect_cal_freq = True
 
     # check if uvdata.x_orientation isn't set (it's required for uvcal)
     uvd_x = uvdata.x_orientation

--- a/pyuvdata/uvbeam/beamfits.py
+++ b/pyuvdata/uvbeam/beamfits.py
@@ -10,7 +10,7 @@ import numpy as np
 from astropy.io import fits
 
 from .. import utils as uvutils
-from .uvbeam import UVBeam
+from .uvbeam import UVBeam, _future_array_shapes_warning
 
 __all__ = ["BeamFITS"]
 
@@ -541,6 +541,8 @@ class BeamFITS(UVBeam):
 
         if use_future_array_shapes:
             self.use_future_array_shapes()
+        else:
+            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
 
         if run_check:
             self.check(
@@ -777,7 +779,7 @@ class BeamFITS(UVBeam):
                 '"efield" or "power".'.format(type=self.beam_type)
             )
         if self.future_array_shapes:
-            primary_data = primary_data[:, np.newaxis]
+            primary_data = primary_data[:, :, np.newaxis]
 
         primary_header["CRPIX" + str(ax_nums["feed_pol"])] = 1
 

--- a/pyuvdata/uvbeam/cst_beam.py
+++ b/pyuvdata/uvbeam/cst_beam.py
@@ -9,7 +9,7 @@ import warnings
 import numpy as np
 
 from .. import utils as uvutils
-from .uvbeam import UVBeam
+from .uvbeam import UVBeam, _future_array_shapes_warning
 
 __all__ = ["CSTBeam"]
 
@@ -366,6 +366,8 @@ class CSTBeam(UVBeam):
 
         if use_future_array_shapes:
             self.use_future_array_shapes()
+        else:
+            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
 
         if run_check:
             self.check(

--- a/pyuvdata/uvbeam/mwa_beam.py
+++ b/pyuvdata/uvbeam/mwa_beam.py
@@ -10,7 +10,7 @@ import numpy as np
 from scipy.special import factorial, lpmv  # associated Legendre function
 
 from .. import utils as uvutils
-from . import UVBeam
+from .uvbeam import UVBeam, _future_array_shapes_warning
 
 __all__ = ["P1sin", "P1sin_array", "MWABeam"]
 
@@ -700,6 +700,8 @@ class MWABeam(UVBeam):
 
         if use_future_array_shapes:
             self.use_future_array_shapes()
+        else:
+            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
 
         if run_check:
             self.check(

--- a/pyuvdata/uvbeam/tests/conftest.py
+++ b/pyuvdata/uvbeam/tests/conftest.py
@@ -16,10 +16,10 @@ cst_folder = "NicCSTbeams"
 cst_files = [os.path.join(DATA_PATH, cst_folder, f) for f in filenames]
 
 # define some values for optional params here so same across efield & power beams
-receiver_temperature_array = np.random.normal(50.0, 5, size=(1, 2))
-loss_array = np.random.normal(50.0, 5, size=(1, 2))
-mismatch_array = np.random.normal(0.0, 1.0, size=(1, 2))
-s_parameters = np.random.normal(0.0, 0.3, size=(4, 1, 2))
+receiver_temperature_array = np.random.normal(50.0, 5, size=2)
+loss_array = np.random.normal(50.0, 5, size=2)
+mismatch_array = np.random.normal(0.0, 1.0, size=2)
+s_parameters = np.random.normal(0.0, 0.3, size=(4, 2))
 
 
 def make_cst_beam(beam_type):
@@ -49,6 +49,7 @@ def make_cst_beam(beam_type):
             "\nOnly 2 files included to keep test data volume low."
         ),
         extra_keywords=extra_keywords,
+        use_future_array_shapes=True,
     )
 
     # add optional parameters for testing purposes
@@ -306,19 +307,12 @@ def phased_array_beam_2freq(cst_efield_2freq):
     beam.antenna_type = "phased_array"
     beam.Nelements = 4
     beam.coupling_matrix = np.zeros(
-        (
-            beam.Nelements,
-            beam.Nelements,
-            beam.Nfeeds,
-            beam.Nfeeds,
-            beam.Nspws,
-            beam.Nfreqs,
-        ),
+        (beam.Nelements, beam.Nelements, beam.Nfeeds, beam.Nfeeds, beam.Nfreqs),
         dtype=complex,
     )
     for element in range(beam.Nelements):
         beam.coupling_matrix[element, element] = np.ones(
-            (beam.Nfeeds, beam.Nfeeds, beam.Nspws, beam.Nfreqs)
+            (beam.Nfeeds, beam.Nfeeds, beam.Nfreqs)
         )
     beam.delay_array = np.zeros(beam.Nelements, dtype=float)
     beam.gain_array = np.ones(beam.Nelements, dtype=float)

--- a/pyuvdata/uvbeam/tests/test_cst_beam.py
+++ b/pyuvdata/uvbeam/tests/test_cst_beam.py
@@ -546,6 +546,11 @@ def test_read_power_multi_pol():
             "If feed_pol and filename are both lists they need to be the same length",
         ],
         [
+            cst_files[0],
+            {"beam_type": "power", "feed_pol": ["x", "y"]},
+            "Too many feed_pols specified",
+        ],
+        [
             [[cst_files[0]], [cst_files[1]]],
             {"beam_type": "power", "frequency": [150e6, 123e6], "feed_pol": ["x"]},
             "filename can not be a nested list",

--- a/pyuvdata/uvbeam/tests/test_mwa_beam.py
+++ b/pyuvdata/uvbeam/tests/test_mwa_beam.py
@@ -11,6 +11,7 @@ import pyuvdata.utils as uvutils
 from pyuvdata import UVBeam
 from pyuvdata.data import DATA_PATH
 from pyuvdata.uvbeam.mwa_beam import P1sin, P1sin_array
+from pyuvdata.uvbeam.uvbeam import _future_array_shapes_warning
 
 filename = os.path.join(DATA_PATH, "mwa_full_EE_test.h5")
 
@@ -18,7 +19,7 @@ filename = os.path.join(DATA_PATH, "mwa_full_EE_test.h5")
 @pytest.fixture(scope="module")
 def mwa_beam_1ppd_main():
     beam = UVBeam()
-    beam.read_mwa_beam(filename, pixels_per_deg=1)
+    beam.read_mwa_beam(filename, pixels_per_deg=1, use_future_array_shapes=True)
 
     yield beam
     del beam
@@ -32,17 +33,24 @@ def mwa_beam_1ppd(mwa_beam_1ppd_main):
     del beam
 
 
-def test_read_write_mwa(mwa_beam_1ppd, tmp_path):
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.parametrize("future_shapes", [True, False])
+def test_read_write_mwa(mwa_beam_1ppd, tmp_path, future_shapes):
     """Basic read/write test."""
     beam1 = mwa_beam_1ppd
     beam2 = UVBeam()
 
-    beam1.read_mwa_beam(filename, pixels_per_deg=1)
+    beam1.read_mwa_beam(
+        filename, pixels_per_deg=1, use_future_array_shapes=future_shapes
+    )
     assert beam1.filename == ["mwa_full_EE_test.h5"]
 
     assert beam1.pixel_coordinate_system == "az_za"
     assert beam1.beam_type == "efield"
-    assert beam1.data_array.shape == (2, 1, 2, 3, 91, 360)
+    if future_shapes:
+        assert beam1.data_array.shape == (2, 2, 3, 91, 360)
+    else:
+        assert beam1.data_array.shape == (2, 1, 2, 3, 91, 360)
 
     # this is entirely empirical, just to prevent unexpected changes.
     # The actual values have been validated through external tests against
@@ -56,7 +64,7 @@ def test_read_write_mwa(mwa_beam_1ppd, tmp_path):
     outfile_name = str(tmp_path / "mwa_beam_out.fits")
     beam1.write_beamfits(outfile_name, clobber=True)
 
-    beam2.read_beamfits(outfile_name)
+    beam2.read_beamfits(outfile_name, use_future_array_shapes=future_shapes)
 
     assert beam1 == beam2
 
@@ -66,10 +74,20 @@ def test_freq_range(mwa_beam_1ppd):
     beam2 = UVBeam()
 
     # include all
-    beam2.read_mwa_beam(filename, pixels_per_deg=1, freq_range=[100e6, 200e6])
+    beam2.read_mwa_beam(
+        filename,
+        pixels_per_deg=1,
+        freq_range=[100e6, 200e6],
+        use_future_array_shapes=True,
+    )
     assert beam1 == beam2
 
-    beam2.read_mwa_beam(filename, pixels_per_deg=1, freq_range=[100e6, 150e6])
+    beam2.read_mwa_beam(
+        filename,
+        pixels_per_deg=1,
+        freq_range=[100e6, 150e6],
+        use_future_array_shapes=True,
+    )
     beam1.select(freq_chans=[0, 1])
     assert beam1.history != beam2.history
     beam1.history = beam2.history
@@ -78,13 +96,25 @@ def test_freq_range(mwa_beam_1ppd):
     with uvtest.check_warnings(
         UserWarning, match="Only one available frequency in freq_range"
     ):
-        beam1.read_mwa_beam(filename, pixels_per_deg=1, freq_range=[100e6, 130e6])
+        beam1.read_mwa_beam(
+            filename,
+            pixels_per_deg=1,
+            freq_range=[100e6, 130e6],
+            use_future_array_shapes=True,
+        )
 
     with pytest.raises(ValueError, match="No frequencies available in freq_range"):
-        beam2.read_mwa_beam(filename, pixels_per_deg=1, freq_range=[100e6, 110e6])
+        beam2.read_mwa_beam(
+            filename,
+            pixels_per_deg=1,
+            freq_range=[100e6, 110e6],
+            use_future_array_shapes=True,
+        )
 
     with pytest.raises(ValueError, match="freq_range must have 2 elements."):
-        beam2.read_mwa_beam(filename, pixels_per_deg=1, freq_range=[100e6])
+        beam2.read_mwa_beam(
+            filename, pixels_per_deg=1, freq_range=[100e6], use_future_array_shapes=True
+        )
 
 
 def test_p1sin_array():
@@ -110,7 +140,9 @@ def test_bad_amps():
 
     amps = np.ones([2, 8])
     with pytest.raises(ValueError) as cm:
-        beam1.read_mwa_beam(filename, pixels_per_deg=1, amplitudes=amps)
+        beam1.read_mwa_beam(
+            filename, pixels_per_deg=1, amplitudes=amps, use_future_array_shapes=True
+        )
     assert str(cm.value).startswith("amplitudes must be shape")
 
 
@@ -119,18 +151,24 @@ def test_bad_delays():
 
     delays = np.zeros([2, 8], dtype="int")
     with pytest.raises(ValueError) as cm:
-        beam1.read_mwa_beam(filename, pixels_per_deg=1, delays=delays)
+        beam1.read_mwa_beam(
+            filename, pixels_per_deg=1, delays=delays, use_future_array_shapes=True
+        )
     assert str(cm.value).startswith("delays must be shape")
 
     delays = np.zeros((2, 16), dtype="int")
     delays = delays + 64
     with pytest.raises(ValueError) as cm:
-        beam1.read_mwa_beam(filename, pixels_per_deg=1, delays=delays)
+        beam1.read_mwa_beam(
+            filename, pixels_per_deg=1, delays=delays, use_future_array_shapes=True
+        )
     assert str(cm.value).startswith("There are delays greater than 32")
 
     delays = np.zeros((2, 16), dtype="float")
     with pytest.raises(ValueError) as cm:
-        beam1.read_mwa_beam(filename, pixels_per_deg=1, delays=delays)
+        beam1.read_mwa_beam(
+            filename, pixels_per_deg=1, delays=delays, use_future_array_shapes=True
+        )
     assert str(cm.value).startswith("Delays must be integers.")
 
 
@@ -141,7 +179,9 @@ def test_dead_dipoles():
     delays[:, 0] = 32
 
     with uvtest.check_warnings(UserWarning, "There are some terminated dipoles"):
-        beam1.read_mwa_beam(filename, pixels_per_deg=1, delays=delays)
+        beam1.read_mwa_beam(
+            filename, pixels_per_deg=1, delays=delays, use_future_array_shapes=True
+        )
 
     delay_str = (
         "[[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -19,6 +19,15 @@ from ..uvbase import UVBase
 
 __all__ = ["UVBeam"]
 
+_future_array_shapes_warning = (
+    "The shapes of several attributes will be changing in the future to remove the "
+    "deprecated spectral window axis. You can call the `use_future_array_shapes` "
+    "method to convert to the future array shapes now or set the parameter of the same "
+    "name on this method to both convert to the future array shapes and silence this "
+    "warning. See the UVBeam tutorial on ReadTheDocs for more details about these "
+    "shape changes."
+)
+
 
 class UVBeam(UVBase):
     """
@@ -696,7 +705,7 @@ class UVBeam(UVBase):
 
         """
         if self.future_array_shapes:
-            raise ValueError("This object already has the future array shapes.")
+            return
         self._set_future_array_shapes()
         self.data_array = self.data_array[:, 0]
         if self.coupling_matrix is not None:
@@ -729,8 +738,14 @@ class UVBeam(UVBase):
             but were required in the past.
 
         """
+        warnings.warn(
+            "This method will be removed in version 3.0 when the current array shapes "
+            "are no longer supported.",
+            DeprecationWarning,
+        )
+
         if not self.future_array_shapes:
-            raise ValueError("This object already has the current array shapes.")
+            return
 
         self._data_array.form = ("Naxes_vec", 1, "Nfeeds", "Nfreqs", "Naxes2", "Naxes1")
         self.data_array = self.data_array[:, np.newaxis]
@@ -4210,7 +4225,7 @@ class UVBeam(UVBase):
 
         if isinstance(feed_pol, np.ndarray):
             if len(feed_pol.shape) > 1:
-                raise ValueError("frequency can not be a multi-dimensional array")
+                raise ValueError("feed_pol can not be a multi-dimensional array")
             feed_pol = feed_pol.tolist()
         if isinstance(feed_pol, (list, tuple)):
             if len(feed_pol) == 1:

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -78,10 +78,8 @@ class CALFITS(UVCal):
             else:
                 ref_freq = self.freq_array[0, 0]
         else:
-            if self.future_array_shapes:
-                ref_freq = self.freq_range[0, 0]
-            else:
-                ref_freq = self.freq_range[0]
+            # can only get here if future_shapes is True
+            ref_freq = self.freq_range[0, 0]
 
         if self.Nfreqs > 1:
             if chanwidth_error:
@@ -620,14 +618,10 @@ class CALFITS(UVCal):
             self.x_orientation = hdr.pop("XORIENT")
             self.cal_type = hdr.pop("CALTYPE")
             if self.cal_type == "delay":
-                self.freq_range = np.asarray(
-                    list(map(float, hdr.pop("FRQRANGE").split(",")))
-                )
+                self.freq_range = list(map(float, hdr.pop("FRQRANGE").split(",")))
             else:
                 if "FRQRANGE" in hdr:
-                    self.freq_range = np.asarray(
-                        list(map(float, hdr.pop("FRQRANGE").split(",")))
-                    )
+                    self.freq_range = list(map(float, hdr.pop("FRQRANGE").split(",")))
 
             self.cal_style = hdr.pop("CALSTYLE")
             if self.cal_style == "sky":

--- a/pyuvdata/uvdata/fhd.py
+++ b/pyuvdata/uvdata/fhd.py
@@ -12,7 +12,7 @@ from scipy.io import readsav
 
 from .. import telescopes as uvtel
 from .. import utils as uvutils
-from .uvdata import UVData
+from .uvdata import UVData, _future_array_shapes_warning
 from .uvdata import radian_tol as default_radian_tol
 
 __all__ = ["get_fhd_history", "get_fhd_layout_info", "FHD"]
@@ -329,6 +329,7 @@ class FHD(UVData):
         strict_uvw_antpos_check=False,
         check_autos=True,
         fix_autos=True,
+        use_future_array_shapes=False,
     ):
         """
         Read in data from a list of FHD files.
@@ -373,6 +374,9 @@ class FHD(UVData):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is False.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Raises
         ------
@@ -726,6 +730,11 @@ class FHD(UVData):
             proc.join()
 
         self._set_app_coords_helper()
+
+        if use_future_array_shapes:
+            self.use_future_array_shapes()
+        else:
+            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
 
         # check if object has all required uv_properties set
         if run_check:

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -12,7 +12,7 @@ from astropy.time import Time
 from .. import get_telescope
 from .. import utils as uvutils
 from . import mir_parser
-from .uvdata import UVData
+from .uvdata import UVData, _future_array_shapes_warning
 
 __all__ = ["Mir"]
 
@@ -42,6 +42,7 @@ class Mir(UVData):
         check_autos=True,
         fix_autos=False,
         rechunk=None,
+        use_future_array_shapes=False,
     ):
         """
         Read in data from an SMA MIR file, and map to the UVData model.
@@ -91,6 +92,10 @@ class Mir(UVData):
         rechunk : int
             Number of channels to average over when reading in the dataset. Optional
             argument, typically required to be a power of 2.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
+
         """
         # Use the mir_parser to read in metadata, which can be used to select data.
         mir_data = mir_parser.MirParser(filepath)
@@ -121,6 +126,11 @@ class Mir(UVData):
             mir_data.rechunk(rechunk)
 
         self._init_from_mir_parser(mir_data, allow_flex_pol=allow_flex_pol)
+
+        if use_future_array_shapes:
+            self.use_future_array_shapes()
+        else:
+            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
 
         if run_check:
             self.check(

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -16,7 +16,7 @@ from astropy.time import Time
 
 from .. import telescopes as uvtel
 from .. import utils as uvutils
-from .uvdata import UVData, reporting_request
+from .uvdata import UVData, _future_array_shapes_warning, reporting_request
 
 __all__ = ["Miriad"]
 
@@ -736,6 +736,7 @@ class Miriad(UVData):
         fix_use_ant_pos=True,
         check_autos=True,
         fix_autos=True,
+        use_future_array_shapes=False,
     ):
         """
         Read in data from a miriad file.
@@ -826,6 +827,9 @@ class Miriad(UVData):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is False.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Raises
         ------
@@ -1684,6 +1688,11 @@ class Miriad(UVData):
         if fix_old_proj and projected:
             # this will error if it could not have been phased with the old method
             self.fix_phase(use_ant_pos=fix_use_ant_pos)
+
+        if use_future_array_shapes:
+            self.use_future_array_shapes()
+        else:
+            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
 
         # check if object has all required uv_properties set
         if run_check:

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -14,7 +14,7 @@ import numpy as np
 from astropy.time import Time
 
 from .. import utils as uvutils
-from .uvdata import UVData, reporting_request
+from .uvdata import UVData, _future_array_shapes_warning, reporting_request
 
 __all__ = ["MS"]
 
@@ -1890,6 +1890,7 @@ class MS(UVData):
         allow_flex_pol=False,
         check_autos=True,
         fix_autos=True,
+        use_future_array_shapes=False,
     ):
         """
         Read in a casa measurement set.
@@ -1954,6 +1955,9 @@ class MS(UVData):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is True.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Raises
         ------
@@ -2357,6 +2361,11 @@ class MS(UVData):
 
         # order polarizations
         self.reorder_pols(order=pol_order, run_check=False)
+
+        if use_future_array_shapes:
+            self.use_future_array_shapes()
+        else:
+            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
 
         if run_check:
             self.check(

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -20,7 +20,7 @@ from pyuvdata.data import DATA_PATH
 
 from .. import _corr_fits
 from .. import utils as uvutils
-from . import UVData
+from .uvdata import UVData, _future_array_shapes_warning
 
 __all__ = ["input_output_mapping", "MWACorrFITS"]
 
@@ -1101,6 +1101,7 @@ class MWACorrFITS(UVData):
         strict_uvw_antpos_check=False,
         check_autos=True,
         fix_autos=True,
+        use_future_array_shapes=False,
     ):
         """
         Read in MWA correlator gpu box files.
@@ -1213,7 +1214,9 @@ class MWACorrFITS(UVData):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is True.
-
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Raises
         ------
@@ -1857,7 +1860,15 @@ class MWACorrFITS(UVData):
             )
 
         # switch to current_array_shape
-        self.use_current_array_shapes()
+        if not use_future_array_shapes:
+            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="This method will be removed in version 3.0 when the "
+                    "current array shapes are no longer supported.",
+                )
+                self.use_current_array_shapes()
 
         # check if object is self-consistent
         # uvws are calcuated using pyuvdata, so turn off the check for speed.

--- a/pyuvdata/uvdata/tests/conftest.py
+++ b/pyuvdata/uvdata/tests/conftest.py
@@ -29,7 +29,7 @@ def casa_uvfits_main():
             "The uvw_array does not match the expected values",
         ],
     ):
-        uv_in.read(casa_tutorial_uvfits)
+        uv_in.read(casa_tutorial_uvfits, use_future_array_shapes=True)
 
     yield uv_in
 
@@ -54,7 +54,7 @@ def hera_uvh5_main():
     # read in test file for the resampling in time functions
     uv_object = UVData()
     testfile = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-    uv_object.read(testfile)
+    uv_object.read(testfile, use_future_array_shapes=True)
 
     yield uv_object
 
@@ -80,7 +80,7 @@ def paper_miriad_main():
     """Read in PAPER miriad file."""
     pytest.importorskip("pyuvdata.uvdata.aipy_extracts")
     uv_in = UVData()
-    uv_in.read(paper_miriad_file)
+    uv_in.read(paper_miriad_file, use_future_array_shapes=True)
 
     yield uv_in
 
@@ -104,7 +104,7 @@ def sma_mir_main():
     # read in test file for the resampling in time functions
     uv_object = UVData()
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    uv_object.read(testfile)
+    uv_object.read(testfile, use_future_array_shapes=True)
 
     yield uv_object
 
@@ -146,8 +146,8 @@ def uv_phase_comp_main():
         ]
         * 2,
     ):
-        uvd1 = UVData.from_file(file1)
-        uvd2 = UVData.from_file(file2)
+        uvd1 = UVData.from_file(file1, use_future_array_shapes=True)
+        uvd2 = UVData.from_file(file2, use_future_array_shapes=True)
 
     yield uvd1, uvd2
 

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -12570,12 +12570,17 @@ def test_normalize_by_autos_errs(uv_phase_comp, select_kwargs, err_type, err_msg
         uv.normalize_by_autos()
 
 
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
+@pytest.mark.parametrize("future_shapes", [True, False])
 @pytest.mark.parametrize("muck_data", ["pol", "time", None])
-def test_normalize_by_autos_roundtrip(hera_uvh5, muck_data):
+def test_normalize_by_autos_roundtrip(hera_uvh5, muck_data, future_shapes):
     """
     Check that we can roundtrip autocorrelation normalization under various
     different circumstances.
     """
+    if not future_shapes:
+        hera_uvh5.use_current_array_shapes()
+
     if muck_data == "pol":
         # Stick in pseudo-Stokes pols and verify that these roundtrip correctly
         hera_uvh5.polarization_array[:] = [1, 2]

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -18,6 +18,7 @@ import pyuvdata.tests as uvtest
 import pyuvdata.utils as uvutils
 from pyuvdata import UVData
 from pyuvdata.data import DATA_PATH
+from pyuvdata.uvdata.uvdata import _future_array_shapes_warning
 
 from .. import uvh5
 
@@ -33,7 +34,7 @@ def uv_uvh5_main():
     # read in a uvh5 test file
     uv_uvh5 = UVData()
     uvh5_filename = os.path.join(DATA_PATH, "zen.2458432.34569.uvh5")
-    uv_uvh5.read_uvh5(uvh5_filename)
+    uv_uvh5.read_uvh5(uvh5_filename, use_future_array_shapes=True)
     return uv_uvh5
 
 
@@ -54,7 +55,7 @@ def uv_partial_write(casa_uvfits, tmp_path):
     testfile = str(tmp_path / "outtest.uvh5")
     uv_uvfits.write_uvh5(testfile)
     uv_uvh5 = UVData()
-    uv_uvh5.read(testfile)
+    uv_uvh5.read(testfile, use_future_array_shapes=True)
 
     yield uv_uvh5
 
@@ -140,6 +141,8 @@ def make_old_shapes(filename):
         h5f["Data/nsamples"] = nsamples[:, np.newaxis, :, :]
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_read_miriad_write_uvh5_read_uvh5(paper_miriad, future_shapes, tmp_path):
@@ -147,8 +150,8 @@ def test_read_miriad_write_uvh5_read_uvh5(paper_miriad, future_shapes, tmp_path)
     Test a miriad file round trip.
     """
     uv_in = paper_miriad
-    if future_shapes:
-        uv_in.use_future_array_shapes()
+    if not future_shapes:
+        uv_in.use_current_array_shapes()
 
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_miriad.uvh5")
@@ -158,9 +161,7 @@ def test_read_miriad_write_uvh5_read_uvh5(paper_miriad, future_shapes, tmp_path)
         h5file.create_dataset("Test", list(range(10)))
 
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile)
-    if future_shapes:
-        uv_out.use_future_array_shapes()
+    uv_out.read(testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["zen.2456865.60537.xy.uvcRREAA"]
@@ -172,9 +173,7 @@ def test_read_miriad_write_uvh5_read_uvh5(paper_miriad, future_shapes, tmp_path)
     # also test round-tripping phased data
     uv_in.phase_to_time(Time(np.mean(uv_in.time_array), format="jd"))
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read_uvh5(testfile)
-    if future_shapes:
-        uv_out.use_future_array_shapes()
+    uv_out.read_uvh5(testfile, use_future_array_shapes=future_shapes)
 
     assert uv_in == uv_out
 
@@ -193,7 +192,7 @@ def test_read_uvfits_write_uvh5_read_uvh5(casa_uvfits, tmp_path):
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_uvfits.uvh5")
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile)
+    uv_out.read(testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["day2_TDEM0003_10s_norx_1src_1spw.uvfits"]
@@ -205,7 +204,7 @@ def test_read_uvfits_write_uvh5_read_uvh5(casa_uvfits, tmp_path):
     # also test writing double-precision data_array
     uv_in.data_array = uv_in.data_array.astype(np.complex128)
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile)
+    uv_out.read(testfile, use_future_array_shapes=True)
     assert uv_in == uv_out
 
     # clean up
@@ -220,32 +219,41 @@ def test_read_uvh5_errors():
     """
     uv_in = UVData()
     fake_file = os.path.join(DATA_PATH, "fake_file.uvh5")
-    with pytest.raises(IOError) as cm:
+    with pytest.raises(IOError, match=re.escape(f"{fake_file} not found")):
         uv_in.read_uvh5(fake_file)
-    assert str(cm.value).startswith("{} not found".format(fake_file))
 
     return
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 def test_write_uvh5_errors(casa_uvfits, tmp_path):
     """
     Test raising errors in write_uvh5 function.
     """
     uv_in = casa_uvfits
+    uv_in.use_current_array_shapes()
+
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_uvfits.uvh5")
     with open(testfile, "a"):
         os.utime(testfile, None)
 
     # assert IOError if file exists
-    with pytest.raises(IOError) as cm:
+    with pytest.raises(IOError, match="File exists; skipping"):
         uv_in.write_uvh5(testfile, clobber=False)
-    assert str(cm.value).startswith("File exists; skipping")
 
     # use clobber=True to write out anyway
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile)
+    with uvtest.check_warnings(
+        [UserWarning, UserWarning, DeprecationWarning],
+        match=[
+            "Telescope EVLA is not in known_telescopes.",
+            "The uvw_array does not match the expected values",
+            _future_array_shapes_warning,
+        ],
+    ):
+        uv_out.read(testfile)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["day2_TDEM0003_10s_norx_1src_1spw.uvfits"]
@@ -279,7 +287,7 @@ def test_uvh5_optional_parameters(casa_uvfits, tmp_path):
 
     # write out and read back in
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile)
+    uv_out.read(testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["day2_TDEM0003_10s_norx_1src_1spw.uvfits"]
@@ -292,7 +300,7 @@ def test_uvh5_optional_parameters(casa_uvfits, tmp_path):
     uv_in.reorder_blts(order="bda")
 
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile)
+    uv_out.read(testfile, use_future_array_shapes=True)
     assert uv_in == uv_out
 
     # clean up
@@ -301,6 +309,8 @@ def test_uvh5_optional_parameters(casa_uvfits, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_compression_options(casa_uvfits, tmp_path):
     """
@@ -312,6 +322,7 @@ def test_uvh5_compression_options(casa_uvfits, tmp_path):
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_uvfits_compression.uvh5")
 
+    uv_in.use_current_array_shapes()
     # write out and read back in
     uv_in.write_uvh5(
         testfile,
@@ -341,8 +352,7 @@ def test_uvh5_compression_options(casa_uvfits, tmp_path):
         flags_compression=None,
         nsample_compression=None,
     )
-    uv_out.read(testfile)
-    uv_out.use_future_array_shapes()
+    uv_out.read(testfile, use_future_array_shapes=True)
     assert uv_in == uv_out
 
     # check that chunks match
@@ -370,7 +380,12 @@ def test_uvh5_read_multiple_files(casa_uvfits, tmp_path):
     uv2.select(freq_chans=np.arange(32, 64))
     uv1.write_uvh5(testfile1, clobber=True)
     uv2.write_uvh5(testfile2, clobber=True)
-    uv1.read(np.array([testfile1, testfile2]), file_type="uvh5", allow_rephase=False)
+    uv1.read(
+        np.array([testfile1, testfile2]),
+        file_type="uvh5",
+        allow_rephase=False,
+        use_future_array_shapes=True,
+    )
 
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
@@ -414,8 +429,13 @@ def test_uvh5_read_multiple_files_metadata_only(casa_uvfits, tmp_path):
 
     uvfits_filename = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
     uv_full = UVData()
-    uv_full.read_uvfits(uvfits_filename, read_data=False)
-    uv1.read([testfile1, testfile2], read_data=False, allow_rephase=False)
+    uv_full.read_uvfits(uvfits_filename, read_data=False, use_future_array_shapes=True)
+    uv1.read(
+        [testfile1, testfile2],
+        read_data=False,
+        allow_rephase=False,
+        use_future_array_shapes=True,
+    )
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
         uv_full.history + "  Downselected to "
@@ -455,7 +475,12 @@ def test_uvh5_read_multiple_files_axis(casa_uvfits, tmp_path):
     uv2.select(freq_chans=np.arange(32, 64))
     uv1.write_uvh5(testfile1, clobber=True)
     uv2.write_uvh5(testfile2, clobber=True)
-    uv1.read([testfile1, testfile2], axis="freq", allow_rephase=False)
+    uv1.read(
+        [testfile1, testfile2],
+        axis="freq",
+        allow_rephase=False,
+        use_future_array_shapes=True,
+    )
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
         uv_in.history + "  Downselected to "
@@ -487,7 +512,6 @@ def test_uvh5_partial_read_antennas(casa_uvfits, tmp_path):
     Test reading in only certain antennas from disk.
     """
     uv_in = casa_uvfits
-    uv_in.use_future_array_shapes()
 
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
@@ -495,12 +519,12 @@ def test_uvh5_partial_read_antennas(casa_uvfits, tmp_path):
     # change telescope name to avoid errors
     uv_in.telescope_name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
-    uvh5_uv.read(testfile)
+    uvh5_uv.read(testfile, use_future_array_shapes=True)
 
     # select on antennas
     ants_to_keep = np.array([1, 20, 12, 25, 4, 24, 2, 21, 22])
-    uvh5_uv.read(testfile, antenna_nums=ants_to_keep)
-    uvh5_uv2.read(testfile)
+    uvh5_uv.read(testfile, antenna_nums=ants_to_keep, use_future_array_shapes=True)
+    uvh5_uv2.read(testfile, use_future_array_shapes=True)
     uvh5_uv2.select(antenna_nums=ants_to_keep)
     assert uvh5_uv == uvh5_uv2
 
@@ -516,7 +540,6 @@ def test_uvh5_partial_read_freqs(casa_uvfits, tmp_path):
     Test reading in only certain frequencies from disk.
     """
     uv_in = casa_uvfits
-    uv_in.use_future_array_shapes()
 
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
@@ -525,12 +548,12 @@ def test_uvh5_partial_read_freqs(casa_uvfits, tmp_path):
     uv_in.telescope_name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
 
-    uvh5_uv.read(testfile)
+    uvh5_uv.read(testfile, use_future_array_shapes=True)
 
     # select on frequency channels
     chans_to_keep = np.arange(12, 22)
-    uvh5_uv.read(testfile, freq_chans=chans_to_keep)
-    uvh5_uv2.read(testfile)
+    uvh5_uv.read(testfile, freq_chans=chans_to_keep, use_future_array_shapes=True)
+    uvh5_uv2.read(testfile, use_future_array_shapes=True)
     uvh5_uv2.select(freq_chans=chans_to_keep)
     assert uvh5_uv == uvh5_uv2
 
@@ -547,7 +570,6 @@ def test_uvh5_partial_read_pols(casa_uvfits, tmp_path):
     Test reading in only certain polarizations from disk.
     """
     uv_in = casa_uvfits
-    uv_in.use_future_array_shapes()
 
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
@@ -555,20 +577,25 @@ def test_uvh5_partial_read_pols(casa_uvfits, tmp_path):
     # change telescope name to avoid errors
     uv_in.telescope_name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
-    uvh5_uv.read(testfile)
+    uvh5_uv.read(testfile, use_future_array_shapes=True)
 
     # select on pols
     pols_to_keep = [-1, -2]
-    uvh5_uv.read(testfile, polarizations=pols_to_keep)
-    uvh5_uv2.read(testfile)
+    uvh5_uv.read(testfile, polarizations=pols_to_keep, use_future_array_shapes=True)
+    uvh5_uv2.read(testfile, use_future_array_shapes=True)
     uvh5_uv2.select(polarizations=pols_to_keep)
     assert uvh5_uv == uvh5_uv2
 
     # select on pols (non contiguous in file)
     # and check consistent results with and without multidim_index
     pols_to_keep = [-1, -2, -4]
-    uvh5_uv.read(testfile, polarizations=pols_to_keep, multidim_index=True)
-    uvh5_uv2.read(testfile, multidim_index=False)
+    uvh5_uv.read(
+        testfile,
+        polarizations=pols_to_keep,
+        multidim_index=True,
+        use_future_array_shapes=True,
+    )
+    uvh5_uv2.read(testfile, multidim_index=False, use_future_array_shapes=True)
     uvh5_uv2.select(polarizations=pols_to_keep)
     assert uvh5_uv == uvh5_uv2
 
@@ -581,7 +608,6 @@ def test_uvh5_partial_read_times(casa_uvfits, tmp_path):
     Test reading in only certain times from disk.
     """
     uv_in = casa_uvfits
-    uv_in.use_future_array_shapes()
 
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
@@ -589,12 +615,16 @@ def test_uvh5_partial_read_times(casa_uvfits, tmp_path):
     # change telescope name to avoid errors
     uv_in.telescope_name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
-    uvh5_uv.read(testfile)
+    uvh5_uv.read(testfile, use_future_array_shapes=True)
 
     # select on read using time_range
     unique_times = np.unique(uvh5_uv.time_array)
-    uvh5_uv.read(testfile, time_range=[unique_times[0], unique_times[1]])
-    uvh5_uv2.read(testfile)
+    uvh5_uv.read(
+        testfile,
+        time_range=[unique_times[0], unique_times[1]],
+        use_future_array_shapes=True,
+    )
+    uvh5_uv2.read(testfile, use_future_array_shapes=True)
     uvh5_uv2.select(time_range=[unique_times[0], unique_times[1]])
     assert uvh5_uv == uvh5_uv2
 
@@ -610,7 +640,6 @@ def test_uvh5_partial_read_lsts(casa_uvfits, tmp_path):
     Test reading in only certain lsts from disk.
     """
     uv_in = casa_uvfits
-    uv_in.use_future_array_shapes()
 
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
@@ -618,12 +647,16 @@ def test_uvh5_partial_read_lsts(casa_uvfits, tmp_path):
     # change telescope name to avoid errors
     uv_in.telescope_name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
-    uvh5_uv.read(testfile)
+    uvh5_uv.read(testfile, use_future_array_shapes=True)
 
     # select on read using lst_range
     unique_lsts = np.unique(uvh5_uv.lst_array)
-    uvh5_uv.read(testfile, lst_range=[unique_lsts[0], unique_lsts[2]])
-    uvh5_uv2.read(testfile)
+    uvh5_uv.read(
+        testfile,
+        lst_range=[unique_lsts[0], unique_lsts[2]],
+        use_future_array_shapes=True,
+    )
+    uvh5_uv2.read(testfile, use_future_array_shapes=True)
     uvh5_uv2.select(lst_range=[unique_lsts[0], unique_lsts[2]])
     assert uvh5_uv == uvh5_uv2
 
@@ -633,6 +666,8 @@ def test_uvh5_partial_read_lsts(casa_uvfits, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected polarization values are not evenly spaced")
 @pytest.mark.parametrize("future_shapes", [True, False])
@@ -641,8 +676,8 @@ def test_uvh5_partial_read_multi1(casa_uvfits, future_shapes, tmp_path):
     Test select-on-read for multiple axes, frequencies being smallest fraction.
     """
     uv_in = casa_uvfits
-    if future_shapes:
-        uv_in.use_future_array_shapes()
+    if not future_shapes:
+        uv_in.use_current_array_shapes()
 
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
@@ -654,7 +689,7 @@ def test_uvh5_partial_read_multi1(casa_uvfits, future_shapes, tmp_path):
     if not future_shapes:
         make_old_shapes(testfile)
 
-    uvh5_uv.read(testfile)
+    uvh5_uv.read(testfile, use_future_array_shapes=future_shapes)
 
     # now test selecting on multiple axes
     # read frequencies first
@@ -666,8 +701,9 @@ def test_uvh5_partial_read_multi1(casa_uvfits, future_shapes, tmp_path):
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
+        use_future_array_shapes=future_shapes,
     )
-    uvh5_uv2.read(testfile)
+    uvh5_uv2.read(testfile, use_future_array_shapes=future_shapes)
     uvh5_uv2.select(
         antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
     )
@@ -688,8 +724,9 @@ def test_uvh5_partial_read_multi1(casa_uvfits, future_shapes, tmp_path):
                 polarizations=pols_to_keep,
                 freq_chans=chans_to_keep,
                 multidim_index=True,
+                use_future_array_shapes=future_shapes,
             )
-            uvh5_uv4.read(testfile)
+            uvh5_uv4.read(testfile, use_future_array_shapes=future_shapes)
             uvh5_uv4.select(
                 blt_inds=blts_to_keep,
                 polarizations=pols_to_keep,
@@ -703,6 +740,8 @@ def test_uvh5_partial_read_multi1(casa_uvfits, future_shapes, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected polarization values are not evenly spaced")
 @pytest.mark.filterwarnings("ignore:Selected frequencies are not evenly spaced")
@@ -712,8 +751,8 @@ def test_uvh5_partial_read_multi2(casa_uvfits, future_shapes, tmp_path):
     Test select-on-read for multiple axes, baselines being smallest fraction.
     """
     uv_in = casa_uvfits
-    if future_shapes:
-        uv_in.use_future_array_shapes()
+    if not future_shapes:
+        uv_in.use_current_array_shapes()
 
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
@@ -725,7 +764,7 @@ def test_uvh5_partial_read_multi2(casa_uvfits, future_shapes, tmp_path):
     if not future_shapes:
         make_old_shapes(testfile)
 
-    uvh5_uv.read(testfile)
+    uvh5_uv.read(testfile, use_future_array_shapes=future_shapes)
 
     # now test selecting on multiple axes
     # read baselines first
@@ -737,8 +776,9 @@ def test_uvh5_partial_read_multi2(casa_uvfits, future_shapes, tmp_path):
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
+        use_future_array_shapes=future_shapes,
     )
-    uvh5_uv2.read(testfile)
+    uvh5_uv2.read(testfile, use_future_array_shapes=future_shapes)
     uvh5_uv2.select(
         antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
     )
@@ -759,8 +799,9 @@ def test_uvh5_partial_read_multi2(casa_uvfits, future_shapes, tmp_path):
                 freq_chans=chans_to_keep,
                 polarizations=pols_to_keep,
                 multidim_index=True,
+                use_future_array_shapes=future_shapes,
             )
-            uvh5_uv4.read(testfile)
+            uvh5_uv4.read(testfile, use_future_array_shapes=future_shapes)
             uvh5_uv4.select(
                 blt_inds=blts_to_keep,
                 freq_chans=chans_to_keep,
@@ -774,6 +815,8 @@ def test_uvh5_partial_read_multi2(casa_uvfits, future_shapes, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected frequencies are not evenly spaced")
 @pytest.mark.parametrize("future_shapes", [True, False])
@@ -782,8 +825,8 @@ def test_uvh5_partial_read_multi3(casa_uvfits, future_shapes, tmp_path):
     Test select-on-read for multiple axes, polarizations being smallest fraction.
     """
     uv_in = casa_uvfits
-    if future_shapes:
-        uv_in.use_future_array_shapes()
+    if not future_shapes:
+        uv_in.use_current_array_shapes()
 
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
@@ -795,7 +838,7 @@ def test_uvh5_partial_read_multi3(casa_uvfits, future_shapes, tmp_path):
     if not future_shapes:
         make_old_shapes(testfile)
 
-    uvh5_uv.read(testfile)
+    uvh5_uv.read(testfile, use_future_array_shapes=future_shapes)
 
     # now test selecting on multiple axes
     # read polarizations first
@@ -807,8 +850,9 @@ def test_uvh5_partial_read_multi3(casa_uvfits, future_shapes, tmp_path):
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
+        use_future_array_shapes=future_shapes,
     )
-    uvh5_uv2.read(testfile)
+    uvh5_uv2.read(testfile, use_future_array_shapes=future_shapes)
     uvh5_uv2.select(
         antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
     )
@@ -830,8 +874,9 @@ def test_uvh5_partial_read_multi3(casa_uvfits, future_shapes, tmp_path):
                 freq_chans=chans_to_keep,
                 polarizations=pols_to_keep,
                 multidim_index=True,
+                use_future_array_shapes=future_shapes,
             )
-            uvh5_uv4.read(testfile)
+            uvh5_uv4.read(testfile, use_future_array_shapes=future_shapes)
             uvh5_uv4.select(
                 blt_inds=blts_to_keep,
                 freq_chans=chans_to_keep,
@@ -845,6 +890,8 @@ def test_uvh5_partial_read_multi3(casa_uvfits, future_shapes, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected frequencies are not evenly spaced")
 @pytest.mark.parametrize("future_shapes", [True, False])
@@ -853,22 +900,27 @@ def test_uvh5_read_multdim_index(tmp_path, future_shapes, casa_uvfits):
     Test some odd cases for UVH5 multdim indexing
     """
     uv_in = casa_uvfits
-    if future_shapes:
-        uv_in.use_future_array_shapes()
+    if not future_shapes:
+        uv_in.use_current_array_shapes()
 
     testfile = str(tmp_path / "outtest.uvh5")
     # change telescope name to avoid errors
     uv_in.telescope_name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
     uvh5_uv = UVData()
-    uvh5_uv.read(testfile)
+    uvh5_uv.read(testfile, use_future_array_shapes=future_shapes)
 
     # check that non sliceable multidim index is caught
     # and does not fail
     ants_to_keep = np.array([1, 20, 12, 25, 4, 24, 2, 21, 22])
     chans_to_keep = [15, 17, 20]
     uvh5_uv = UVData()
-    uvh5_uv.read(testfile, antenna_nums=ants_to_keep, freq_chans=chans_to_keep)
+    uvh5_uv.read(
+        testfile,
+        antenna_nums=ants_to_keep,
+        freq_chans=chans_to_keep,
+        use_future_array_shapes=future_shapes,
+    )
 
     # clean up
     os.remove(testfile)
@@ -876,6 +928,8 @@ def test_uvh5_read_multdim_index(tmp_path, future_shapes, casa_uvfits):
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_partial_write_antpairs(uv_partial_write, future_shapes, tmp_path):
@@ -883,8 +937,8 @@ def test_uvh5_partial_write_antpairs(uv_partial_write, future_shapes, tmp_path):
     Test writing an entire UVH5 file in pieces by antpairs.
     """
     full_uvh5 = uv_partial_write
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     # delete data arrays in partial file
     partial_uvh5 = full_uvh5.copy()
@@ -905,9 +959,7 @@ def test_uvh5_partial_write_antpairs(uv_partial_write, future_shapes, tmp_path):
         partial_uvh5.write_uvh5_part(partial_testfile, data, flags, nsamples, bls=key)
 
     # now read in the full file and make sure that it matches the original
-    partial_uvh5.read(partial_testfile)
-    if future_shapes:
-        partial_uvh5.use_future_array_shapes()
+    partial_uvh5.read(partial_testfile, use_future_array_shapes=future_shapes)
 
     # make sure filename is what we expect
     assert full_uvh5.filename == ["outtest.uvh5"]
@@ -933,6 +985,8 @@ def test_uvh5_partial_write_antpairs(uv_partial_write, future_shapes, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_partial_write_frequencies(uv_partial_write, future_shapes, tmp_path):
@@ -940,8 +994,8 @@ def test_uvh5_partial_write_frequencies(uv_partial_write, future_shapes, tmp_pat
     Test writing an entire UVH5 file in pieces by frequencies.
     """
     full_uvh5 = uv_partial_write
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     # start over, and write frequencies
     partial_uvh5 = full_uvh5.copy()
@@ -981,9 +1035,7 @@ def test_uvh5_partial_write_frequencies(uv_partial_write, future_shapes, tmp_pat
     )
 
     # read in the full file and make sure it matches
-    partial_uvh5.read(partial_testfile)
-    if future_shapes:
-        partial_uvh5.use_future_array_shapes()
+    partial_uvh5.read(partial_testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames match what we expect
     assert full_uvh5.filename == ["outtest.uvh5"]
@@ -998,6 +1050,8 @@ def test_uvh5_partial_write_frequencies(uv_partial_write, future_shapes, tmp_pat
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_partial_write_blts(uv_partial_write, future_shapes, tmp_path):
@@ -1005,8 +1059,8 @@ def test_uvh5_partial_write_blts(uv_partial_write, future_shapes, tmp_path):
     Test writing an entire UVH5 file in pieces by blt.
     """
     full_uvh5 = uv_partial_write
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     # start over, write chunks of blts
     partial_uvh5 = full_uvh5.copy()
@@ -1036,9 +1090,7 @@ def test_uvh5_partial_write_blts(uv_partial_write, future_shapes, tmp_path):
     )
 
     # read in the full file and make sure it matches
-    partial_uvh5.read(partial_testfile)
-    if future_shapes:
-        partial_uvh5.use_future_array_shapes()
+    partial_uvh5.read(partial_testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames are what we expect
     assert full_uvh5.filename == ["outtest.uvh5"]
@@ -1053,6 +1105,8 @@ def test_uvh5_partial_write_blts(uv_partial_write, future_shapes, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_partial_write_pols(uv_partial_write, future_shapes, tmp_path):
@@ -1060,8 +1114,8 @@ def test_uvh5_partial_write_pols(uv_partial_write, future_shapes, tmp_path):
     Test writing an entire UVH5 file in pieces by pol.
     """
     full_uvh5 = uv_partial_write
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     # start over, write groups of pols
     partial_uvh5 = full_uvh5.copy()
@@ -1109,9 +1163,7 @@ def test_uvh5_partial_write_pols(uv_partial_write, future_shapes, tmp_path):
     )
 
     # read in the full file and make sure it matches
-    partial_uvh5.read(partial_testfile)
-    if future_shapes:
-        partial_uvh5.use_future_array_shapes()
+    partial_uvh5.read(partial_testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames are what we expect
     assert full_uvh5.filename == ["outtest.uvh5"]
@@ -1153,21 +1205,21 @@ def test_uvh5_partial_write_irregular_blt(uv_partial_write, tmp_path):
 
     # write a single blt to file
     blt_inds = np.arange(1)
-    data = full_uvh5.data_array[blt_inds, :, :, :]
-    flags = full_uvh5.flag_array[blt_inds, :, :, :]
-    nsamples = full_uvh5.nsample_array[blt_inds, :, :, :]
+    data = full_uvh5.data_array[blt_inds]
+    flags = full_uvh5.flag_array[blt_inds]
+    nsamples = full_uvh5.nsample_array[blt_inds]
     partial_uvh5.write_uvh5_part(
         partial_testfile, data, flags, nsamples, blt_inds=blt_inds
     )
 
     # also write the arrays to the partial object
-    partial_uvh5.data_array[blt_inds, :, :, :] = data
-    partial_uvh5.flag_array[blt_inds, :, :, :] = flags
-    partial_uvh5.nsample_array[blt_inds, :, :, :] = nsamples
+    partial_uvh5.data_array[blt_inds] = data
+    partial_uvh5.flag_array[blt_inds] = flags
+    partial_uvh5.nsample_array[blt_inds] = nsamples
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile)
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1209,21 +1261,21 @@ def test_uvh5_partial_write_irregular_freq(uv_partial_write, tmp_path):
 
     # write a single freq to file
     freq_inds = np.arange(1)
-    data = full_uvh5.data_array[:, :, freq_inds, :]
-    flags = full_uvh5.flag_array[:, :, freq_inds, :]
-    nsamples = full_uvh5.nsample_array[:, :, freq_inds, :]
+    data = full_uvh5.data_array[:, freq_inds, :]
+    flags = full_uvh5.flag_array[:, freq_inds, :]
+    nsamples = full_uvh5.nsample_array[:, freq_inds, :]
     partial_uvh5.write_uvh5_part(
         partial_testfile, data, flags, nsamples, freq_chans=freq_inds
     )
 
     # also write the arrays to the partial object
-    partial_uvh5.data_array[:, :, freq_inds, :] = data
-    partial_uvh5.flag_array[:, :, freq_inds, :] = flags
-    partial_uvh5.nsample_array[:, :, freq_inds, :] = nsamples
+    partial_uvh5.data_array[:, freq_inds, :] = data
+    partial_uvh5.flag_array[:, freq_inds, :] = flags
+    partial_uvh5.nsample_array[:, freq_inds, :] = nsamples
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile)
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1265,9 +1317,9 @@ def test_uvh5_partial_write_irregular_pol(uv_partial_write, tmp_path):
 
     # write a single pol to file
     pol_inds = np.arange(1)
-    data = full_uvh5.data_array[:, :, :, pol_inds]
-    flags = full_uvh5.flag_array[:, :, :, pol_inds]
-    nsamples = full_uvh5.nsample_array[:, :, :, pol_inds]
+    data = full_uvh5.data_array[:, :, pol_inds]
+    flags = full_uvh5.flag_array[:, :, pol_inds]
+    nsamples = full_uvh5.nsample_array[:, :, pol_inds]
     partial_uvh5.write_uvh5_part(
         partial_testfile,
         data,
@@ -1277,13 +1329,13 @@ def test_uvh5_partial_write_irregular_pol(uv_partial_write, tmp_path):
     )
 
     # also write the arrays to the partial object
-    partial_uvh5.data_array[:, :, :, pol_inds] = data
-    partial_uvh5.flag_array[:, :, :, pol_inds] = flags
-    partial_uvh5.nsample_array[:, :, :, pol_inds] = nsamples
+    partial_uvh5.data_array[:, :, pol_inds] = data
+    partial_uvh5.flag_array[:, :, pol_inds] = flags
+    partial_uvh5.nsample_array[:, :, pol_inds] = nsamples
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile)
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1298,6 +1350,8 @@ def test_uvh5_partial_write_irregular_pol(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_partial_write_irregular_multi1(uv_partial_write, future_shapes, tmp_path):
@@ -1306,8 +1360,8 @@ def test_uvh5_partial_write_irregular_multi1(uv_partial_write, future_shapes, tm
     """
     full_uvh5 = uv_partial_write
     full_uvh5.telescope_name = "PAPER"
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     # delete data arrays in partial file
     partial_uvh5 = full_uvh5.copy()
@@ -1382,9 +1436,7 @@ def test_uvh5_partial_write_irregular_multi1(uv_partial_write, future_shapes, tm
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile)
-    if future_shapes:
-        partial_uvh5_file.use_future_array_shapes()
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1399,6 +1451,8 @@ def test_uvh5_partial_write_irregular_multi1(uv_partial_write, future_shapes, tm
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_partial_write_irregular_multi2(uv_partial_write, future_shapes, tmp_path):
@@ -1407,8 +1461,8 @@ def test_uvh5_partial_write_irregular_multi2(uv_partial_write, future_shapes, tm
     """
     full_uvh5 = uv_partial_write
     full_uvh5.telescope_name = "PAPER"
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     # delete data arrays in partial file
     partial_uvh5 = full_uvh5.copy()
@@ -1487,9 +1541,7 @@ def test_uvh5_partial_write_irregular_multi2(uv_partial_write, future_shapes, tm
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile)
-    if future_shapes:
-        partial_uvh5_file.use_future_array_shapes()
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1504,6 +1556,8 @@ def test_uvh5_partial_write_irregular_multi2(uv_partial_write, future_shapes, tm
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_partial_write_irregular_multi3(uv_partial_write, future_shapes, tmp_path):
@@ -1512,8 +1566,8 @@ def test_uvh5_partial_write_irregular_multi3(uv_partial_write, future_shapes, tm
     """
     full_uvh5 = uv_partial_write
     full_uvh5.telescope_name = "PAPER"
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     # delete data arrays in partial file
     partial_uvh5 = full_uvh5.copy()
@@ -1586,9 +1640,7 @@ def test_uvh5_partial_write_irregular_multi3(uv_partial_write, future_shapes, tm
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile)
-    if future_shapes:
-        partial_uvh5_file.use_future_array_shapes()
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1600,6 +1652,8 @@ def test_uvh5_partial_write_irregular_multi3(uv_partial_write, future_shapes, tm
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_partial_write_irregular_multi4(uv_partial_write, future_shapes, tmp_path):
@@ -1608,8 +1662,8 @@ def test_uvh5_partial_write_irregular_multi4(uv_partial_write, future_shapes, tm
     """
     full_uvh5 = uv_partial_write
     full_uvh5.telescope_name = "PAPER"
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     # delete data arrays in partial file
     partial_uvh5 = full_uvh5.copy()
@@ -1706,9 +1760,7 @@ def test_uvh5_partial_write_irregular_multi4(uv_partial_write, future_shapes, tm
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile)
-    if future_shapes:
-        partial_uvh5_file.use_future_array_shapes()
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1761,20 +1813,20 @@ def test_uvh5_partial_write_errors(uv_partial_write, tmp_path):
         AssertionError, match="data_array and flag_array must have the same shape"
     ):
         partial_uvh5.write_uvh5_part(
-            partial_testfile, data, flags[:, :, :, 0], nsamples, bls=key
+            partial_testfile, data, flags[:, :, 0], nsamples, bls=key
         )
 
     with pytest.raises(
         AssertionError, match="data_array and nsample_array must have the same shape"
     ):
         partial_uvh5.write_uvh5_part(
-            partial_testfile, data, flags, nsamples[:, :, :, 0], bls=key
+            partial_testfile, data, flags, nsamples[:, :, 0], bls=key
         )
 
     # pass in arrays that are the same size, but don't match expected shape
     with pytest.raises(AssertionError, match="data_array has shape"):
         partial_uvh5.write_uvh5_part(
-            partial_testfile, data[:, :, :, 0], flags[:, :, :, 0], nsamples[:, :, :, 0]
+            partial_testfile, data[:, :, 0], flags[:, :, 0], nsamples[:, :, 0]
         )
 
     # initialize a file on disk, and pass in a different object so check_header fails
@@ -1793,6 +1845,8 @@ def test_uvh5_partial_write_errors(uv_partial_write, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_initialize_uvh5_file(uv_partial_write, future_shapes, tmp_path):
@@ -1800,8 +1854,8 @@ def test_initialize_uvh5_file(uv_partial_write, future_shapes, tmp_path):
     Test initializing a UVH5 file on disk.
     """
     full_uvh5 = uv_partial_write
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     full_uvh5.data_array = None
     full_uvh5.flag_array = None
@@ -1813,10 +1867,9 @@ def test_initialize_uvh5_file(uv_partial_write, future_shapes, tmp_path):
     partial_uvh5.initialize_uvh5_file(partial_testfile, clobber=True)
 
     # read it in and make sure that the metadata matches the original
-    partial_uvh5.read(partial_testfile, read_data=False)
-    if future_shapes:
-        # by default, current shapes are used. Change to the future ones.
-        partial_uvh5.use_future_array_shapes()
+    partial_uvh5.read(
+        partial_testfile, read_data=False, use_future_array_shapes=future_shapes
+    )
 
     # make sure filenames are what we expect
     assert partial_uvh5.filename == ["outtest_partial.uvh5"]
@@ -1881,7 +1934,7 @@ def test_initialize_uvh5_file_compression_opts(uv_partial_write, tmp_path):
         flags_compression=None,
         nsample_compression=None,
     )
-    partial_uvh5.read(partial_testfile, read_data=False)
+    partial_uvh5.read(partial_testfile, read_data=False, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert partial_uvh5.filename == ["outtest_partial.uvh5"]
@@ -1910,7 +1963,7 @@ def test_uvh5_lst_array(casa_uvfits, tmp_path):
     # remove lst_array from file; check that it's correctly computed on read
     with h5py.File(testfile, "r+") as h5f:
         del h5f["/Header/lst_array"]
-    uv_out.read_uvh5(testfile)
+    uv_out.read_uvh5(testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["day2_TDEM0003_10s_norx_1src_1spw.uvfits"]
@@ -1933,7 +1986,7 @@ def test_uvh5_lst_array(casa_uvfits, tmp_path):
             "positions.",
         ],
     ):
-        uv_out.read_uvh5(testfile)
+        uv_out.read_uvh5(testfile, use_future_array_shapes=True)
     uv_out.lst_array = lst_array
     assert uv_in == uv_out
 
@@ -1967,7 +2020,7 @@ def test_uvh5_read_header_special_cases(casa_uvfits, tmp_path):
             "The uvw_array does not match the expected values",
         ],
     ):
-        uv_out.read_uvh5(testfile)
+        uv_out.read_uvh5(testfile, use_future_array_shapes=True)
 
     # make input and output values match now
     uv_in.history = uv_out.history
@@ -1997,7 +2050,7 @@ def test_uvh5_read_ints(uv_uvh5, tmp_path):
     uv_in.write_uvh5(testfile, clobber=True)
 
     # read it back in to make sure data is the same
-    uv_out.read(testfile)
+    uv_out.read(testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["zen.2458432.34569.uvh5"]
@@ -2008,7 +2061,9 @@ def test_uvh5_read_ints(uv_uvh5, tmp_path):
 
     # now read in as np.complex128
     uvh5_filename = os.path.join(DATA_PATH, "zen.2458432.34569.uvh5")
-    uv_in.read_uvh5(uvh5_filename, data_array_dtype=np.complex128)
+    uv_in.read_uvh5(
+        uvh5_filename, data_array_dtype=np.complex128, use_future_array_shapes=True
+    )
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["zen.2458432.34569.uvh5"]
@@ -2032,32 +2087,33 @@ def test_uvh5_read_ints_error():
     uvh5_filename = os.path.join(DATA_PATH, "zen.2458432.34569.uvh5")
 
     # raise error for bogus data_array_dtype
-    with pytest.raises(ValueError) as cm:
-        uv_in.read_uvh5(uvh5_filename, data_array_dtype=np.int32)
-    assert str(cm.value).startswith(
-        "data_array_dtype must be np.complex64 or np.complex128"
-    )
+    with pytest.raises(
+        ValueError, match="data_array_dtype must be np.complex64 or np.complex128"
+    ):
+        uv_in.read_uvh5(
+            uvh5_filename, data_array_dtype=np.int32, use_future_array_shapes=True
+        )
 
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_write_ints(uv_uvh5, future_shapes, tmp_path):
     """
     Test writing visibility data as integers.
     """
     uv_in = uv_uvh5
-    if future_shapes:
-        uv_in.use_future_array_shapes()
+    if not future_shapes:
+        uv_in.use_current_array_shapes()
 
     uv_out = UVData()
     testfile = str(tmp_path / "outtest.uvh5")
     uv_in.write_uvh5(testfile, clobber=True, data_write_dtype=uvh5._hera_corr_dtype)
 
     # read it back in to make sure data is the same
-    uv_out.read(testfile)
-    if future_shapes:
-        uv_out.use_future_array_shapes()
+    uv_out.read(testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["zen.2458432.34569.uvh5"]
@@ -2093,8 +2149,8 @@ def test_uvh5_partial_read_ints_antennas():
 
     # select on antennas
     ants_to_keep = np.array([0, 1])
-    uvh5_uv.read(uvh5_file, antenna_nums=ants_to_keep)
-    uvh5_uv2.read(uvh5_file)
+    uvh5_uv.read(uvh5_file, antenna_nums=ants_to_keep, use_future_array_shapes=True)
+    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
     uvh5_uv2.select(antenna_nums=ants_to_keep)
     assert uvh5_uv == uvh5_uv2
 
@@ -2114,8 +2170,8 @@ def test_uvh5_partial_read_ints_freqs():
 
     # select on frequency channels
     chans_to_keep = np.arange(12, 22)
-    uvh5_uv.read(uvh5_file, freq_chans=chans_to_keep)
-    uvh5_uv2.read(uvh5_file)
+    uvh5_uv.read(uvh5_file, freq_chans=chans_to_keep, use_future_array_shapes=True)
+    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
     uvh5_uv2.select(freq_chans=chans_to_keep)
     assert uvh5_uv == uvh5_uv2
 
@@ -2135,8 +2191,8 @@ def test_uvh5_partial_read_ints_pols():
 
     # select on pols
     pols_to_keep = [-5, -6]
-    uvh5_uv.read(uvh5_file, polarizations=pols_to_keep)
-    uvh5_uv2.read(uvh5_file)
+    uvh5_uv.read(uvh5_file, polarizations=pols_to_keep, use_future_array_shapes=True)
+    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
     uvh5_uv2.select(polarizations=pols_to_keep)
     assert uvh5_uv == uvh5_uv2
 
@@ -2155,10 +2211,14 @@ def test_uvh5_partial_read_ints_times():
     # which breaks the phasing when trying to check if the uvws match the antpos.
 
     # select on read using time_range
-    uvh5_uv.read_uvh5(uvh5_file, read_data=False)
+    uvh5_uv.read_uvh5(uvh5_file, read_data=False, use_future_array_shapes=True)
     unique_times = np.unique(uvh5_uv.time_array)
-    uvh5_uv.read(uvh5_file, time_range=[unique_times[0], unique_times[1]])
-    uvh5_uv2.read(uvh5_file)
+    uvh5_uv.read(
+        uvh5_file,
+        time_range=[unique_times[0], unique_times[1]],
+        use_future_array_shapes=True,
+    )
+    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
     uvh5_uv2.select(times=unique_times[0:2])
     assert uvh5_uv == uvh5_uv2
 
@@ -2185,8 +2245,9 @@ def test_uvh5_partial_read_ints_multi1():
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
+        use_future_array_shapes=True,
     )
-    uvh5_uv2.read(uvh5_file)
+    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
     uvh5_uv2.select(
         antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
     )
@@ -2215,8 +2276,9 @@ def test_uvh5_partial_read_ints_multi2():
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
+        use_future_array_shapes=True,
     )
-    uvh5_uv2.read(uvh5_file)
+    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
     uvh5_uv2.select(
         antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
     )
@@ -2245,8 +2307,9 @@ def test_uvh5_partial_read_ints_multi3():
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
+        use_future_array_shapes=True,
     )
-    uvh5_uv2.read(uvh5_file)
+    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
     uvh5_uv2.select(
         antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
     )
@@ -2282,7 +2345,7 @@ def test_uvh5_partial_write_ints_antpairs(uv_uvh5, tmp_path):
         partial_uvh5.write_uvh5_part(partial_testfile, data, flags, nsamples, bls=key)
 
     # now read in the full file and make sure that it matches the original
-    partial_uvh5.read(partial_testfile)
+    partial_uvh5.read(partial_testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert full_uvh5.filename == ["zen.2458432.34569.uvh5"]
@@ -2320,21 +2383,21 @@ def test_uvh5_partial_write_ints_frequencies(uv_uvh5, tmp_path):
     Hfreqs = Nfreqs // 2
     freqs1 = np.arange(Hfreqs)
     freqs2 = np.arange(Hfreqs, Nfreqs)
-    data = full_uvh5.data_array[:, :, freqs1, :]
-    flags = full_uvh5.flag_array[:, :, freqs1, :]
-    nsamples = full_uvh5.nsample_array[:, :, freqs1, :]
+    data = full_uvh5.data_array[:, freqs1, :]
+    flags = full_uvh5.flag_array[:, freqs1, :]
+    nsamples = full_uvh5.nsample_array[:, freqs1, :]
     partial_uvh5.write_uvh5_part(
         partial_testfile, data, flags, nsamples, freq_chans=freqs1
     )
-    data = full_uvh5.data_array[:, :, freqs2, :]
-    flags = full_uvh5.flag_array[:, :, freqs2, :]
-    nsamples = full_uvh5.nsample_array[:, :, freqs2, :]
+    data = full_uvh5.data_array[:, freqs2, :]
+    flags = full_uvh5.flag_array[:, freqs2, :]
+    nsamples = full_uvh5.nsample_array[:, freqs2, :]
     partial_uvh5.write_uvh5_part(
         partial_testfile, data, flags, nsamples, freq_chans=freqs2
     )
 
     # read in the full file and make sure it matches
-    partial_uvh5.read(partial_testfile)
+    partial_uvh5.read(partial_testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert full_uvh5.filename == ["zen.2458432.34569.uvh5"]
@@ -2372,21 +2435,21 @@ def test_uvh5_partial_write_ints_blts(uv_uvh5, tmp_path):
     Hblts = Nblts // 2
     blts1 = np.arange(Hblts)
     blts2 = np.arange(Hblts, Nblts)
-    data = full_uvh5.data_array[blts1, :, :, :]
-    flags = full_uvh5.flag_array[blts1, :, :, :]
-    nsamples = full_uvh5.nsample_array[blts1, :, :, :]
+    data = full_uvh5.data_array[blts1]
+    flags = full_uvh5.flag_array[blts1]
+    nsamples = full_uvh5.nsample_array[blts1]
     partial_uvh5.write_uvh5_part(
         partial_testfile, data, flags, nsamples, blt_inds=blts1
     )
-    data = full_uvh5.data_array[blts2, :, :, :]
-    flags = full_uvh5.flag_array[blts2, :, :, :]
-    nsamples = full_uvh5.nsample_array[blts2, :, :, :]
+    data = full_uvh5.data_array[blts2]
+    flags = full_uvh5.flag_array[blts2]
+    nsamples = full_uvh5.nsample_array[blts2]
     partial_uvh5.write_uvh5_part(
         partial_testfile, data, flags, nsamples, blt_inds=blts2
     )
 
     # read in the full file and make sure it matches
-    partial_uvh5.read(partial_testfile)
+    partial_uvh5.read(partial_testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert full_uvh5.filename == ["zen.2458432.34569.uvh5"]
@@ -2424,9 +2487,9 @@ def test_uvh5_partial_write_ints_pols(uv_uvh5, tmp_path):
     Hpols = Npols // 2
     pols1 = np.arange(Hpols)
     pols2 = np.arange(Hpols, Npols)
-    data = full_uvh5.data_array[:, :, :, pols1]
-    flags = full_uvh5.flag_array[:, :, :, pols1]
-    nsamples = full_uvh5.nsample_array[:, :, :, pols1]
+    data = full_uvh5.data_array[:, :, pols1]
+    flags = full_uvh5.flag_array[:, :, pols1]
+    nsamples = full_uvh5.nsample_array[:, :, pols1]
     partial_uvh5.write_uvh5_part(
         partial_testfile,
         data,
@@ -2434,9 +2497,9 @@ def test_uvh5_partial_write_ints_pols(uv_uvh5, tmp_path):
         nsamples,
         polarizations=full_uvh5.polarization_array[:Hpols],
     )
-    data = full_uvh5.data_array[:, :, :, pols2]
-    flags = full_uvh5.flag_array[:, :, :, pols2]
-    nsamples = full_uvh5.nsample_array[:, :, :, pols2]
+    data = full_uvh5.data_array[:, :, pols2]
+    flags = full_uvh5.flag_array[:, :, pols2]
+    nsamples = full_uvh5.nsample_array[:, :, pols2]
     partial_uvh5.write_uvh5_part(
         partial_testfile,
         data,
@@ -2446,7 +2509,7 @@ def test_uvh5_partial_write_ints_pols(uv_uvh5, tmp_path):
     )
 
     # read in the full file and make sure it matches
-    partial_uvh5.read(partial_testfile)
+    partial_uvh5.read(partial_testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert full_uvh5.filename == ["zen.2458432.34569.uvh5"]
@@ -2590,22 +2653,22 @@ def test_uvh5_partial_write_ints_irregular_blt(uv_uvh5, tmp_path):
 
     # write a single blt to file
     blt_inds = np.arange(1)
-    data = full_uvh5.data_array[blt_inds, :, :, :]
-    flags = full_uvh5.flag_array[blt_inds, :, :, :]
-    nsamples = full_uvh5.nsample_array[blt_inds, :, :, :]
+    data = full_uvh5.data_array[blt_inds]
+    flags = full_uvh5.flag_array[blt_inds]
+    nsamples = full_uvh5.nsample_array[blt_inds]
     partial_uvh5.write_uvh5_part(
         partial_testfile, data, flags, nsamples, blt_inds=blt_inds
     )
 
     # also write the arrays to the partial object
-    partial_uvh5.data_array[blt_inds, :, :, :] = data
-    partial_uvh5.flag_array[blt_inds, :, :, :] = flags
-    partial_uvh5.nsample_array[blt_inds, :, :, :] = nsamples
+    partial_uvh5.data_array[blt_inds] = data
+    partial_uvh5.flag_array[blt_inds] = flags
+    partial_uvh5.nsample_array[blt_inds] = nsamples
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile)
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -2643,22 +2706,22 @@ def test_uvh5_partial_write_ints_irregular_freq(uv_uvh5, tmp_path):
 
     # write a single freq to file
     freq_inds = np.arange(1)
-    data = full_uvh5.data_array[:, :, freq_inds, :]
-    flags = full_uvh5.flag_array[:, :, freq_inds, :]
-    nsamples = full_uvh5.nsample_array[:, :, freq_inds, :]
+    data = full_uvh5.data_array[:, freq_inds, :]
+    flags = full_uvh5.flag_array[:, freq_inds, :]
+    nsamples = full_uvh5.nsample_array[:, freq_inds, :]
     partial_uvh5.write_uvh5_part(
         partial_testfile, data, flags, nsamples, freq_chans=freq_inds
     )
 
     # also write the arrays to the partial object
-    partial_uvh5.data_array[:, :, freq_inds, :] = data
-    partial_uvh5.flag_array[:, :, freq_inds, :] = flags
-    partial_uvh5.nsample_array[:, :, freq_inds, :] = nsamples
+    partial_uvh5.data_array[:, freq_inds, :] = data
+    partial_uvh5.flag_array[:, freq_inds, :] = flags
+    partial_uvh5.nsample_array[:, freq_inds, :] = nsamples
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile)
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -2696,9 +2759,9 @@ def test_uvh5_partial_write_ints_irregular_pol(uv_uvh5, tmp_path):
 
     # write a single pol to file
     pol_inds = np.arange(1)
-    data = full_uvh5.data_array[:, :, :, pol_inds]
-    flags = full_uvh5.flag_array[:, :, :, pol_inds]
-    nsamples = full_uvh5.nsample_array[:, :, :, pol_inds]
+    data = full_uvh5.data_array[:, :, pol_inds]
+    flags = full_uvh5.flag_array[:, :, pol_inds]
+    nsamples = full_uvh5.nsample_array[:, :, pol_inds]
     partial_uvh5.write_uvh5_part(
         partial_testfile,
         data,
@@ -2708,14 +2771,14 @@ def test_uvh5_partial_write_ints_irregular_pol(uv_uvh5, tmp_path):
     )
 
     # also write the arrays to the partial object
-    partial_uvh5.data_array[:, :, :, pol_inds] = data
-    partial_uvh5.flag_array[:, :, :, pol_inds] = flags
-    partial_uvh5.nsample_array[:, :, :, pol_inds] = nsamples
+    partial_uvh5.data_array[:, :, pol_inds] = data
+    partial_uvh5.flag_array[:, :, pol_inds] = flags
+    partial_uvh5.nsample_array[:, :, pol_inds] = nsamples
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile)
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -2730,6 +2793,8 @@ def test_uvh5_partial_write_ints_irregular_pol(uv_uvh5, tmp_path):
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, future_shapes, tmp_path):
     """
@@ -2737,8 +2802,8 @@ def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, future_shapes, tmp_pa
     integer dtype.
     """
     full_uvh5 = uv_uvh5
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     partial_uvh5 = full_uvh5.copy()
     partial_uvh5.data_array = None
@@ -2813,9 +2878,7 @@ def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, future_shapes, tmp_pa
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile)
-    if future_shapes:
-        partial_uvh5_file.use_future_array_shapes()
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -2830,6 +2893,8 @@ def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, future_shapes, tmp_pa
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, future_shapes, tmp_path):
     """
@@ -2837,8 +2902,8 @@ def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, future_shapes, tmp_pa
     integer dtype.
     """
     full_uvh5 = uv_uvh5
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     partial_uvh5 = full_uvh5.copy()
     partial_uvh5.data_array = None
@@ -2917,9 +2982,7 @@ def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, future_shapes, tmp_pa
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile)
-    if future_shapes:
-        partial_uvh5_file.use_future_array_shapes()
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -2934,14 +2997,16 @@ def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, future_shapes, tmp_pa
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_partial_write_ints_irregular_multi3(uv_uvh5, future_shapes, tmp_path):
     """
     Test writing a uvh5 file using irregular interval for blt and pol and integer dtype.
     """
     full_uvh5 = uv_uvh5
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     partial_uvh5 = full_uvh5.copy()
     partial_uvh5.data_array = None
@@ -3014,9 +3079,7 @@ def test_uvh5_partial_write_ints_irregular_multi3(uv_uvh5, future_shapes, tmp_pa
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile)
-    if future_shapes:
-        partial_uvh5_file.use_future_array_shapes()
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -3031,14 +3094,16 @@ def test_uvh5_partial_write_ints_irregular_multi3(uv_uvh5, future_shapes, tmp_pa
     return
 
 
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_uvh5_partial_write_ints_irregular_multi4(uv_uvh5, future_shapes, tmp_path):
     """
     Test writing a uvh5 file using irregular interval for all axes and integer dtype.
     """
     full_uvh5 = uv_uvh5
-    if future_shapes:
-        full_uvh5.use_future_array_shapes()
+    if not future_shapes:
+        full_uvh5.use_current_array_shapes()
 
     partial_uvh5 = full_uvh5.copy()
     partial_uvh5.data_array = None
@@ -3135,9 +3200,7 @@ def test_uvh5_partial_write_ints_irregular_multi4(uv_uvh5, future_shapes, tmp_pa
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile)
-    if future_shapes:
-        partial_uvh5_file.use_future_array_shapes()
+    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -3166,7 +3229,7 @@ def test_antenna_names_not_list(casa_uvfits, tmp_path):
     uv_in.antenna_names = np.array(uv_in.antenna_names, dtype="U")
 
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile)
+    uv_out.read(testfile, use_future_array_shapes=True)
 
     # recast as list since antenna names should be a list and will be cast as
     # list on read
@@ -3194,7 +3257,7 @@ def test_eq_coeffs_roundtrip(casa_uvfits, tmp_path):
     uv_in.eq_coeffs = np.ones((uv_in.Nants_telescope, uv_in.Nfreqs))
     uv_in.eq_coeffs_convention = "divide"
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile)
+    uv_out.read(testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["day2_TDEM0003_10s_norx_1src_1spw.uvfits"]
@@ -3223,7 +3286,7 @@ def test_read_metadata(casa_uvfits, tmp_path):
         f["Header"]["telescope_name"] = bytes(tname)
     # now read
     uv_out = UVData()
-    uv_out.read(testfile)
+    uv_out.read(testfile, use_future_array_shapes=True)
     assert isinstance(uv_out.telescope_name, str)
 
     # clean up when done
@@ -3239,7 +3302,7 @@ def test_cast_to_multiphase(uv_uvh5, tmp_path):
     testfile = os.path.join(tmp_path, "out_cast_to_multiphase.uvh5")
 
     uv_uvh5.write_uvh5(testfile)
-    test_uvh5.read(testfile)
+    test_uvh5.read(testfile, use_future_array_shapes=True)
 
     assert test_uvh5 == uv_uvh5
 
@@ -3261,7 +3324,7 @@ def test_old_phase_center_catalog_format(sma_mir, tmp_path):
             temp_name = temp_dict.pop("cat_name")
             phase_dict[temp_name] = np.string_(json.dumps(temp_dict))
 
-    uvd = UVData.from_file(testfile)
+    uvd = UVData.from_file(testfile, use_future_array_shapes=True)
     uvd.history = sma_mir.history
     assert uvd == sma_mir
 
@@ -3308,7 +3371,9 @@ def test_old_phase_attributes_header(casa_uvfits, tmp_path):
             "to address this issue.",
         ],
     ):
-        uvd = UVData.from_file(testfile, fix_old_proj=False)
+        uvd = UVData.from_file(
+            testfile, fix_old_proj=False, use_future_array_shapes=True
+        )
     uvd.history = casa_uvfits.history
     assert uvd == casa_uvfits
 
@@ -3319,7 +3384,7 @@ def test_old_phase_attributes_header(casa_uvfits, tmp_path):
             "Fixing phases using antenna positions.",
         ],
     ):
-        uvd2 = UVData.from_file(testfile)
+        uvd2 = UVData.from_file(testfile, use_future_array_shapes=True)
 
     with uvtest.check_warnings(
         UserWarning, match="Fixing phases using antenna positions."
@@ -3337,7 +3402,7 @@ def test_none_extra_keywords(uv_uvh5, tmp_path):
     uv_uvh5.extra_keywords["foo"] = None
 
     uv_uvh5.write_uvh5(testfile)
-    test_uvh5.read(testfile)
+    test_uvh5.read(testfile, use_future_array_shapes=True)
 
     assert test_uvh5 == uv_uvh5
 
@@ -3356,7 +3421,7 @@ def test_write_uvh5_part_fix_autos(uv_uvh5, tmp_path):
     # Select out the relevant data (where the 0 and 1 indicies of the pol array
     # correspond to xx and yy polarization data), and corrupt it accordingly
     auto_data = uv_uvh5.data_array[uv_uvh5.ant_1_array == uv_uvh5.ant_2_array]
-    auto_data[:, :, :, [0, 1]] *= 1j
+    auto_data[:, :, [0, 1]] *= 1j
     uv_uvh5.data_array[uv_uvh5.ant_1_array == uv_uvh5.ant_2_array] = auto_data
 
     # Create and write out the data, with fix_autos set to operate
@@ -3370,11 +3435,11 @@ def test_write_uvh5_part_fix_autos(uv_uvh5, tmp_path):
     )
 
     # Fix the autos we corrupted earlier, and plug the data back in to data_array
-    auto_data[:, :, :, [0, 1]] *= -1j
+    auto_data[:, :, [0, 1]] *= -1j
     uv_uvh5.data_array[uv_uvh5.ant_1_array == uv_uvh5.ant_2_array] = auto_data
 
     # Read in the data on disk, make sure it looks like our manually repaired data
-    test_uvh5.read(testfile)
+    test_uvh5.read(testfile, use_future_array_shapes=True)
 
     assert uv_uvh5 == test_uvh5
 
@@ -3401,5 +3466,5 @@ def test_uvh5_bitshuffle(uv_phase_comp, tmp_path):
         dgrp = f["/Data"]
         assert "32008" in dgrp["visdata"]._filters
 
-    uvd2 = UVData.from_file(outfile)
+    uvd2 = UVData.from_file(outfile, use_future_array_shapes=True)
     assert uvd == uvd2

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -7602,6 +7602,10 @@ class UVData(UVBase):
             for axis, subdict in axis_dict.items():
                 for name, param in zip(this._data_params, this.data_like_parameters):
                     if len(subdict["inds"]) > 0:
+                        unique_order_diffs = np.unique(np.diff(subdict["order"]))
+                        if np.array_equal(unique_order_diffs, np.array([1])):
+                            # everything is already in order
+                            continue
                         setattr(this, name, np.take(param, subdict["order"], axis=axis))
 
         if len(fnew_inds) > 0:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -35,6 +35,15 @@ reporting_request = (
     "this feature, we would like to investigate this more."
 )
 
+_future_array_shapes_warning = (
+    "The shapes of several attributes will be changing in the future to remove the "
+    "deprecated spectral window axis. You can call the `use_future_array_shapes` "
+    "method to convert to the future array shapes now or set the parameter of the same "
+    "name on this method to both convert to the future array shapes and silence this "
+    "warning. See the UVData tutorial on ReadTheDocs for more details about these "
+    "shape changes."
+)
+
 old_phase_attrs = [
     "phase_type",
     "phase_center_ra",
@@ -2249,6 +2258,9 @@ class UVData(UVBase):
         parameter on this object to True.
 
         """
+        if self.future_array_shapes:
+            return
+
         self._set_future_array_shapes()
         if not self.metadata_only:
             # remove the length-1 spw axis for all data-like parameters
@@ -2272,6 +2284,13 @@ class UVData(UVBase):
         This method sets allows users to convert back to the current array shapes.
         This method sets the `future_array_shapes` parameter on this object to False.
         """
+        warnings.warn(
+            "This method will be removed in version 3.0 when the current array shapes "
+            "are no longer supported.",
+            DeprecationWarning,
+        )
+        if not self.future_array_shapes:
+            return
         if not self.flex_spw:
             unique_channel_widths = np.unique(self.channel_width)
             if unique_channel_widths.size > 1:
@@ -10953,6 +10972,7 @@ class UVData(UVBase):
         strict_uvw_antpos_check=False,
         check_autos=True,
         fix_autos=True,
+        use_future_array_shapes=False,
     ):
         """
         Read in data from a list of FHD files.
@@ -10994,6 +11014,9 @@ class UVData(UVBase):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is True.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Raises
         ------
@@ -11024,6 +11047,7 @@ class UVData(UVBase):
             strict_uvw_antpos_check=strict_uvw_antpos_check,
             check_autos=check_autos,
             fix_autos=fix_autos,
+            use_future_array_shapes=use_future_array_shapes,
         )
         self._convert_from_filetype(fhd_obj)
         del fhd_obj
@@ -11044,6 +11068,7 @@ class UVData(UVBase):
         check_autos=True,
         fix_autos=True,
         rechunk=None,
+        use_future_array_shapes=False,
     ):
         """
         Read in data from an SMA MIR file.
@@ -11095,6 +11120,13 @@ class UVData(UVBase):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is True.
+        rechunk : int
+            Number of channels to average over when reading in the dataset. Optional
+            argument, typically required to be a power of 2.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
+
         """
         from . import mir
 
@@ -11114,6 +11146,7 @@ class UVData(UVBase):
             check_autos=check_autos,
             fix_autos=fix_autos,
             rechunk=rechunk,
+            use_future_array_shapes=use_future_array_shapes,
         )
         self._convert_from_filetype(mir_obj)
         del mir_obj
@@ -11140,6 +11173,7 @@ class UVData(UVBase):
         fix_use_ant_pos=True,
         check_autos=True,
         fix_autos=True,
+        use_future_array_shapes=False,
     ):
         """
         Read in data from a miriad file.
@@ -11228,6 +11262,9 @@ class UVData(UVBase):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is True.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Raises
         ------
@@ -11273,6 +11310,7 @@ class UVData(UVBase):
             fix_use_ant_pos=fix_use_ant_pos,
             check_autos=check_autos,
             fix_autos=fix_autos,
+            use_future_array_shapes=use_future_array_shapes,
         )
         self._convert_from_filetype(miriad_obj)
         del miriad_obj
@@ -11293,6 +11331,7 @@ class UVData(UVBase):
         strict_uvw_antpos_check=False,
         check_autos=True,
         fix_autos=True,
+        use_future_array_shapes=False,
     ):
         """
         Read in data from a measurement set.
@@ -11357,6 +11396,9 @@ class UVData(UVBase):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is True.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Raises
         ------
@@ -11394,6 +11436,7 @@ class UVData(UVBase):
             strict_uvw_antpos_check=strict_uvw_antpos_check,
             check_autos=check_autos,
             fix_autos=fix_autos,
+            use_future_array_shapes=use_future_array_shapes,
         )
         self._convert_from_filetype(ms_obj)
         del ms_obj
@@ -11428,6 +11471,7 @@ class UVData(UVBase):
         strict_uvw_antpos_check=False,
         check_autos=True,
         fix_autos=True,
+        use_future_array_shapes=False,
     ):
         """
         Read in MWA correlator gpu box files.
@@ -11537,6 +11581,9 @@ class UVData(UVBase):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is True.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Raises
         ------
@@ -11602,6 +11649,7 @@ class UVData(UVBase):
             strict_uvw_antpos_check=strict_uvw_antpos_check,
             check_autos=check_autos,
             fix_autos=fix_autos,
+            use_future_array_shapes=use_future_array_shapes,
         )
         self._convert_from_filetype(corr_obj)
         del corr_obj
@@ -11633,6 +11681,7 @@ class UVData(UVBase):
         fix_use_ant_pos=True,
         check_autos=True,
         fix_autos=True,
+        use_future_array_shapes=False,
     ):
         """
         Read in header, metadata and data from a single uvfits file.
@@ -11747,6 +11796,9 @@ class UVData(UVBase):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is True.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Raises
         ------
@@ -11796,6 +11848,7 @@ class UVData(UVBase):
             fix_use_ant_pos=fix_use_ant_pos,
             check_autos=check_autos,
             fix_autos=fix_autos,
+            use_future_array_shapes=use_future_array_shapes,
         )
         self._convert_from_filetype(uvfits_obj)
         del uvfits_obj
@@ -11830,6 +11883,7 @@ class UVData(UVBase):
         fix_use_ant_pos=True,
         check_autos=True,
         fix_autos=True,
+        use_future_array_shapes=False,
     ):
         """
         Read a UVH5 file.
@@ -11959,6 +12013,9 @@ class UVData(UVBase):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is True.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Raises
         ------
@@ -12010,6 +12067,7 @@ class UVData(UVBase):
             fix_use_ant_pos=fix_use_ant_pos,
             check_autos=check_autos,
             fix_autos=fix_autos,
+            use_future_array_shapes=use_future_array_shapes,
         )
         self._convert_from_filetype(uvh5_obj)
         del uvh5_obj
@@ -12023,6 +12081,7 @@ class UVData(UVBase):
         skip_bad_files=False,
         background_lsts=True,
         ignore_name=False,
+        use_future_array_shapes=False,
         # phasing parameters
         allow_rephase=None,
         phase_center_radec=None,
@@ -12149,6 +12208,9 @@ class UVData(UVBase):
             combining multiple files, which would otherwise result in an error being
             raised because of attributes not matching. Doing so effectively adopts the
             name found in the first file read in. Default is False.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Phasing
         -------
@@ -12462,6 +12524,9 @@ class UVData(UVBase):
             Correlator chunk code for MIR dataset.
         pseudo_cont : boolean
             Read in only pseudo-continuuum values in MIR dataset.
+        rechunk : int
+            Number of channels to average over when reading in the dataset. Optional
+            argument, typically required to be a power of 2.
         allow_flex_pol : bool
             If only one polarization per spectral window is read (and the polarization
             differs from window to window), allow for the `UVData` object to use
@@ -12592,12 +12657,21 @@ class UVData(UVBase):
                         self.read(
                             filename[file_num],
                             file_type=file_type,
+                            read_data=read_data,
+                            skip_bad_files=skip_bad_files,
+                            background_lsts=background_lsts,
+                            use_future_array_shapes=use_future_array_shapes,
+                            # phasing parameters
+                            fix_old_proj=fix_old_proj,
+                            fix_use_ant_pos=fix_use_ant_pos,
+                            make_multi_phase=make_multi_phase,
                             allow_rephase=allow_rephase,
                             phase_center_radec=phase_center_radec,
                             phase_frame=phase_frame,
                             phase_epoch=phase_epoch,
                             phase_use_ant_pos=phase_use_ant_pos,
                             unphase_to_drift=unphase_to_drift,
+                            # selecting parameters
                             antenna_nums=antenna_nums,
                             antenna_names=antenna_names,
                             ant_str=ant_str,
@@ -12605,40 +12679,67 @@ class UVData(UVBase):
                             frequencies=frequencies,
                             freq_chans=freq_chans,
                             times=times,
-                            polarizations=polarizations,
-                            blt_inds=blt_inds,
-                            phase_center_ids=phase_center_ids,
                             time_range=time_range,
                             lsts=lsts,
                             lst_range=lst_range,
+                            polarizations=polarizations,
+                            blt_inds=blt_inds,
+                            phase_center_ids=phase_center_ids,
                             keep_all_metadata=keep_all_metadata,
-                            read_data=read_data,
-                            phase_type=phase_type,
-                            projected=projected,
-                            correct_lat_lon=correct_lat_lon,
-                            use_model=use_model,
-                            data_column=data_column,
-                            pol_order=pol_order,
-                            data_array_dtype=data_array_dtype,
-                            nsample_array_dtype=nsample_array_dtype,
-                            skip_bad_files=skip_bad_files,
-                            background_lsts=background_lsts,
+                            # checking parameters
                             run_check=run_check,
                             check_extra=check_extra,
                             run_check_acceptability=run_check_acceptability,
                             strict_uvw_antpos_check=strict_uvw_antpos_check,
-                            isource=isource,
+                            check_autos=check_autos,
+                            fix_autos=fix_autos,
+                            # file-type specific parameters
+                            # miriad
+                            phase_type=phase_type,
+                            projected=projected,
+                            correct_lat_lon=correct_lat_lon,
+                            calc_lst=calc_lst,
+                            # FHD
+                            use_model=use_model,
+                            # MS
+                            data_column=data_column,
+                            pol_order=pol_order,
+                            ignore_single_chan=ignore_single_chan,
+                            raise_error=raise_error,
+                            read_weights=read_weights,
+                            # MS & MIR
+                            allow_flex_pol=allow_flex_pol,
+                            # uvh5
+                            multidim_index=multidim_index,
+                            remove_flex_pol=remove_flex_pol,
+                            # uvh5 & mwa_corr_fits
+                            data_array_dtype=data_array_dtype,
+                            # mwa_corr_fits
+                            use_aoflagger_flags=use_aoflagger_flags,
+                            use_cotter_flags=use_cotter_flags,
+                            remove_dig_gains=remove_dig_gains,
+                            remove_coarse_band=remove_coarse_band,
+                            correct_cable_len=correct_cable_len,
+                            correct_van_vleck=correct_van_vleck,
+                            cheby_approx=cheby_approx,
+                            flag_small_auto_ants=flag_small_auto_ants,
+                            flag_small_sig_ants=flag_small_sig_ants,
+                            propagate_coarse_flags=propagate_coarse_flags,
+                            flag_init=flag_init,
+                            edge_width=edge_width,
+                            start_flag=start_flag,
+                            end_flag=end_flag,
+                            flag_dc_offset=flag_dc_offset,
+                            remove_flagged_ants=remove_flagged_ants,
+                            phase_to_pointing_center=phase_to_pointing_center,
+                            nsample_array_dtype=nsample_array_dtype,
+                            # MIR
+                            isource=None,
                             irec=irec,
                             isb=isb,
                             corrchunk=corrchunk,
                             pseudo_cont=pseudo_cont,
-                            calc_lst=calc_lst,
-                            fix_old_proj=fix_old_proj,
-                            fix_use_ant_pos=fix_use_ant_pos,
-                            make_multi_phase=make_multi_phase,
-                            allow_flex_pol=allow_flex_pol,
-                            check_autos=check_autos,
-                            fix_autos=fix_autos,
+                            rechunk=rechunk,
                         )
                     unread = False
                 except KeyError as err:
@@ -12729,11 +12830,20 @@ class UVData(UVBase):
                                 f,
                                 file_type=file_type,
                                 allow_rephase=allow_rephase,
+                                read_data=read_data,
+                                skip_bad_files=skip_bad_files,
+                                background_lsts=background_lsts,
+                                use_future_array_shapes=use_future_array_shapes,
+                                # phasing parameters
+                                fix_old_proj=fix_old_proj,
+                                fix_use_ant_pos=fix_use_ant_pos,
+                                make_multi_phase=make_multi_phase,
                                 phase_center_radec=phase_center_radec,
                                 phase_frame=phase_frame,
                                 phase_epoch=phase_epoch,
                                 phase_use_ant_pos=phase_use_ant_pos,
                                 unphase_to_drift=unphase_to_drift,
+                                # selecting parameters
                                 antenna_nums=antenna_nums,
                                 antenna_names=antenna_names,
                                 ant_str=ant_str,
@@ -12741,40 +12851,66 @@ class UVData(UVBase):
                                 frequencies=frequencies,
                                 freq_chans=freq_chans,
                                 times=times,
-                                polarizations=polarizations,
-                                blt_inds=blt_inds,
-                                phase_center_ids=phase_center_ids,
                                 time_range=time_range,
                                 lsts=lsts,
                                 lst_range=lst_range,
+                                polarizations=polarizations,
+                                blt_inds=blt_inds,
+                                phase_center_ids=phase_center_ids,
                                 keep_all_metadata=keep_all_metadata,
-                                read_data=read_data,
-                                phase_type=phase_type,
-                                projected=projected,
-                                correct_lat_lon=correct_lat_lon,
-                                use_model=use_model,
-                                data_column=data_column,
-                                pol_order=pol_order,
-                                data_array_dtype=data_array_dtype,
-                                nsample_array_dtype=nsample_array_dtype,
-                                skip_bad_files=skip_bad_files,
-                                background_lsts=background_lsts,
+                                # checking parameters
                                 run_check=run_check,
                                 check_extra=check_extra,
                                 run_check_acceptability=run_check_acceptability,
                                 strict_uvw_antpos_check=strict_uvw_antpos_check,
-                                isource=isource,
+                                check_autos=check_autos,
+                                fix_autos=fix_autos,
+                                # file-type specific parameters
+                                # miriad
+                                phase_type=phase_type,
+                                projected=projected,
+                                correct_lat_lon=correct_lat_lon,
+                                calc_lst=calc_lst,
+                                # FHD
+                                use_model=use_model,
+                                # MS
+                                data_column=data_column,
+                                pol_order=pol_order,
+                                ignore_single_chan=ignore_single_chan,
+                                raise_error=raise_error,
+                                read_weights=read_weights,
+                                # MS & MIR
+                                allow_flex_pol=allow_flex_pol,
+                                # uvh5
+                                multidim_index=multidim_index,
+                                remove_flex_pol=remove_flex_pol,
+                                # uvh5 & mwa_corr_fits
+                                data_array_dtype=data_array_dtype,
+                                # mwa_corr_fits
+                                use_aoflagger_flags=use_aoflagger_flags,
+                                use_cotter_flags=use_cotter_flags,
+                                remove_dig_gains=remove_dig_gains,
+                                remove_coarse_band=remove_coarse_band,
+                                correct_cable_len=correct_cable_len,
+                                correct_van_vleck=correct_van_vleck,
+                                cheby_approx=cheby_approx,
+                                flag_small_auto_ants=flag_small_auto_ants,
+                                flag_small_sig_ants=flag_small_sig_ants,
+                                propagate_coarse_flags=propagate_coarse_flags,
+                                flag_init=flag_init,
+                                edge_width=edge_width,
+                                start_flag=start_flag,
+                                end_flag=end_flag,
+                                flag_dc_offset=flag_dc_offset,
+                                remove_flagged_ants=remove_flagged_ants,
+                                phase_to_pointing_center=phase_to_pointing_center,
+                                nsample_array_dtype=nsample_array_dtype,
+                                # MIR
+                                isource=None,
                                 irec=irec,
                                 isb=isb,
                                 corrchunk=corrchunk,
                                 pseudo_cont=pseudo_cont,
-                                calc_lst=calc_lst,
-                                fix_old_proj=fix_old_proj,
-                                fix_use_ant_pos=fix_use_ant_pos,
-                                make_multi_phase=make_multi_phase,
-                                allow_flex_pol=allow_flex_pol,
-                                check_autos=check_autos,
-                                fix_autos=fix_autos,
                                 rechunk=rechunk,
                             )
                         if phase_dict is not None:
@@ -12977,6 +13113,7 @@ class UVData(UVBase):
                     fix_use_ant_pos=fix_use_ant_pos,
                     check_autos=check_autos,
                     fix_autos=fix_autos,
+                    use_future_array_shapes=use_future_array_shapes,
                 )
 
             elif file_type == "mir":
@@ -12995,6 +13132,7 @@ class UVData(UVBase):
                     check_autos=check_autos,
                     fix_autos=fix_autos,
                     rechunk=rechunk,
+                    use_future_array_shapes=use_future_array_shapes,
                 )
 
             elif file_type == "miriad":
@@ -13019,6 +13157,7 @@ class UVData(UVBase):
                     fix_use_ant_pos=fix_use_ant_pos,
                     check_autos=check_autos,
                     fix_autos=fix_autos,
+                    use_future_array_shapes=use_future_array_shapes,
                 )
 
             elif file_type == "mwa_corr_fits":
@@ -13051,6 +13190,7 @@ class UVData(UVBase):
                     strict_uvw_antpos_check=strict_uvw_antpos_check,
                     check_autos=check_autos,
                     fix_autos=fix_autos,
+                    use_future_array_shapes=use_future_array_shapes,
                 )
 
             elif file_type == "fhd":
@@ -13065,6 +13205,7 @@ class UVData(UVBase):
                     strict_uvw_antpos_check=strict_uvw_antpos_check,
                     check_autos=check_autos,
                     fix_autos=fix_autos,
+                    use_future_array_shapes=use_future_array_shapes,
                 )
 
             elif file_type == "ms":
@@ -13083,6 +13224,7 @@ class UVData(UVBase):
                     strict_uvw_antpos_check=strict_uvw_antpos_check,
                     check_autos=check_autos,
                     fix_autos=fix_autos,
+                    use_future_array_shapes=use_future_array_shapes,
                 )
 
             elif file_type == "uvh5":
@@ -13115,6 +13257,7 @@ class UVData(UVBase):
                     fix_use_ant_pos=fix_use_ant_pos,
                     check_autos=check_autos,
                     fix_autos=fix_autos,
+                    use_future_array_shapes=use_future_array_shapes,
                 )
                 select = False
 
@@ -13160,6 +13303,7 @@ class UVData(UVBase):
         skip_bad_files=False,
         background_lsts=True,
         ignore_name=False,
+        use_future_array_shapes=False,
         # phasing parameters
         allow_rephase=None,
         phase_center_radec=None,
@@ -13286,6 +13430,9 @@ class UVData(UVBase):
             combining multiple files, which would otherwise result in an error being
             raised because of attributes not matching. Doing so effectively adopts the
             name found in the first file read in. Default is False.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Phasing
         -------
@@ -13599,6 +13746,9 @@ class UVData(UVBase):
             Correlator chunk code for MIR dataset.
         pseudo_cont : boolean
             Read in only pseudo-continuuum values in MIR dataset.
+        rechunk : int
+            Number of channels to average over when reading in the dataset. Optional
+            argument, typically required to be a power of 2.
         allow_flex_pol : bool
             If only one polarization per spectral window is read (and the polarization
             differs from window to window), allow for the `UVData` object to use
@@ -13625,6 +13775,7 @@ class UVData(UVBase):
             skip_bad_files=skip_bad_files,
             background_lsts=background_lsts,
             ignore_name=ignore_name,
+            use_future_array_shapes=use_future_array_shapes,
             # phasing parameters
             allow_rephase=allow_rephase,
             phase_center_radec=phase_center_radec,

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -11,7 +11,7 @@ import h5py
 import numpy as np
 
 from .. import utils as uvutils
-from .uvdata import UVData
+from .uvdata import UVData, _future_array_shapes_warning
 
 __all__ = ["UVH5"]
 
@@ -835,6 +835,7 @@ class UVH5(UVData):
         fix_use_ant_pos=True,
         check_autos=True,
         fix_autos=True,
+        use_future_array_shapes=False,
     ):
         """
         Read in data from a UVH5 file.
@@ -963,6 +964,9 @@ class UVH5(UVData):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is True.
+        use_future_array_shapes : bool
+            Option to convert to the future planned array shapes before the changes go
+            into effect by removing the spectral window axis.
 
         Returns
         -------
@@ -1055,6 +1059,23 @@ class UVH5(UVData):
                     "issue."
                 )
 
+        if remove_flex_pol:
+            self.remove_flex_pol()
+
+        if use_future_array_shapes:
+            if not self.future_array_shapes:
+                self.use_future_array_shapes()
+        else:
+            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
+            if self.future_array_shapes:
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        message="This method will be removed in version 3.0 when the "
+                        "current array shapes are no longer supported.",
+                    )
+                    self.use_current_array_shapes()
+
         # check if object has all required UVParameters set
         if run_check:
             self.check(
@@ -1065,14 +1086,6 @@ class UVH5(UVData):
                 check_autos=check_autos,
                 fix_autos=fix_autos,
             )
-
-        if remove_flex_pol:
-            self.remove_flex_pol()
-
-        # For now, always use current shapes when data is read in, even if the file
-        # has the future shapes.
-        if self.future_array_shapes:
-            self.use_current_array_shapes()
 
         return
 
@@ -1362,7 +1375,13 @@ class UVH5(UVData):
             )
 
         if revert_fas:
-            self.use_current_array_shapes()
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="This method will be removed in version 3.0 when the "
+                    "current array shapes are no longer supported.",
+                )
+                self.use_current_array_shapes()
 
         return
 
@@ -1495,7 +1514,13 @@ class UVH5(UVData):
             )
 
         if revert_fas:
-            self.use_current_array_shapes()
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="This method will be removed in version 3.0 when the "
+                    "current array shapes are no longer supported.",
+                )
+                self.use_current_array_shapes()
 
         return
 
@@ -1938,6 +1963,12 @@ class UVH5(UVData):
                 f["Header"]["history"] = np.string_(history)
 
         if revert_fas:
-            self.use_current_array_shapes()
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="This method will be removed in version 3.0 when the "
+                    "current array shapes are no longer supported.",
+                )
+                self.use_current_array_shapes()
 
         return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add deprecation warnings about future array shapes when reading in files and when initializing UVFlag objects from UVData or UVCal objects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #1157 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Breaking change checklist:
- [x] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to reflect my changes (if appropriate).
- [x] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
