### PR TITLE
Deprecate the 'unknown' cal_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - A new generic `read` method on `UVCal` that, like the `read` methods on our other objects, supports all file types and a new `from_file` class method to allow one-line reading of UVCal files.
 
 ### Deprecated
+- Support for the 'unknown' cal_type in UVCal.
 - Reading in multiple files to `UVCal` using file-type specific read methods
 (e.g. `read_calfits`) in favor of the generic `read` method.
 

--- a/pyuvdata/uvcal/tests/test_calfits.py
+++ b/pyuvdata/uvcal/tests/test_calfits.py
@@ -155,7 +155,12 @@ def test_error_unknown_cal_type(delay_data, tmp_path):
     cal_in = delay_data
     write_file = str(tmp_path / "outtest_firstcal.fits")
 
-    cal_in._set_unknown_cal_type()
+    with uvtest.check_warnings(
+        DeprecationWarning,
+        match="Setting the cal_type to 'unknown' is deprecated. This will become an "
+        "error in version 2.5",
+    ):
+        cal_in._set_unknown_cal_type()
     with pytest.raises(ValueError, match="unknown calibration type"):
         cal_in.write_calfits(write_file, run_check=False, clobber=True)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Deprecates 'unknown' as an option for UVCal.cal_type. There's no good reason for it to exist.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #855

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Breaking change checklist:
- [x] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [x] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
