### PR TITLE
Fix some handling for old phase attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ they are converted between types using UVData and UVCalobjects.
 to set several of these new parameters.
 
 ### Fixed
+- Fixed a bug where objects created from scratch with the old phase attributes weren't
+properly getting converted to the new `phase_center_catalog` representation. That
+conversion now happens in the check so will happen before any `write`. There could still
+be errors if some methods are called before a check is done (or if the check is turned
+off).
 - Fix a bug in how `frame_pa` was calculated in `phase` and `_set_app_coords_helper` for
 multi_phase_center objects (it was using the old `phase_center_frame` attribute).
 - Fix a bug where trying to select lsts or lst_ranges on read didn't work for some file

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -3065,59 +3065,11 @@ class UVData(UVBase):
             # Finally, plug the modified values back into data_array
             self.data_array[auto_screen] = auto_data
 
-    def check(
-        self,
-        check_extra=True,
-        run_check_acceptability=True,
-        check_freq_spacing=False,
-        strict_uvw_antpos_check=False,
-        allow_flip_conj=False,
-        check_autos=False,
-        fix_autos=False,
-    ):
+    def _convert_old_phase_attributes(self):
         """
-        Add some extra checks on top of checks on UVBase class.
+        Convert old phase attributes set on object to the phase_center_catalog.
 
-        Check that required parameters exist. Check that parameters have
-        appropriate shapes and optionally that the values are acceptable.
-
-        Parameters
-        ----------
-        check_extra : bool
-            If true, check all parameters, otherwise only check required parameters.
-        run_check_acceptability : bool
-            Option to check if values in parameters are acceptable.
-        check_freq_spacing :  bool
-            Option to check if frequencies are evenly spaced and the spacing is
-            equal to their channel_width. This is not required for UVData
-            objects in general but is required to write to uvfits and miriad files.
-        strict_uvw_antpos_check : bool
-            Option to raise an error rather than a warning if the check that
-            uvws match antenna positions does not pass.
-        allow_flip_conj : bool
-            If set to True, and the UVW coordinates do not match antenna positions,
-            check and see if flipping the conjugation of the baselines (i.e, multiplying
-            the UVWs by -1) resolves  the apparent discrepancy -- and if it does, fix
-            the apparent conjugation error in `uvw_array` and `data_array`. Default is
-            False.
-        check_autos : bool
-            Check whether any auto-correlations have non-zero imaginary values in
-            data_array (which should not mathematically exist). Default is False.
-        fix_autos : bool
-            If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only in data_array. Default is False.
-
-        Returns
-        -------
-        bool
-            True if check passes
-
-        Raises
-        ------
-        ValueError
-            if parameter shapes or types are wrong or do not have acceptable
-            values (if run_check_acceptability is True)
-
+        This method can be removed in version 3.0.
         """
         if self.phase_center_catalog is None or len(self.phase_center_catalog) == 0:
             # first handle any old phase parameters that have been added to the object
@@ -3191,6 +3143,64 @@ class UVData(UVBase):
                         "phase_center_catalog. You can use `_add_phase_center_catalog` "
                         "to set the phase_center_catalog."
                     )
+
+    def check(
+        self,
+        check_extra=True,
+        run_check_acceptability=True,
+        check_freq_spacing=False,
+        strict_uvw_antpos_check=False,
+        allow_flip_conj=False,
+        check_autos=False,
+        fix_autos=False,
+    ):
+        """
+        Add some extra checks on top of checks on UVBase class.
+
+        Check that required parameters exist. Check that parameters have
+        appropriate shapes and optionally that the values are acceptable.
+
+        Parameters
+        ----------
+        check_extra : bool
+            If true, check all parameters, otherwise only check required parameters.
+        run_check_acceptability : bool
+            Option to check if values in parameters are acceptable.
+        check_freq_spacing :  bool
+            Option to check if frequencies are evenly spaced and the spacing is
+            equal to their channel_width. This is not required for UVData
+            objects in general but is required to write to uvfits and miriad files.
+        strict_uvw_antpos_check : bool
+            Option to raise an error rather than a warning if the check that
+            uvws match antenna positions does not pass.
+        allow_flip_conj : bool
+            If set to True, and the UVW coordinates do not match antenna positions,
+            check and see if flipping the conjugation of the baselines (i.e, multiplying
+            the UVWs by -1) resolves  the apparent discrepancy -- and if it does, fix
+            the apparent conjugation error in `uvw_array` and `data_array`. Default is
+            False.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is False.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is False.
+
+        Returns
+        -------
+        bool
+            True if check passes
+
+        Raises
+        ------
+        ValueError
+            if parameter shapes or types are wrong or do not have acceptable
+            values (if run_check_acceptability is True)
+
+        """
+        # first check for any old phase attributes set on the object and move the info
+        # into the phase_center_catalog.
+        self._convert_old_phase_attributes()
 
         # first run the basic check from UVBase
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -10856,9 +10856,16 @@ class UVData(UVBase):
         else:
             raise ValueError("filetype must be uvfits, mir, miriad, ms, fhd, or uvh5")
 
-        for p in self:
-            param = getattr(self, p)
-            setattr(other_obj, p, param)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "The older phase attributes, including")
+            for par in self:
+                param = getattr(self, par)
+                setattr(other_obj, par, param)
+            if self.phase_center_catalog is None or len(self.phase_center_catalog) == 0:
+                for attr in old_phase_attrs:
+                    if hasattr(self, attr):
+                        attr_val = getattr(self, attr)
+                        setattr(other_obj, attr, attr_val)
         return other_obj
 
     def read_fhd(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a follow-on to #1170 to fix a couple of things that were left out and were breaking hera_cal.

The main thing this fixes is that if a new object is created from scratch with the old phase attributes, the old attributes were not getting correctly converted into the phase_center_catalog. In hera_cal there's a method to make a new object from scratch (sort of) and then write it out and it errored in the write (in the call to `check` before any actual writing). I decided to put the conversion from the old to new attributes in the `check` method so that it would always happen before a write. There could still be errors though if someone makes an object and doesn't call check before calling some of the other methods on the object, hopefully that is uncommon.

It turned out to be a little tricky to handle the interaction between `__getattribute__` and the detection of the old phase attributes because the handling for the old attributes in `__getattribute__` make `hasattr` return `True` for the old phase attributes. So I used the presence of a sensible `phase_center_catalog` to decide whether or not to check for the old attributes. A consequence is that if there is a sensible `phase_center_catalog`, setting any of the old attributes will not change any behavior. There will be a warning if a user does that, however.

I also added a deprecation warning when setting the old attributes (using `__setattr__`) which @kartographer suggested on #1170 but I forgot to do.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes errors in hera_cal.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
