### PR TITLE
feat: add FastUVH5Meta reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- A new `FastUVH5Meta` object that enables quick partial reading of uvh5 file metadata.
+This is used by default in the `UVData.read_uvh5` method to initialize a `UVData`
+object, without any apparent change for the user. To get the benefits of the new class,
+use it directly to interface with the metadata portion of a `.uvh5` file.
+
+### Changed
+- Updated numpy requirements to `>=1.20`.
+- Updated scipy requirements to `>=1.5`.
+
 ### Fixed
 - Handling of antenna_names and antenna_numbers in `read_fhd` and `read_fhd_cal`.
 
 ## [2.3.0] - 2023-03-13
 
 ### Added
-- A new `FastUVH5Meta` object that enables quick partial reading of uvh5 file metadata.
 - A new `interpolation_function` parameter to `UVBeam.interp` and `UVBeam.to_healpix`
 to allow the function name to be passed into the methods, with sensible defaulting.
 - Support for selecting on phase center IDs, including on read.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,13 @@ from them will inherit them. UVFlag objects will also inherit these parameters w
 they are converted between types using UVData and UVCalobjects.
 - The `UVFlag.set_telescope_params` method, similar to the ones on UVData and UVCal,
 to set several of these new parameters.
+- A new `FastUVH5Meta` object that enables quick partial reading of uvh5 file metadata.
 
 ### Changed
 - Increases the h5py minimum version to 3.1.
 - Increase the minimum compatible version for lunarsky to 0.2.1 to fix astropy
 deprecation warnings.
+
 
 ### Fixed
 - Fixed some bugs related to handling of the `UVCal.time_range` parameter in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ## [2.3.0] - 2023-03-13
 
 ### Added
+- A new `FastUVH5Meta` object that enables quick partial reading of uvh5 file metadata.
 - A new `interpolation_function` parameter to `UVBeam.interp` and `UVBeam.to_healpix`
 to allow the function name to be passed into the methods, with sensible defaulting.
 - Support for selecting on phase center IDs, including on read.
@@ -22,13 +23,11 @@ from them will inherit them. UVFlag objects will also inherit these parameters w
 they are converted between types using UVData and UVCalobjects.
 - The `UVFlag.set_telescope_params` method, similar to the ones on UVData and UVCal,
 to set several of these new parameters.
-- A new `FastUVH5Meta` object that enables quick partial reading of uvh5 file metadata.
 
 ### Changed
 - Increases the h5py minimum version to 3.1.
 - Increase the minimum compatible version for lunarsky to 0.2.1 to fix astropy
 deprecation warnings.
-
 
 ### Fixed
 - Fixed some bugs related to handling of the `UVCal.time_range` parameter in

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Required:
 
 * astropy >= 5.0.4
 * h5py >= 3.1
-* numpy >= 1.19
+* numpy >= 1.20
 * pyerfa >= 2.0
 * scipy >= 1.3
 * setuptools_scm <7.0|>=7.0.3

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Required:
 * h5py >= 3.1
 * numpy >= 1.20
 * pyerfa >= 2.0
-* scipy >= 1.3
+* scipy >= 1.5
 * setuptools_scm <7.0|>=7.0.3
 
 Optional:

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -3,9 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - astropy>=5.0.4
-  - numpy>=1.19.*
-  - scipy>=1.3
   - h5py>=3.1
+  - h5py>=3.0
   - pyerfa>=2.0
   - coverage
   - pytest>=6.2.0

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - astropy>=5.0.4
   - h5py>=3.1
+  - scipy>=1.5
   - numpy>=1.20.*
   - pyerfa>=2.0
   - coverage

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - astropy>=5.0.4
   - h5py>=3.1
-  - h5py>=3.0
+  - numpy>=1.20.*
   - pyerfa>=2.0
   - coverage
   - pytest>=6.2.0

--- a/ci/pyuvdata_min_versions_tests.yml
+++ b/ci/pyuvdata_min_versions_tests.yml
@@ -11,7 +11,7 @@ dependencies:
   - pyerfa==2.0
   - python-casacore==3.3.1
   - pyyaml==5.1.*
-  - scipy==1.3.*
+  - scipy==1.5.*
   - coverage
   - pytest==6.2.0
   - pytest-cases==3.6.9

--- a/ci/pyuvdata_min_versions_tests.yml
+++ b/ci/pyuvdata_min_versions_tests.yml
@@ -7,7 +7,7 @@ dependencies:
   - astroquery==0.4.4
   - h5py==3.1.*
   - hdf5plugin==3.1.*
-  - numpy==1.19.*
+  - numpy==1.20.*
   - pyerfa==2.0
   - python-casacore==3.3.1
   - pyyaml==5.1.*

--- a/ci/pyuvdata_publish.yml
+++ b/ci/pyuvdata_publish.yml
@@ -4,8 +4,8 @@ channels:
 dependencies:
   - astropy>=5.0.4
   - numpy>=1.19.*
-  - scipy>=1.3
   - h5py>=3.1
+  - scipy>=1.5
   - pyerfa>=2.0
   - cython
   - setuptools_scm<7.0|>=7.0.3

--- a/ci/pyuvdata_publish.yml
+++ b/ci/pyuvdata_publish.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - astropy>=5.0.4
-  - numpy>=1.19.*
+  - numpy>=1.20.*
   - h5py>=3.1
   - scipy>=1.5
   - pyerfa>=2.0

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -11,7 +11,7 @@ dependencies:
   - pyerfa>=2.0
   - python-casacore>=3.3.1
   - pyyaml>=5.1
-  - scipy>=1.3
+  - scipy>=1.5
   - coverage
   - pytest>=6.2.0
   - pytest-cases>=3.6.9

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -11,7 +11,7 @@ dependencies:
   - numpy>=1.19.*
   - pyerfa>=2.0
   - pyyaml>=5.1
-  - scipy>=1.3
+  - scipy>=1.5
   - coverage
   - pytest>=6.2.0
   - pytest-cases>=3.6.9

--- a/ci/pyuvdata_warning_test.yml
+++ b/ci/pyuvdata_warning_test.yml
@@ -11,7 +11,7 @@ dependencies:
   - pyerfa>=2.0
   - python-casacore>=3.3.1
   - pyyaml>=5.1
-  - scipy>=1.3
+  - scipy>=1.5
   - coverage
   - pytest>=6.2.0
   - pytest-cases>=3.6.9

--- a/environment.yaml
+++ b/environment.yaml
@@ -9,7 +9,7 @@ dependencies:
   - cython>=0.23
   - h5py>=3.1
   - hdf5plugin>=3.1.0
-  - numpy>=1.19
+  - numpy>=1.20
   - pip
   - pre-commit
   - pyerfa>=2.0

--- a/environment.yaml
+++ b/environment.yaml
@@ -20,7 +20,7 @@ dependencies:
   - pytest-xdist
   - python-casacore>=3.3.1
   - pyyaml>=5.1
-  - scipy>=1.3
+  - scipy>=1.5
   - setuptools_scm<7.0|>=7.0.3
   - sphinx
   - pip:

--- a/pyuvdata/__init__.py
+++ b/pyuvdata/__init__.py
@@ -33,6 +33,7 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 from .telescopes import Telescope, get_telescope, known_telescopes  # noqa
 from .uvbeam import UVBeam  # noqa
 from .uvcal import UVCal  # noqa
+from .uvdata import FastUVH5Meta  # noqa
 from .uvdata import UVData  # noqa
 from .uvflag import UVFlag  # noqa
 

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -305,7 +305,9 @@ class UVParameter(object):
             When set to False (default), descriptive text is printed out when parameters
             do not match. If set to True, this text is not printed.
         """
-        if not isinstance(other, self.__class__) and isinstance(self, other.__class__):
+        if not (
+            isinstance(other, self.__class__) and isinstance(self, other.__class__)
+        ):
             if not silent:
                 print(f"{self.name} parameter classes are different")
             return False

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4061,3 +4061,9 @@ def test_determine_rect_time_first():
     BL = np.tile(bls, len(times))
     is_rect, time_first = uvutils.determine_rectangularity(TIME, BL, nbls=9, ntimes=10)
     assert not is_rect
+
+    TIME = np.array([1000.0, 1000.0, 2000.0, 1000.0])
+    BLS = np.array([0, 0, 1, 0])
+
+    is_rect, time_first = uvutils.determine_rectangularity(TIME, BLS, nbls=2, ntimes=2)
+    assert not is_rect

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4041,16 +4041,23 @@ def test_determine_blt_order_size_1():
     assert time_first
 
 
-def test_determine_blt_order_time_first():
+def test_determine_rect_time_first():
     times = np.linspace(2458119.5, 2458120.5, 10)
     ant1 = np.arange(3)
     ant2 = np.arange(3)
     ANT1, ANT2 = np.meshgrid(ant1, ant2)
-    BL = uvutils.antnums_to_baseline(ANT1.flatten(), ANT2.flatten(), 3)
+    bls = uvutils.antnums_to_baseline(ANT1.flatten(), ANT2.flatten(), 3)
 
-    TIME = np.tile(times, len(ANT1))
     rng = np.random.default_rng(12345)
-    BL = np.concatenate([rng.permuted(BL) for i in range(len(times))])
 
+    TIME = np.tile(times, len(bls))
+    BL = np.concatenate([rng.permuted(bls) for i in range(len(times))])
+
+    is_rect, time_first = uvutils.determine_rectangularity(TIME, BL, nbls=9, ntimes=10)
+    assert not is_rect
+
+    # now, permute time instead of bls
+    TIME = np.concatenate([rng.permuted(times) for i in range(len(bls))])
+    BL = np.tile(bls, len(times))
     is_rect, time_first = uvutils.determine_rectangularity(TIME, BL, nbls=9, ntimes=10)
     assert not is_rect

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4049,7 +4049,8 @@ def test_determine_blt_order_time_first():
     BL = uvutils.antnums_to_baseline(ANT1.flatten(), ANT2.flatten(), 3)
 
     TIME = np.tile(times, len(ANT1))
-    BL = np.concatenate([np.shuffle(BL) for i in range(len(times))])
+    rng = np.random.default_rng(12345)
+    BL = np.concatenate([rng.permuted(BL) for i in range(len(times))])
 
     is_rect, time_first = uvutils.determine_rectangularity(TIME, BL, nbls=9, ntimes=10)
     assert not is_rect

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4026,3 +4026,30 @@ def test_determine_blt_order(blt_order):
             or (len(blt_order) == 1 and blt_order[0] != "time")
             or not blt_order  # we by default move time first (backwards, but still)
         )
+
+
+def test_determine_blt_order_size_1():
+    times = np.array([2458119.5])
+    ant1 = np.array([0])
+    ant2 = np.array([1])
+    bl = uvutils.antnums_to_baseline(ant1, ant2, 2)
+
+    order = uvutils.determine_blt_order(times, ant1, ant2, bl, Nbls=1, Ntimes=1)
+    assert order == ("baseline", "time")
+    is_rect, time_first = uvutils.determine_rectangularity(times, bl, nbls=1, ntimes=1)
+    assert is_rect
+    assert time_first
+
+
+def test_determine_blt_order_time_first():
+    times = np.linspace(2458119.5, 2458120.5, 10)
+    ant1 = np.arange(3)
+    ant2 = np.arange(3)
+    ANT1, ANT2 = np.meshgrid(ant1, ant2)
+    BL = uvutils.antnums_to_baseline(ANT1.flatten(), ANT2.flatten(), 3)
+
+    TIME = np.tile(times, len(ANT1))
+    BL = np.concatenate([np.shuffle(BL) for i in range(len(times))])
+
+    is_rect, time_first = uvutils.determine_rectangularity(TIME, BL, nbls=9, ntimes=10)
+    assert not is_rect

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -5527,11 +5527,19 @@ def determine_blt_order(
     for i, (t, a, b, bl) in enumerate(
         zip(times[1:], ant1[1:], ant2[1:], bls[1:]), start=1
     ):
+        on_bl_boundary = i % Nbls == 0
+        on_time_boundary = i % Ntimes == 0
+
         if t < times[i - 1]:
             time_bl = False
             time_a = False
             time_b = False
             time_order = False
+
+            if not on_time_boundary:
+                bl_time = False
+                a_time = False
+                b_time = False
 
             if bl == bls[i - 1]:
                 bl_time = False
@@ -5551,12 +5559,18 @@ def determine_blt_order(
         if bl < bls[i - 1]:
             bl_time = False
             bl_order = False
+            if not on_bl_boundary:
+                time_bl = False
         if a < ant1[i - 1]:
             a_time = False
             a_order = False
+            if not on_bl_boundary:
+                time_a = False
         if b < ant2[i - 1]:
             b_time = False
             b_order = False
+            if not on_bl_boundary:
+                time_b = False
 
         if not any(
             (
@@ -5649,43 +5663,47 @@ def determine_rectangularity(time_array, baseline_array, nbls, ntimes):
     bl_first = True
 
     if time_array.size != nbls * ntimes:
+        print("time_array.size != nbls * ntimes")
         return False, False
 
     if nbls * ntimes == 1:
         return True, True
 
     # check if we're moving time first
-    for i in range(1, nbls):
+    for i in range(1, ntimes):
         if time_array[i] == time_array[0]:
             time_first = False
             break
 
     # check if we're moving bl first
     bl0 = baseline_array[0]
-    for i in range(1, ntimes):
+    for i in range(1, nbls):
         if baseline_array[i] == bl0:
             bl_first = False
             break
 
     if not time_first and not bl_first:
+        print("not time_first and not bl_first")
         return False, False
 
     # Now do a proper check.
     if time_first:
-        for i in range(nbls):
+        for i in range(ntimes):
             if (
                 np.unique(time_array[i::ntimes]).size != 1
                 or np.unique(baseline_array[i::ntimes]).size != nbls
             ):
+                print("unique times != 1 or unique baselines != nbls")
                 is_rect = False
                 break
 
-    if bl_first:
-        for i in range(ntimes):
+    elif bl_first:
+        for i in range(nbls):
             if (
                 np.unique(baseline_array[i::nbls]).size != 1
                 or np.unique(time_array[i::nbls]).size != ntimes
             ):
+                print("unique baselines != 1 or unique times != ntimes")
                 is_rect = False
                 break
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -5692,7 +5692,8 @@ def determine_rectangularity(time_array, baseline_array, nbls, ntimes):
     if not is_rect:
         return False, False
 
-    if time_first and bl_first:
-        raise ValueError("Something went wrong when determining rectangularity.")
+    assert (
+        time_first and bl_first
+    ), "Something went wrong when determining rectangularity."
 
     return is_rect, time_first

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -5575,16 +5575,16 @@ def determine_blt_order(
         ):
             break
 
-    if (Nbls > 1 and Ntimes > 1) and (
-        (time_bl and bl_time)
-        or (time_a and a_time)
-        or (time_b and b_time)
-        or (time_order and a_order)
-        or (time_order and b_order)
-        or (a_order and b_order)
-        or (time_order and bl_order)
-    ):
-        raise ValueError(
+    if Nbls > 1 and Ntimes > 1:
+        assert not (
+            (time_bl and bl_time)
+            or (time_a and a_time)
+            or (time_b and b_time)
+            or (time_order and a_order)
+            or (time_order and b_order)
+            or (a_order and b_order)
+            or (time_order and bl_order)
+        ), (
             "Something went horribly wrong when trying to determine the order of "
             "the blts axis."
             "Please raise an issue on github, as this is not meant to happen."
@@ -5692,7 +5692,7 @@ def determine_rectangularity(time_array, baseline_array, nbls, ntimes):
     if not is_rect:
         return False, False
 
-    assert (
+    assert not (
         time_first and bl_first
     ), "Something went wrong when determining rectangularity."
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -5660,9 +5660,10 @@ def determine_rectangularity(time_array, baseline_array, nbls, ntimes):
     -------
     is_rect : bool
         True if the data is rectangular, False otherwise.
-    time_first : bool
-        True if the data is rectangular and time moves first (i.e. is "last axis").
-        False either if baseline moves first, OR if it is not rectangular.
+    time_axis_faster_than_bls : bool
+        True if the data is rectangular and the time axis is the last axis (i.e. times
+        change first, then bls). False either if baselines change first, OR if it is
+        not rectangular.
 
     Notes
     -----

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -5703,7 +5703,6 @@ def determine_rectangularity(
         time_first = False
     if baseline_array[1] == baseline_array[0]:
         bl_first = False
-
     if not time_first and not bl_first:
         return False, False
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -5599,9 +5599,23 @@ def determine_blt_order(
             or (a_order and b_order)
             or (time_order and bl_order)
         ), (
-            "Something went horribly wrong when trying to determine the order of "
-            "the blts axis."
+            "Something went wrong when trying to determine the order of the blts axis. "
             "Please raise an issue on github, as this is not meant to happen."
+            "None of the following should ever be True: \n"
+            f"\ttime_bl and bl_time: {time_bl and bl_time}\n"
+            f"\ttime_a and a_time: {time_a and a_time}\n"
+            f"\ttime_b and b_time: {time_b and b_time}\n"
+            f"\ttime_order and a_order: {time_order and a_order}\n"
+            f"\ttime_order and b_order: {time_order and b_order}\n"
+            f"\ta_order and b_order: {a_order and b_order}\n"
+            f"\ttime_order and bl_order: {time_order and bl_order}\n\n"
+            "Please include the following information in your issue:\n"
+            f"Nbls: {Nbls}\n"
+            f"Ntimes: {Ntimes}\n"
+            f"TIMES: {times}\n"
+            f"ANT1: {ant1}\n"
+            f"ANT2: {ant2}\n"
+            f"BASELINES: {bls}\n"
         )
 
     if time_bl:
@@ -5663,11 +5677,15 @@ def determine_rectangularity(time_array, baseline_array, nbls, ntimes):
     bl_first = True
 
     if time_array.size != nbls * ntimes:
-        print("time_array.size != nbls * ntimes")
         return False, False
 
     if nbls * ntimes == 1:
         return True, True
+
+    if nbls == 1:
+        return True, True
+    if ntimes == 1:
+        return True, False
 
     # check if we're moving time first
     for i in range(1, ntimes):
@@ -5683,7 +5701,6 @@ def determine_rectangularity(time_array, baseline_array, nbls, ntimes):
             break
 
     if not time_first and not bl_first:
-        print("not time_first and not bl_first")
         return False, False
 
     # Now do a proper check.
@@ -5693,7 +5710,6 @@ def determine_rectangularity(time_array, baseline_array, nbls, ntimes):
                 np.unique(time_array[i::ntimes]).size != 1
                 or np.unique(baseline_array[i::ntimes]).size != nbls
             ):
-                print("unique times != 1 or unique baselines != nbls")
                 is_rect = False
                 break
 
@@ -5703,15 +5719,20 @@ def determine_rectangularity(time_array, baseline_array, nbls, ntimes):
                 np.unique(baseline_array[i::nbls]).size != 1
                 or np.unique(time_array[i::nbls]).size != ntimes
             ):
-                print("unique baselines != 1 or unique times != ntimes")
                 is_rect = False
                 break
 
     if not is_rect:
         return False, False
 
-    assert not (
-        time_first and bl_first
-    ), "Something went wrong when determining rectangularity."
+    # We can't be rectangular AND have time/bl move first.
+    assert not (time_first and bl_first), (
+        "Something went wrong when determining rectangularity. "
+        "Data was determined to be rectangular, but also to have time AND "
+        "baseline moving first. "
+        "Please raise an issue on github, as this is not meant to happen."
+        f"Got TIMES = {time_array}\n"
+        f"Got BLs = {baseline_array}\n"
+    )
 
     return is_rect, time_first

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -392,7 +392,11 @@ class UVBase(object):
             yield a
 
     def __eq__(
-        self, other, check_extra=True, allowed_failures=("filename",), silent=False
+        self,
+        other,
+        check_extra=True,
+        allowed_failures=("filename", "blt_order"),
+        silent=False,
     ):
         """
         Test if classes match and parameters are equal.
@@ -408,7 +412,9 @@ class UVBase(object):
             List or tuple of parameter names that are allowed to fail while
             still passing an overall equality check. These should only include
             optional parameters. By default, the `filename` parameter will be
-            ignored.
+            ignored. 'blt_order' is also ignored, because currently it is ascertained
+            directly, if not provided, by UVH5 files, but not by other file types.
+            In any case, if it was to fail, other parameters would fail as well.
         silent : bool
             Option to turn off printing explanations of why equality fails. Useful to
             prevent __ne__ from printing lots of messages.

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -392,11 +392,7 @@ class UVBase(object):
             yield a
 
     def __eq__(
-        self,
-        other,
-        check_extra=True,
-        allowed_failures=("filename", "blt_order"),
-        silent=False,
+        self, other, check_extra=True, allowed_failures=("filename",), silent=False
     ):
         """
         Test if classes match and parameters are equal.

--- a/pyuvdata/uvdata/__init__.py
+++ b/pyuvdata/uvdata/__init__.py
@@ -4,3 +4,4 @@
 
 """Init file for UVData."""
 from .uvdata import *  # noqa
+from .uvh5 import FastUVH5Meta  # noqa

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -17,7 +17,6 @@ from astropy import units
 from astropy.coordinates import Angle, EarthLocation, Latitude, Longitude, SkyCoord
 from astropy.time import Time
 from astropy.utils import iers
-from packaging import version
 
 import pyuvdata.tests as uvtest
 import pyuvdata.utils as uvutils
@@ -10081,11 +10080,7 @@ def test_multifile_read_check(hera_uvh5, tmp_path):
     with h5py.File(testfile, "r+") as h5f:
         del h5f["Header/ant_1_array"]
 
-    if version.parse(h5py.version.hdf5_version) >= version.parse("1.14.0"):
-        err_msg = "Unable to synchronously open object"
-    else:
-        err_msg = "Unable to open object"
-
+    err_msg = "ant_1_array not found in"
     uv = UVData()
     # Test that the expected error arises
     with pytest.raises(KeyError, match=err_msg):
@@ -10221,10 +10216,7 @@ def test_multifile_read_check_long_list(hera_uvh5, tmp_path, err_type):
 
     assert uv_test == uv_true
 
-    if version.parse(h5py.version.hdf5_version) >= version.parse("1.14.0"):
-        err_msg = "Unable to synchronously open object"
-    else:
-        err_msg = "Unable to open object"
+    err_msg = "ant_1_array not found"
 
     # Test with corrupted file first in list, but with skip_bad_files=False
     uv_test = UVData()

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -88,6 +88,8 @@ def uvdata_props():
         "flex_spw_id_array",
         "flex_spw_polarization_array",
         "filename",
+        "blts_are_rectangular",
+        "time_axis_faster_than_bls",
     ]
     extra_parameters = ["_" + prop for prop in extra_properties]
 

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -12848,6 +12848,7 @@ def test_init_like_hera_cal(
     assert uvd2 == hera_uvh5
 
 
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_setting_time_axis_wrongly(casa_uvfits):
     casa_uvfits.time_axis_faster_than_bls = True
     with pytest.raises(ValueError, match="time_axis_faster_than_bls is True but"):

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -12872,3 +12872,20 @@ def test_setting_time_axis_wrongly(casa_uvfits):
     assert not casa_uvfits.time_axis_faster_than_bls
     casa_uvfits.blts_are_rectangular = True
     assert not casa_uvfits.time_axis_faster_than_bls
+
+
+def test_set_rectangularity(casa_uvfits, hera_uvh5):
+    # without setting force=True, starting from unknown rectangularity, it does nothing.
+    casa_uvfits.set_rectangularity()
+    assert casa_uvfits.blts_are_rectangular is None
+    assert casa_uvfits.time_axis_faster_than_bls is None
+
+    # setting force=True will set the rectangularity attributes only if obvious
+    casa_uvfits.set_rectangularity(force=True)
+    assert casa_uvfits.blts_are_rectangular is False
+    assert casa_uvfits.time_axis_faster_than_bls is False
+
+    hera_uvh5.reorder_blts(order="time", minor_order="baseline")
+    hera_uvh5.set_rectangularity(force=True, calculate=True)
+    assert hera_uvh5.blts_are_rectangular is True
+    assert hera_uvh5.time_axis_faster_than_bls is False

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -1640,8 +1640,24 @@ def test_select_phase_center_id(tmp_path, carma_miriad):
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_select_phase_center_id_blts(carma_miriad):
     uv_obj = carma_miriad
-    uv_obj.reorder_blts(order="baseline")
+    print(
+        uv_obj.Nbls,
+        uv_obj.Nblts,
+        uv_obj.Ntimes,
+        uv_obj.Nbls * uv_obj.Ntimes,
+        uv_obj.blts_are_rectangular,
+        uv_obj.time_axis_faster_than_bls,
+    )
 
+    uv_obj.reorder_blts(order="baseline")
+    print(
+        uv_obj.Nbls,
+        uv_obj.Nblts,
+        uv_obj.Ntimes,
+        uv_obj.Nbls * uv_obj.Ntimes,
+        uv_obj.blts_are_rectangular,
+        uv_obj.time_axis_faster_than_bls,
+    )
     uv1 = uv_obj.select(
         phase_center_ids=0, blt_inds=np.arange(uv_obj.Nblts // 2), inplace=False
     )

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -12889,3 +12889,8 @@ def test_set_rectangularity(casa_uvfits, hera_uvh5):
     hera_uvh5.set_rectangularity(force=True)
     assert hera_uvh5.blts_are_rectangular is True
     assert hera_uvh5.time_axis_faster_than_bls is False
+
+    hera_uvh5.reorder_blts(order=np.random.permutation(hera_uvh5.Nblts))
+    hera_uvh5.set_rectangularity(force=True)
+    assert hera_uvh5.blts_are_rectangular is False
+    assert hera_uvh5.time_axis_faster_than_bls is False

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -12886,6 +12886,6 @@ def test_set_rectangularity(casa_uvfits, hera_uvh5):
     assert casa_uvfits.time_axis_faster_than_bls is False
 
     hera_uvh5.reorder_blts(order="time", minor_order="baseline")
-    hera_uvh5.set_rectangularity(force=True, calculate=True)
+    hera_uvh5.set_rectangularity(force=True)
     assert hera_uvh5.blts_are_rectangular is True
     assert hera_uvh5.time_axis_faster_than_bls is False

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -13,6 +13,7 @@ import h5py
 import numpy as np
 import pytest
 from astropy.time import Time
+from packaging import version
 
 import pyuvdata.tests as uvtest
 import pyuvdata.utils as uvutils
@@ -217,9 +218,14 @@ def test_read_uvh5_errors():
     """
     Test raising errors in read function.
     """
+    if version.parse(h5py.version.hdf5_version) >= version.parse("1.14.0"):
+        err_msg = "Unable to synchronously open object"
+    else:
+        err_msg = "Unable to open object"
+
     uv_in = UVData()
     fake_file = os.path.join(DATA_PATH, "fake_file.uvh5")
-    with pytest.raises(IOError, match="Unable to open file"):
+    with pytest.raises(IOError, match=err_msg):
         uv_in.read_uvh5(fake_file)
 
 

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3591,6 +3591,9 @@ class TestFastUVH5Meta:
                 np.unique(meta.baseline_array)
             )
             assert set(meta.antpairs) == set(uvd.get_antpairs())
+            assert meta.unique_ants == set(
+                np.concatenate([meta.ant_1_array, meta.ant_2_array])
+            )
 
         meta = uvh5.FastUVH5Meta(self.fl, blts_are_rectangular=False)
         uvd = meta.to_uvdata()
@@ -3612,10 +3615,6 @@ class TestFastUVH5Meta:
 
         assert meta.has_key((0, 1, "xy"))
         assert meta.has_key((1, 0, "yx"))
-
-    def test_freqs_is_1d(self):
-        meta = uvh5.FastUVH5Meta(self.fl)
-        assert meta.freqs.ndim == 1
 
     def test_pols(self):
         meta = uvh5.FastUVH5Meta(self.fl)

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -219,10 +219,8 @@ def test_read_uvh5_errors():
     """
     uv_in = UVData()
     fake_file = os.path.join(DATA_PATH, "fake_file.uvh5")
-    with pytest.raises(IOError, match=re.escape(f"{fake_file} not found")):
+    with pytest.raises(IOError, match="Unable to open file"):
         uv_in.read_uvh5(fake_file)
-
-    return
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -219,9 +219,9 @@ def test_read_uvh5_errors():
     Test raising errors in read function.
     """
     if version.parse(h5py.version.hdf5_version) >= version.parse("1.14.0"):
-        err_msg = "Unable to synchronously open object"
+        err_msg = "Unable to synchronously open file"
     else:
-        err_msg = "Unable to open object"
+        err_msg = "Unable to open file"
 
     uv_in = UVData()
     fake_file = os.path.join(DATA_PATH, "fake_file.uvh5")

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3493,8 +3493,10 @@ class TestFastUVH5Meta:
         meta = uvh5.FastUVH5Meta(self.fl)
         uvd = meta.to_uvdata()
         uvd.reorder_blts(order="baseline", minor_order="time")
-        self.fl_time_first = os.path.join(self.tmp_path.name, "time_first.uvh5")
-        uvd.initialize_uvh5_file(self.fl_time_first, clobber=True)
+        self.fltime_axis_faster_than_bls = os.path.join(
+            self.tmp_path.name, "time_axis_faster_than_bls.uvh5"
+        )
+        uvd.initialize_uvh5_file(self.fltime_axis_faster_than_bls, clobber=True)
 
     def teardown_class(self):
         self.tmp_path.cleanup()
@@ -3549,22 +3551,22 @@ class TestFastUVH5Meta:
         meta = uvh5.FastUVH5Meta(self.fl, blts_are_rectangular=False)
         assert not meta.blts_are_rectangular
 
-    def test_time_first(self):
-        meta = uvh5.FastUVH5Meta(self.fl, time_first=None)
-        assert not meta._time_first
+    def testtime_axis_faster_than_bls(self):
+        meta = uvh5.FastUVH5Meta(self.fl, time_axis_faster_than_bls=None)
+        assert not meta.time_axis_faster_than_bls
 
         meta = uvh5.FastUVH5Meta(self.fl_singlebl)
-        assert meta._time_first
+        assert meta.time_axis_faster_than_bls
 
         meta = uvh5.FastUVH5Meta(self.fl_singlebl, blts_are_rectangular=True)
-        assert meta._time_first
+        assert meta.time_axis_faster_than_bls
 
         meta = uvh5.FastUVH5Meta(self.fl, blts_are_rectangular=False)
-        assert not meta._time_first
+        assert not meta.time_axis_faster_than_bls
 
-        meta1 = uvh5.FastUVH5Meta(self.fl_time_first)
+        meta1 = uvh5.FastUVH5Meta(self.fltime_axis_faster_than_bls)
         assert np.all(meta1.times == meta.times)
-        assert meta1._time_first
+        assert meta1.time_axis_faster_than_bls
 
     def test_phase_type_with_pcc(self):
         meta = uvh5.FastUVH5Meta(self.fl)
@@ -3591,10 +3593,13 @@ class TestFastUVH5Meta:
         uvd = meta.to_uvdata()
         uvd.reorder_blts(order="baseline", minor_order="time")
         uvd.initialize_uvh5_file(
-            os.path.join(self.tmp_path.name, "time_first.uvh5"), clobber=True
+            os.path.join(self.tmp_path.name, "time_axis_faster_than_bls.uvh5"),
+            clobber=True,
         )
 
-        meta1 = uvh5.FastUVH5Meta(os.path.join(self.tmp_path.name, "time_first.uvh5"))
+        meta1 = uvh5.FastUVH5Meta(
+            os.path.join(self.tmp_path.name, "time_axis_faster_than_bls.uvh5")
+        )
         assert np.allclose(meta1.lsts, meta.lsts)
 
     def test_unique_arrays(self):
@@ -3616,7 +3621,7 @@ class TestFastUVH5Meta:
         meta = uvh5.FastUVH5Meta(self.fl, blts_are_rectangular=True)
         do_asserts(meta)
 
-        meta = uvh5.FastUVH5Meta(self.fl_time_first)
+        meta = uvh5.FastUVH5Meta(self.fltime_axis_faster_than_bls)
         do_asserts(meta)
 
     def test_has_key(self):

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3551,7 +3551,7 @@ class TestFastUVH5Meta:
         meta = uvh5.FastUVH5Meta(self.fl, blts_are_rectangular=False)
         assert not meta.blts_are_rectangular
 
-    def testtime_axis_faster_than_bls(self):
+    def test_time_axis_faster_than_bls(self):
         meta = uvh5.FastUVH5Meta(self.fl, time_axis_faster_than_bls=None)
         assert not meta.time_axis_faster_than_bls
 
@@ -3649,3 +3649,27 @@ class TestFastUVH5Meta:
         sma_mir.write_uvh5(os.path.join(testdir, "sma_mir.uvh5"))
         meta = uvh5.FastUVH5Meta(os.path.join(testdir, "sma_mir.uvh5"))
         assert meta.phase_type == "phased"
+
+    def test_rectangularity_roundtrip(self):
+        meta = uvh5.FastUVH5Meta(self.fl)
+        uvd = meta.to_uvdata()
+        uvd.initialize_uvh5_file(
+            os.path.join(self.tmp_path.name, "rectangular.uvh5"), clobber=True
+        )
+        meta1 = uvh5.FastUVH5Meta(os.path.join(self.tmp_path.name, "rectangular.uvh5"))
+        assert meta1.blts_are_rectangular
+        assert not meta1.time_axis_faster_than_bls
+
+        # force them to be wrong!
+        meta = uvh5.FastUVH5Meta(self.fl)
+        uvd = meta.to_uvdata()
+        uvd.blts_are_rectangular = False
+        uvd.time_axis_faster_than_bls = False
+        uvd.initialize_uvh5_file(
+            os.path.join(self.tmp_path.name, "not_rectangular.uvh5"), clobber=True
+        )
+        meta1 = uvh5.FastUVH5Meta(
+            os.path.join(self.tmp_path.name, "not_rectangular.uvh5")
+        )
+        assert not meta1.blts_are_rectangular
+        assert not meta1.time_axis_faster_than_bls

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3486,7 +3486,7 @@ class TestFastUVH5Meta:
         self.tmp_path = tempfile.TemporaryDirectory("fastuvh5meta")
 
         uvd = UVData()
-        uvd.read(self.fl, bls=[(26, 26)])
+        uvd.read(self.fl, bls=[(26, 26)], use_future_array_shapes=True)
         self.fl_singlebl = os.path.join(self.tmp_path.name, "singlebl.uvh5")
         uvd.write_uvh5(self.fl_singlebl)
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -1285,7 +1285,6 @@ class UVData(UVBase):
         else:
             if cat_id is None:
                 cat_id = 0
-
         # If source is unique, begin creating a dictionary for it
         phase_dict = {
             "cat_name": cat_name,
@@ -1306,7 +1305,9 @@ class UVData(UVBase):
             self.phase_center_catalog[cat_id] = phase_dict
         else:
             self.phase_center_catalog = {cat_id: phase_dict}
+
         self.Nphase = len(self.phase_center_catalog)
+
         return cat_id
 
     def _remove_phase_center(self, defunct_id):

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -5057,6 +5057,17 @@ class UVData(UVBase):
             self.flag_array = self.flag_array[index_array]
             self.nsample_array = self.nsample_array[index_array]
 
+        # Fix the rectangularity attributes
+        if order in ("bda", "ant1", "ant2") or minor_order in ("ant1", "ant2", None):
+            self.blts_are_rectangular = False
+            self.time_axis_faster_than_bls = False
+        elif order == "baseline" and minor_order == "time":
+            self.blts_are_rectangular = True
+            self.time_axis_faster_than_bls = True
+        elif order == "time" and minor_order == "baseline":
+            self.blts_are_rectangular = True
+            self.time_axis_faster_than_bls = False
+
         # check if object is self-consistent
         if run_check:
             self.check(

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -9429,6 +9429,27 @@ class UVData(UVBase):
             blt_inds, freq_inds, pol_inds, history_update_string, keep_all_metadata
         )
 
+        # Update the rectangularity attributes
+        if blt_inds is not None:
+            if self.Nbls > 1 and self.Ntimes > 1:
+                # We don't know. We could check, but it takes time.
+                self.blts_are_rectangular = None
+            else:
+                self.blts_are_rectangular = True
+
+        if self.blts_are_rectangular is False:
+            self.time_axis_faster_than_bls = False
+        elif self.blts_are_rectangular is None:
+            self.time_axis_faster_than_bls = None
+
+        if self.time_axis_faster_than_bls is not None:
+            if self.Ntimes == 1 and self.Nbls > 1:
+                self.time_axis_faster_than_bls = False
+            elif self.Ntimes > 1 and self.Nbls == 1:
+                self.time_axis_faster_than_bls = True
+            elif self.Ntimes == 1 and self.Nbls == 1:
+                self.time_axis_faster_than_bls = True
+
         # If we have a flex-pol data set, but we only have one pol, then this doesn't
         # need to be flex-pol anymore, and we can drop it here
         if uv_obj.flex_spw_polarization_array is not None:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -4856,7 +4856,7 @@ class UVData(UVBase):
             self.time_axis_faster_than_bls = None
             return
 
-        rect, time = uvutils.detect_rectangularity(
+        rect, time = uvutils.determine_rectangularity(
             self.time_array,
             self.baseline_array,
             self.Nbls,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -3289,7 +3289,7 @@ class UVData(UVBase):
                 raise ValueError("time_axis_faster_than_bls is True but Ntimes is 1. ")
             if self.Ntimes > 1 and self.time_array[1] == self.time_array[0]:
                 raise ValueError(
-                    "time_axis_faster_than_bls is True but time_array does not"
+                    "time_axis_faster_than_bls is True but time_array does not "
                     "move first"
                 )
 
@@ -5065,14 +5065,13 @@ class UVData(UVBase):
 
         # Fix the rectangularity attributes
         if order in ("bda", "ant1", "ant2") or minor_order in ("ant1", "ant2", None):
-            self.blts_are_rectangular = False
-            self.time_axis_faster_than_bls = False
-        elif order == "baseline" and minor_order == "time":
-            self.blts_are_rectangular = True
-            self.time_axis_faster_than_bls = True
-        elif order == "time" and minor_order == "baseline":
-            self.blts_are_rectangular = True
-            self.time_axis_faster_than_bls = False
+            self.blts_are_rectangular = None
+            self.time_axis_faster_than_bls = None
+        elif self.blts_are_rectangular:
+            if order == "baseline" and minor_order == "time":
+                self.time_axis_faster_than_bls = True
+            elif order == "time" and minor_order == "baseline":
+                self.time_axis_faster_than_bls = False
 
         # check if object is self-consistent
         if run_check:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -637,6 +637,7 @@ class UVData(UVBase):
             required=False,
             expected_type=str,
             acceptable_vals=blt_order_options,
+            ignore_eq_none=True,
         )
 
         desc = (
@@ -645,7 +646,11 @@ class UVData(UVBase):
             "operation, so if you know it, it can be provided."
         )
         self._blts_are_rectangular = uvp.UVParameter(
-            "blts_are_rectangular", description=desc, required=False, expected_type=bool
+            "blts_are_rectangular",
+            description=desc,
+            required=False,
+            expected_type=bool,
+            ignore_eq_none=True,
         )
 
         desc = (
@@ -658,6 +663,7 @@ class UVData(UVBase):
             description=desc,
             required=False,
             expected_type=bool,
+            ignore_eq_none=True,
         )
 
         desc = (

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -4837,15 +4837,12 @@ class UVData(UVBase):
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
             )
 
-    def set_rectangularity(self, calculate: bool = False, force: bool = False) -> None:
+    def set_rectangularity(self, force: bool = False) -> None:
         """
         Set the rectangularity attributes of the object.
 
         Parameters
         ----------
-        calculate : bool, optional
-            Whether to manually calculate the rectangularity of the object. This can
-            take extra time, compared to rudimentary checks on the object's attributes.
         force : bool, optional
             Whether to foce setting the rectangularity attributes, even if they are
             unset. Default is to leave them unset if they are not already set, but
@@ -4859,36 +4856,15 @@ class UVData(UVBase):
             self.time_axis_faster_than_bls = None
             return
 
-        # Clear all info, so we recalculate from scratch.
-        self.blts_are_rectangular = None
-        self.time_axis_faster_than_bls = None
-
-        # Simple checks.
-        if self.Nbls * self.Ntimes != self.Nblts:
-            self.blts_are_rectangular = False
-            self.time_axis_faster_than_bls = False
-        elif self.Nbls == 1:
-            self.blts_are_rectangular = True
-            self.time_axis_faster_than_bls = True
-        elif self.Ntimes == 1:
-            self.blts_are_rectangular = True
-            self.time_axis_faster_than_bls = False
-        elif self.blt_order == ("time", "baseline"):
-            self.blts_are_rectangular = True
-            self.time_axis_faster_than_bls = False
-        elif self.blt_order == ("baseline", "time"):
-            self.blts_are_rectangular = True
-            self.time_axis_faster_than_bls = True
-
-        if calculate and self.blts_are_rectangular is None:
-            rect, time = uvutils.detect_rectangularity(
-                self.time_array, self.baseline_array, self.Nbls, self.Ntimes
-            )
-            self.blts_are_rectangular = rect
-            self.time_axis_faster_than_bls = time
-
-        if self.blts_are_rectangular is False:
-            self.time_axis_faster_than_bls = False
+        rect, time = uvutils.detect_rectangularity(
+            self.time_array,
+            self.baseline_array,
+            self.Nbls,
+            self.Ntimes,
+            blt_order=self.blt_order,
+        )
+        self.blts_are_rectangular = rect
+        self.time_axis_faster_than_bls = time
 
     def reorder_blts(
         self,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -9464,24 +9464,6 @@ class UVData(UVBase):
         # Update the rectangularity attributes
         if blt_inds is not None:
             self.set_rectangularity(force=True)
-        #     if self.Nbls > 1 and self.Ntimes > 1:
-        #         # We don't know. We could check, but it takes time.
-        #         self.blts_are_rectangular = None
-        #     else:
-        #         self.blts_are_rectangular = True
-
-        # if self.blts_are_rectangular is False:
-        #     self.time_axis_faster_than_bls = False
-        # elif self.blts_are_rectangular is None:
-        #     self.time_axis_faster_than_bls = None
-
-        # if self.time_axis_faster_than_bls is not None:
-        #     if self.Ntimes == 1 and self.Nbls > 1:
-        #         self.time_axis_faster_than_bls = False
-        #     elif self.Ntimes > 1 and self.Nbls == 1:
-        #         self.time_axis_faster_than_bls = True
-        #     elif self.Ntimes == 1 and self.Nbls == 1:
-        #         self.time_axis_faster_than_bls = True
 
         # If we have a flex-pol data set, but we only have one pol, then this doesn't
         # need to be flex-pol anymore, and we can drop it here

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -5091,12 +5091,7 @@ class UVData(UVBase):
             self.flag_array = self.flag_array[index_array]
             self.nsample_array = self.nsample_array[index_array]
 
-        # Fix the rectangularity attributes
-        if order in ("bda", "ant1", "ant2") or minor_order in ("ant1", "ant2", None):
-            self.blts_are_rectangular = None
-            self.time_axis_faster_than_bls = None
-        else:
-            self.set_rectangularity(force=True)
+        self.set_rectangularity(force=True)
 
         # check if object is self-consistent
         if run_check:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -3,6 +3,8 @@
 # Licensed under the 2-clause BSD License
 
 """Primary container for radio interferometer datasets."""
+from __future__ import annotations
+
 import copy
 import os
 import threading

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -638,7 +638,7 @@ class FastUVH5Meta:
         The object will be metadata-only.
         """
         uvd = UVH5()
-        uvd.read(self, read_data=False, run_check_acceptability=check_lsts)
+        uvd.read_uvh5(self, read_data=False, run_check_acceptability=check_lsts)
         return uvd
 
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -16,7 +16,7 @@ import h5py
 import numpy as np
 
 from .. import utils as uvutils
-from .uvdata import UVData, radian_tol, _future_array_shapes_warning
+from .uvdata import UVData, _future_array_shapes_warning, radian_tol
 
 __all__ = ["UVH5", "FastUVH5Meta"]
 
@@ -725,7 +725,12 @@ class FastUVH5Meta:
         The object will be metadata-only.
         """
         uvd = UVH5()
-        uvd.read_uvh5(self, read_data=False, run_check_acceptability=check_lsts)
+        uvd.read_uvh5(
+            self,
+            read_data=False,
+            run_check_acceptability=check_lsts,
+            use_future_array_shapes=True,
+        )
         return uvd
 
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -737,6 +737,7 @@ class UVH5(UVData):
 
         if "lst_array" in obj.header:
             self.lst_array = obj.header["lst_array"][:]
+            proc = None
         else:
             proc = self.set_lsts_from_time_array(background=background_lsts)
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -292,16 +292,18 @@ class FastUVH5Meta:
         self.__header = None
         if self.__file:
             self.__file.close()
+        self.__file = None
 
     def open(self):  # noqa: A003
         """Open the file."""
-        self.__file = h5py.File(self.path, "r")
-        self.__header = self.__file["/Header"]
+        if self.__file is None:
+            self.__file = h5py.File(self.path, "r")
+            self.__header = self.__file["/Header"]
 
     @cached_property
     def header(self) -> h5py.Group:
         """Get the header group."""
-        if self.__header is None:
+        if self.__file is None:
             self.open()
         return self.__header
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -431,8 +431,8 @@ class FastUVH5Meta:
         if "phase_center_catalog" not in header:
             return None
         phase_center_catalog = {}
-        key_list = list(header["phase_center_catalog"].keys())
-        if isinstance(header["phase_center_catalog"][key_list[0]], h5py.Group):
+        key0 = next(iter(header["phase_center_catalog"].keys()))
+        if isinstance(header["phase_center_catalog"][key0], h5py.Group):
             # This is the new, correct way
             for pc, pc_dict in header["phase_center_catalog"].items():
                 pc_id = int(pc)

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -513,7 +513,7 @@ class FastUVH5Meta:
         """The unique times in the file."""
         h = self.header
         if self.blts_are_rectangular:
-            if self._time_first:
+            if self.time_axis_faster_than_bls:
                 return h["time_array"][: self.Ntimes]
             else:
                 return h["time_array"][:: self.Nbls]
@@ -526,7 +526,7 @@ class FastUVH5Meta:
         h = self.header
         if "lst_array" in h:
             if self.blts_are_rectangular:
-                if self._time_first:
+                if self.time_axis_faster_than_bls:
                     return h["lst_array"][: self.Ntimes]
                 else:
                     return h["lst_array"][:: self.Nbls]
@@ -599,7 +599,7 @@ class FastUVH5Meta:
         """The unique antenna 1 indices in the file."""
         h = self.header
         if self.blts_are_rectangular:
-            if self._time_first:
+            if self.time_axis_faster_than_bls:
                 return h["ant_1_array"][:: self.Ntimes]
             else:
                 return h["ant_1_array"][: self.Nbls]
@@ -611,7 +611,7 @@ class FastUVH5Meta:
         """The unique antenna 2 indices in the file."""
         h = self.header
         if self.blts_are_rectangular:
-            if self._time_first:
+            if self.time_axis_faster_than_bls:
                 return h["ant_2_array"][:: self.Ntimes]
             else:
                 return h["ant_2_array"][: self.Nbls]

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -695,9 +695,7 @@ class UVH5(UVData):
 
             if obj.phase_type == "drift":
                 if cat_name is None:
-                    print("HERE")
                     cat_name = "unprojected"
-
                 cat_id = self._add_phase_center(cat_name, cat_type="unprojected")
             else:
                 cat_id = self._add_phase_center(
@@ -709,7 +707,6 @@ class UVH5(UVData):
                     cat_epoch=obj.phase_center_epoch,
                 )
             self.phase_center_id_array = np.zeros(self.Nblts, dtype=int) + cat_id
-            print("ON READ: ", self.phase_center_catalog)
         # set telescope params
         try:
             self.set_telescope_params()

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -437,7 +437,7 @@ class FastUVH5Meta:
         if self.__time_first is not None:
             return self.__time_first
         if "time_axis_faster_than_bls" in self.header:
-            return self.header["time_axis_faster_than_bls"]
+            return bool(self.header["time_axis_faster_than_bls"][()])
         if self.Ntimes == 1:
             return False
         if self.Nbls == 1:
@@ -800,6 +800,8 @@ class UVH5(UVData):
             "uvw_array",
             "channel_width",
             "phase_center_catalog",
+            # "blts_are_rectangular",
+            # "time_axis_faster_than_bls",
         ]:
             try:
                 setattr(self, attr, getattr(obj, attr))

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -815,9 +815,9 @@ class UVH5(UVData):
         # the file. These could be set automatically later on, but for now we'll leave
         # that up to the user dealing with the UVData object.
         if "blts_are_rectangular" in obj.header:
-            self.blts_are_rectangular = obj.header["blts_are_rectangular"]
+            self.blts_are_rectangular = obj.blts_are_rectangular
         if "time_axis_faster_than_bls" in obj.header:
-            self.time_axis_faster_than_bls = obj.header["time_axis_faster_than_bls"]
+            self.time_axis_faster_than_bls = obj.time_axis_faster_than_bls
 
         if not uvutils._check_history_version(self.history, self.pyuvdata_version_str):
             self.history += self.pyuvdata_version_str

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -837,6 +837,9 @@ class UVH5(UVData):
         if obj.flex_spw:
             self._set_flex_spw()
 
+        if self.flex_spw_id_array is None and not self.flex_spw:
+            self.flex_spw_id_array = np.full(self.Nfreqs, self.spw_array[0], dtype=int)
+
         # Here is where we start handling phase center information.  If we have a
         # multi phase center dataset, we need to get different header items
         if self.phase_center_catalog is not None:

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -232,40 +232,46 @@ class FastUVH5Meta:
     gotten dynamically from the file.
     """
 
-    _string_attrs = (
-        "history",
-        "instrument",
-        "object_name",
-        "x_orientation",
-        "telescope_name",
-        "rdate",
-        "timesys",
-        "eq_coeffs_convention",
-        "phase_type",
-        "phase_center_frame",
+    _string_attrs = frozenset(
+        {
+            "history",
+            "instrument",
+            "object_name",
+            "x_orientation",
+            "telescope_name",
+            "rdate",
+            "timesys",
+            "eq_coeffs_convention",
+            "phase_type",
+            "phase_center_frame",
+        }
     )
 
     _defaults = {"x_orientation": None, "flex_spw": False}
 
-    _int_attrs = (
-        "Nblts",
-        "Ntimes",
-        "Npols",
-        "Nspws",
-        "Nfreqs",
-        "uvplane_reference_time",
-        "Nphase",
-        "Nants_data",
-        "Nants_telescope",
+    _int_attrs = frozenset(
+        {
+            "Nblts",
+            "Ntimes",
+            "Npols",
+            "Nspws",
+            "Nfreqs",
+            "uvplane_reference_time",
+            "Nphase",
+            "Nants_data",
+            "Nants_telescope",
+        }
     )
-    _float_attrs = (
-        "dut1",
-        "earth_omega",
-        "gst0",
-        "phase_center_ra" "phase_center_dec",
-        "phase_center_epoch",
+    _float_attrs = frozenset(
+        {
+            "dut1",
+            "earth_omega",
+            "gst0",
+            "phase_center_ra" "phase_center_dec",
+            "phase_center_epoch",
+        }
     )
-    _bool_attrs = ("flex_spw",)
+    _bool_attrs = frozenset(("flex_spw",))
 
     def __init__(
         self,
@@ -755,8 +761,13 @@ class UVH5(UVData):
             "phase_center_frame_pa",
             "extra_keywords",
         ]:
-            if hasattr(obj, attr):
+            try:
                 setattr(self, attr, getattr(obj, attr))
+            except AttributeError:
+                pass
+
+            # if hasattr(obj, attr):
+            #     setattr(self, attr, getattr(obj, attr))
 
         if self.blt_order is not None:
             self._blt_order.form = (len(self.blt_order),)

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -16,7 +16,7 @@ import h5py
 import numpy as np
 
 from .. import utils as uvutils
-from .uvdata import UVData, radian_tol, _future_array_shapes_warning
+from .uvdata import UVData, _future_array_shapes_warning, radian_tol
 
 __all__ = ["UVH5", "FastUVH5Meta"]
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -811,6 +811,14 @@ class UVH5(UVData):
             except AttributeError as e:
                 raise KeyError(str(e)) from e
 
+        # For now, only set the rectangularity parameters if they exist in the header of
+        # the file. These could be set automatically later on, but for now we'll leave
+        # that up to the user dealing with the UVData object.
+        if "blts_are_rectangular" in obj.header:
+            self.blts_are_rectangular = obj.header["blts_are_rectangular"]
+        if "time_axis_faster_than_bls" in obj.header:
+            self.time_axis_faster_than_bls = obj.header["time_axis_faster_than_bls"]
+
         if not uvutils._check_history_version(self.history, self.pyuvdata_version_str):
             self.history += self.pyuvdata_version_str
 
@@ -1450,9 +1458,6 @@ class UVH5(UVData):
                 blts_are_rectangular=blts_are_rectangular,
                 time_axis_faster_than_bls=time_axis_faster_than_bls,
             )
-
-        if not os.path.exists(filename):
-            raise IOError(filename + " not found")
 
         # update filename attribute
         basename = os.path.basename(filename)

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -800,8 +800,6 @@ class UVH5(UVData):
             "uvw_array",
             "channel_width",
             "phase_center_catalog",
-            # "blts_are_rectangular",
-            # "time_axis_faster_than_bls",
         ]:
             try:
                 setattr(self, attr, getattr(obj, attr))

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -282,20 +282,16 @@ class FastUVH5Meta:
     ):
         self.__file = None
 
-        if isinstance(path, h5py.Group):
+        if isinstance(path, h5py.File):
+            self.path = Path(path.filename)
+            self.__file = path
+            self.__header = path["/Header"]
+            self.__datagrp = path["/Data"]
+        elif isinstance(path, h5py.Group):
             self.path = Path(path.file.filename)
-            if path.file:  # False if File not open
-                self.__file = path.file
-                self.__header = path
-                self.__datagrp = self.__file["/Data"]
-            else:
-                self.open()
-        elif isinstance(path, h5py.File):
-            self.path = Path(path.file.filename)
-            if path:  # False if File not open
-                self.__file = path
-                self.__header = path["/Header"]
-                self.__datagrp = path["/Data"]
+            self.__file = path.file
+            self.__header = path
+            self.__datagrp = self.__file["/Data"]
         elif isinstance(path, (str, Path)):
             self.path = Path(path)
 
@@ -656,19 +652,6 @@ class FastUVH5Meta:
             return True
         else:
             return False
-
-    @cached_property
-    def freqs(self) -> np.ndarray:
-        """The frequencies in the file, in Hz.
-
-        Always a 1D array.
-        """
-        fq = self.freq_array
-
-        if fq.ndim == 2:
-            return fq[0]
-        else:
-            return fq
 
     @cached_property
     def pols(self) -> list[str]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,16 @@ per-file-ignores =
     pyuvdata/tests/__init__.py: D,N802
 docstring-convention = numpy
 select = C,E,W,T4,B9,F,D,A,N,RST,B
+rst-roles =
+    class
+    func
+    mod
+    data
+    const
+    meth
+    attr
+    exc
+    obj
 # List of other checks to consider adding:
 # it's recommended to have max-complexity ~ 18
 # max-complexity = 18

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup_args = {
         "h5py>=3.1",
         "numpy>=1.20",
         "pyerfa>=2.0",
-        "scipy>=1.3",
+        "scipy>=1.5",
         "setuptools_scm!=7.0.0,!=7.0.1,!=7.0.2",
     ],
     "extras_require": {

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup_args = {
     "install_requires": [
         "astropy>=5.0.4",
         "h5py>=3.1",
-        "numpy>=1.19",
+        "numpy>=1.20",
         "pyerfa>=2.0",
         "scipy>=1.3",
         "setuptools_scm!=7.0.0,!=7.0.1,!=7.0.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a new class, `FastUVH5Meta`, which makes it possible to do partial-loading of the metadata from UVH5 files. I've threaded it through so that the `_read_header` method of `UVH5` uses this class to do its reading (although in doing so, it loses the benefit of the partial reading, because `UVData` objects themselves require all metadata to be present before a `check()`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The motivation here is that it is often desirable to be able to read a small fraction of a file's header to get some info. For example, say I have a thousand files on disk, all different times. I want to open each, check which times they're at, and discard them if they're not within a certain range. Currently, this involves reading a lot of unnecessary metadata on each file, which stacks up over 1000 files. By using the new `FastUVH5Meta` class _directly_, one can now access _just_ the time array, and do it in a way that is officially supported (because the `UVH5` class itself uses this reader to read).

Some notes:

* I think we can be using the `blt_order` attribute more effectively. I've tried to use it to some advantage in this code, but I think we can do better.
* In the future it might be nice to use a similar interface to enable data reading.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

