### PR TITLE
Use importlib.metadata rather than pkg_resources

### DIFF
--- a/pyuvdata/__init__.py
+++ b/pyuvdata/__init__.py
@@ -4,9 +4,9 @@
 
 """Init file for pyuvdata."""
 import warnings
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
-from pkg_resources import DistributionNotFound, get_distribution
 from setuptools_scm import get_version
 
 from .branch_scheme import branch_scheme
@@ -20,8 +20,8 @@ try:  # pragma: nocover
 except (LookupError, ImportError):
     try:
         # Set the version automatically from the package details.
-        __version__ = get_distribution(__name__).version
-    except DistributionNotFound:  # pragma: nocover
+        __version__ = version("pyuvdata")
+    except PackageNotFoundError:  # pragma: nocover
         # package is not installed
         pass
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`pkg_resources` from setuptools is being replaced by `importlib` (which is a core python library).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This fixes a new deprecation warning first seen in hera_mc when importing pyuvdata.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [x] Other

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
