### PR TITLE
Minor fix to MIR unit testing

### DIFF
--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -1252,13 +1252,13 @@ def test_add_overwrite(mir_data, muck_attr):
         ]:
             for field in getattr(mir_data, item).dtype.names:
                 if field not in prot_fields:
-                    getattr(mir_data, item)[field] = -1
+                    getattr(mir_data, item)[field] = 255
     elif muck_attr == "codes":
         mir_data.codes_data.set_value("code", "1", where=("v_name", "eq", "filever"))
     else:
         for field in getattr(mir_data, muck_attr).dtype.names:
             if field not in prot_fields:
-                getattr(mir_data, muck_attr)[field] = -1
+                getattr(mir_data, muck_attr)[field] = 255
 
     # After mucking, verify that at least something looks different
     assert mir_data != mir_copy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Makes a small adjustment to MIR-related testing, which was throwing a deprecation warning during CI runs.

## Description
<!--- Describe your changes in detail -->
A pair of tests in `test_mir_parser` have been changed so that the default "dummy" value is a positive integer instead of a negative one.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes a warning that was thrown in MIR unit testing where unsigned int fields were being assigned negative values, which numpy will no longer allow in the near future.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
