### PR TITLE
fix: error when times or freqs are length 1

### DIFF
--- a/pyuvdata/uvdata/tests/test_initializers.py
+++ b/pyuvdata/uvdata/tests/test_initializers.py
@@ -285,6 +285,15 @@ def test_alternate_time_inputs():
     assert np.allclose(times, times3)
     assert np.allclose(ints, ints3)
 
+    # Single time
+    with pytest.warns(
+        UserWarning, match="integration_time not provided, and cannot be inferred"
+    ):
+        times4, ints4 = get_time_params(
+            time_array=time_array[:1], telescope_location=loc
+        )
+        assert np.allclose(ints4, 1.0)
+
 
 def test_alternate_freq_inputs():
     freq_array = np.linspace(1e8, 2e8, 15)
@@ -301,6 +310,13 @@ def test_alternate_freq_inputs():
     freqs3, widths3 = get_freq_params(freq_array=freq_array)
     assert np.allclose(freqs, freqs3)
     assert np.allclose(widths, widths3)
+
+    # Single frequency
+    with pytest.warns(
+        UserWarning, match="channel_width not provided, and cannot be inferred"
+    ):
+        freqs4, widths4 = get_freq_params(freq_array=freq_array[:1])
+        assert np.allclose(widths4, 1.0)
 
 
 def test_empty(simplest_working_params: dict[str, Any]):
@@ -461,12 +477,12 @@ def test_set_phase_params(simplest_working_params):
     pcc = obj.phase_center_catalog
 
     new = UVData.new(phase_center_catalog=pcc, **simplest_working_params)
-
     assert new.phase_center_catalog == pcc
 
     pccnew = copy.deepcopy(pcc)
     pccnew[1] = copy.deepcopy(pccnew[0])
     pccnew[1]["cat_type"] = "driftscan"
+    pccnew[1]["cat_name"] = "another_unprojected"
 
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes the failing Warnings test from #1281 and also fixes logic when inferring either `channel_width` from `freq_array` or `integration_time` from `time_array` when the latter are length-one. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

