### PR TITLE
Improved UVData to MirParser interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- The `catalog_name` keyword has been added to the `UVData.read` and `UVData.select`
+methods to allow users to select on source name.
+
+### Changed
+- The keywords for `UVData.read` have been changed for MIR-specific values to more
+generally match those founds with other data types.
+- The `UVData.read_mir` method has been overhauled to mak reading in of MIR data more
+efficiency in memory/processor usage.
+
+### Fixed
+- Frequency frame information for MS datasets is now correctly recorded as "TOPO".
 
 ## [2.3.1] - 2023-04-03
 

--- a/docs/uvdata_tutorial.rst
+++ b/docs/uvdata_tutorial.rst
@@ -1621,7 +1621,7 @@ into a standard UVData object (which doubles its size).
   >>> print(mir_uv.polarization_array)
   [0]
   >>> print(mir_uv.data_array.shape)
-  (1, 1, 262160, 1)
+  (1, 262160, 1)
 
   >>> # Use the ``remove_flex_pol`` method to get a standard object. Note that it
   >>> # doubles the data_array size
@@ -1634,7 +1634,7 @@ into a standard UVData object (which doubles its size).
   >>> print(mir_uv.polarization_array)
   [-6 -5]
   >>> print(mir_uv.data_array.shape)
-  (1, 1, 262160, 2)
+  (1, 262160, 2)
 
 
 b) Converting between standard and flex_pol objects

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -33,12 +33,10 @@ class Mir(UVData):
         antenna_nums=None,
         antenna_names=None,
         bls=None,
-        times=None,
         time_range=None,
-        lsts=None,
         lst_range=None,
         polarizations=None,
-        sources=None,
+        catalog_names=None,
         corrchunk=None,
         receivers=None,
         sidebands=None,
@@ -118,26 +116,21 @@ class Mir(UVData):
                 select_where += [
                     ("blcd", "eq", ["%i-%i" % (tup[0], tup[1]) for tup in bls])
                 ]
-            if times is not None:
-                # Have to convert times from UTC JD -> TT MJD for mIR
-                select_where += [
-                    ("mjd", "eq", Time(times, format="jd", scale="utc").tt.mjd)
-                ]
             if time_range is not None:
                 # Have to convert times from UTC JD -> TT MJD for mIR
                 select_where += [
-                    ("mjd", "btw", Time(time_range, format="jd", scale="utc").tt.mjd)
+                    (
+                        "mjd",
+                        "between",
+                        Time(time_range, format="jd", scale="utc").tt.mjd,
+                    )
                 ]
-            if time_range is not None:
-                select_where += [("lst", "eq", time_range)]
-            if lsts is not None:
-                select_where += [("lst", "eq", lsts)]
             if lst_range is not None:
-                select_where += [("lst_range", "btw", lst_range)]
+                select_where += [("lst_range", "between", lst_range)]
             if polarizations is not None:
                 select_where += [("pol", "eq", polarizations)]
-            if sources is not None:
-                select_where += [("source", "eq", sources)]
+            if catalog_names is not None:
+                select_where += [("source", "eq", catalog_names)]
             if receivers is not None:
                 select_where += [("rec", "eq", receivers)]
             if sidebands is not None:

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -218,7 +218,6 @@ class Mir(UVData):
         apply_tsys=True,
         apply_flags=True,
         apply_dedoppler=False,
-        load_lite=None,
     ):
         """
         Convert a MirParser object into a UVData object.
@@ -457,22 +456,22 @@ class Mir(UVData):
         self.flag_array = np.ones((Nblts, Npols, Nfreqs), dtype=bool)
 
         inhid_list = mir_data.in_data["inhid"]
-        if (load_lite) or (load_lite is None and mir_data.vis_data is None):
+        mir_copy = None
+        if (mir_data.vis_data is None) and (mir_data.auto_data is None):
+            inhid_step = (len(inhid_list) // 10) + 1
             mir_copy = mir_data.copy(metadata_only=True, apply_mask=True)
-            inhid_step = max(len(inhid_list) // 10, 1)
         else:
-            mir_copy = mir_data
             inhid_step = len(inhid_list)
 
         for start in range(0, len(inhid_list), inhid_step):
-            if mir_data is not mir_copy:
+            if mir_copy is not None:
                 mir_copy.select(
                     where=("inhid", "eq", inhid_list[start : start + inhid_step]),
                     reset=True,
                 )
 
             self._prep_and_insert_data(
-                mir_copy,
+                mir_data if mir_copy is None else mir_copy,
                 sphid_dict,
                 spdx_dict,
                 blhid_blt_order,
@@ -480,6 +479,9 @@ class Mir(UVData):
                 apply_tsys=apply_tsys,
                 apply_dedoppler=apply_dedoppler,
             )
+
+        # Don't need the copy any more, so delete it
+        del mir_copy
 
         # Now handle the weights
         self.nsample_array = np.zeros((Nblts, Npols, Nfreqs), dtype=np.float32)

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -439,12 +439,13 @@ class Mir(UVData):
             pol_idx = spdx_dict[window]["pol_idx"]
             vis_data[blt_idx, pol_idx, ch_slice] = np.conj(vis_rec["data"])
             vis_flags[blt_idx, pol_idx, ch_slice] = vis_rec["flags"]
-            # The "wt" column is calculated as (T_DSB ** 2)/(integ time), but we want
-            # units of Jy**-2. To do this, we just need to multiply by the forward gain
-            # of the antenna squared and the channel width. The factor of 2**2 (4)
-            # arises because we need to convert T_DSB**2 to T_SSB**2.
+            # The "wt" column is calculated as (integ time)/(T_DSB ** 2), but we want
+            # units of Jy**-2. To do this, we just need to multiply by one of the
+            # forward gain of the antenna (130 Jy/K for SMA) squared and the channel
+            # width. The factor of 2**2 (4) arises because we need to convert T_DSB**2
+            # to T_SSB**2.
             vis_weights[blt_idx, pol_idx, ch_slice] = (
-                ((130.0 * 2.0) ** 2.0) * sp_rec["wt"] * np.abs(sp_rec["fres"])
+                ((130.0 * 2.0) ** (-2.0)) * sp_rec["wt"] * np.abs(1e6 * sp_rec["fres"])
             )
 
         # Drop the data from the MirParser object once we have it loaded up.

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -645,8 +645,8 @@ class Mir(UVData):
                 self._add_phase_center(
                     mir_data.codes_data["source"][sou_id],
                     cat_type="sidereal",
-                    cat_lon=icrs_ra,
-                    cat_lat=icrs_dec,
+                    cat_lon=np.median(icrs_ra),
+                    cat_lat=np.median(icrs_dec),
                     cat_frame="icrs",
                     info_source="file",
                     cat_id=int(sou_id),

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -516,16 +516,8 @@ class Mir(UVData):
         self.Nblts = Nblts
         self.Npols = Npols
         self.Ntimes = len(mir_data.in_data)
-        self.antenna_names = [
-            "Ant 1",
-            "Ant 2",
-            "Ant 3",
-            "Ant 4",
-            "Ant 5",
-            "Ant 6",
-            "Ant 7",
-            "Ant 8",
-        ]
+        self.antenna_names = ["Ant%i" % idx for idx in range(1, 9)]
+
         self.antenna_numbers = np.arange(1, 9)
 
         # Prepare the XYZ coordinates of the antenna positions.

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -198,6 +198,9 @@ class Mir(UVData):
         # will hopefully become the default for all data sets.
         self._set_flex_spw()
 
+        # Also set future array shapes here
+        self._set_future_array_shapes()
+
         # Create a simple list for broadcasting values stored on a
         # per-integration basis in MIR into the (tasty) per-blt records in UVDATA.
         bl_in_idx = mir_data.in_data._index_query(header_key=mir_data.bl_data["inhid"])
@@ -445,8 +448,7 @@ class Mir(UVData):
         mir_data.unload_data()
 
         # Now assign our flexible arrays to the object itself
-        # TODO: Spw axis to be collapsed in future release
-        self.freq_array = freq_array[np.newaxis, :]
+        self.freq_array = freq_array
         self.Nfreqs = Nfreqs
         self.Nspws = Nspws
         self.channel_width = channel_width
@@ -688,11 +690,10 @@ class Mir(UVData):
         self._filename.form = (1,)
 
         # We call transpose here since vis_data above is shape (Nblts, Npols, Nfreqs),
-        # and we need to get it to (Nblts, 1, Nfreqs, Npols) to match what UVData
-        # expects.
-        self.data_array = np.transpose(vis_data, (0, 2, 1))[:, np.newaxis, :, :]
-        self.flag_array = np.transpose(vis_flags, (0, 2, 1))[:, np.newaxis, :, :]
-        self.nsample_array = np.transpose(vis_weights, (0, 2, 1))[:, np.newaxis, :, :]
+        # and we need to get it to (Nblts,Nfreqs, Npols) to match what UVData expects.
+        self.data_array = np.transpose(vis_data, (0, 2, 1))
+        self.flag_array = np.transpose(vis_flags, (0, 2, 1))
+        self.nsample_array = np.transpose(vis_weights, (0, 2, 1))
 
     def write_mir(self, filename):
         """

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -644,11 +644,10 @@ class Mir(UVData):
                 )
                 self._add_phase_center(
                     mir_data.codes_data["source"][sou_id],
-                    cat_type="ephem",
+                    cat_type="sidereal",
                     cat_lon=icrs_ra,
                     cat_lat=icrs_dec,
                     cat_frame="icrs",
-                    cat_times=time_arr,
                     info_source="file",
                     cat_id=int(sou_id),
                 )

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -637,9 +637,9 @@ class Mir(UVData):
                     mir_data.in_data["mjd"][source_mask], scale="tt", format="mjd"
                 ).utc.jd
                 icrs_ra, icrs_dec = uvutils.transform_app_to_icrs(
+                    time_arr,
                     mir_data.in_data["ara"][source_mask],
                     mir_data.in_data["adec"][source_mask],
-                    time_arr,
                     self.telescope_location_lat_lon_alt,
                 )
                 self._add_phase_center(

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -765,6 +765,9 @@ class Mir(UVData):
             source_dec = np.mean(mir_data.in_data["decr"][source_mask]).astype(float)
             source_epoch = np.mean(mir_data.in_data["epoch"][source_mask]).astype(float)
             if source_epoch != 2000.0:
+                # When fed a non-J2000 coordinate, we want to convert that so that it
+                # can easily be written into CASA MS format. In this case, we take the
+                # median apparent position and translate that to ICRS
                 time_arr = Time(
                     mir_data.in_data["mjd"][source_mask], scale="tt", format="mjd"
                 ).utc.jd

--- a/pyuvdata/uvdata/mir_meta_data.py
+++ b/pyuvdata/uvdata/mir_meta_data.py
@@ -796,7 +796,7 @@ class MirMetaData(object):
             discard_flagged=discard_flagged,
         )
 
-    def copy(self, skip_data=False, apply_mask=False):
+    def copy(self, skip_data=False):
         """
         Make and return a copy of the MirMetaData object.
 
@@ -829,9 +829,6 @@ class MirMetaData(object):
                     copy_attr = copy.deepcopy(getattr(self, attr))
 
             setattr(copy_obj, attr, copy_attr)
-
-        if apply_mask:
-            copy_obj._hard_apply_mask()
 
         return copy_obj
 
@@ -2320,14 +2317,6 @@ class MirMetaData(object):
             # and record size within the sch_read file itself.
             record_start += record_size + 8
         return int_dict, recpos_dict
-
-    def _hard_apply_mask(self):
-        """Do a thing."""
-        if self._data is not None:
-            self._data = self._data[self._mask]
-            self._mask = np.ones(self._size, dtype=bool)
-            self._set_header_key_index_dict()
-            self._stored_values = {}
 
     def _make_key_mask(
         self,

--- a/pyuvdata/uvdata/mir_meta_data.py
+++ b/pyuvdata/uvdata/mir_meta_data.py
@@ -2325,12 +2325,50 @@ class MirMetaData(object):
         use_mask=True,
         check_field=None,
         set_mask=True,
-        use_cipher=False,
+        use_cipher=True,
     ):
         """
-        Do a thing.
+        Generate a key mask by field-matching between MirMetaData objects.
 
-        This does a thing.
+        This creates a (meta)data mask based on when the header key of one object is
+        found in another. Useful for propagating flag information between different
+        types of objects (e.g., between per-integration and per-baseline records).
+
+        Parameters
+        ----------
+        other : MirMetaData object
+            MirMetaData object to use to compare against this object. Must either
+            contain the header key values as fields, or have the field(s) specified by
+            the `check_field` keyword.
+        reverse : bool
+            When set to False, the default, the normal pattern of behavior is to check
+            and see if the header key values in this object are found in the
+            corresponding field in the `other` object. If set to True, then the header
+            keys from the `other` object are sought in the corresponding fields in
+            this object.
+        use_mask : bool
+            If set to False, ignore the underlying data mask (as set by e.g., previous
+            select commands). Default is True.
+        check_field : str or list of str
+            Field in `other` (or this object, if `reverse=True`) to check against header
+            key values. Default is to use the same name(s) as the header key field(s).
+        set_mask : bool
+            If set to True, the default, then after the comparison is complete, the
+            method will set the underlying data mask based on matches found (keeping
+            only records where matching keys are found).
+        use_cipher : bool
+            Normally if header key values encompass two fields, pairs of values are
+            compared, which can be slow. If set to True, the method will try to combine
+            the information of the two fields via bit-shifting and addition, which can
+            significantly speed up the operation of the matching. Default is True if
+            not supplying an str-type for `check_field`.
+
+        Returns
+        -------
+        return_val : bool or ndarray of bool
+            If `set_mask=True`, then a bool is returned which specifies whether or not
+            any underlying mask values were changed. If `set_mask=False`, then the mask
+            is returned based on key-matching results.
         """
         if check_field is None:
             check_field = (other if reverse else self)._identifier

--- a/pyuvdata/uvdata/mir_meta_data.py
+++ b/pyuvdata/uvdata/mir_meta_data.py
@@ -796,7 +796,7 @@ class MirMetaData(object):
             discard_flagged=discard_flagged,
         )
 
-    def copy(self, skip_data=False):
+    def copy(self, skip_data=False, apply_mask=False):
         """
         Make and return a copy of the MirMetaData object.
 
@@ -829,6 +829,9 @@ class MirMetaData(object):
                     copy_attr = copy.deepcopy(getattr(self, attr))
 
             setattr(copy_obj, attr, copy_attr)
+
+        if apply_mask:
+            copy_obj._hard_apply_mask()
 
         return copy_obj
 
@@ -2317,6 +2320,14 @@ class MirMetaData(object):
             # and record size within the sch_read file itself.
             record_start += record_size + 8
         return int_dict, recpos_dict
+
+    def _hard_apply_mask(self):
+        """Do a thing."""
+        if self._data is not None:
+            self._data = self._data[self._mask]
+            self._mask = np.ones(self._size, dtype=bool)
+            self._set_header_key_index_dict()
+            self._stored_values = {}
 
     def _make_key_mask(
         self,

--- a/pyuvdata/uvdata/mir_meta_data.py
+++ b/pyuvdata/uvdata/mir_meta_data.py
@@ -566,6 +566,7 @@ class MirMetaData(object):
         len : int
             Number of unique entries contained within the meta data.
         """
+        # TODO: Consider caching value as usage expands
         return np.sum(self._mask)
 
     def __eq__(self, other, verbose=False, ignore_params=None, use_mask=False):

--- a/pyuvdata/uvdata/mir_meta_data.py
+++ b/pyuvdata/uvdata/mir_meta_data.py
@@ -1136,7 +1136,8 @@ class MirMetaData(object):
             If set to True, return a list of tuples containing the value of each field
             (in the order provided in `field_name`). If False, return an ndarray or
             list of ndarrays, where each array contains the set of values matching the
-            specified selection criteria.
+            specified selection criteria. Default is to return tuples if multiple fields
+            are being extracted, otherwise to return an ndarray of values.
 
         Returns
         -------

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -1615,10 +1615,10 @@ class MirParser(object):
         sel_mask = np.isin(self.ac_data._data["iband"], unique_bands)
 
         self.ac_data._data = self.ac_data._data[sel_mask]
-        self.ac_data._mask = np.ones(len(self.ac_data), dtype=bool)
+        self.ac_data._mask = np.ones(self.ac_data._size, dtype=bool)
 
         # Set up the header index for the object, and then construct the header key dict
-        self.ac_data._data["achid"] = np.arange(1, len(self.ac_data) + 1)
+        self.ac_data._data["achid"] = np.arange(1, self.ac_data._size + 1)
         self.ac_data._set_header_key_index_dict()
 
         # Now that we've got vitals, we want to import in metadata from some of the

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -1466,11 +1466,22 @@ class MirParser(object):
             Default is True.
         """
         if unload_vis:
-            self.vis_data = None
+            if self.vis_data is not None:
+                for item in self.vis_data.values():
+                    del item["data"]
+                    del item["flags"]
+                self.vis_data = None
             self._tsys_applied = False
-        if unload_raw:
+        if unload_raw and self.raw_data is not None:
+            for item in self.raw_data.values():
+                print(item.keys())
+                del item["data"]
+                del item["scale_fac"]
             self.raw_data = None
-        if unload_auto:
+        if unload_auto and self.auto_data is not None:
+            for item in self.auto_data.values():
+                del item["data"]
+                del item["flags"]
             self.auto_data = None
 
     def _update_filter(self, update_data=None):

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -290,7 +290,7 @@ class MirParser(object):
         """
         return not self.__eq__(other, verbose=verbose, metadata_only=metadata_only)
 
-    def copy(self, metadata_only=False, apply_mask=False):
+    def copy(self, metadata_only=False):
         """
         Make and return a copy of the MirParser object.
 
@@ -310,7 +310,7 @@ class MirParser(object):
         # include all attributes, not just UVParameter ones.
         for attr in vars(self):
             if issubclass(getattr(self, attr).__class__, MirMetaData):
-                setattr(new_obj, attr, getattr(self, attr).copy(apply_mask=apply_mask))
+                setattr(new_obj, attr, getattr(self, attr).copy())
             elif not (metadata_only and attr in ["vis_data", "raw_data", "auto_data"]):
                 if attr not in ["_metadata_attrs", "_sp_dict", "_ac_dict"]:
                     setattr(new_obj, attr, copy.deepcopy(getattr(self, attr)))

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -419,6 +419,9 @@ class MirParser(object):
             # Don't attempt to fix kludged headers, since this implies that the file
             # metadata cannot be trusted
             if idict[data_type]["ignore_header"]:
+                warnings.warn(
+                    "Cannot fix %s file headers for %s, skipping." % (data_type, ifile)
+                )
                 continue
 
             int_dict = copy.deepcopy(idict[data_type]["int_dict"])

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -1838,14 +1838,6 @@ class MirParser(object):
         self.vis_data = self.raw_data = self.auto_data = None
         self._tsys_applied = False
 
-        try:
-            # Check to make sure that records are properly cross-referenced
-            self._update_filter()
-        except KeyError:
-            # If we do see a key error, it means that we've got an unlinked record
-            # that we need to filter out.
-            self._crosscheck_records()
-
         # If requested, now we load up the visibilities.
         self.load_data(load_cross=load_cross, load_raw=load_raw, load_auto=load_auto)
 

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1415,11 +1415,14 @@ class MS(UVData):
         ref_name = None
         try:
             ref_name = reverse_dict[
-                (str(frame_name), None if (epoch_val is None) else float(epoch_val))
+                (str(frame_name), 2000.0 if (epoch_val is None) else float(epoch_val))
             ]
         except KeyError as err:
+            epoch_msg = (
+                "no epoch" if epoch_val is None else f"epoch {format(epoch_val,'g')}"
+            )
             message = (
-                f"Frame {frame_name} (epoch {format(epoch_val,'g')}) does not have a "
+                f"Frame {frame_name} ({epoch_msg}) does not have a "
                 "corresponding match to supported frames in the MS file format."
             )
             if raise_error:

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -720,7 +720,7 @@ class MS(UVData):
             sw_table.putcell("RESOLUTION", idx, ch_width[ch_mask])
             # TODO: These are placeholders for now, but should be replaced with
             # actual frequency reference info (once UVData handles that)
-            sw_table.putcell("MEAS_FREQ_REF", idx, VEL_DICT["LSRK"])
+            sw_table.putcell("MEAS_FREQ_REF", idx, VEL_DICT["TOPO"])
             sw_table.putcell("REF_FREQUENCY", idx, freq_array[0])
 
         sw_table.done()

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1414,7 +1414,9 @@ class MS(UVData):
 
         ref_name = None
         try:
-            ref_name = reverse_dict[(str(frame_name), float(epoch_val))]
+            ref_name = reverse_dict[
+                (str(frame_name), None if (epoch_val is None) else float(epoch_val))
+            ]
         except KeyError as err:
             message = (
                 f"Frame {frame_name} (epoch {format(epoch_val,'g')}) does not have a "

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -280,8 +280,7 @@ def test_multi_nchan_spw_read(tmp_path):
     """
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
     uv_in = UVData()
-    with uvtest.check_warnings(DeprecationWarning, _future_array_shapes_warning):
-        uv_in.read_mir(testfile, corrchunk=[0, 1, 2, 3, 4])
+    uv_in.read_mir(testfile, corrchunk=[0, 1, 2, 3, 4])
 
     dummyfile = os.path.join(tmp_path, "dummy.mirtest.uvfits")
     with pytest.raises(IndexError):

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -605,15 +605,15 @@ def test_bad_sphid(mir_data):
 
 def test_bad_pol_code(mir_data):
     """
-    Test that an extra (unused) pol coode doesn't produce an error. Note that we want
+    Test that an extra (unused) pol code doesn't produce an error. Note that we want
     this check because the "Unknown" pol code is something present in some data sets.
     """
     mir_obj = Mir()
     mir_data.codes_data._data = np.resize(
-        mir_data.codes_data._data, len(mir_data.codes_data) + 1
+        mir_data.codes_data._data, mir_data.codes_data._size + 1
     )
     mir_data.codes_data._data[-1] = ("pol", -999, "Unknown", 0)
-    mir_data.codes_data._mask = np.ones(len(mir_data.codes_data), dtype=bool)
+    mir_data.codes_data._mask = np.ones(mir_data.codes_data._size, dtype=bool)
 
     mir_obj._init_from_mir_parser(mir_data)
 

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -289,59 +289,6 @@ def test_multi_nchan_spw_read(tmp_path):
         uv_in.write_uvfits(dummyfile)
 
 
-def test_read_mir_no_records():
-    """
-    Mir no-records check
-
-    Make sure that mir correctly handles the case where no matching records are found
-    """
-    testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    uv_in = UVData()
-    with pytest.raises(ValueError, match="No valid sources selected!"):
-        uv_in.read_mir(testfile, isource=-1)
-
-    with pytest.raises(ValueError, match="No valid receivers selected!"):
-        uv_in.read_mir(testfile, irec=-1)
-
-    with pytest.raises(ValueError, match="No valid sidebands selected!"):
-        uv_in.read_mir(testfile, isb=-156)
-
-    with pytest.raises(ValueError, match="No valid spectral bands selected!"):
-        uv_in.read_mir(testfile, corrchunk=999)
-
-
-@pytest.mark.parametrize("pseudo_cont", [True, False])
-def test_read_mir_sideband_select(sma_mir, pseudo_cont):
-    """
-    Mir sideband read check
-
-    Make sure that we can read the individual sidebands out of MIR correctly, and then
-    stitch them back together as though they were read together from the start.
-    """
-    testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    if pseudo_cont:
-        sma_mir.read(testfile, pseudo_cont=pseudo_cont, use_future_array_shapes=True)
-
-    # Re-order here so that we can more easily compare the two
-    sma_mir.reorder_freqs(channel_order="freq", spw_order="freq")
-    # Drop the history
-    sma_mir.history = ""
-
-    mir_lsb = UVData()
-    mir_lsb.read(testfile, isb=0, pseudo_cont=pseudo_cont, use_future_array_shapes=True)
-
-    mir_usb = UVData()
-    mir_usb.read(testfile, isb=1, pseudo_cont=pseudo_cont, use_future_array_shapes=True)
-
-    mir_recomb = mir_lsb + mir_usb
-    # Re-order here so that we can more easily compare the two
-    mir_recomb.reorder_freqs(spw_order="freq", channel_order="freq")
-    # Drop the history
-    mir_recomb.history = ""
-
-    assert sma_mir == mir_recomb
-
-
 def test_read_mir_write_ms_flex_pol(mir_data, tmp_path):
     """
     Mir to MS loopback test with flex-pol.

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -248,9 +248,8 @@ def test_mir_partial_read(sma_mir):
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
     with uvtest.check_warnings(
         UserWarning,
-        'Warning: select on read keyword set, but file_type is "mir" which does not '
-        "support select on read. Entire file will be read and then select will be "
-        "performed",
+        "Warning: a select on read keyword is set that is "
+        "not supported by read_mir. This select will be done after reading the file.",
     ):
         uv3 = UVData.from_file(
             testfile, freq_chans=freq_chans_to_keep, use_future_array_shapes=True

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -625,3 +625,26 @@ def test_rechunk_on_read():
     # Do some basic checks to make sure that this loaded correctly.
     assert uv_data.freq_array.size == 8
     assert np.all(uv_data.channel_width == 2.288e09)
+
+
+@pytest.mark.parametrize(
+    "select_kwargs",
+    [
+        {"antenna_nums": [1, 4]},
+        {"antenna_names": ["1", "4"]},
+        {"bls": [(1, 4)]},
+        {"time_range": [2459055, 2459056]},
+        {"lst_range": [2, 2.5]},
+        {"polarizations": ["hh", "vv"]},
+        {"catalog_names": ["3c84"]},
+        {"corrchunk": [1, 2, 3, 4]},
+        {"receivers": ["230", "240"]},
+        {"sidebands": ["l", "u"]},
+    ],
+)
+def test_select_on_read(select_kwargs, sma_mir):
+    print(select_kwargs)
+    testfile = os.path.join(DATA_PATH, "sma_test.mir")
+    uv_data = UVData.from_file(testfile, use_future_array_shapes=True, **select_kwargs)
+    uv_data.history = sma_mir.history
+    assert sma_mir == uv_data

--- a/pyuvdata/uvdata/tests/test_mir_meta_data.py
+++ b/pyuvdata/uvdata/tests/test_mir_meta_data.py
@@ -264,7 +264,11 @@ def test_mir_meta_get_value_errs(mir_in_data, field_name, err_type, err_msg):
         ["inhid", {}, [1] * 20],
         ["corrchunk", {"index": [0, 5, 10, 15]}, [0] * 4],
         ["blhid", {"where": ("blhid", "eq", 2)}, [2] * 5],
-        [["blhid", "sphid"], {"index": [1, 4]}, [[1, 1], [2, 5]]],
+        [
+            ["blhid", "sphid"],
+            {"index": [1, 4], "return_tuples": False},
+            [[1, 1], [2, 5]],
+        ],
         [["igq", "sphid"], {"index": [0, 3], "return_tuples": True}, [(0, 1), (0, 4)]],
     ],
 )
@@ -333,7 +337,10 @@ def test_mir_meta_generate_mask(mir_bl_data, arg, output):
         [{"where": ("u", "ne", 0), "and_mask": False}, True],
         [{"index": [1, 3], "reset": True}, [False, True, False, True]],
         [{"header_key": [3, 4, 3]}, [False, False, False, True]],
-        [{"mask": [True, False, True, False]}, [True, False, False, False]],
+        [
+            {"mask": [True, False, True, False], "use_mask": False},
+            [True, False, False, False],
+        ],
     ],
 )
 def test_mir_meta_set_mask(mir_bl_data, arg, output):

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -121,7 +121,7 @@ def test_mir_parser_unload_data(mir_data):
     Check that the unload_data function works as expected
     """
     # Spoof for just this test
-    mir_data.raw_data = mir_data.vis_data
+    mir_data.raw_data = {1: {"data": [1] * 16384, "scale_fac": [1]}}
 
     attr_list = ["vis_data", "raw_data", "auto_data"]
 
@@ -755,7 +755,7 @@ def test_downselect_data(mir_data, select_vis, select_raw, select_auto):
 def test_unload_data(mir_data, unload_vis, unload_raw, unload_auto):
     """Verify that unload_data unloads data as expected."""
     # Spoof raw_data for just this test.
-    mir_data.raw_data = mir_data.vis_data
+    mir_data.raw_data = {1: {"data": [1] * 16384, "scale_fac": [1]}}
 
     mir_data.unload_data(
         unload_vis=unload_vis, unload_raw=unload_raw, unload_auto=unload_auto

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -482,7 +482,6 @@ def test_scan_int_start(mir_data):
 
 def test_fix_int_dict(mir_data):
     """Verify that we can fix a "bad" integration start record."""
-    mir_data._clear_auto()
     bad_entry = {2: {"inhid": 1, "record_size": 120, "record_start": 120}}
 
     good_dict = {
@@ -496,6 +495,12 @@ def test_fix_int_dict(mir_data):
             }
         }
     }
+
+    # First, check that doing the autos throws a warning since it's a not a
+    # "true" int_dict but instead is synthetically generated
+    with uvtest.check_warnings(UserWarning, "Cannot fix auto file headers for "):
+        mir_data._fix_int_dict("auto")
+
     # Muck with the records so that the inhid does not match that on disk.
     mir_data.sp_data._data["inhid"][:] = 2
     mir_data.bl_data._data["inhid"][:] = 2

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -12908,7 +12908,10 @@ def test_select_catalog_name_errs(hera_uvh5):
 def test_select_catalog_name(carma_miriad):
     # Select out the source
     for cat_id, cat_dict in carma_miriad.phase_center_catalog.items():
-        uv_name = carma_miriad.select(catalog_names=cat_dict["cat_name"], inplace=False)
-        uv_id = carma_miriad.select(phase_center_ids=cat_id, inplace=False)
+        uv_name = carma_miriad.copy()
+        uv_id = carma_miriad.copy()
+
+        uv_name.select(catalog_names=cat_dict["cat_name"])
+        uv_id.select(phase_center_ids=cat_id)
 
         assert uv_name == uv_id

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -219,7 +219,7 @@ def carma_miriad_main():
     yield uv_object
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def carma_miriad(carma_miriad_main):
     pytest.importorskip("pyuvdata._miriad")
     uv_object = carma_miriad_main.copy()
@@ -12908,10 +12908,7 @@ def test_select_catalog_name_errs(hera_uvh5):
 def test_select_catalog_name(carma_miriad):
     # Select out the source
     for cat_id, cat_dict in carma_miriad.phase_center_catalog.items():
-        uv_name = carma_miriad.copy()
-        uv_id = carma_miriad.copy()
-
-        uv_name.select(catalog_names=cat_dict["cat_name"])
-        uv_id.select(phase_center_ids=cat_id)
+        uv_name = carma_miriad.select(catalog_names=cat_dict["cat_name"], inplace=False)
+        uv_id = carma_miriad.select(phase_center_ids=cat_id, inplace=False)
 
         assert uv_name == uv_id

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -11122,6 +11122,9 @@ def test_split_phase_center(hera_uvh5):
     assert np.all(hera_uvh5.phase_center_id_array[select_mask] == cat_id2)
     assert hera_uvh5.Nphase == 2
 
+    cat_id_all = hera_uvh5._look_for_name(["3c84", "3c84_2"])
+    assert np.all(np.isin(hera_uvh5.phase_center_id_array, cat_id_all))
+
     # Make sure the catalog makes sense -- entries should be identical sans cat_id
     temp_cat = hera_uvh5.phase_center_catalog.copy()
     temp_cat[cat_id1[0]]["cat_name"] = "3c84_2"
@@ -12910,5 +12913,8 @@ def test_select_catalog_name(carma_miriad):
     for cat_id, cat_dict in carma_miriad.phase_center_catalog.items():
         uv_name = carma_miriad.select(catalog_names=cat_dict["cat_name"], inplace=False)
         uv_id = carma_miriad.select(phase_center_ids=cat_id, inplace=False)
+
+        assert uv_id.history != uv_name.history
+        uv_id.history = uv_name.history = None
 
         assert uv_name == uv_id

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -12895,3 +12895,20 @@ def test_set_rectangularity(casa_uvfits, hera_uvh5):
     hera_uvh5.set_rectangularity(force=True)
     assert hera_uvh5.blts_are_rectangular is False
     assert hera_uvh5.time_axis_faster_than_bls is False
+
+
+def test_select_catalog_name_errs(hera_uvh5):
+    with pytest.raises(
+        ValueError, match="Cannot set both phase_center_ids and catalog_names."
+    ):
+        hera_uvh5.select(phase_center_ids=[1, 2, 3], catalog_names=[1, 2, 3])
+
+
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_select_catalog_name(carma_miriad):
+    # Select out the source
+    for cat_id, cat_dict in carma_miriad.phase_center_catalog.items():
+        uv_name = carma_miriad.select(catalog_names=cat_dict["cat_name"], inplace=False)
+        uv_id = carma_miriad.select(phase_center_ids=cat_id, inplace=False)
+
+        assert uv_name == uv_id

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -9391,7 +9391,11 @@ class UVData(UVBase):
             not commonly used.
         phase_center_ids : array_like of int, optional
             Phase center IDs to keep on the object (effectively a selection on
-            baseline-times).
+            baseline-times). Cannot be used with `catalog_names`.
+        catalog_names : str or array-like of str
+            The names of the phase centers (sources) to keep in the object, which should
+            match exactly in spelling and capitalization. Cannot be used with
+            `phase_center_ids`.
         inplace : bool
             Option to perform the select directly on self or return a new UVData
             object with just the selected data (the default is True, meaning the
@@ -11177,7 +11181,6 @@ class UVData(UVBase):
         allow_flex_pol=True,
         check_autos=True,
         fix_autos=True,
-        use_future_array_shapes=False,
     ):
         """
         Read in data from an SMA MIR file.
@@ -12493,6 +12496,9 @@ class UVData(UVBase):
             length-3 tuples, the polarization string is in the order of the two
             antennas. If length-3 tuples are provided, `polarizations` must be
             None.
+        catalog_names : str or array-like of str
+            The names of the phase centers (sources) to include when reading data into
+            the object, which should match exactly in spelling and capitalization.
         frequencies : array_like of float, optional
             The frequencies to include when reading data into the object, each
             value passed here should exist in the freq_array.
@@ -12738,13 +12744,31 @@ class UVData(UVBase):
 
         MIR
         ---
-        corrchunk : int
-            Correlator chunk code for MIR dataset.
-        pseudo_cont : boolean
-            Read in only pseudo-continuuum values in MIR dataset.
-        rechunk : int
-            Number of channels to average over when reading in the dataset. Optional
-            argument, typically required to be a power of 2.
+        corrchunk : int or array-like of int
+            Correlator "chunk" (spectral window) to include when reading data into the
+            object, where 0 corresponds to the pseudo-continuum channel.
+        receivers : str or array-like of str
+            The names of the receivers ("230", "240", "345", "400") to include when
+            reading data into the object.
+        sidebands : str or array-like of str
+            The names of the sidebands ("l" for lower, "u" for upper) to include when
+            reading data into the object.
+        mir_select_where : tuple or list of tuples, optional
+            Argument to pass to the `MirParser.select` method, which will downselect
+            which data is read into the object.
+        apply_flags : bool
+            If set to True, apply "wideband" flags to the visibilities, which are
+            recorded by the realtime system to denote when data are expected to be bad
+            (e.g., antennas not on source, dewar warm). Default it true.
+        apply_tsys : bool
+            If set to False, data are returned as correlation coefficients (normalized
+            by the auto-correlations). Default is True, which instead scales the raw
+            visibilities and forward-gain of the antenna to produce values in Jy
+            (uncalibrated).
+        apply_dedoppler : bool
+            If set to True, data will be corrected for any doppler-tracking performed
+            during observations, and brought into the topocentric rest frame (default
+            for UVData objects). Default is False.
         allow_flex_pol : bool
             If only one polarization per spectral window is read (and the polarization
             differs from window to window), allow for the `UVData` object to use

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -8593,6 +8593,7 @@ class UVData(UVBase):
         lst_range,
         polarizations,
         blt_inds,
+        catalog_identifier,
         phase_center_ids,
     ):
         """
@@ -8663,9 +8664,11 @@ class UVData(UVBase):
         blt_inds : array_like of int, optional
             The baseline-time indices to keep in the object. This is
             not commonly used.
-        phase_center_ids : array_like of int, optional
-            Phase center IDs to keep on the object (effectively a selection on
-            baseline-times).
+        sources : str or list of str, optional
+            Names of the phase centers to keep in the object, matched against entries
+            in the phase center catalog ("cat_name").
+        cat_ids : array_like of int, optional
+            ID numbers of phase centers to keep.
 
         Returns
         -------
@@ -8994,6 +8997,49 @@ class UVData(UVBase):
                     f"{lst_range[1]}."
                 )
 
+        if catalog_identifier is not None:
+            cat_ids = set()
+            if isinstance(catalog_identifier, (int, str)):
+                catalog_identifier = [catalog_identifier]
+
+            for item in catalog_identifier:
+                if isinstance(item, str):
+                    temp_ids = []
+                    for key, pc_dict in self.phase_center_catalog.items():
+                        if item == pc_dict["cat_name"]:
+                            temp_ids.append(key)
+                    if len(temp_ids) == 0:
+                        raise ValueError(
+                            "No catalog entries matching the name %s." % item
+                        )
+                    cat_ids |= set(temp_ids)
+                elif isinstance(item, int):
+                    if item not in self.phase_center_catalog:
+                        raise ValueError(
+                            "No catalog entry with the source ID %i." % item
+                        )
+                    cat_ids |= {item}
+            # Need to cast back to a list here for isin to work correctly.
+            sou_blt_inds = np.where(np.isin(self.phase_center_id_array, list(cat_ids)))[
+                0
+            ]
+            if time_blt_inds.size == 0:
+                raise ValueError("No entries matching provided catalog identifiers.")
+            if blt_inds is not None:
+                # Use intesection (and) to join
+                # antenna_names/nums/ant_pairs_nums/blt_inds with times
+                blt_inds = np.array(
+                    list(set(blt_inds).intersection(sou_blt_inds)), dtype=np.int64
+                )
+            else:
+                blt_inds = sou_blt_inds
+
+            if n_selects > 0:
+                history_update_string += ", phase centers"
+            else:
+                history_update_string += "phase centers"
+            n_selects += 1
+
         if times is not None or time_range is not None:
             if n_selects > 0:
                 history_update_string += ", times"
@@ -9305,7 +9351,7 @@ class UVData(UVBase):
         lst_range=None,
         polarizations=None,
         blt_inds=None,
-        phase_center_ids=None,
+        catalog_identifier=None,
         inplace=True,
         keep_all_metadata=True,
         run_check=True,
@@ -9447,7 +9493,7 @@ class UVData(UVBase):
             lst_range,
             polarizations,
             blt_inds,
-            phase_center_ids,
+            catalog_identifier,
         )
 
         # Call the low-level selection method.
@@ -11142,11 +11188,24 @@ class UVData(UVBase):
     def read_mir(
         self,
         filepath,
-        isource=None,
-        irec=None,
-        isb=None,
+        mir_select_where=None,
+        antenna_nums=None,
+        antenna_names=None,
+        bls=None,
+        times=None,
+        time_range=None,
+        lsts=None,
+        lst_range=None,
+        polarizations=None,
+        catalog_identifier=None,
         corrchunk=None,
+        receivers=None,
+        sidebands=None,
+        apply_tsys=True,
+        apply_flags=True,
+        apply_dedoppler=False,
         pseudo_cont=False,
+        rechunk=None,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -11154,7 +11213,6 @@ class UVData(UVBase):
         allow_flex_pol=True,
         check_autos=True,
         fix_autos=True,
-        rechunk=None,
         use_future_array_shapes=False,
     ):
         """
@@ -11167,14 +11225,6 @@ class UVData(UVBase):
         ----------
         filepath : str
              The file path to the MIR folder to read from.
-        isource : int
-            Source code for MIR dataset. The default is None, which selects all sources.
-        irec : int
-            Receiver code for MIR dataset. The default is None, which selects all
-            receivers.
-        isb : int
-            Sideband code for MIR dataset. The default is None, which selects both
-            sidebands.
         corrchunk : int
             Correlator chunk code for MIR dataset. The default is None, which selects
             all chunks.
@@ -11220,11 +11270,24 @@ class UVData(UVBase):
         mir_obj = mir.Mir()
         mir_obj.read_mir(
             filepath,
-            isource=isource,
-            irec=irec,
-            isb=isb,
+            select_where=mir_select_where,
+            antenna_nums=antenna_nums,
+            antenna_names=antenna_names,
+            bls=bls,
+            times=times,
+            time_range=time_range,
+            lsts=lsts,
+            lst_range=lst_range,
+            polarizations=polarizations,
+            sources=catalog_identifier,
             corrchunk=corrchunk,
+            receivers=receivers,
+            sidebands=sidebands,
+            apply_tsys=apply_tsys,
+            apply_flags=apply_flags,
+            apply_dedoppler=apply_dedoppler,
             pseudo_cont=pseudo_cont,
+            rechunk=rechunk,
             run_check=run_check,
             check_extra=check_extra,
             run_check_acceptability=run_check_acceptability,
@@ -11232,7 +11295,6 @@ class UVData(UVBase):
             allow_flex_pol=allow_flex_pol,
             check_autos=check_autos,
             fix_autos=fix_autos,
-            rechunk=rechunk,
             use_future_array_shapes=use_future_array_shapes,
         )
         self._convert_from_filetype(mir_obj)
@@ -11756,7 +11818,7 @@ class UVData(UVBase):
         lst_range=None,
         polarizations=None,
         blt_inds=None,
-        phase_center_ids=None,
+        catalog_identifier=None,
         keep_all_metadata=True,
         read_data=True,
         background_lsts=True,
@@ -11924,6 +11986,7 @@ class UVData(UVBase):
             lst_range=lst_range,
             polarizations=polarizations,
             blt_inds=blt_inds,
+            catalog_identifier=catalog_identifier,
             keep_all_metadata=keep_all_metadata,
             read_data=read_data,
             background_lsts=background_lsts,
@@ -11955,7 +12018,7 @@ class UVData(UVBase):
         lst_range=None,
         polarizations=None,
         blt_inds=None,
-        phase_center_ids=None,
+        catalog_identifier=None,
         keep_all_metadata=True,
         read_data=True,
         data_array_dtype=np.complex128,
@@ -12169,7 +12232,7 @@ class UVData(UVBase):
             lst_range=lst_range,
             polarizations=polarizations,
             blt_inds=blt_inds,
-            phase_center_ids=phase_center_ids,
+            catalog_identifier=catalog_identifier,
             data_array_dtype=data_array_dtype,
             keep_all_metadata=keep_all_metadata,
             read_data=read_data,
@@ -12280,10 +12343,14 @@ class UVData(UVBase):
         phase_to_pointing_center=False,
         nsample_array_dtype=np.float32,
         # MIR
-        isource=None,
-        irec=None,
-        isb=None,
+        catalog_identifier=None,
         corrchunk=None,
+        receivers=None,
+        sidebands=None,
+        mir_select_where=None,
+        apply_tsys=True,
+        apply_flags=True,
+        apply_dedoppler=False,
         pseudo_cont=False,
         rechunk=None,
         recompute_nbls: bool | None = None,
@@ -12666,12 +12733,6 @@ class UVData(UVBase):
 
         MIR
         ---
-        isource : int
-            Source code for MIR dataset.
-        irec : int
-            Receiver code for MIR dataset.
-        isb : int
-            Sideband code for MIR dataset.
         corrchunk : int
             Correlator chunk code for MIR dataset.
         pseudo_cont : boolean
@@ -12885,11 +12946,13 @@ class UVData(UVBase):
                             remove_flagged_ants=remove_flagged_ants,
                             phase_to_pointing_center=phase_to_pointing_center,
                             nsample_array_dtype=nsample_array_dtype,
-                            # MIR
-                            isource=None,
-                            irec=irec,
-                            isb=isb,
                             corrchunk=corrchunk,
+                            receivers=receivers,
+                            sidebands=sidebands,
+                            mir_select_where=mir_select_where,
+                            apply_tsys=apply_tsys,
+                            apply_flags=apply_flags,
+                            apply_dedoppler=apply_dedoppler,
                             pseudo_cont=pseudo_cont,
                             rechunk=rechunk,
                             recompute_nbls=recompute_nbls,
@@ -13064,9 +13127,6 @@ class UVData(UVBase):
                                 phase_to_pointing_center=phase_to_pointing_center,
                                 nsample_array_dtype=nsample_array_dtype,
                                 # MIR
-                                isource=None,
-                                irec=irec,
-                                isb=isb,
                                 corrchunk=corrchunk,
                                 pseudo_cont=pseudo_cont,
                                 rechunk=rechunk,
@@ -13242,6 +13302,33 @@ class UVData(UVBase):
                     select_phase_center_ids = phase_center_ids
                 else:
                     select = False
+            elif file_type in ["mir"]:
+                select = True
+                # these are all done by partial read, so set to None
+                select_antenna_nums = None
+                select_antenna_names = None
+                select_ant_str = None
+                select_bls = None
+                select_times = None
+                select_time_range = None
+                select_polarizations = None
+
+                # MIR can handle length-two bls tuples, so if any three element tuples
+                # are seen, we need to deal w/ that via select.
+                if bls is not None:
+                    select_bls = bls if any(len(item) == 3 for item in bls) else None
+
+                # these aren't supported by partial read, so do it in select
+                select_frequencies = frequencies
+                select_freq_chans = freq_chans
+                select_blt_inds = blt_inds
+
+                if all(
+                    item is None
+                    for item in [select_bls, frequencies, freq_chans, blt_inds]
+                ):
+                    # If there's nothing to select, just bypass that operation.
+                    select = False
 
             # reading a single "file". Call the appropriate file-type read
             if file_type == "uvfits":
@@ -13277,11 +13364,24 @@ class UVData(UVBase):
             elif file_type == "mir":
                 self.read_mir(
                     filename,
-                    isource=isource,
-                    irec=irec,
-                    isb=isb,
+                    mir_select_where=mir_select_where,
+                    antenna_nums=antenna_nums,
+                    antenna_names=antenna_names,
+                    bls=bls,
+                    times=times,
+                    time_range=time_range,
+                    lsts=lsts,
+                    lst_range=lst_range,
+                    polarizations=polarizations,
+                    catalog_identifier=catalog_identifier,
                     corrchunk=corrchunk,
+                    receivers=receivers,
+                    sidebands=sidebands,
+                    apply_dedoppler=apply_dedoppler,
+                    apply_tsys=apply_tsys,
+                    apply_flags=apply_flags,
                     pseudo_cont=pseudo_cont,
+                    rechunk=rechunk,
                     run_check=run_check,
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability,
@@ -13289,10 +13389,8 @@ class UVData(UVBase):
                     allow_flex_pol=allow_flex_pol,
                     check_autos=check_autos,
                     fix_autos=fix_autos,
-                    rechunk=rechunk,
                     use_future_array_shapes=use_future_array_shapes,
                 )
-
             elif file_type == "miriad":
                 self.read_miriad(
                     filename,
@@ -13543,10 +13641,14 @@ class UVData(UVBase):
         phase_to_pointing_center=False,
         nsample_array_dtype=np.float32,
         # MIR
-        isource=None,
-        irec=None,
-        isb=None,
+        catalog_identifier=None,
         corrchunk=None,
+        receivers=None,
+        sidebands=None,
+        mir_select_where=None,
+        apply_tsys=True,
+        apply_flags=True,
+        apply_dedoppler=False,
         pseudo_cont=False,
         rechunk=None,
     ):
@@ -14046,10 +14148,14 @@ class UVData(UVBase):
             remove_flagged_ants=remove_flagged_ants,
             phase_to_pointing_center=phase_to_pointing_center,
             # MIR
-            isource=isource,
-            irec=irec,
-            isb=isb,
+            catalog_identifier=catalog_identifier,
             corrchunk=corrchunk,
+            receivers=receivers,
+            sidebands=sidebands,
+            mir_select_where=mir_select_where,
+            apply_tsys=apply_tsys,
+            apply_flags=apply_flags,
+            apply_dedoppler=apply_dedoppler,
             pseudo_cont=pseudo_cont,
             rechunk=rechunk,
         )

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -9431,6 +9431,16 @@ class UVData(UVBase):
         else:
             uv_obj = self.copy()
 
+        if catalog_names is not None:
+            if isinstance(catalog_names, str):
+                catalog_names = [catalog_names]
+            if phase_center_ids is not None:
+                raise ValueError("Cannot set both phase_center_ids and catalog_names.")
+            phase_center_ids = []
+            for cat_id, cat_dict in self.phase_center_catalog.items():
+                if cat_dict["cat_name"] in catalog_names:
+                    phase_center_ids.append(cat_id)
+
         # Figure out which index positions we want to hold on to.
         (
             blt_inds,
@@ -11149,12 +11159,10 @@ class UVData(UVBase):
         antenna_nums=None,
         antenna_names=None,
         bls=None,
-        times=None,
         time_range=None,
-        lsts=None,
         lst_range=None,
         polarizations=None,
-        catalog_identifier=None,
+        catalog_names=None,
         corrchunk=None,
         receivers=None,
         sidebands=None,
@@ -11231,12 +11239,10 @@ class UVData(UVBase):
             antenna_nums=antenna_nums,
             antenna_names=antenna_names,
             bls=bls,
-            times=times,
             time_range=time_range,
-            lsts=lsts,
             lst_range=lst_range,
             polarizations=polarizations,
-            sources=catalog_identifier,
+            catalog_names=catalog_names,
             corrchunk=corrchunk,
             receivers=receivers,
             sidebands=sidebands,
@@ -12239,7 +12245,7 @@ class UVData(UVBase):
         antenna_names=None,
         ant_str=None,
         bls=None,
-        catalog_identifier=None,
+        catalog_names=None,
         frequencies=None,
         freq_chans=None,
         times=None,
@@ -13023,10 +13029,10 @@ class UVData(UVBase):
                                 antenna_names=antenna_names,
                                 ant_str=ant_str,
                                 bls=bls,
+                                catalog_names=catalog_names,
                                 frequencies=frequencies,
                                 freq_chans=freq_chans,
                                 times=times,
-                                catalog_identifier=catalog_identifier,
                                 time_range=time_range,
                                 lsts=lsts,
                                 lst_range=lst_range,
@@ -13267,9 +13273,7 @@ class UVData(UVBase):
                 select_antenna_names = None
                 select_ant_str = None
                 select_bls = None
-                select_lsts = None
                 select_lst_range = None
-                select_times = None
                 select_time_range = None
                 select_polarizations = None
 
@@ -13283,6 +13287,8 @@ class UVData(UVBase):
                 select_freq_chans = freq_chans
                 select_blt_inds = blt_inds
                 select_phase_center_ids = phase_center_ids
+                select_times = times
+                select_lsts = lsts
 
                 if all(
                     item is None
@@ -13292,6 +13298,8 @@ class UVData(UVBase):
                         freq_chans,
                         blt_inds,
                         phase_center_ids,
+                        times,
+                        lsts,
                     ]
                 ):
                     # If there's nothing to select, just bypass that operation.
@@ -13340,12 +13348,10 @@ class UVData(UVBase):
                     antenna_nums=antenna_nums,
                     antenna_names=antenna_names,
                     bls=bls,
-                    times=times,
                     time_range=time_range,
-                    lsts=lsts,
                     lst_range=lst_range,
                     polarizations=polarizations,
-                    catalog_identifier=catalog_identifier,
+                    catalog_names=catalog_names,
                     corrchunk=corrchunk,
                     receivers=receivers,
                     sidebands=sidebands,
@@ -13551,6 +13557,7 @@ class UVData(UVBase):
         antenna_names=None,
         ant_str=None,
         bls=None,
+        catalog_names=None,
         frequencies=None,
         freq_chans=None,
         times=None,
@@ -13613,7 +13620,6 @@ class UVData(UVBase):
         phase_to_pointing_center=False,
         nsample_array_dtype=np.float32,
         # MIR
-        catalog_identifier=None,
         corrchunk=None,
         receivers=None,
         sidebands=None,
@@ -14058,6 +14064,7 @@ class UVData(UVBase):
             antenna_names=antenna_names,
             ant_str=ant_str,
             bls=bls,
+            catalog_names=catalog_names,
             frequencies=frequencies,
             freq_chans=freq_chans,
             times=times,
@@ -14068,7 +14075,6 @@ class UVData(UVBase):
             blt_inds=blt_inds,
             phase_center_ids=phase_center_ids,
             keep_all_metadata=keep_all_metadata,
-            catalog_identifier=catalog_identifier,
             # checking parameters
             run_check=run_check,
             check_extra=check_extra,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -9437,10 +9437,16 @@ class UVData(UVBase):
             if phase_center_ids is not None:
                 raise ValueError("Cannot set both phase_center_ids and catalog_names.")
             phase_center_ids = []
+            print("Match names: ", end="")
+            print(catalog_names)
             for cat_id, cat_dict in self.phase_center_catalog.items():
+                print("Cat name: ", end="")
+                print(cat_dict["cat_name"])
                 if cat_dict["cat_name"] in catalog_names:
+                    print("Match made!")
                     phase_center_ids.append(cat_id)
-
+            print("PCIDs: ", end="")
+            print(phase_center_ids)
         # Figure out which index positions we want to hold on to.
         (
             blt_inds,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -9437,16 +9437,9 @@ class UVData(UVBase):
             if phase_center_ids is not None:
                 raise ValueError("Cannot set both phase_center_ids and catalog_names.")
             phase_center_ids = []
-            print("Match names: ", end="")
-            print(catalog_names)
             for cat_id, cat_dict in self.phase_center_catalog.items():
-                print("Cat name: ", end="")
-                print(cat_dict["cat_name"])
                 if cat_dict["cat_name"] in catalog_names:
-                    print("Match made!")
                     phase_center_ids.append(cat_id)
-            print("PCIDs: ", end="")
-            print(phase_center_ids)
         # Figure out which index positions we want to hold on to.
         (
             blt_inds,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -13168,7 +13168,7 @@ class UVData(UVBase):
                 # everything is merged into it at the end of this loop
 
         else:
-            if file_type in ["fhd", "ms", "mwa_corr_fits", "mir"]:
+            if file_type in ["fhd", "ms", "mwa_corr_fits"]:
                 if (
                     antenna_nums is not None
                     or antenna_names is not None
@@ -13267,6 +13267,8 @@ class UVData(UVBase):
                 select_antenna_names = None
                 select_ant_str = None
                 select_bls = None
+                select_lsts = None
+                select_lst_range = None
                 select_times = None
                 select_time_range = None
                 select_polarizations = None
@@ -13280,14 +13282,26 @@ class UVData(UVBase):
                 select_frequencies = frequencies
                 select_freq_chans = freq_chans
                 select_blt_inds = blt_inds
+                select_phase_center_ids = phase_center_ids
 
                 if all(
                     item is None
-                    for item in [select_bls, frequencies, freq_chans, blt_inds]
+                    for item in [
+                        select_bls,
+                        frequencies,
+                        freq_chans,
+                        blt_inds,
+                        phase_center_ids,
+                    ]
                 ):
                     # If there's nothing to select, just bypass that operation.
                     select = False
-
+                else:
+                    warnings.warn(
+                        "Warning: a select on read keyword is set that is "
+                        "not supported by read_mir. This select will "
+                        "be done after reading the file."
+                    )
             # reading a single "file". Call the appropriate file-type read
             if file_type == "uvfits":
                 self.read_uvfits(

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -14073,19 +14073,31 @@ class UVData(UVBase):
 
         MIR
         ---
-        isource : int
-            Source code for MIR dataset.
-        irec : int
-            Receiver code for MIR dataset.
-        isb : int
-            Sideband code for MIR dataset.
-        corrchunk : int
-            Correlator chunk code for MIR dataset.
-        pseudo_cont : boolean
-            Read in only pseudo-continuuum values in MIR dataset.
-        rechunk : int
-            Number of channels to average over when reading in the dataset. Optional
-            argument, typically required to be a power of 2.
+        corrchunk : int or array-like of int
+            Correlator "chunk" (spectral window) to include when reading data into the
+            object, where 0 corresponds to the pseudo-continuum channel.
+        receivers : str or array-like of str
+            The names of the receivers ("230", "240", "345", "400") to include when
+            reading data into the object.
+        sidebands : str or array-like of str
+            The names of the sidebands ("l" for lower, "u" for upper) to include when
+            reading data into the object.
+        mir_select_where : tuple or list of tuples, optional
+            Argument to pass to the `MirParser.select` method, which will downselect
+            which data is read into the object.
+        apply_flags : bool
+            If set to True, apply "wideband" flags to the visibilities, which are
+            recorded by the realtime system to denote when data are expected to be bad
+            (e.g., antennas not on source, dewar warm). Default it true.
+        apply_tsys : bool
+            If set to False, data are returned as correlation coefficients (normalized
+            by the auto-correlations). Default is True, which instead scales the raw
+            visibilities and forward-gain of the antenna to produce values in Jy
+            (uncalibrated).
+        apply_dedoppler : bool
+            If set to True, data will be corrected for any doppler-tracking performed
+            during observations, and brought into the topocentric rest frame (default
+            for UVData objects). Default is False.
         allow_flex_pol : bool
             If only one polarization per spectral window is read (and the polarization
             differs from window to window), allow for the `UVData` object to use

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -8593,7 +8593,6 @@ class UVData(UVBase):
         lst_range,
         polarizations,
         blt_inds,
-        catalog_identifier,
         phase_center_ids,
     ):
         """
@@ -8997,49 +8996,6 @@ class UVData(UVBase):
                     f"{lst_range[1]}."
                 )
 
-        if catalog_identifier is not None:
-            cat_ids = set()
-            if isinstance(catalog_identifier, (int, str)):
-                catalog_identifier = [catalog_identifier]
-
-            for item in catalog_identifier:
-                if isinstance(item, str):
-                    temp_ids = []
-                    for key, pc_dict in self.phase_center_catalog.items():
-                        if item == pc_dict["cat_name"]:
-                            temp_ids.append(key)
-                    if len(temp_ids) == 0:
-                        raise ValueError(
-                            "No catalog entries matching the name %s." % item
-                        )
-                    cat_ids |= set(temp_ids)
-                elif isinstance(item, int):
-                    if item not in self.phase_center_catalog:
-                        raise ValueError(
-                            "No catalog entry with the source ID %i." % item
-                        )
-                    cat_ids |= {item}
-            # Need to cast back to a list here for isin to work correctly.
-            sou_blt_inds = np.where(np.isin(self.phase_center_id_array, list(cat_ids)))[
-                0
-            ]
-            if time_blt_inds.size == 0:
-                raise ValueError("No entries matching provided catalog identifiers.")
-            if blt_inds is not None:
-                # Use intesection (and) to join
-                # antenna_names/nums/ant_pairs_nums/blt_inds with times
-                blt_inds = np.array(
-                    list(set(blt_inds).intersection(sou_blt_inds)), dtype=np.int64
-                )
-            else:
-                blt_inds = sou_blt_inds
-
-            if n_selects > 0:
-                history_update_string += ", phase centers"
-            else:
-                history_update_string += "phase centers"
-            n_selects += 1
-
         if times is not None or time_range is not None:
             if n_selects > 0:
                 history_update_string += ", times"
@@ -9351,7 +9307,8 @@ class UVData(UVBase):
         lst_range=None,
         polarizations=None,
         blt_inds=None,
-        catalog_identifier=None,
+        phase_center_ids=None,
+        catalog_names=None,
         inplace=True,
         keep_all_metadata=True,
         run_check=True,
@@ -9493,7 +9450,7 @@ class UVData(UVBase):
             lst_range,
             polarizations,
             blt_inds,
-            catalog_identifier,
+            phase_center_ids,
         )
 
         # Call the low-level selection method.
@@ -11818,7 +11775,7 @@ class UVData(UVBase):
         lst_range=None,
         polarizations=None,
         blt_inds=None,
-        catalog_identifier=None,
+        phase_center_ids=None,
         keep_all_metadata=True,
         read_data=True,
         background_lsts=True,
@@ -11986,7 +11943,7 @@ class UVData(UVBase):
             lst_range=lst_range,
             polarizations=polarizations,
             blt_inds=blt_inds,
-            catalog_identifier=catalog_identifier,
+            phase_center_ids=phase_center_ids,
             keep_all_metadata=keep_all_metadata,
             read_data=read_data,
             background_lsts=background_lsts,
@@ -12018,7 +11975,7 @@ class UVData(UVBase):
         lst_range=None,
         polarizations=None,
         blt_inds=None,
-        catalog_identifier=None,
+        phase_center_ids=None,
         keep_all_metadata=True,
         read_data=True,
         data_array_dtype=np.complex128,
@@ -12232,7 +12189,7 @@ class UVData(UVBase):
             lst_range=lst_range,
             polarizations=polarizations,
             blt_inds=blt_inds,
-            catalog_identifier=catalog_identifier,
+            phase_center_ids=phase_center_ids,
             data_array_dtype=data_array_dtype,
             keep_all_metadata=keep_all_metadata,
             read_data=read_data,
@@ -12282,6 +12239,7 @@ class UVData(UVBase):
         antenna_names=None,
         ant_str=None,
         bls=None,
+        catalog_identifier=None,
         frequencies=None,
         freq_chans=None,
         times=None,
@@ -12343,7 +12301,6 @@ class UVData(UVBase):
         phase_to_pointing_center=False,
         nsample_array_dtype=np.float32,
         # MIR
-        catalog_identifier=None,
         corrchunk=None,
         receivers=None,
         sidebands=None,
@@ -13069,6 +13026,7 @@ class UVData(UVBase):
                                 frequencies=frequencies,
                                 freq_chans=freq_chans,
                                 times=times,
+                                catalog_identifier=catalog_identifier,
                                 time_range=time_range,
                                 lsts=lsts,
                                 lst_range=lst_range,
@@ -14096,6 +14054,7 @@ class UVData(UVBase):
             blt_inds=blt_inds,
             phase_center_ids=phase_center_ids,
             keep_all_metadata=keep_all_metadata,
+            catalog_identifier=catalog_identifier,
             # checking parameters
             run_check=run_check,
             check_extra=check_extra,
@@ -14148,7 +14107,6 @@ class UVData(UVBase):
             remove_flagged_ants=remove_flagged_ants,
             phase_to_pointing_center=phase_to_pointing_center,
             # MIR
-            catalog_identifier=catalog_identifier,
             corrchunk=corrchunk,
             receivers=receivers,
             sidebands=sidebands,

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -209,7 +209,7 @@ class UVFITS(UVData):
         lst_range,
         polarizations,
         blt_inds,
-        phase_center_ids,
+        catalog_identifier,
         read_metadata,
         keep_all_metadata,
         run_check,
@@ -240,7 +240,7 @@ class UVFITS(UVData):
             lst_range,
             polarizations,
             blt_inds,
-            phase_center_ids,
+            catalog_identifier,
         )
 
         if blt_inds is not None:
@@ -363,7 +363,7 @@ class UVFITS(UVData):
         lst_range=None,
         polarizations=None,
         blt_inds=None,
-        phase_center_ids=None,
+        catalog_identifier=None,
         keep_all_metadata=True,
         read_data=True,
         background_lsts=True,
@@ -864,7 +864,6 @@ class UVFITS(UVData):
                     lst_range,
                     polarizations,
                     blt_inds,
-                    phase_center_ids,
                     False,
                     keep_all_metadata,
                     run_check,

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -209,17 +209,10 @@ class UVFITS(UVData):
         lst_range,
         polarizations,
         blt_inds,
-        catalog_identifier,
-        read_metadata,
+        phase_center_ids,
         keep_all_metadata,
-        run_check,
-        check_extra,
-        run_check_acceptability,
-        strict_uvw_antpos_check,
         fix_old_proj,
         fix_use_ant_pos,
-        check_autos,
-        fix_autos,
     ):
         """
         Read just the visibility and flag data of the uvfits file.
@@ -240,7 +233,7 @@ class UVFITS(UVData):
             lst_range,
             polarizations,
             blt_inds,
-            catalog_identifier,
+            phase_center_ids,
         )
 
         if blt_inds is not None:
@@ -363,7 +356,7 @@ class UVFITS(UVData):
         lst_range=None,
         polarizations=None,
         blt_inds=None,
-        catalog_identifier=None,
+        phase_center_ids=None,
         keep_all_metadata=True,
         read_data=True,
         background_lsts=True,
@@ -864,16 +857,10 @@ class UVFITS(UVData):
                     lst_range,
                     polarizations,
                     blt_inds,
-                    False,
+                    None,
                     keep_all_metadata,
-                    run_check,
-                    check_extra,
-                    run_check_acceptability,
-                    strict_uvw_antpos_check,
                     fix_old_proj,
                     fix_use_ant_pos,
-                    check_autos,
-                    fix_autos,
                 )
         if use_future_array_shapes:
             self.use_future_array_shapes()

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -210,6 +210,7 @@ class UVFITS(UVData):
         polarizations,
         blt_inds,
         phase_center_ids,
+        catalog_names,
         keep_all_metadata,
         fix_old_proj,
         fix_use_ant_pos,
@@ -234,6 +235,7 @@ class UVFITS(UVData):
             polarizations,
             blt_inds,
             phase_center_ids,
+            catalog_names,
         )
 
         if blt_inds is not None:
@@ -357,6 +359,7 @@ class UVFITS(UVData):
         polarizations=None,
         blt_inds=None,
         phase_center_ids=None,
+        catalog_names=None,
         keep_all_metadata=True,
         read_data=True,
         background_lsts=True,
@@ -443,7 +446,11 @@ class UVFITS(UVData):
             object. This is not commonly used. Ignored if read_data is False.
         phase_center_ids : array_like of int, optional
             Phase center IDs to include when reading data into the object (effectively
-            a selection on baseline-times).
+            a selection on baseline-times). Cannot be used with catalog_names.
+        catalog_names : str or array-like of str
+            The names of the phase centers (sources) to include when reading data into
+            the object, which should match exactly in spelling and capitalization.
+            Cannot be used with phase_center_ids.
         keep_all_metadata : bool
             Option to keep all the metadata associated with antennas, even those
             that do not have data associated with them after the select option.
@@ -857,7 +864,8 @@ class UVFITS(UVData):
                     lst_range,
                     polarizations,
                     blt_inds,
-                    None,
+                    phase_center_ids,
+                    catalog_names,
                     keep_all_metadata,
                     fix_old_proj,
                     fix_use_ant_pos,

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -1022,7 +1022,7 @@ class UVH5(UVData):
         lst_range,
         polarizations,
         blt_inds,
-        phase_center_ids,
+        catalog_identifier,
         data_array_dtype,
         keep_all_metadata,
         multidim_index,
@@ -1083,7 +1083,7 @@ class UVH5(UVData):
             lst_range,
             polarizations,
             blt_inds,
-            phase_center_ids,
+            catalog_identifier,
         )
 
         # figure out which axis is the most selective
@@ -1342,7 +1342,7 @@ class UVH5(UVData):
         lst_range=None,
         polarizations=None,
         blt_inds=None,
-        phase_center_ids=None,
+        catalog_identifier=None,
         keep_all_metadata=True,
         read_data=True,
         data_array_dtype=np.complex128,
@@ -2179,6 +2179,7 @@ class UVH5(UVData):
         time_range=None,
         lsts=None,
         lst_range=None,
+        catalog_identifier=None,
         polarizations=None,
         blt_inds=None,
         phase_center_ids=None,
@@ -2325,7 +2326,7 @@ class UVH5(UVData):
             lst_range,
             polarizations,
             blt_inds,
-            phase_center_ids,
+            catalog_identifier,
         )
 
         # make sure that the dimensions of the data to write are correct

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -1022,7 +1022,7 @@ class UVH5(UVData):
         lst_range,
         polarizations,
         blt_inds,
-        catalog_identifier,
+        phase_center_ids,
         data_array_dtype,
         keep_all_metadata,
         multidim_index,
@@ -1083,7 +1083,7 @@ class UVH5(UVData):
             lst_range,
             polarizations,
             blt_inds,
-            catalog_identifier,
+            phase_center_ids,
         )
 
         # figure out which axis is the most selective
@@ -1342,7 +1342,7 @@ class UVH5(UVData):
         lst_range=None,
         polarizations=None,
         blt_inds=None,
-        catalog_identifier=None,
+        phase_center_ids=None,
         keep_all_metadata=True,
         read_data=True,
         data_array_dtype=np.complex128,
@@ -2326,7 +2326,7 @@ class UVH5(UVData):
             lst_range,
             polarizations,
             blt_inds,
-            catalog_identifier,
+            phase_center_ids,
         )
 
         # make sure that the dimensions of the data to write are correct

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -1023,17 +1023,10 @@ class UVH5(UVData):
         polarizations,
         blt_inds,
         phase_center_ids,
+        catalog_names,
         data_array_dtype,
         keep_all_metadata,
         multidim_index,
-        run_check,
-        check_extra,
-        run_check_acceptability,
-        strict_uvw_antpos_check,
-        fix_old_proj,
-        fix_use_ant_pos,
-        check_autos,
-        fix_autos,
     ):
         """
         Read the data-size arrays (data, flags, nsamples) from a file.
@@ -1084,6 +1077,7 @@ class UVH5(UVData):
             polarizations,
             blt_inds,
             phase_center_ids,
+            catalog_names,
         )
 
         # figure out which axis is the most selective
@@ -1343,6 +1337,7 @@ class UVH5(UVData):
         polarizations=None,
         blt_inds=None,
         phase_center_ids=None,
+        catalog_names=None,
         keep_all_metadata=True,
         read_data=True,
         data_array_dtype=np.complex128,
@@ -1435,7 +1430,11 @@ class UVH5(UVData):
             object. This is not commonly used. Ignored if read_data is False.
         phase_center_ids : array_like of int, optional
             Phase center IDs to include when reading data into the object (effectively
-            a selection on baseline-times).
+            a selection on baseline-times). Cannot be used with catalog_names.
+        catalog_names : str or array-like of str
+            The names of the phase centers (sources) to include when reading data into
+            the object, which should match exactly in spelling and capitalization.
+            Cannot be used with phase_center_ids.
         keep_all_metadata : bool
             Option to keep all the metadata associated with antennas, even those
             that do not have data associated with them after the select option.
@@ -1576,17 +1575,10 @@ class UVH5(UVData):
                 polarizations,
                 blt_inds,
                 phase_center_ids,
+                catalog_names,
                 data_array_dtype,
                 keep_all_metadata,
                 multidim_index,
-                run_check,
-                check_extra,
-                run_check_acceptability,
-                strict_uvw_antpos_check,
-                fix_old_proj,
-                fix_use_ant_pos,
-                check_autos,
-                fix_autos,
             )
 
         # Finally, backfill the apparent coords if they aren't in the original datafile
@@ -2179,10 +2171,10 @@ class UVH5(UVData):
         time_range=None,
         lsts=None,
         lst_range=None,
-        catalog_identifier=None,
         polarizations=None,
         blt_inds=None,
         phase_center_ids=None,
+        catalog_names=None,
         run_check_acceptability=True,
         add_to_history=None,
     ):
@@ -2268,8 +2260,12 @@ class UVH5(UVData):
             The baseline-time indices to include when writing data to the file.
             This is not commonly used.
         phase_center_ids : array_like of int, optional
-            Phase center IDs to include when writing data into the file (effectively
-            a selection on baseline-times).
+            Phase center IDs to include when reading data into the object (effectively
+            a selection on baseline-times). Cannot be used with catalog_names.
+        catalog_names : str or array-like of str
+            The names of the phase centers (sources) to include when reading data into
+            the object, which should match exactly in spelling and capitalization.
+            Cannot be used with phase_center_ids.
         add_to_history : str
             String to append to history before write out. Default is no appending.
 
@@ -2327,6 +2323,7 @@ class UVH5(UVData):
             polarizations,
             blt_inds,
             phase_center_ids,
+            catalog_names,
         )
 
         # make sure that the dimensions of the data to write are correct


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates the interface between `UVData.read` method and the `MirParser` module.

## Description
<!--- Describe your changes in detail -->
Overhauls the `read_mir` method inside of `Mir`. This includes being able to sub-select desired data on read (rather than after-the-fact), with keywords matched to those typically used inside of `UVData.read`. Additionally, some updates to the `MirParser` and `Mir` modules have been made to improve speed/memory performance (by up to a factor of two). The `UVData.read` and `UVData.select` have also had the `catalog_names` keyword added, which allows users to select sources/phase centers by their names rather than their ID numbers (the latter of which are sometimes arbitrarily assigned).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This PR covers a final suite of changes that are needed for moving support for MIR data for general users of SMA -- in this case, primarily via improving the interface between the `UVData` and MIR-type files. Previously, in order to handle MIR files _without_ loading the whole dataset first, one needed to pass forward specific indexing codes that were not necessarily known by lay-users of the telescope.

After this PR is closed, I'd like to request a new pyuvdata version be spun up.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).