### PR TITLE
Transactional FastUVH5Meta

### DIFF
--- a/docs/fast_uvh5_meta.rst
+++ b/docs/fast_uvh5_meta.rst
@@ -1,0 +1,5 @@
+FastUVH5Meta
+=================
+
+.. autoclass:: pyuvdata.uvdata.FastUVH5Meta
+   :members:

--- a/docs/make_index.py
+++ b/docs/make_index.py
@@ -49,6 +49,7 @@ def write_index_rst(readme_file=None, write_file=None):
         "   uvcal\n"
         "   uvbeam\n"
         "   uvflag\n"
+        "   fast_uvh5_meta\n"
         "   utility_functions\n"
         "   known_telescopes\n"
         "   developer_docs\n"

--- a/docs/uvdata_tutorial.rst
+++ b/docs/uvdata_tutorial.rst
@@ -1453,8 +1453,8 @@ for each file, you can read just the time array (for example), using the special
   False
 
   # FastUVH5Meta is meant to be a read-only view into the HDF5 file, not a general
-  # data manipulation class. You should set attributes or write to the file.
-  # Use UVData for that.
+  # data manipulation class. You should *not* set attributes or use it to write to the
+  # file. Use UVData for that.
 
 .. _sorting_data:
 

--- a/docs/uvdata_tutorial.rst
+++ b/docs/uvdata_tutorial.rst
@@ -1426,7 +1426,8 @@ for each file, you can read just the time array (for example), using the special
 
   # No data is read in when creating the object, and you can access each bit of metadata
   # individually, and it will lazy-load from the file
-  >>> print(meta.time_array)
+  >>> print(len(meta.time_array))
+  200
 
   # Once loaded, the data is cached, so you can access it again without reading from disk
   >>> "time_array" in meta.__dict__
@@ -1438,16 +1439,18 @@ for each file, you can read just the time array (for example), using the special
 
   # If the metadata itself doesn't define whether the blt-axis is rectangular, this can
   # be specified directly, which speeds up accessing the unique baselines and times.
-  >>> uvd = meta.to_uvdata(filename, blts_are_rectangular=True)
+  >>> meta = FastUVH5Meta(filename, blts_are_rectangular=True)
 
   # By default, the h5py.File object is opened on the first time you access a metadata
   # attribute, and then closed only when the object is deleted. If you loop through
   # many files, this can be a problem, as h5py has a limit on the number of open files.
   # You can access metadata without keeping the file open by with the following:
-  >>> meta.get_transactional('lst_array')
+  >>> lsts = meta.get_transactional('lst_array')
 
   # If you also want the data not to be cached on the object, specify cache=False
-  >>> lsts = meta.get_transactional('lst_array', cache=False)
+  >>> freqs = meta.get_transactional('freq_array', cache=False)
+  >>> "freq_array" in meta.__dict__
+  False
 
   # FastUVH5Meta is meant to be a read-only view into the HDF5 file, not a general
   # data manipulation class. You should set attributes or write to the file.

--- a/docs/uvdata_tutorial.rst
+++ b/docs/uvdata_tutorial.rst
@@ -1409,6 +1409,49 @@ are written to the appropriate parts of the file on disk.
   >>> nsample_array = uvd2.nsample_array
   >>> uvd.write_uvh5_part(partfile, data_array, flag_array, nsample_array, freq_chans=freq_inds2)
 
+d) Accessing partial metadata for uvh5 files
+********************************************
+
+For UVH5 files, you can access specific metadata without reading in the entire metadata,
+which is useful when, for example, you have thousands of files and need to quickly filter
+which files to eventually read based on the times. Instead of reading in the entire metadata
+for each file, you can read just the time array (for example), using the specialty
+``FastUVH5Meta`` class.
+
+.. code-block:: python
+
+  >>> from pyuvdata.uvdata import FastUVH5Meta
+  >>> filename = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
+  >>> meta = FastUVH5Meta(filename)
+
+  # No data is read in when creating the object, and you can access each bit of metadata
+  # individually, and it will lazy-load from the file
+  >>> print(meta.time_array)
+
+  # Once loaded, the data is cached, so you can access it again without reading from disk
+  >>> "time_array" in meta.__dict__
+  True
+
+  # Once you've decided if you need this datafile, you can instantiate a
+  # (metadata-only) UVData object
+  >>> uvd = meta.to_uvdata()
+
+  # If the metadata itself doesn't define whether the blt-axis is rectangular, this can
+  # be specified directly, which speeds up accessing the unique baselines and times.
+  >>> uvd = meta.to_uvdata(filename, blts_are_rectangular=True)
+
+  # By default, the h5py.File object is opened on the first time you access a metadata
+  # attribute, and then closed only when the object is deleted. If you loop through
+  # many files, this can be a problem, as h5py has a limit on the number of open files.
+  # You can access metadata without keeping the file open by with the following:
+  >>> meta.get_transactional('lst_array')
+
+  # If you also want the data not to be cached on the object, specify cache=False
+  >>> lsts = meta.get_transactional('lst_array', cache=False)
+
+  # FastUVH5Meta is meant to be a read-only view into the HDF5 file, not a general
+  # data manipulation class. You should set attributes or write to the file.
+  # Use UVData for that.
 
 .. _sorting_data:
 

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3745,3 +3745,9 @@ class TestFastUVH5Meta:
         assert "channel_width" not in meta.__dict__
         assert np.allclose(chwidth, meta.channel_width)
         assert "channel_width" in meta.__dict__
+
+    def test_close_before_open(self):
+        meta = uvh5.FastUVH5Meta(self.fl)
+        meta.close()
+        assert not meta.is_open()
+        assert isinstance(meta.header, h5py.Group)

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3726,3 +3726,10 @@ class TestFastUVH5Meta:
 
         assert meta == meta
         assert meta != 1
+
+    def test_transactional(self):
+        meta = uvh5.FastUVH5Meta(self.fl)
+
+        lsts = meta.get_transactional("lsts")
+        assert not meta.is_open()
+        assert np.allclose(lsts, meta.lsts)

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3733,3 +3733,15 @@ class TestFastUVH5Meta:
         lsts = meta.get_transactional("lsts")
         assert not meta.is_open()
         assert np.allclose(lsts, meta.lsts)
+
+        # This attribute uses __getattr__
+        meta.get_transactional("freq_array", cache=False)
+        assert not meta.is_open()
+        assert "freq_array" not in meta.__dict__
+
+        # This is cached property
+        chwidth = meta.get_transactional("channel_width", cache=False)
+        assert not meta.is_open()
+        assert "channel_width" not in meta.__dict__
+        assert np.allclose(chwidth, meta.channel_width)
+        assert "channel_width" in meta.__dict__

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -446,6 +446,7 @@ class FastUVH5Meta:
             elif name in self._float_attrs:
                 x = float(x)
 
+            self.__dict__[name] = x
             return x
         except KeyError:
             try:

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -404,12 +404,18 @@ class FastUVH5Meta:
             self.open()
         return self.__datagrp
 
-    def get_transactional(self, item: str):
+    def get_transactional(self, item: str, cache: bool = True) -> Any:
         """Get an attribute from the metadata but close the file object afterwards."""
         try:
-            return getattr(self, item)
+            val = getattr(self, item)
         finally:
             self.close()
+
+            if not cache:
+                if item in self.__dict__:
+                    del self.__dict__[item]
+
+        return val
 
     def __getattr__(self, name: str) -> Any:
         """Get attribute directly from header group."""
@@ -422,7 +428,6 @@ class FastUVH5Meta:
             elif name in self._float_attrs:
                 x = float(x)
 
-            self.__dict__[name] = x
             return x
         except KeyError:
             try:

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -548,7 +548,7 @@ class FastUVH5Meta:
             return bool(self.header["time_axis_faster_than_bls"][()])
         if self.Ntimes == 1:
             return False
-        if self.Nbls == 1:
+        if self.Ntimes == self.Nblts:
             return True
         return self.header["time_array"][1] != self.header["time_array"][0]
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -315,13 +315,14 @@ class FastUVH5Meta:
         elif isinstance(path, (str, Path)):
             self.path = Path(path)
 
-        if not self.__file:  # either None, or False (not open)
-            self.open()
-
         self.__blts_are_rectangular = blts_are_rectangular
         self.__time_first = time_axis_faster_than_bls
         self.__blt_order = blt_order
         self._recompute_nbls = recompute_nbls
+
+    def is_open(self) -> bool:
+        """Whether the file is open."""
+        return bool(self.__file)
 
     def __del__(self):
         """Close the file when the object is deleted."""
@@ -330,7 +331,7 @@ class FastUVH5Meta:
 
     def __getstate__(self):
         """Get the state of the object."""
-        state = {
+        return {
             k: v
             for k, v in self.__dict__.items()
             if k
@@ -342,13 +343,11 @@ class FastUVH5Meta:
                 "datagrp",
             )
         }
-        return state
 
     def __setstate__(self, state):
         """Set the state of the object."""
         self.__dict__.update(state)
         self.__file = None
-        self.open()
 
     def __eq__(self, other):
         """Check equality of two FastUVH5Meta objects."""
@@ -404,6 +403,13 @@ class FastUVH5Meta:
         if not self.__file:
             self.open()
         return self.__datagrp
+
+    def get_transactional(self, item: str):
+        """Get an attribute from the metadata but close the file object afterwards."""
+        try:
+            return getattr(self, item)
+        finally:
+            self.close()
 
     def __getattr__(self, name: str) -> Any:
         """Get attribute directly from header group."""

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -405,7 +405,19 @@ class FastUVH5Meta:
         return self.__datagrp
 
     def get_transactional(self, item: str, cache: bool = True) -> Any:
-        """Get an attribute from the metadata but close the file object afterwards."""
+        """Get an attribute from the metadata but close the file object afterwards.
+
+        Using this method is safer than direct attribute access when dealing with
+        many files.
+
+        Parameters
+        ----------
+        item
+            The attribute to get.
+        cache
+            Whether to cache the attribute in the object so that the next access is
+            faster.
+        """
         try:
             val = getattr(self, item)
         finally:

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -374,11 +374,17 @@ class FastUVH5Meta:
         """Close the file."""
         self.__header = None
         self.__datagrp = None
-        del self.header  # need to refresh these
+
+        try:
+            del self.header  # need to refresh these
+        except AttributeError:
+            pass
+
         try:
             del self.datagrp
         except AttributeError:
             pass
+
         if self.__file:
             self.__file.close()
         self.__file = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As it stands, the `FastUVH5Meta` class will open up the HDF5 file when you instantiate it, and it will stay open unless you explicitly call `.close()`. Furthermore, each time you read something from the metadata, it will cache it (so it accesses from memory the second time). This is the fastest way to do things, and generally what you want. However, you may want to close the file every time you get something out of it, and you may not want to cache everything (you may just want to read it into a new variable that you go and use). This PR implements these features.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The reason you might not want to generally keep the file open is that HDF5 only allows a finite number of open files at a time. In practice, we may have a list of many thousands of files that we wish to process. Making each of those a light `FastUVH5Meta` class currently breaks. Of course, you can go through and make each one in turn, get the stuff you need, then close it before opening the next one, however it is cleaner to be able to just make the whole list of files into UVH5 meta objects in one list comprehension, and this will break.

For a similar reason, you might want to only retrieve a bit of metadata without caching it in the object. Say you want to calculate the median LST for each file in a big list, and then you know you don't care about anything else in the files. Currently you could do:

```python
metas = [FastUVH5Meta(fl) for fl in file_list]
lst_medians = [np.median(meta.lsts) for meta in metas]
for meta in metas:
    del meta.lsts
```

However, after the second line, there's a bunch of memory taken up, because each of the elements of `metas` has an attached `lsts` array (also, if `file_lst` is a long list, this will also break due to number of open files).

We could instead do:

```python
lst_medians = []
for fl in file_list:
    meta = FastUVH5Meta(fl)
    lst_medians.append(np.median(meta.lsts))
```

This works fine, but in a complex pipeline, you might want to pass through the files to another function that expects them as `FastUVH5Meta` objects, and here' we've lost that association. In this PR, you can just do:

```python
metas = [FastUVH5Meta(fl) for fl in file_list]  # Files don't auto-open until you access something.
lst_medians = [np.median(meta.get_transactional('lsts', cache=False) for meta in metas]
```

You can omit the `cache=False` if you want to keep the full LSTs around in the meta objects for later *but still want to close the file after reading*. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

