### PR TITLE
fix: allow reading of old uvh5 files that were silently broken

### DIFF
--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3702,6 +3702,11 @@ class TestFastUVH5Meta:
         meta4 = uvh5.FastUVH5Meta(newfl, recompute_nbls=None)
         assert meta4.Nbls == meta.Nbls
 
+        meta5 = uvh5.FastUVH5Meta(
+            self.fl, recompute_nbls=True, blts_are_rectangular=True
+        )
+        assert meta5.Nbls == meta.Nbls
+
     def test_pickleability(self):
         meta = uvh5.FastUVH5Meta(self.fl)
         meta2 = deepcopy(meta)

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3720,3 +3720,9 @@ class TestFastUVH5Meta:
         assert meta != meta2
         dct = {meta: 1, meta2: 2}
         assert dct[meta] == 1
+
+    def test_equality(self):
+        meta = uvh5.FastUVH5Meta(self.fl)
+
+        assert meta == meta
+        assert meta != 1

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -10,6 +10,7 @@ import os
 import re
 import shutil
 import tempfile
+from copy import deepcopy
 from pathlib import Path
 
 import h5py
@@ -3690,7 +3691,6 @@ class TestFastUVH5Meta:
 
         meta3 = uvh5.FastUVH5Meta(newfl, recompute_nbls=None)
 
-        print(meta.Nbls, meta2.Nbls, meta3.Nbls)
         assert meta.Nbls == meta2.Nbls == meta3.Nbls
 
         newfl = os.path.join(self.tmp_path.name, "not_hera.uvh5")
@@ -3701,3 +3701,17 @@ class TestFastUVH5Meta:
 
         meta4 = uvh5.FastUVH5Meta(newfl, recompute_nbls=None)
         assert meta4.Nbls == meta.Nbls
+
+    def test_pickleability(self):
+        meta = uvh5.FastUVH5Meta(self.fl)
+        meta2 = deepcopy(meta)
+
+        assert meta == meta2
+
+    def test_hashability(self):
+        meta = uvh5.FastUVH5Meta(self.fl)
+        meta2 = uvh5.FastUVH5Meta(self.fltime_axis_faster_than_bls)
+
+        assert meta != meta2
+        dct = {meta: 1, meta2: 2}
+        assert dct[meta] == 1

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -11974,7 +11974,7 @@ class UVData(UVBase):
         time_axis_faster_than_bls=None,
         blts_are_rectangular=None,
         blt_order=None,
-        nbl_function=None,
+        recompute_nbls: bool | None = None,
     ):
         """
         Read a UVH5 file.
@@ -12126,13 +12126,13 @@ class UVData(UVBase):
             the fastest-moving virtual axis. Various reading functions benefit from
             knowing this, so if it is known, it can be provided here to speed up
             reading. It will be determined from the data if not provided.
-        nbl_function : callable, optional
-            A function that takes the FastUVH5Meta object as an argument and returns the
-            number of unique baselines. This is only called for UVH5 files whose format
-            spec version is <1.2 (if provided). If not provided, the number of baselines
-            will be taken directly from the header. Before v1.2 of the UVH5 spec, it was
-            possible to have an incorrect number of baselines in the header without
-            error, so this provides an opportunity to rectify it.
+        recompute_nbls : bool, optional
+            Whether to recompute the number of unique baselines from the data. Before
+            v1.2 of the UVH5 spec, it was possible to have an incorrect number of
+            baselines in the header without error, so this provides an opportunity to
+            rectify it. Old HERA files (< March 2023) may have this issue, but in this
+            case the correct number of baselines can be computed more quickly than by
+            fully re=computing, and so we do this.
 
         Raises
         ------
@@ -12185,7 +12185,7 @@ class UVData(UVBase):
             check_autos=check_autos,
             fix_autos=fix_autos,
             use_future_array_shapes=use_future_array_shapes,
-            nbl_function=nbl_function,
+            recompute_nbls=recompute_nbls,
             blt_order=blt_order,
             blts_are_rectangular=blts_are_rectangular,
             time_axis_faster_than_bls=time_axis_faster_than_bls,
@@ -12286,7 +12286,7 @@ class UVData(UVBase):
         corrchunk=None,
         pseudo_cont=False,
         rechunk=None,
-        nbl_function=None,
+        recompute_nbls: bool | None = None,
     ):
         """
         Read a generic file into a UVData object.
@@ -12584,13 +12584,14 @@ class UVData(UVBase):
             the fastest-moving virtual axis. Various reading functions benefit from
             knowing this, so if it is known, it can be provided here to speed up
             reading. It will be determined from the data if not provided.
-        nbl_function : callable, optional
-            A function that takes the FastUVH5Meta object as an argument and returns the
-            number of unique baselines. This is only called for UVH5 files whose format
-            spec version is <1.2 (if provided). If not provided, the number of baselines
-            will be taken directly from the header. Before v1.2 of the UVH5 spec, it was
-            possible to have an incorrect number of baselines in the header without
-            error, so this provides an opportunity to rectify it.
+        recompute_nbls : bool, optional
+            Whether to recompute the number of unique baselines from the data. Before
+            v1.2 of the UVH5 spec, it was possible to have an incorrect number of
+            baselines in the header without error, so this provides an opportunity to
+            rectify it. Old HERA files (< March 2023) may have this issue, but in this
+            case the correct number of baselines can be computed more quickly than by
+            fully re=computing, and so we do this.
+
 
         MWA FITS
         --------
@@ -12891,7 +12892,7 @@ class UVData(UVBase):
                             corrchunk=corrchunk,
                             pseudo_cont=pseudo_cont,
                             rechunk=rechunk,
-                            nbl_function=nbl_function,
+                            recompute_nbls=recompute_nbls,
                             time_axis_faster_than_bls=time_axis_faster_than_bls,
                             blts_are_rectangular=blts_are_rectangular,
                         )
@@ -13040,7 +13041,7 @@ class UVData(UVBase):
                                 remove_flex_pol=remove_flex_pol,
                                 blts_are_rectangular=blts_are_rectangular,
                                 time_axis_faster_than_bls=time_axis_faster_than_bls,
-                                nbl_function=nbl_function,
+                                recompute_nbls=recompute_nbls,
                                 # uvh5 & mwa_corr_fits
                                 data_array_dtype=data_array_dtype,
                                 # mwa_corr_fits
@@ -13417,7 +13418,7 @@ class UVData(UVBase):
                     use_future_array_shapes=use_future_array_shapes,
                     time_axis_faster_than_bls=time_axis_faster_than_bls,
                     blts_are_rectangular=blts_are_rectangular,
-                    nbl_function=nbl_function,
+                    recompute_nbls=recompute_nbls,
                 )
                 select = False
 
@@ -13519,7 +13520,7 @@ class UVData(UVBase):
         blt_order=None,
         time_axis_faster_than_bls=None,
         blts_are_rectangular=None,
-        nbl_function=None,
+        recompute_nbls: bool | None = None,
         # uvh5 & mwa_corr_fits
         data_array_dtype=np.complex128,
         # mwa_corr_fits
@@ -13845,13 +13846,14 @@ class UVData(UVBase):
             the fastest-moving virtual axis. Various reading functions benefit from
             knowing this, so if it is known, it can be provided here to speed up
             reading. It will be determined from the data if not provided.
-        nbl_function : callable, optional
-            A function that takes the FastUVH5Meta object as an argument and returns the
-            number of unique baselines. This is only called for UVH5 files whose format
-            spec version is <1.2 (if provided). If not provided, the number of baselines
-            will be taken directly from the header. Before v1.2 of the UVH5 spec, it was
-            possible to have an incorrect number of baselines in the header without
-            error, so this provides an opportunity to rectify it.
+        recompute_nbls : bool, optional
+            Whether to recompute the number of unique baselines from the data. Before
+            v1.2 of the UVH5 spec, it was possible to have an incorrect number of
+            baselines in the header without error, so this provides an opportunity to
+            rectify it. Old HERA files (< March 2023) may have this issue, but in this
+            case the correct number of baselines can be computed more quickly than by
+            fully re=computing, and so we do this.
+
 
         MWA FITS
         --------
@@ -14024,7 +14026,7 @@ class UVData(UVBase):
             blt_order=blt_order,
             time_axis_faster_than_bls=time_axis_faster_than_bls,
             blts_are_rectangular=blts_are_rectangular,
-            nbl_function=nbl_function,
+            recompute_nbls=recompute_nbls,
             # mwa_corr_fits
             use_aoflagger_flags=use_aoflagger_flags,
             use_cotter_flags=use_cotter_flags,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -13039,7 +13039,7 @@ class UVData(UVBase):
                                 multidim_index=multidim_index,
                                 remove_flex_pol=remove_flex_pol,
                                 blts_are_rectangular=blts_are_rectangular,
-                                time_axis_faster_than_blt=time_axis_faster_than_bls,
+                                time_axis_faster_than_bls=time_axis_faster_than_bls,
                                 nbl_function=nbl_function,
                                 # uvh5 & mwa_corr_fits
                                 data_array_dtype=data_array_dtype,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -11971,6 +11971,9 @@ class UVData(UVBase):
         check_autos=True,
         fix_autos=True,
         use_future_array_shapes=False,
+        time_axis_faster_than_bls=None,
+        blts_are_rectangular=None,
+        blt_order=None,
         nbl_function=None,
     ):
         """
@@ -12104,13 +12107,32 @@ class UVData(UVBase):
         use_future_array_shapes : bool
             Option to convert to the future planned array shapes before the changes go
             into effect by removing the spectral window axis.
+        blt_order : tuple of str or "determine", optional
+            The order of the baseline-time axis *in the file*. This can be determined,
+            or read directly from file, however since it has been optional in the past,
+            many existing files do not contain it in the metadata.
+            Some reading operations are significantly faster if this is known, so
+            providing it here can provide a speedup. Default is to try and read it from
+            file, and if not there, just leave it as None. Set to "determine" to
+            auto-detect the blt_order from the metadata (takes extra time to do so).
+        blts_are_rectangular : bool, optional
+            Whether the baseline-time axis is rectangular. This can be read from
+            metadata in new files, but many old files do not contain it. If not
+            provided, the rectangularity will be determined from the data. This is a
+            non-negligible operation, so if you know it, it can be provided here to
+            speed up reading.
+        time_axis_faster_than_bls : bool, optional
+            If blts are rectangular, this variable specifies whether the time axis is
+            the fastest-moving virtual axis. Various reading functions benefit from
+            knowing this, so if it is known, it can be provided here to speed up
+            reading. It will be determined from the data if not provided.
         nbl_function : callable, optional
             A function that takes the FastUVH5Meta object as an argument and returns the
-            number of unique baselines. This is *only* called for UVH5 files whose
-            format spec version is <1.2 (if provided). If not provided, the number of
-            baselines will be taken directly from the header. Before v1.2 of the UVH5
-            spec, it was possible to have an incorrect number of baselines in the header
-            without error, so this provides an opportunity to rectify it.
+            number of unique baselines. This is only called for UVH5 files whose format
+            spec version is <1.2 (if provided). If not provided, the number of baselines
+            will be taken directly from the header. Before v1.2 of the UVH5 spec, it was
+            possible to have an incorrect number of baselines in the header without
+            error, so this provides an opportunity to rectify it.
 
         Raises
         ------
@@ -12164,6 +12186,9 @@ class UVData(UVBase):
             fix_autos=fix_autos,
             use_future_array_shapes=use_future_array_shapes,
             nbl_function=nbl_function,
+            blt_order=blt_order,
+            blts_are_rectangular=blts_are_rectangular,
+            time_axis_faster_than_bls=time_axis_faster_than_bls,
         )
         self._convert_from_filetype(uvh5_obj)
         del uvh5_obj

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -10,7 +10,7 @@ import os
 import threading
 import warnings
 from collections.abc import Iterable
-from typing import Callable, Literal
+from typing import Literal
 
 import astropy.units as units
 import numpy as np
@@ -24,7 +24,6 @@ from .. import parameter as uvp
 from .. import telescopes as uvtel
 from .. import utils as uvutils
 from ..uvbase import UVBase
-from .uvh5 import FastUVH5Meta
 
 __all__ = ["UVData"]
 import logging
@@ -11972,7 +11971,7 @@ class UVData(UVBase):
         check_autos=True,
         fix_autos=True,
         use_future_array_shapes=False,
-        nbl_function: Callable[[FastUVH5Meta], int] | None = None,
+        nbl_function=None,
     ):
         """
         Read a UVH5 file.
@@ -12262,7 +12261,7 @@ class UVData(UVBase):
         corrchunk=None,
         pseudo_cont=False,
         rechunk=None,
-        nbl_function: Callable[[FastUVH5Meta], int] | None = None,
+        nbl_function=None,
     ):
         """
         Read a generic file into a UVData object.

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -367,6 +367,10 @@ class FastUVH5Meta:
             and self.Nbls == other.Nbls
         )
 
+    def __hash__(self):
+        """Get a unique hash for the object."""
+        return hash(self.path)
+
     def close(self):
         """Close the file."""
         self.__header = None

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -423,7 +423,9 @@ class FastUVH5Meta:
     @cached_property
     def Nbls(self) -> int:  # noqa: N802
         """The number of unique baselines."""
-        if self.version < "1.2" and self._nbl_function is not None:
+        if (
+            "version" not in self.header or self.version < "1.2"
+        ) and self._nbl_function is not None:
             return self._nbl_function(self)
 
         return int(self.header["Nbls"][()])

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -328,6 +328,45 @@ class FastUVH5Meta:
         if self.__file:
             self.__file.close()
 
+    def __getstate__(self):
+        """Get the state of the object."""
+        state = {
+            k: v
+            for k, v in self.__dict__.items()
+            if k
+            not in (
+                "_FastUVH5Meta__file",
+                "_FastUVH5Meta__header",
+                "_FastUVH5Meta__datagrp",
+                "header",
+                "datagrp",
+            )
+        }
+        return state
+
+    def __setstate__(self, state):
+        """Set the state of the object."""
+        self.__dict__.update(state)
+        self.__file = None
+        self.open()
+
+    def __eq__(self, other):
+        """Check equality of two FastUVH5Meta objects."""
+        if not isinstance(other, FastUVH5Meta):
+            return False
+
+        return (
+            self.path == other.path
+            and self.__blts_are_rectangular == other.__blts_are_rectangular
+            and (
+                self.__time_first == other.__time_first
+                or self.__time_first is None
+                or other.__time_first is None
+            )
+            and self.__blt_order == other.__blt_order
+            and self.Nbls == other.Nbls
+        )
+
     def close(self):
         """Close the file."""
         self.__header = None
@@ -383,7 +422,7 @@ class FastUVH5Meta:
 
     @cached_property
     def Nbls(self) -> int:  # noqa: N802
-        """Get the number of unique baselines."""
+        """The number of unique baselines."""
         if self.version < "1.2" and self._nbl_function is not None:
             return self._nbl_function(self)
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -428,7 +428,10 @@ class FastUVH5Meta:
     def Nbls(self) -> int:  # noqa: N802
         """The number of unique baselines."""
         if self._recompute_nbls:
-            return len(np.unique(self.baseline_array))
+            if self.__blts_are_rectangular:
+                return self.Nblts // self.Ntimes
+            else:
+                return len(np.unique(self.baseline_array))
         else:
             nbls = int(self.header["Nbls"][()])
 
@@ -438,7 +441,7 @@ class FastUVH5Meta:
                 if (
                     self.telescope_name == "HERA"
                     and nbls == self.Nblts
-                    and self.Nblts % self.Ntimes == 0
+                    and (self.__blts_are_rectangular or self.Nblts % self.Ntimes == 0)
                 ):
                     return self.Nblts // self.Ntimes
                 else:

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -806,6 +806,7 @@ class UVH5(UVData):
             "Nspws",
             "Ntimes",
             "Nblts",
+            "Nbls",
             "Nants_data",
             "Nants_telescope",
             "antenna_names",
@@ -1483,6 +1484,7 @@ class UVH5(UVData):
                 blt_order=blt_order,
                 blts_are_rectangular=blts_are_rectangular,
                 time_axis_faster_than_bls=time_axis_faster_than_bls,
+                nbl_function=nbl_function,
             )
 
         # update filename attribute


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds the option to tell `FastUVH5Meta` to recompute `Nbls` from the `baseline_array` (instead of just getting it directly from metadata).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

The problem was that older versions of `pyuvdata` directly set `UVData.Nbls` (from uvh5 files) using `np.unique(self.baseline_array).size`, which was guaranteed to always be the true number of baselines. This meant that one could write a UVH5 file with *incorrect metadata*, and it would still read perfectly fine. This in turn means that any old files have the possibility of being wrongly defined without knowing it. In fact, as it turns out, all HERA data before last month or so had this problem (they defined `Nbls=Nblts`). Since the new `FastUVH5Meta` code reads the file metadata correctly, those old files throw errors upon `.check()`. Thus, the newest pyuvdata on `main` right now will make reading all previous HERA files impossible. 

The fix here just allows the user to pass `recompute_nbls=True` to ensure that they are correct on read, using `len(np.unique(self.baseline_array))`. By default, this is set to None, and the Nbls are recomputed only for old HERA files. If the user passes `blts_are_rectangular`, the `Nbls` can be computed faster by `self.Nblts/self.Ntimes` (if this is asked for).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
