### PR TITLE
Deprecate the utility methods used by the (deprecated) old phasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ types.
 - Severe performance hit when calling `polnum2str` and its variants for many baselines.
 
 ### Deprecated
+- The utility functions `phase_uvw` and `unphase_uvw` associated with the deprecated
+old phasing method.
 - The `flex_spw_id_array` will be required on all UVData and UVFlag and all
 non-wide-band UVCal objects in version 3.0.
 - Deprecated the `interpolation_function` attribute on UVBeams.

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -2224,7 +2224,14 @@ def test_phasing_funcs():
         (gcrs_from_itrs_coord.cartesian - gcrs_array_center.cartesian).get_xyz().T
     )
 
-    gcrs_uvw = uvutils.phase_uvw(gcrs_coord.ra.rad, gcrs_coord.dec.rad, gcrs_rel.value)
+    with uvtest.check_warnings(
+        DeprecationWarning,
+        match="This function supports the old phasing method and will be removed along "
+        "with the old phasing code in version 2.4",
+    ):
+        gcrs_uvw = uvutils.phase_uvw(
+            gcrs_coord.ra.rad, gcrs_coord.dec.rad, gcrs_rel.value
+        )
 
     mwa_tools_calcuvw_u = -97.122828
     mwa_tools_calcuvw_v = 50.388281
@@ -2235,9 +2242,14 @@ def test_phasing_funcs():
     assert np.allclose(gcrs_uvw[0, 2], mwa_tools_calcuvw_w, atol=1e-3)
 
     # also test unphasing
-    temp2 = uvutils.unphase_uvw(
-        gcrs_coord.ra.rad, gcrs_coord.dec.rad, np.squeeze(gcrs_uvw)
-    )
+    with uvtest.check_warnings(
+        DeprecationWarning,
+        match="This function supports the old phasing method and will be removed along "
+        "with the old phasing code in version 2.4",
+    ):
+        temp2 = uvutils.unphase_uvw(
+            gcrs_coord.ra.rad, gcrs_coord.dec.rad, np.squeeze(gcrs_uvw)
+        )
     assert np.allclose(gcrs_rel.value, temp2)
 
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1588,6 +1588,9 @@ def phase_uvw(ra, dec, initial_uvw):
     """
     Calculate phased uvws/positions from unphased ones in an icrs or gcrs frame.
 
+    This method is deprecated because it is associated with the old style of phasing,
+    which is less correct than the way we do it now.
+
     This code expects input uvws or positions relative to the telescope
     location in the same frame that ra/dec are in (e.g. icrs or gcrs) and
     returns phased ones in the same frame.
@@ -1629,6 +1632,9 @@ def phase_uvw(ra, dec, initial_uvw):
 def unphase_uvw(ra, dec, uvw):
     """
     Calculate unphased uvws/positions from phased ones in an icrs or gcrs frame.
+
+    This method is deprecated because it is associated with the old style of phasing,
+    which is less correct than the way we do it now.
 
     This code expects phased uvws or positions in the same frame that ra/dec
     are in (e.g. icrs or gcrs) and returns unphased ones in the same frame.

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1611,6 +1611,11 @@ def phase_uvw(ra, dec, initial_uvw):
         uvw array in the same frame as initial_uvws, ra and dec.
 
     """
+    warnings.warn(
+        "This function supports the old phasing method and will be removed along with "
+        "the old phasing code in version 2.4",
+        DeprecationWarning,
+    )
     if initial_uvw.ndim == 1:
         initial_uvw = initial_uvw[np.newaxis, :]
 
@@ -1645,6 +1650,11 @@ def unphase_uvw(ra, dec, uvw):
         shape (Nlocs, 3).
 
     """
+    warnings.warn(
+        "This function supports the old phasing method and will be removed along with "
+        "the old phasing code in version 2.4",
+        DeprecationWarning,
+    )
     if uvw.ndim == 1:
         uvw = uvw[np.newaxis, :]
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -5511,11 +5511,15 @@ class UVData(UVBase):
             obs_time = obs_times[ind]
 
             if use_ant_pos:
-                ant_uvw = uvutils.phase_uvw(
-                    self.telescope_location_lat_lon_alt[1],
-                    self.telescope_location_lat_lon_alt[0],
-                    self.antenna_positions,
-                )
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore", "This function supports the old phasing method"
+                    )
+                    ant_uvw = uvutils.phase_uvw(
+                        self.telescope_location_lat_lon_alt[1],
+                        self.telescope_location_lat_lon_alt[0],
+                        self.antenna_positions,
+                    )
                 # instead of looping through every ind, find the spot in antenna number
                 # array where ant_num <= ant1 < ant_number and similarly for ant2
                 # for all baselines in inds
@@ -5541,9 +5545,13 @@ class UVData(UVBase):
 
                 uvws_use = self.uvw_array[inds, :]
 
-                uvw_rel_positions = uvutils.unphase_uvw(
-                    frame_phase_center.ra.rad, frame_phase_center.dec.rad, uvws_use
-                )
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore", "This function supports the old phasing method"
+                    )
+                    uvw_rel_positions = uvutils.unphase_uvw(
+                        frame_phase_center.ra.rad, frame_phase_center.dec.rad, uvws_use
+                    )
 
                 frame_uvw_coord = SkyCoord(
                     x=uvw_rel_positions[:, 0] * units.m + frame_telescope_location.x,
@@ -6263,9 +6271,15 @@ class UVData(UVBase):
                     .T.value
                 )
 
-                frame_ant_uvw = uvutils.phase_uvw(
-                    frame_phase_center.ra.rad, frame_phase_center.dec.rad, frame_ant_rel
-                )
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore", "This function supports the old phasing method"
+                    )
+                    frame_ant_uvw = uvutils.phase_uvw(
+                        frame_phase_center.ra.rad,
+                        frame_phase_center.dec.rad,
+                        frame_ant_rel,
+                    )
                 # instead of looping through every ind, find the spot in antenna number
                 # array where ant_num <= ant1 < ant_number and similarly for ant2
                 # for all baselines in inds
@@ -6308,9 +6322,15 @@ class UVData(UVBase):
                     - frame_telescope_location.cartesian.get_xyz().value
                 )
 
-                self.uvw_array[inds, :] = uvutils.phase_uvw(
-                    frame_phase_center.ra.rad, frame_phase_center.dec.rad, frame_rel_uvw
-                )
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore", "This function supports the old phasing method"
+                    )
+                    self.uvw_array[inds, :] = uvutils.phase_uvw(
+                        frame_phase_center.ra.rad,
+                        frame_phase_center.dec.rad,
+                        frame_rel_uvw,
+                    )
 
         # calculate data and apply phasor
         if not self.metadata_only:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When we deprecated the old phasing methods in UVData, we forgot to also add deprecation warnings to the utility functions called by those methods. This remedies that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #1267 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Breaking change checklist:
- [x] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [x] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
