### PR TITLE
perf: use lru_cache for polstr and variants

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         args: [--skip, "B101", --recursive, pyuvdata]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ off).
 multi_phase_center objects (it was using the old `phase_center_frame` attribute).
 - Fix a bug where trying to select lsts or lst_ranges on read didn't work for some file
 types.
-
+- Severe performance hit when calling `polnum2str` and its variants for many baselines.
 ### Deprecated
 - Deprecated the `interpolation_function` attribute on UVBeams.
 - Deprecated the older phase attributes (`phase_type`, `phase_center_ra`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ multi_phase_center objects (it was using the old `phase_center_frame` attribute)
 - Fix a bug where trying to select lsts or lst_ranges on read didn't work for some file
 types.
 - Severe performance hit when calling `polnum2str` and its variants for many baselines.
+
 ### Deprecated
 - Deprecated the `interpolation_function` attribute on UVBeams.
 - Deprecated the older phase attributes (`phase_type`, `phase_center_ra`,

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -9,6 +9,7 @@ import warnings
 from collections.abc import Iterable
 from copy import deepcopy
 from functools import lru_cache, wraps
+from typing import Iterable as IterableType
 
 import erfa
 import numpy as np
@@ -881,7 +882,7 @@ def np_cache(function):
 
 
 @np_cache
-def polstr2num(pol: str | Iterable[str], x_orientation: str | None = None):
+def polstr2num(pol: str | IterableType[str], x_orientation: str | None = None):
     """
     Convert polarization str to number according to AIPS Memo 117.
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -3,6 +3,8 @@
 # Licensed under the 2-clause BSD License
 
 """Commonly used utility functions."""
+from __future__ import annotations
+
 import copy
 import re
 import warnings

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -8,6 +8,7 @@ import re
 import warnings
 from collections.abc import Iterable
 from copy import deepcopy
+from functools import lru_cache
 
 import erfa
 import numpy as np
@@ -859,6 +860,7 @@ def _x_orientation_rep_dict(x_orientation):
         raise ValueError("x_orientation not recognized.")
 
 
+@lru_cache
 def polstr2num(pol, x_orientation=None):
     """
     Convert polarization str to number according to AIPS Memo 117.
@@ -916,6 +918,7 @@ def polstr2num(pol, x_orientation=None):
     return out
 
 
+@lru_cache
 def polnum2str(num, x_orientation=None):
     """
     Convert polarization number to str according to AIPS Memo 117.
@@ -969,6 +972,7 @@ def polnum2str(num, x_orientation=None):
     return out
 
 
+@lru_cache
 def jstr2num(jstr, x_orientation=None):
     """
     Convert jones polarization str to number according to calfits memo.
@@ -1021,6 +1025,7 @@ def jstr2num(jstr, x_orientation=None):
     return out
 
 
+@lru_cache
 def jnum2str(jnum, x_orientation=None):
     """
     Convert jones polarization number to str according to calfits memo.
@@ -1072,6 +1077,7 @@ def jnum2str(jnum, x_orientation=None):
     return out
 
 
+@lru_cache
 def parse_polstr(polstr, x_orientation=None):
     """
     Parse a polarization string and return pyuvdata standard polarization string.
@@ -1109,6 +1115,7 @@ def parse_polstr(polstr, x_orientation=None):
     )
 
 
+@lru_cache
 def parse_jpolstr(jpolstr, x_orientation=None):
     """
     Parse a Jones polarization string and return pyuvdata standard jones string.

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description_file = README.md
 # B905 is for using zip without the `strict` argument, which was introduced in
 # python 3.10. We should probably add this check (remove it from the ignore) when we
 # require 3.10.
-ignore = W503, E203, N806, B905, B907, B028
+ignore = W503, E203, N806, B905, B907
 max-line-length = 88
 per-file-ignores =
     pyuvdata/tests/*.py: D

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description_file = README.md
 # B905 is for using zip without the `strict` argument, which was introduced in
 # python 3.10. We should probably add this check (remove it from the ignore) when we
 # require 3.10.
-ignore = W503, E203, N806, B905, B907
+ignore = W503, E203, N806, B905, B907, B028
 max-line-length = 88
 per-file-ignores =
     pyuvdata/tests/*.py: D


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Applies the `lru_cache` decorator to some utility functions, especially the `polnum2str` function and its variants. These are good functions for this decorator, as they have a very limited set of possible input parameters, so do not take much extra cache memory. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

It turns out that these functions can take a LOT of the total time for some `hera_cal` scripts, because they are called *every time* you request a baseline-pol key from a `HERAData` object. Thus, if you loop over all baselines in a file to get their data, you end up calling `polstr2num` like 65k times. Since `polstr2num` does a deepcopy of a dict, it actually takes a non-negligible amount of time (for example, the delay filter was taking ~20min for a 2-integration file, of which about 7min was taken by the `polstr2num` function). 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
