### PR TITLE
feat: faster blt indexing via known rectangularity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         - id: mixed-line-ending
           args: ['--fix=no']
   - repo: https://github.com/pycqa/flake8
-    rev: '6.1.0'
+    rev: '7.0.0'
     hooks:
       - id: flake8
         additional_dependencies:
@@ -29,19 +29,19 @@ repos:
           - flake8-rst-docstrings
           - pep8-naming
 
-  - repo: https://github.com/psf/black
-    rev: 23.11.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.12.1
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
+    rev: 1.7.6
     hooks:
       - id: bandit
         args: [--skip, "B101", --recursive, pyuvdata]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ positions are near surface of whatever celestial body their positions are refere
 (either the Earth or Moon, currently).
 
 ### Changed
+- Improved performance for `antpair2ind` and `_key2inds` by using the
+`blts_are_rectangular` parameter, and also by caching the results. To improve performance of the cache, the resulting indices are returned as slices whenever possible.
 - Changed the way files are passed for reading FHD files. Rather than one list including
 all the types of files, each file type (e.g. params, obs, layout) must be passed to
 their own parameter. This makes the API for reading FHD data files more similar to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ positions are near surface of whatever celestial body their positions are refere
 
 ### Changed
 - Improved performance for `antpair2ind` and `_key2inds` by using the
-`blts_are_rectangular` parameter, and also by caching the results. To improve performance of the cache, the resulting indices are returned as slices whenever possible.
+`blts_are_rectangular` parameter, and also by caching the results. To improve
+performance of the cache, the resulting indices are returned as slices whenever possible.
 - Changed the way files are passed for reading FHD files. Rather than one list including
 all the types of files, each file type (e.g. params, obs, layout) must be passed to
 their own parameter. This makes the API for reading FHD data files more similar to the

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -11,6 +11,8 @@ UVBase. This module also includes specialized subclasses for particular types
 of metadata.
 
 """
+from __future__ import annotations
+
 import builtins
 import warnings
 
@@ -157,7 +159,7 @@ def _param_dict_equal(this_dict, other_dict):
     return True, ""
 
 
-class UVParameter(object):
+class UVParameter:
     """
     Data and metadata objects for interferometric data sets.
 
@@ -204,6 +206,10 @@ class UVParameter(object):
         When True, the input expected_type is used exactly, otherwise a more
         generic type is found to allow changes in precisions or to/from numpy
         dtypes to not break checks.
+    setter : function, optional
+        An optional function to be called after the parameter is set.
+        The function should take a single argument, the instance of the class
+        to which the parameter is attached.
 
     Attributes
     ----------
@@ -265,6 +271,7 @@ class UVParameter(object):
         tols=(1e-05, 1e-08),
         strict_type_check=False,
         ignore_eq_none: bool = False,
+        setter: callable | None = None,
     ):
         """Init UVParameter object."""
         self.name = name
@@ -293,6 +300,7 @@ class UVParameter(object):
             self.tols = tols
 
         self.ignore_eq_none = ignore_eq_none and not required
+        self._setter = setter
 
     def __eq__(self, other, *, silent=False):
         """
@@ -701,6 +709,16 @@ class UVParameter(object):
         else:
             # Otherwise just default to checking equality
             return value == self.value
+
+    def setter(self, inst):
+        """Extra operations to perform on the parent instance when setting the param.
+
+        This can be used to do things like cache invalidation, for example,
+        if there is a cache of antpairs to blt indices, when the ant_1_array
+        or ant_2_array are set, this cache should be cleared here.
+        """
+        if self._setter is not None:
+            self._setter(inst)
 
 
 class AngleParameter(UVParameter):

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4632,3 +4632,13 @@ def test_pol_order(pols, aips_order, casa_order, order):
         assert all(check == casa_order)
     if order == "AIPS":
         assert all(check == aips_order)
+
+
+def test_slicify():
+    assert uvutils.slicify(None) is None
+    assert uvutils.slicify(slice(None)) == slice(None)
+    assert uvutils.slicify([]) is None
+    assert uvutils.slicify([1, 2, 3]) == slice(1, 4, 1)
+    assert uvutils.slicify([1]) == slice(1, 2, 1)
+    assert uvutils.slicify([0, 2, 4]) == slice(0, 5, 2)
+    assert uvutils.slicify([0, 1, 2, 7]) == [0, 1, 2, 7]

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -6285,3 +6285,16 @@ def determine_rectangularity(
         if (np.diff(baseline_array, axis=0) != 0).any():
             return False, False
         return True, False
+
+
+def slicify(ind):
+    if ind is None or isinstance(ind, slice):
+        return ind
+    if len(ind) == 0:
+        return None
+
+    if len(set(np.ediff1d(ind))) <= 1:
+        return slice(ind[0], ind[-1] + 1, ind[1] - ind[0] if len(ind) > 1 else 1)
+    else:
+        # can't slicify
+        return ind

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -6287,7 +6287,8 @@ def determine_rectangularity(
         return True, False
 
 
-def slicify(ind):
+def slicify(ind: slice | None | IterableType[int]) -> slice | None | IterableType[int]:
+    """Convert an iterable of integers into a slice object if possible."""
     if ind is None or isinstance(ind, slice):
         return ind
     if len(ind) == 0:

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -167,6 +167,7 @@ class UVBase(object):
         def fset(self, value):
             this_param = getattr(self, param_name)
             this_param.value = value
+            this_param.setter(self)
             setattr(self, param_name, this_param)
 
         return fset
@@ -214,6 +215,7 @@ class UVBase(object):
         def fset(self, value):
             this_param = getattr(self, param_name)
             this_param.set_degrees(value)
+            this_param.setter(self)
             setattr(self, param_name, this_param)
 
         return fset
@@ -261,6 +263,7 @@ class UVBase(object):
         def fset(self, value):
             this_param = getattr(self, param_name)
             this_param.set_lat_lon_alt(value)
+            this_param.setter(self)
             setattr(self, param_name, this_param)
 
         return fset
@@ -308,6 +311,7 @@ class UVBase(object):
         def fset(self, value):
             this_param = getattr(self, param_name)
             this_param.set_lat_lon_alt_degrees(value)
+            this_param.setter(self)
             setattr(self, param_name, this_param)
 
         return fset

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -4992,7 +4992,6 @@ IRREG_POL = [0, 1, 3]
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("future_shapes", [True, False])
 @pytest.mark.parametrize(
     "ind1, ind2, indp, squeeze, force_copy",
     [
@@ -5011,16 +5010,11 @@ IRREG_POL = [0, 1, 3]
         (SINGLE_IND, None, REG_POL, "full", False),
     ],
 )
-def test_smart_slicing(
-    casa_uvfits, future_shapes, ind1, ind2, indp, squeeze, force_copy
-):
+def test_smart_slicing(casa_uvfits, ind1, ind2, indp, squeeze, force_copy):
     # Test function to slice data
     uv = casa_uvfits
 
-    if future_shapes:
-        uv.use_future_array_shapes()
-    else:
-        uv.use_current_array_shapes()
+    uv.use_future_array_shapes()
 
     if ind1 is None:
         polind = (None, indp)
@@ -5073,18 +5067,11 @@ def test_smart_slicing(
         else:
             assert not d.flags.writeable
 
-        if future_shapes:
-            uv.data_array[bltinds[1], 0, polidx[0]] = 5.43
-            if copy_made:
-                assert d[1, 0, 0] != uv.data_array[bltinds[1], 0, polidx[0]]
-            else:
-                assert d[1, 0, 0] == uv.data_array[bltinds[1], 0, polidx[0]]
+        uv.data_array[bltinds[1], 0, polidx[0]] = 5.43
+        if copy_made:
+            assert d[1, 0, 0] != uv.data_array[bltinds[1], 0, polidx[0]]
         else:
-            uv.data_array[bltinds[1], 0, 0, polidx[0]] = 5.43
-            if copy_made:
-                assert d[1, 0, 0] != uv.data_array[bltinds[1], 0, 0, polidx[0]]
-            else:
-                assert d[1, 0, 0] == uv.data_array[bltinds[1], 0, 0, polidx[0]]
+            assert d[1, 0, 0] == uv.data_array[bltinds[1], 0, polidx[0]]
 
 
 @pytest.mark.parametrize("kind", ["data", "flags", "nsamples", "times", "lsts"])

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -1379,6 +1379,7 @@ def test_select_blts(paper_uvh5, future_shapes):
     # check that it also works with higher dimension array
     uv_object2 = uv_object.copy()
     uv_object2.select(blt_inds=blt_inds[np.newaxis, :])
+
     assert len(blt_inds) == uv_object2.Nblts
 
     assert uvutils._check_histories(

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -12493,13 +12493,14 @@ def test_antpair2ind_not_rect_not_ordered(hera_uvh5):
 
 def test_antpair2ind_unordered_both_exist(hera_uvh5):
     # Make a new object that has conjugated baselines in it as well.
+    hera_uvh5.set_rectangularity()
     hera_uvh5.conjugate_bls("ant1<ant2")
     full = hera_uvh5.copy()
-    full.conjugate_bls("ant2<ant1")
-    full.fast_concat(hera_uvh5, axis="blt")
 
-    print(full.get_antpairs())
-    print(hera_uvh5.get_antpairs())
+    full.conjugate_bls("ant2<ant1")
+    full.fast_concat(hera_uvh5, axis="blt", inplace=True)
+    full.select(bls=[(0, 1), (1, 0)], inplace=True)
+    full.reorder_blts(order="time", minor_order="baseline")
     inds_ordered = full.antpair2ind((0, 1), ordered=True)
     inds_unordered = full.antpair2ind((0, 1), ordered=False)
 

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -12447,6 +12447,23 @@ def test_set_rectangularity(casa_uvfits, hera_uvh5):
     assert hera_uvh5.time_axis_faster_than_bls is False
 
 
+def test_determine_blt_order(hera_uvh5):
+    # test that the blt order is determined correctly
+    hera_uvh5.reorder_blts(order="time", minor_order="baseline")
+    assert hera_uvh5.blt_order == ("time", "baseline")
+
+    # Run determine with order already set -- should short-circuit.
+    order = hera_uvh5.determine_blt_order()
+    assert order == ("time", "baseline")
+
+    # woops, forgot the blt_order!
+    hera_uvh5.blt_order = None
+
+    # lets find it again....
+    order = hera_uvh5.determine_blt_order()
+    assert order == ("time", "baseline")
+
+
 def test_select_catalog_name_errs(hera_uvh5):
     with pytest.raises(
         ValueError, match="Cannot set both phase_center_ids and catalog_names."
@@ -12465,3 +12482,21 @@ def test_select_catalog_name(carma_miriad):
         uv_id.history = uv_name.history = None
 
         assert uv_name == uv_id
+
+
+def test_antpair2ind_rect_not_ordered(hera_uvh5):
+    hera_uvh5.reorder_blts(order="baseline", minor_order="time")
+
+    assert hera_uvh5.blts_are_rectangular
+    inds = hera_uvh5.antpair2ind((0, 1), ordered=False)
+
+    assert inds == hera_uvh5.antpair2ind((1, 0), ordered=True)
+
+
+def test_antpair2ind_not_rect_not_ordered(hera_uvh5):
+    hera_uvh5.reorder_blts(order="ant1")
+
+    assert not hera_uvh5.blts_are_rectangular
+    inds = hera_uvh5.antpair2ind((0, 1), ordered=False)
+
+    assert inds == hera_uvh5.antpair2ind((1, 0), ordered=True)

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -12493,10 +12493,13 @@ def test_antpair2ind_not_rect_not_ordered(hera_uvh5):
 
 def test_antpair2ind_unordered_both_exist(hera_uvh5):
     # Make a new object that has conjugated baselines in it as well.
-    conj = hera_uvh5.copy()
-    conj.conjugate_bls()
-    full = conj.concat(hera_uvh5)
+    hera_uvh5.conjugate_bls("ant1<ant2")
+    full = hera_uvh5.copy()
+    full.conjugate_bls("ant2<ant1")
+    full.fast_concat(hera_uvh5, axis="blt")
 
+    print(full.get_antpairs())
+    print(hera_uvh5.get_antpairs())
     inds_ordered = full.antpair2ind((0, 1), ordered=True)
     inds_unordered = full.antpair2ind((0, 1), ordered=False)
 

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -3,6 +3,8 @@
 # Licensed under the 2-clause BSD License
 
 """Tests for uvdata object."""
+from __future__ import annotations
+
 import copy
 import itertools
 import os
@@ -252,7 +254,7 @@ def paper_uvh5_main():
 def paper_uvh5(paper_uvh5_main):
     # read in test file for the resampling in time functions
     uv_object = paper_uvh5_main.copy()
-
+    uv_object.set_rectangularity()
     yield uv_object
 
     # cleanup
@@ -441,7 +443,11 @@ def test_unexpected_parameters(uvdata_props):
     expected_parameters = (
         uvdata_props.required_parameters + uvdata_props.extra_parameters
     )
-    attributes = [i for i in uvdata_props.uv_object.__dict__.keys() if i[0] == "_"]
+    attributes = [
+        i
+        for i in uvdata_props.uv_object.__dict__.keys()
+        if (i[0] == "_" and not i.startswith("_UVData__"))
+    ]
     for a in attributes:
         assert a in expected_parameters, (
             "unexpected parameter " + a + " found in UVData"
@@ -4752,7 +4758,8 @@ def test_fast_concat_errors(casa_uvfits):
         uv1.fast_concat(cal, "freq", inplace=True)
 
 
-def test_key2inds(casa_uvfits):
+@pytest.mark.parametrize("tuplify", [False, True])
+def test_key2inds(casa_uvfits, tuplify):
     # Test function to interpret key as antpair, pol
     uv = casa_uvfits
 
@@ -4761,73 +4768,76 @@ def test_key2inds(casa_uvfits):
     ant2 = uv.ant_2_array[0]
     pol = uv.polarization_array[0]
     bltind = np.where((uv.ant_1_array == ant1) & (uv.ant_2_array == ant2))[0]
-    ind1, ind2, indp = uv._key2inds((ant1, ant2, pol))
+    key = (ant1, ant2, pol)
+    if tuplify:
+        key = (key,)
+    ind1, ind2, indp = uv._key2inds(key)
+
     assert np.array_equal(bltind, ind1)
-    assert np.array_equal(np.array([]), ind2)
-    assert np.array_equal([0], indp[0])
-    # Any of these inputs can also be a tuple of a tuple, so need to be checked twice.
-    ind1, ind2, indp = uv._key2inds(((ant1, ant2, pol),))
-    assert np.array_equal(bltind, ind1)
-    assert np.array_equal(np.array([]), ind2)
-    assert np.array_equal([0], indp[0])
+    assert ind2 is None
+    assert indp[0] == slice(0, 1, 1)
 
     # Combo with pol as string
-    ind1, ind2, indp = uv._key2inds((ant1, ant2, uvutils.polnum2str(pol)))
-    assert np.array_equal([0], indp[0])
-    ind1, ind2, indp = uv._key2inds(((ant1, ant2, uvutils.polnum2str(pol)),))
-    assert np.array_equal([0], indp[0])
+    key = (ant1, ant2, uvutils.polnum2str(pol))
+    if tuplify:
+        key = (key,)
+    ind1, ind2, indp = uv._key2inds(key)
+    assert indp[0] == slice(0, 1, 1)
 
     # Check conjugation
-    ind1, ind2, indp = uv._key2inds((ant2, ant1, pol))
+    key = (ant2, ant1, pol)
+    if tuplify:
+        key = (key,)
+    ind1, ind2, indp = uv._key2inds(key)
     assert np.array_equal(bltind, ind2)
-    assert np.array_equal(np.array([]), ind1)
-    assert np.array_equal([0], indp[1])
+    assert ind1 is None
+    assert indp[1] == slice(0, 1, 1)
+
     # Conjugation with pol as string
-    ind1, ind2, indp = uv._key2inds((ant2, ant1, uvutils.polnum2str(pol)))
+    key = (ant2, ant1, uvutils.polnum2str(pol))
+    if tuplify:
+        key = (key,)
+    ind1, ind2, indp = uv._key2inds(key)
     assert np.array_equal(bltind, ind2)
-    assert np.array_equal(np.array([]), ind1)
-    assert np.array_equal([0], indp[1])
-    assert np.array_equal([], indp[0])
+    assert ind1 is None
+    assert indp[1] == slice(0, 1, 1)
+    assert indp[0] is None
 
     # Antpair only
-    ind1, ind2, indp = uv._key2inds((ant1, ant2))
+    key = (ant1, ant2)
+    if tuplify:
+        key = (key,)
+    ind1, ind2, indp = uv._key2inds(key)
     assert np.array_equal(bltind, ind1)
-    assert np.array_equal(np.array([]), ind2)
-    assert np.array_equal(np.arange(uv.Npols), indp[0])
-    ind1, ind2, indp = uv._key2inds(((ant1, ant2)))
-    assert np.array_equal(bltind, ind1)
-    assert np.array_equal(np.array([]), ind2)
-    assert np.array_equal(np.arange(uv.Npols), indp[0])
+    assert ind2 is None
+    assert indp[0] == slice(None)
 
     # Baseline number only
-    ind1, ind2, indp = uv._key2inds(uv.antnums_to_baseline(ant1, ant2))
+    key = uv.antnums_to_baseline(ant1, ant2)
+    if tuplify:
+        key = (key,)
+    ind1, ind2, indp = uv._key2inds(key)
     assert np.array_equal(bltind, ind1)
-    assert np.array_equal(np.array([]), ind2)
-    assert np.array_equal(np.arange(uv.Npols), indp[0])
-    ind1, ind2, indp = uv._key2inds((uv.antnums_to_baseline(ant1, ant2),))
-    assert np.array_equal(bltind, ind1)
-    assert np.array_equal(np.array([]), ind2)
-    assert np.array_equal(np.arange(uv.Npols), indp[0])
+    assert ind2 is None
+    assert indp[0] == slice(None)
 
     # Pol number only
-    ind1, ind2, indp = uv._key2inds(pol)
-    assert np.array_equal(np.arange(uv.Nblts), ind1)
-    assert np.array_equal(np.array([]), ind2)
-    assert np.array_equal(np.array([0]), indp[0])
-    ind1, ind2, indp = uv._key2inds((pol))
-    assert np.array_equal(np.arange(uv.Nblts), ind1)
-    assert np.array_equal(np.array([]), ind2)
-    assert np.array_equal(np.array([0]), indp[0])
+    key = pol
+    if tuplify:
+        key = (key,)
+    ind1, ind2, indp = uv._key2inds(key)
+    assert ind1 == slice(None)
+    assert ind2 is None
+    assert indp[0] == slice(0, 1, 1)
 
     # Pol string only
-    ind1, ind2, indp = uv._key2inds("LL")
-    assert np.array_equal(np.arange(uv.Nblts), ind1)
-    assert np.array_equal(np.array([]), ind2)
-    assert np.array_equal(np.array([1]), indp[0])
-    ind1, ind2, indp = uv._key2inds(("LL"))
-    assert np.array_equal(np.arange(uv.Nblts), ind1)
-    assert np.array_equal(np.array([]), ind2)
-    assert np.array_equal(np.array([1]), indp[0])
+    key = "LL"
+    if tuplify:
+        key = (key,)
+    ind1, ind2, indp = uv._key2inds(key)
+    assert ind1 == slice(None)
+    assert ind2 is None
+    assert indp[0] == slice(1, 2, 1)
 
     # Test invalid keys
     with pytest.raises(KeyError, match="Polarization I not found in data."):
@@ -4846,8 +4856,8 @@ def test_key2inds(casa_uvfits):
     # Test autos are handled correctly
     uv.ant_2_array[0] = uv.ant_1_array[0]
     ind1, ind2, indp = uv._key2inds((ant1, ant1, pol))
-    assert np.array_equal(ind1, [0])
-    assert np.array_equal(ind2, [])
+    assert ind1 == slice(0, 1, 1)
+    assert ind2 is None
 
 
 def test_key2inds_conj_all_pols(casa_uvfits):
@@ -4861,8 +4871,8 @@ def test_key2inds_conj_all_pols(casa_uvfits):
     # Pols in data are 'rr', 'll', 'rl', 'lr'
     # So conjugated order should be [0, 1, 3, 2]
     assert np.array_equal(bltind, ind2)
-    assert np.array_equal(np.array([]), ind1)
-    assert np.array_equal(np.array([]), indp[0])
+    assert ind1 is None
+    assert indp[0] is None
     assert np.array_equal([0, 1, 3, 2], indp[1])
 
 
@@ -4880,9 +4890,9 @@ def test_key2inds_conj_all_pols_fringe(casa_uvfits):
     ind1, ind2, indp = uv._key2inds((ant1, ant2))
 
     assert np.array_equal(bltind, ind1)
-    assert np.array_equal(np.array([]), ind2)
-    assert np.array_equal(np.array([0]), indp[0])
-    assert np.array_equal(np.array([]), indp[1])
+    assert ind2 is None
+    assert indp[0] == slice(None)
+    assert indp[1] is None
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
@@ -4903,9 +4913,9 @@ def test_key2inds_conj_all_pols_bl_fringe(casa_uvfits):
     ind1, ind2, indp = uv._key2inds(bl)
 
     assert np.array_equal(bltind, ind1)
-    assert np.array_equal(np.array([]), ind2)
-    assert np.array_equal(np.array([0]), indp[0])
-    assert np.array_equal(np.array([]), indp[1])
+    assert ind2 is None
+    assert indp[0] == slice(None)
+    assert indp[1] is None
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
@@ -4934,8 +4944,8 @@ def test_key2inds_conj_all_pols_bls(casa_uvfits):
     # Pols in data are 'rr', 'll', 'rl', 'lr'
     # So conjugated order should be [0, 1, 3, 2]
     assert np.array_equal(bltind, ind2)
-    assert np.array_equal(np.array([]), ind1)
-    assert np.array_equal(np.array([]), indp[0])
+    assert ind1 is None
+    assert indp[0] is None
     assert np.array_equal([0, 1, 3, 2], indp[1])
 
 
@@ -4964,374 +4974,202 @@ def test_smart_slicing_err(casa_uvfits):
         'or "full" are allowed.',
     ):
         casa_uvfits._smart_slicing(
-            casa_uvfits.data_array, [0, 4, 5], [], ([0, 1], []), squeeze="notasqueeze"
+            casa_uvfits.data_array,
+            [0, 4, 5],
+            None,
+            ([0, 1], None),
+            squeeze="notasqueeze",
         )
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
+REG_IND = slice(0, 90, 10)
+SINGLE_IND = [45]
+REG_POL = slice(0, 2)
+IRREG_IND = [0, 4, 5]
+IRREG_POL = [0, 1, 3]
+
+
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("future_shapes", [True, False])
-def test_smart_slicing(casa_uvfits, future_shapes):
+@pytest.mark.parametrize(
+    "ind1, ind2, indp, squeeze, force_copy",
+    [
+        (REG_IND, None, REG_POL, "default", False),  # ind1 reg, ind2 empty, pol reg
+        (REG_IND, None, REG_POL, "default", True),
+        (REG_IND, None, IRREG_POL, "default", False),
+        (IRREG_IND, None, REG_POL, "default", False),
+        (IRREG_IND, None, IRREG_POL, "default", False),
+        (None, REG_IND, REG_POL, "default", False),
+        (None, REG_IND, IRREG_POL, "default", False),
+        (None, IRREG_IND, REG_POL, "default", False),
+        (slice(20), slice(20, 30), REG_POL, "default", False),
+        (slice(20), slice(20, 30), IRREG_POL, "default", False),
+        (SINGLE_IND, None, REG_POL, "default", False),
+        (None, SINGLE_IND, REG_POL, "default", False),
+        (SINGLE_IND, None, REG_POL, "full", False),
+    ],
+)
+def test_smart_slicing(
+    casa_uvfits, future_shapes, ind1, ind2, indp, squeeze, force_copy
+):
     # Test function to slice data
     uv = casa_uvfits
 
-    if not future_shapes:
+    if future_shapes:
+        uv.use_future_array_shapes()
+    else:
         uv.use_current_array_shapes()
 
-    # ind1 reg, ind2 empty, pol reg
-    ind1 = 10 * np.arange(9)
-    ind2 = []
-    indp = [0, 1]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, (indp, []))
-    dcheck = uv.data_array[ind1]
-    if future_shapes:
-        dcheck = np.squeeze(dcheck[:, :, indp])
-    else:
-        dcheck = np.squeeze(dcheck[:, :, :, indp])
-    assert np.all(d == dcheck)
-    assert not d.flags.writeable
-    # Ensure a view was returned
-    if future_shapes:
-        uv.data_array[ind1[1], 0, indp[0]] = 5.43
-        assert d[1, 0, 0] == uv.data_array[ind1[1], 0, indp[0]]
-    else:
-        uv.data_array[ind1[1], 0, 0, indp[0]] = 5.43
-        assert d[1, 0, 0] == uv.data_array[ind1[1], 0, 0, indp[0]]
+    if ind1 is None:
+        polind = (None, indp)
+        ind = ind2
+        # Get actual arrays of integers for indexing
+        bltinds = np.arange(uv.Nblts)[ind]
+        polidx = np.arange(uv.Npols)[indp]
 
-    # force copy
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, (indp, []), force_copy=True)
-    dcheck = uv.data_array[ind1]
-    if future_shapes:
-        dcheck = np.squeeze(dcheck[:, :, indp])
-    else:
-        dcheck = np.squeeze(dcheck[:, :, :, indp])
-    assert np.all(d == dcheck)
-    assert d.flags.writeable
-    # Ensure a copy was returned
-    if future_shapes:
-        uv.data_array[ind1[1], 0, indp[0]] = 4.3
-        assert d[1, 0, 0] != uv.data_array[ind1[1], 0, indp[0]]
-    else:
-        uv.data_array[ind1[1], 0, 0, indp[0]] = 4.3
-        assert d[1, 0, 0] != uv.data_array[ind1[1], 0, 0, indp[0]]
+    elif ind2 is None:
+        polind = (indp, None)
+        ind = ind1
+        # Get actual arrays of integers for indexing
+        bltinds = np.arange(uv.Nblts)[ind]
+        polidx = np.arange(uv.Npols)[indp]
 
-    # ind1 reg, ind2 empty, pol not reg
-    ind1 = 10 * np.arange(9)
-    ind2 = []
-    indp = [0, 1, 3]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, (indp, []))
-    dcheck = uv.data_array[ind1]
-    if future_shapes:
-        dcheck = np.squeeze(dcheck[:, :, indp])
     else:
-        dcheck = np.squeeze(dcheck[:, :, :, indp])
-    assert np.all(d == dcheck)
-    assert not d.flags.writeable
-    # Ensure a copy was returned
-    if future_shapes:
-        uv.data_array[ind1[1], 0, indp[0]] = 1.2
-        assert d[1, 0, 0] != uv.data_array[ind1[1], 0, indp[0]]
-    else:
-        uv.data_array[ind1[1], 0, 0, indp[0]] = 1.2
-        assert d[1, 0, 0] != uv.data_array[ind1[1], 0, 0, indp[0]]
+        polind = (indp, indp)
 
-    # ind1 not reg, ind2 empty, pol reg
-    ind1 = [0, 4, 5]
-    ind2 = []
-    indp = [0, 1]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, (indp, []))
-    dcheck = uv.data_array[ind1]
-    if future_shapes:
-        dcheck = np.squeeze(dcheck[:, :, indp])
-    else:
-        dcheck = np.squeeze(dcheck[:, :, :, indp])
-    assert np.all(d == dcheck)
-    assert not d.flags.writeable
-    # Ensure a copy was returned
-    if future_shapes:
-        uv.data_array[ind1[1], 0, indp[0]] = 8.2
-        assert d[1, 0, 0] != uv.data_array[ind1[1], 0, indp[0]]
-    else:
-        uv.data_array[ind1[1], 0, 0, indp[0]] = 8.2
-        assert d[1, 0, 0] != uv.data_array[ind1[1], 0, 0, indp[0]]
+    copy_made = force_copy or not all(
+        (
+            isinstance(ind1, slice) or ind1 is None,
+            isinstance(ind2, slice) or ind2 is None,
+            isinstance(indp, slice),
+        )
+    )
 
-    # ind1 not reg, ind2 empty, pol not reg
-    ind1 = [0, 4, 5]
-    ind2 = []
-    indp = [0, 1, 3]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, (indp, []))
-    dcheck = uv.data_array[ind1]
-    if future_shapes:
-        dcheck = np.squeeze(dcheck[:, :, indp])
+    d = uv._smart_slicing(
+        uv.data_array, ind1, ind2, polind, force_copy=force_copy, squeeze=squeeze
+    )
+    if ind1 is None:
+        dcheck = np.conj(uv.data_array[ind])
+    elif ind2 is None:
+        dcheck = uv.data_array[ind]
     else:
-        dcheck = np.squeeze(dcheck[:, :, :, indp])
-    assert np.all(d == dcheck)
-    assert not d.flags.writeable
-    # Ensure a copy was returned
-    if future_shapes:
-        uv.data_array[ind1[1], 0, indp[0]] = 3.4
-        assert d[1, 0, 0] != uv.data_array[ind1[1], 0, indp[0]]
-    else:
-        uv.data_array[ind1[1], 0, 0, indp[0]] = 3.4
-        assert d[1, 0, 0] != uv.data_array[ind1[1], 0, 0, indp[0]]
+        dcheck = np.append(uv.data_array[ind1], np.conj(uv.data_array[ind2]), axis=0)
 
-    # ind1 empty, ind2 reg, pol reg
-    # Note conjugation test ensures the result is a copy, not a view.
-    ind1 = []
-    ind2 = 10 * np.arange(9)
-    indp = [0, 1]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, ([], indp))
-    dcheck = uv.data_array[ind2]
-    if future_shapes:
-        dcheck = np.squeeze(np.conj(dcheck[:, :, indp]))
-    else:
-        dcheck = np.squeeze(np.conj(dcheck[:, :, :, indp]))
-    assert np.all(d == dcheck)
+    dcheck = dcheck[..., indp]
+    # if squeeze == "default" and ind1 != SINGLE_IND:
+    dcheck = np.squeeze(dcheck)
 
-    # ind1 empty, ind2 reg, pol not reg
-    ind1 = []
-    ind2 = 10 * np.arange(9)
-    indp = [0, 1, 3]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, ([], indp))
-    dcheck = uv.data_array[ind2]
-    if future_shapes:
-        dcheck = np.squeeze(np.conj(dcheck[:, :, indp]))
-    else:
-        dcheck = np.squeeze(np.conj(dcheck[:, :, :, indp]))
-    assert np.all(d == dcheck)
+    assert np.all(d == dcheck)  # don't care about shape.
 
-    # ind1 empty, ind2 not reg, pol reg
-    ind1 = []
-    ind2 = [1, 4, 5, 10]
-    indp = [0, 1]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, ([], indp))
-    dcheck = uv.data_array[ind2]
-    if future_shapes:
-        dcheck = np.squeeze(np.conj(dcheck[:, :, indp]))
-    else:
-        dcheck = np.squeeze(np.conj(dcheck[:, :, :, indp]))
-    assert np.all(d == dcheck)
+    # Ensure a view/copy was returned
+    if ind1 in (
+        REG_IND,
+        IRREG_IND,
+    ):  # Note conjugation test ensures the result is a copy, not a view.
+        if force_copy:
+            assert d.flags.writeable
+        else:
+            assert not d.flags.writeable
 
-    # ind1 empty, ind2 not reg, pol not reg
-    ind1 = []
-    ind2 = [1, 4, 5, 10]
-    indp = [0, 1, 3]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, ([], indp))
-    dcheck = uv.data_array[ind2]
-    if future_shapes:
-        dcheck = np.squeeze(np.conj(dcheck[:, :, indp]))
-    else:
-        dcheck = np.squeeze(np.conj(dcheck[:, :, :, indp]))
-    assert np.all(d == dcheck)
-
-    # ind1, ind2 not empty, pol reg
-    ind1 = np.arange(20)
-    ind2 = np.arange(30, 40)
-    indp = [0, 1]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, (indp, indp))
-    dcheck = np.append(uv.data_array[ind1], np.conj(uv.data_array[ind2]), axis=0)
-    if future_shapes:
-        dcheck = np.squeeze(dcheck[:, :, indp])
-    else:
-        dcheck = np.squeeze(dcheck[:, :, :, indp])
-    assert np.all(d == dcheck)
-
-    # ind1, ind2 not empty, pol not reg
-    ind1 = np.arange(20)
-    ind2 = np.arange(30, 40)
-    indp = [0, 1, 3]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, (indp, indp))
-    dcheck = np.append(uv.data_array[ind1], np.conj(uv.data_array[ind2]), axis=0)
-    if future_shapes:
-        dcheck = np.squeeze(dcheck[:, :, indp])
-    else:
-        dcheck = np.squeeze(dcheck[:, :, :, indp])
-    assert np.all(d == dcheck)
-
-    # test single element
-    ind1 = [45]
-    ind2 = []
-    indp = [0, 1]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, (indp, []))
-    dcheck = uv.data_array[ind1]
-    if future_shapes:
-        dcheck = np.squeeze(dcheck[:, :, indp])
-    else:
-        dcheck = np.squeeze(dcheck[:, :, :, indp])
-    assert np.all(d == dcheck)
-
-    # test single element
-    ind1 = []
-    ind2 = [45]
-    indp = [0, 1]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, ([], indp))
-    assert np.all(d == np.conj(dcheck))
-
-    # Full squeeze
-    ind1 = [45]
-    ind2 = []
-    indp = [0, 1]
-    d = uv._smart_slicing(uv.data_array, ind1, ind2, (indp, []), squeeze="full")
-    dcheck = uv.data_array[ind1]
-    if future_shapes:
-        dcheck = np.squeeze(dcheck[:, :, indp])
-    else:
-        dcheck = np.squeeze(dcheck[:, :, :, indp])
-    assert np.all(d == dcheck)
+        if future_shapes:
+            uv.data_array[bltinds[1], 0, polidx[0]] = 5.43
+            if copy_made:
+                assert d[1, 0, 0] != uv.data_array[bltinds[1], 0, polidx[0]]
+            else:
+                assert d[1, 0, 0] == uv.data_array[bltinds[1], 0, polidx[0]]
+        else:
+            uv.data_array[bltinds[1], 0, 0, polidx[0]] = 5.43
+            if copy_made:
+                assert d[1, 0, 0] != uv.data_array[bltinds[1], 0, 0, polidx[0]]
+            else:
+                assert d[1, 0, 0] == uv.data_array[bltinds[1], 0, 0, polidx[0]]
 
 
-def test_get_data(casa_uvfits):
+@pytest.mark.parametrize("kind", ["data", "flags", "nsamples", "times", "lsts"])
+def test_get_data(casa_uvfits, kind):
     # Test get_data function for easy access to data
     uv = casa_uvfits
 
+    fnc = getattr(uv, "get_" + kind)
+    if kind.endswith("s"):
+        kind = kind[:-1]
+    thing = getattr(uv, kind + "_array")
+
     # Get an antpair/pol combo
     ant1 = uv.ant_1_array[0]
     ant2 = uv.ant_2_array[0]
     pol = uv.polarization_array[0]
     bltind = np.where((uv.ant_1_array == ant1) & (uv.ant_2_array == ant2))[0]
-    dcheck = np.squeeze(uv.data_array[bltind, :, 0])
-    d = uv.get_data(ant1, ant2, pol)
+    if kind in ["time", "lst"]:
+        dcheck = thing[bltind]
+    else:
+        dcheck = np.squeeze(thing[bltind, :, 0])
+
+    d = fnc(ant1, ant2, pol)
     assert np.all(dcheck == d)
 
-    d = uv.get_data(ant1, ant2, uvutils.polnum2str(pol))
+    d = fnc(ant1, ant2, uvutils.polnum2str(pol))
     assert np.all(dcheck == d)
 
-    d = uv.get_data((ant1, ant2, pol))
+    d = fnc((ant1, ant2, pol))
     assert np.all(dcheck == d)
 
     with pytest.raises(ValueError, match="no more than 3 key values can be passed"):
-        uv.get_data((ant1, ant2, pol), (ant1, ant2, pol))
+        fnc((ant1, ant2, pol), (ant1, ant2, pol))
 
     # Check conjugation
-    d = uv.get_data(ant2, ant1, pol)
+    d = fnc(ant2, ant1, pol)
     assert np.all(dcheck == np.conj(d))
+    assert d.dtype == dcheck.dtype
 
     # Check cross pol conjugation
-    d = uv.get_data(ant2, ant1, uv.polarization_array[2])
-    d1 = uv.get_data(ant1, ant2, uv.polarization_array[3])
+    d = fnc(ant2, ant1, uv.polarization_array[2])
+    d1 = fnc(ant1, ant2, uv.polarization_array[3])
     assert np.all(d == np.conj(d1))
 
     # Antpair only
-    dcheck = np.squeeze(uv.data_array[bltind])
-    d = uv.get_data(ant1, ant2)
+    if kind in ["time", "lst"]:
+        dcheck = thing[bltind]
+    else:
+        dcheck = np.squeeze(thing[bltind, :, :])
+
+    d = fnc(ant1, ant2)
     assert np.all(dcheck == d)
 
     # Pol number only
-    dcheck = np.squeeze(uv.data_array[..., 0])
-    d = uv.get_data(pol)
-    assert np.all(dcheck == d)
+    if kind in ["time", "lst"]:
+        dcheck = thing
+    else:
+        dcheck = np.squeeze(thing[..., 0])
 
-
-def test_get_flags(casa_uvfits):
-    # Test function for easy access to flags
-    uv = casa_uvfits
-
-    # Get an antpair/pol combo
-    ant1 = uv.ant_1_array[0]
-    ant2 = uv.ant_2_array[0]
-    pol = uv.polarization_array[0]
-    bltind = np.where((uv.ant_1_array == ant1) & (uv.ant_2_array == ant2))[0]
-    dcheck = np.squeeze(uv.flag_array[bltind, :, 0])
-    d = uv.get_flags(ant1, ant2, pol)
-    assert np.all(dcheck == d)
-
-    d = uv.get_flags(ant1, ant2, uvutils.polnum2str(pol))
-    assert np.all(dcheck == d)
-
-    d = uv.get_flags((ant1, ant2, pol))
-    assert np.all(dcheck == d)
-
-    with pytest.raises(ValueError, match="no more than 3 key values can be passed"):
-        uv.get_flags((ant1, ant2, pol), (ant1, ant2, pol))
-
-    # Check conjugation
-    d = uv.get_flags(ant2, ant1, pol)
-    assert np.all(dcheck == d)
-    assert d.dtype == np.bool_
-
-    # Antpair only
-    dcheck = np.squeeze(uv.flag_array[bltind])
-    d = uv.get_flags(ant1, ant2)
-    assert np.all(dcheck == d)
-
-    # Pol number only
-    dcheck = np.squeeze(uv.flag_array[..., 0])
-    d = uv.get_flags(pol)
-    assert np.all(dcheck == d)
-
-
-def test_get_nsamples(casa_uvfits):
-    # Test function for easy access to nsample array
-    uv = casa_uvfits
-
-    # Get an antpair/pol combo
-    ant1 = uv.ant_1_array[0]
-    ant2 = uv.ant_2_array[0]
-    pol = uv.polarization_array[0]
-    bltind = np.where((uv.ant_1_array == ant1) & (uv.ant_2_array == ant2))[0]
-    dcheck = np.squeeze(uv.nsample_array[bltind, :, 0])
-    d = uv.get_nsamples(ant1, ant2, pol)
-    assert np.all(dcheck == d)
-
-    d = uv.get_nsamples(ant1, ant2, uvutils.polnum2str(pol))
-    assert np.all(dcheck == d)
-
-    d = uv.get_nsamples((ant1, ant2, pol))
-    assert np.all(dcheck == d)
-
-    with pytest.raises(ValueError, match="no more than 3 key values can be passed"):
-        uv.get_nsamples((ant1, ant2, pol), (ant1, ant2, pol))
-
-    # Check conjugation
-    d = uv.get_nsamples(ant2, ant1, pol)
-    assert np.all(dcheck == d)
-
-    # Antpair only
-    dcheck = np.squeeze(uv.nsample_array[bltind])
-    d = uv.get_nsamples(ant1, ant2)
-    assert np.all(dcheck == d)
-
-    # Pol number only
-    dcheck = np.squeeze(uv.nsample_array[..., 0])
-    d = uv.get_nsamples(pol)
+    d = fnc(pol)
     assert np.all(dcheck == d)
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_antpair2ind(paper_uvh5):
+    paper_uvh5.set_rectangularity()
+
+    print(paper_uvh5.blts_are_rectangular, paper_uvh5.time_axis_faster_than_bls)
+
     # Test for baseline-time axis indexer
     uv = paper_uvh5
 
     # get indices
     inds = uv.antpair2ind(0, 1, ordered=False)
-    # fmt: off
-    np.testing.assert_array_equal(
-        inds,
-        np.array(
-            [
-                1, 22, 43, 64, 85, 106, 127, 148, 169,
-                190, 211, 232, 253, 274, 295, 316, 337,
-                358, 379
-            ]
-        )
-    )
-    # fmt: on
-    assert np.issubdtype(inds.dtype, np.integer)
-
-    return
+    print(inds)
+    assert inds == slice(1, None, 21)
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_antpair2ind_conj(paper_uvh5):
     # conjugate (and use key rather than arg expansion)
     uv = paper_uvh5
+    uv.set_rectangularity()
     inds = uv.antpair2ind(0, 1, ordered=False)
     inds2 = uv.antpair2ind((1, 0), ordered=False)
-    np.testing.assert_array_equal(inds, inds2)
-    assert np.issubdtype(inds2.dtype, np.integer)
-
-    return
+    assert inds == inds2
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
@@ -5342,14 +5180,11 @@ def test_antpair2ind_ordered(paper_uvh5):
 
     # make sure conjugated baseline returns nothing
     inds2 = uv.antpair2ind(1, 0, ordered=True)
-    assert inds2.size == 0
+    assert inds2 is None
 
     # now use baseline actually in data
     inds2 = uv.antpair2ind(0, 1, ordered=True)
-    np.testing.assert_array_equal(inds, inds2)
-    assert np.issubdtype(inds2.dtype, np.integer)
-
-    return
+    assert inds == inds2
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
@@ -5359,11 +5194,7 @@ def test_antpair2ind_autos(paper_uvh5):
 
     inds = uv.antpair2ind(0, 0, ordered=True)
     inds2 = uv.antpair2ind(0, 0, ordered=False)
-    np.testing.assert_array_equal(inds, inds2)
-    assert np.issubdtype(inds.dtype, np.integer)
-    assert np.issubdtype(inds2.dtype, np.integer)
-
-    return
+    assert inds == inds2
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
@@ -5377,76 +5208,6 @@ def test_antpair2ind_exceptions(paper_uvh5):
         uv.antpair2ind("bar", "foo")
     with pytest.raises(ValueError, match="ordered must be a boolean"):
         uv.antpair2ind(0, 1, ordered="foo")
-
-    return
-
-
-def test_get_times(casa_uvfits):
-    # Test function for easy access to times, to work in conjunction with get_data
-    uv = casa_uvfits
-    # Get an antpair/pol combo (pol shouldn't actually effect result)
-    ant1 = uv.ant_1_array[0]
-    ant2 = uv.ant_2_array[0]
-    pol = uv.polarization_array[0]
-    bltind = np.where((uv.ant_1_array == ant1) & (uv.ant_2_array == ant2))[0]
-    dcheck = uv.time_array[bltind]
-    d = uv.get_times(ant1, ant2, pol)
-    assert np.all(dcheck == d)
-
-    d = uv.get_times(ant1, ant2, uvutils.polnum2str(pol))
-    assert np.all(dcheck == d)
-
-    d = uv.get_times((ant1, ant2, pol))
-    assert np.all(dcheck == d)
-
-    with pytest.raises(ValueError, match="no more than 3 key values can be passed"):
-        uv.get_times((ant1, ant2, pol), (ant1, ant2, pol))
-
-    # Check conjugation
-    d = uv.get_times(ant2, ant1, pol)
-    assert np.all(dcheck == d)
-
-    # Antpair only
-    d = uv.get_times(ant1, ant2)
-    assert np.all(dcheck == d)
-
-    # Pol number only
-    d = uv.get_times(pol)
-    assert np.all(d == uv.time_array)
-
-
-def test_get_lsts(casa_uvfits):
-    # Test function for easy access to LSTs, to work in conjunction with get_data
-    uv = casa_uvfits
-    # Get an antpair/pol combo (pol shouldn't actually effect result)
-    ant1 = uv.ant_1_array[0]
-    ant2 = uv.ant_2_array[0]
-    pol = uv.polarization_array[0]
-    bltind = np.where((uv.ant_1_array == ant1) & (uv.ant_2_array == ant2))[0]
-    dcheck = uv.lst_array[bltind]
-    d = uv.get_lsts(ant1, ant2, pol)
-    assert np.all(dcheck == d)
-
-    d = uv.get_lsts(ant1, ant2, uvutils.polnum2str(pol))
-    assert np.all(dcheck == d)
-
-    d = uv.get_lsts((ant1, ant2, pol))
-    assert np.all(dcheck == d)
-
-    with pytest.raises(ValueError, match="no more than 3 key values can be passed"):
-        uv.get_lsts((ant1, ant2, pol), (ant1, ant2, pol))
-
-    # Check conjugation
-    d = uv.get_lsts(ant2, ant1, pol)
-    assert np.all(dcheck == d)
-
-    # Antpair only
-    d = uv.get_lsts(ant1, ant2)
-    assert np.all(dcheck == d)
-
-    # Pol number only
-    d = uv.get_lsts(pol)
-    assert np.all(d == uv.lst_array)
 
 
 def test_antpairpol_iter(casa_uvfits):
@@ -6788,6 +6549,7 @@ def test_redundancy_missing_groups(method, pyuvsim_redundant, tmp_path):
     uv1._consolidate_phase_center_catalogs(
         reference_catalog=uv0.phase_center_catalog, ignore_name=True
     )
+    print(uv0.flag_array.shape, uv1.flag_array.shape)
     assert uv0 == uv1  # Check that writing compressed files causes no issues.
 
     with uvtest.check_warnings(
@@ -7113,7 +6875,7 @@ def test_upsample_in_time_with_flags(hera_uvh5):
 
     # add flags and upsample again
     inds01 = uv_object.antpair2ind(0, 1)
-    uv_object.flag_array[inds01[0], 0, 0] = True
+    uv_object.flag_array[inds01.start or 0, 0, 0] = True
     uv_object.upsample_in_time(max_integration_time, blt_order="baseline")
 
     # data and nsamples should be changed as normal, but flagged
@@ -7245,7 +7007,7 @@ def test_upsample_in_time_summing_correlator_mode_with_flags(hera_uvh5):
 
     # add flags and upsample again
     inds01 = uv_object.antpair2ind(0, 1)
-    uv_object.flag_array[inds01[0], 0, 0] = True
+    uv_object.flag_array[inds01, 0, 0] = True
     max_integration_time = np.amin(uv_object.integration_time) / 2.0
     uv_object.upsample_in_time(
         max_integration_time, blt_order="baseline", summing_correlator_mode=True
@@ -7524,7 +7286,7 @@ def test_downsample_in_time_partial_flags(hera_uvh5):
     # just be the unflagged value and nsample should be half the unflagged one
     # and the output should not be flagged.
     inds01 = uv_object.antpair2ind(0, 1)
-    uv_object.flag_array[inds01[0], 0, 0] = True
+    uv_object.flag_array[inds01, 0, 0][0] = True
     uv_object2 = uv_object.copy()
 
     uv_object.downsample_in_time(
@@ -7581,9 +7343,9 @@ def test_downsample_in_time_totally_flagged(hera_uvh5, future_shapes):
     # should be flagged
     inds01 = uv_object.antpair2ind(0, 1)
     if future_shapes:
-        uv_object.flag_array[inds01[:2], 0, 0] = True
+        uv_object.flag_array[inds01, 0, 0][:2] = True
     else:
-        uv_object.flag_array[inds01[:2], 0, 0, 0] = True
+        uv_object.flag_array[inds01, 0, 0, 0][:2] = True
     uv_object2 = uv_object.copy()
 
     uv_object.downsample_in_time(
@@ -7774,7 +7536,7 @@ def test_downsample_in_time_summing_correlator_mode_partial_flags(hera_uvh5):
     # just be the unflagged value and nsample should be half the unflagged one
     # and the output should not be flagged.
     inds01 = uv_object.antpair2ind(0, 1)
-    uv_object.flag_array[inds01[0], 0, 0] = True
+    uv_object.flag_array[inds01, 0, 0][0] = True
     uv_object.downsample_in_time(
         min_int_time=min_integration_time,
         blt_order="baseline",
@@ -7820,7 +7582,7 @@ def test_downsample_in_time_summing_correlator_mode_totally_flagged(hera_uvh5):
     # data and nsample should have the same results as no flags but the output
     # should be flagged
     inds01 = uv_object.antpair2ind(0, 1)
-    uv_object.flag_array[inds01[:2], 0, 0] = True
+    uv_object.flag_array[inds01, 0, 0][:2] = True
     uv_object.downsample_in_time(
         min_int_time=min_integration_time,
         blt_order="baseline",
@@ -8135,7 +7897,7 @@ def test_downsample_in_time_nsample_precision(hera_uvh5):
     # just be the unflagged value and nsample should be half the unflagged one
     # and the output should not be flagged.
     inds01 = uv_object.antpair2ind(0, 1)
-    uv_object.flag_array[inds01[0], 0, 0] = True
+    uv_object.flag_array[inds01, 0, 0][0] = True
     uv_object2 = uv_object.copy()
 
     # change precision of nsample array
@@ -8243,9 +8005,9 @@ def test_downsample_in_time_errors(hera_uvh5):
 
     # make a gap in the times to check a warning about that
     inds01 = uv_object.antpair2ind(0, 1)
-    initial_int_time = uv_object.integration_time[inds01[0]]
+    initial_int_time = uv_object.integration_time[inds01][0]
     # time array is in jd, integration time is in sec
-    uv_object.time_array[inds01[-1]] += initial_int_time / (24 * 3600)
+    uv_object.time_array[inds01][-1] += initial_int_time / (24 * 3600)
     uv_object.Ntimes += 1
     min_integration_time = 2 * np.amin(uv_object.integration_time)
     times_01 = uv_object.get_times(0, 1)
@@ -8339,7 +8101,7 @@ def test_downsample_in_time_varying_integration_time(hera_uvh5):
     # test handling (& warnings) with varying integration time in a baseline
     # First, change both integration time & time array to match
     inds01 = uv_object.antpair2ind(0, 1)
-    initial_int_time = uv_object.integration_time[inds01[0]]
+    initial_int_time = uv_object.integration_time[inds01][0]
     # time array is in jd, integration time is in sec
     uv_object.time_array[inds01[-2]] += (initial_int_time / 2) / (24 * 3600)
     uv_object.time_array[inds01[-1]] += (3 * initial_int_time / 2) / (24 * 3600)
@@ -8397,7 +8159,7 @@ def test_downsample_in_time_varying_int_time_partial_flags(hera_uvh5):
     # (so 12 normal length, 2 double length)
     # change integration time & time array to match
     inds01 = uv_object.antpair2ind(0, 1)
-    initial_int_time = uv_object.integration_time[inds01[0]]
+    initial_int_time = uv_object.integration_time[inds01][0]
     # time array is in jd, integration time is in sec
     uv_object.time_array[inds01[-2]] += (initial_int_time / 2) / (24 * 3600)
     uv_object.time_array[inds01[-1]] += (3 * initial_int_time / 2) / (24 * 3600)
@@ -8406,9 +8168,9 @@ def test_downsample_in_time_varying_int_time_partial_flags(hera_uvh5):
     uv_object.Ntimes = np.unique(uv_object.time_array).size
 
     # add a flag on last time
-    uv_object.flag_array[inds01[-1]] = True
+    uv_object.flag_array[inds01][-1] = True
     # add a flag on thrid to last time
-    uv_object.flag_array[inds01[-3]] = True
+    uv_object.flag_array[inds01][-3] = True
 
     uv_object2 = uv_object.copy()
 
@@ -8444,8 +8206,8 @@ def test_downsample_in_time_varying_integration_time_warning(hera_uvh5):
 
     # Next, change just integration time, so time array doesn't match
     inds01 = uv_object.antpair2ind(0, 1)
-    initial_int_time = uv_object.integration_time[inds01[0]]
-    uv_object.integration_time[inds01[-2:]] += initial_int_time
+    initial_int_time = uv_object.integration_time[inds01][0]
+    uv_object.integration_time[inds01][-2:] += initial_int_time
     min_integration_time = 2 * np.amin(uv_object.integration_time)
     with uvtest.check_warnings(
         UserWarning, "The time difference between integrations is different than"
@@ -8794,15 +8556,8 @@ def test_resample_in_time_only_upsample(bda_test_file):
     # again, with only_upsample set
     uv_object.resample_in_time(8, only_upsample=True, allow_drift=True)
     # Should have all greater than or equal to the target integration time
-    assert np.all(
-        np.logical_or(
-            np.logical_or(
-                np.isclose(uv_object.integration_time, 2.0),
-                np.isclose(uv_object.integration_time, 4.0),
-            ),
-            np.isclose(uv_object.integration_time, 8.0),
-        )
-    )
+    tint = uv_object.integration_time
+    assert np.all(np.isclose(tint, 2.0) | np.isclose(tint, 4.0) | np.isclose(tint, 8.0))
 
     # 2s integration time
     out_data_1_136 = uv_object.get_data((1, 136))
@@ -12675,11 +12430,6 @@ def test_setting_time_axis_wrongly(casa_uvfits):
 
 
 def test_set_rectangularity(casa_uvfits, hera_uvh5):
-    # without setting force=True, starting from unknown rectangularity, it does nothing.
-    casa_uvfits.set_rectangularity()
-    assert casa_uvfits.blts_are_rectangular is None
-    assert casa_uvfits.time_axis_faster_than_bls is None
-
     # setting force=True will set the rectangularity attributes only if obvious
     casa_uvfits.set_rectangularity(force=True)
     assert casa_uvfits.blts_are_rectangular is False

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -6586,7 +6586,7 @@ def test_quick_redundant_vs_redundant_test_array(pyuvsim_redundant):
         grp = []
         grp.extend(bl.compressed())
         for other_bls in reds:
-            if set(reds.compressed()).issubset(other_bls.compressed()):
+            if set(reds.compressed()).issubset(other_bls.compressed()):  # noqa: B038
                 grp.extend(other_bls.compressed())
         grp = np.unique(grp).tolist()
         groups.append(grp)
@@ -6627,7 +6627,7 @@ def test_redundancy_finder_when_nblts_not_nbls_times_ntimes(casa_uvfits):
         grp = []
         grp.extend(bl.compressed())
         for other_bls in reds:
-            if set(reds.compressed()).issubset(other_bls.compressed()):
+            if set(reds.compressed()).issubset(other_bls.compressed()):  # noqa: B038
                 grp.extend(other_bls.compressed())
         grp = np.unique(grp).tolist()
         groups.append(grp)
@@ -12488,15 +12488,17 @@ def test_antpair2ind_rect_not_ordered(hera_uvh5):
     hera_uvh5.reorder_blts(order="baseline", minor_order="time")
 
     assert hera_uvh5.blts_are_rectangular
-    inds = hera_uvh5.antpair2ind((0, 1), ordered=False)
 
-    assert inds == hera_uvh5.antpair2ind((1, 0), ordered=True)
+    print(hera_uvh5.get_antpairs())
+
+    inds = hera_uvh5.antpair2ind((0, 1), ordered=True)
+
+    assert np.all(inds == hera_uvh5.antpair2ind((1, 0), ordered=False))
 
 
 def test_antpair2ind_not_rect_not_ordered(hera_uvh5):
-    hera_uvh5.reorder_blts(order="ant1")
-
+    hera_uvh5.reorder_blts(order=np.random.permutation(hera_uvh5.Nblts))
     assert not hera_uvh5.blts_are_rectangular
-    inds = hera_uvh5.antpair2ind((0, 1), ordered=False)
+    inds = hera_uvh5.antpair2ind((1, 0), ordered=False)
 
-    assert inds == hera_uvh5.antpair2ind((1, 0), ordered=True)
+    assert np.all(inds == hera_uvh5.antpair2ind((0, 1), ordered=True))

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -8104,10 +8104,10 @@ def test_downsample_in_time_varying_integration_time(hera_uvh5):
     inds01 = uv_object.antpair2ind(0, 1)
     initial_int_time = uv_object.integration_time[inds01][0]
     # time array is in jd, integration time is in sec
-    uv_object.time_array[inds01[-2]] += (initial_int_time / 2) / (24 * 3600)
-    uv_object.time_array[inds01[-1]] += (3 * initial_int_time / 2) / (24 * 3600)
+    uv_object.time_array[inds01][-2] += (initial_int_time / 2) / (24 * 3600)
+    uv_object.time_array[inds01][-1] += (3 * initial_int_time / 2) / (24 * 3600)
     uv_object.set_lsts_from_time_array()
-    uv_object.integration_time[inds01[-2:]] += initial_int_time
+    uv_object.integration_time[inds01][-2:] += initial_int_time
     uv_object.Ntimes = np.unique(uv_object.time_array).size
     min_integration_time = 2 * np.amin(uv_object.integration_time)
     # check that there are no warnings about inconsistencies between
@@ -8162,10 +8162,10 @@ def test_downsample_in_time_varying_int_time_partial_flags(hera_uvh5):
     inds01 = uv_object.antpair2ind(0, 1)
     initial_int_time = uv_object.integration_time[inds01][0]
     # time array is in jd, integration time is in sec
-    uv_object.time_array[inds01[-2]] += (initial_int_time / 2) / (24 * 3600)
-    uv_object.time_array[inds01[-1]] += (3 * initial_int_time / 2) / (24 * 3600)
+    uv_object.time_array[inds01][-2] += (initial_int_time / 2) / (24 * 3600)
+    uv_object.time_array[inds01][-1] += (3 * initial_int_time / 2) / (24 * 3600)
     uv_object.set_lsts_from_time_array()
-    uv_object.integration_time[inds01[-2:]] += initial_int_time
+    uv_object.integration_time[inds01][-2:] += initial_int_time
     uv_object.Ntimes = np.unique(uv_object.time_array).size
 
     # add a flag on last time

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -12489,3 +12489,34 @@ def test_antpair2ind_not_rect_not_ordered(hera_uvh5):
     inds = hera_uvh5.antpair2ind((1, 0), ordered=False)
 
     assert np.all(inds == hera_uvh5.antpair2ind((0, 1), ordered=True))
+
+
+def test_antpair2ind_unordered_both_exist(hera_uvh5):
+    # Make a new object that has conjugated baselines in it as well.
+    conj = hera_uvh5.copy()
+    conj.conjugate_bls()
+    full = conj.concat(hera_uvh5)
+
+    inds_ordered = full.antpair2ind((0, 1), ordered=True)
+    inds_unordered = full.antpair2ind((0, 1), ordered=False)
+
+    idxs = np.arange(full.Nblts)
+    assert len(idxs[inds_ordered]) < len(idxs[inds_unordered])
+
+
+def test_key2inds_nonexistent_pol(hera_uvh5):
+    with pytest.raises(KeyError, match="Polarization -7 not found in data"):
+        hera_uvh5._key2inds((1, 0, -7))
+
+
+def test_get_ants_rectangular(hera_uvh5):
+    hera_uvh5.blts_are_rectangular = False  # even if its true...
+    ants = np.sort(hera_uvh5.get_ants())
+
+    hera_uvh5.reorder_blts(order="baseline", minor_order="time")
+    ants1 = np.sort(hera_uvh5.get_ants())
+    assert np.all(ants1 == ants)
+
+    hera_uvh5.reorder_blts(order="time", minor_order="baseline")
+    ants1 = np.sort(hera_uvh5.get_ants())
+    assert np.all(ants1 == ants)

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -8714,7 +8714,7 @@ class UVData(UVBase):
 
         # Update the rectangularity attributes
         if blt_inds is not None:
-            self.set_rectangularity(force=True)
+            uv_obj.set_rectangularity(force=True)
 
         # If we have a flex-pol data set, but we only have one pol, then this doesn't
         # need to be flex-pol anymore, and we can drop it here

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -111,6 +111,17 @@ def _warn_old_phase_attr(__name):
     warnings.warn(warn_str, DeprecationWarning)
 
 
+def _clear_antpair2ind_cache(self):
+    """Clear the antpair2ind cache."""
+    self.__antpair2ind_cache = {}
+    self.__key2ind_cache = {}
+
+
+def _clear_key2ind_cache(self):
+    """Clear the antpair2ind cache."""
+    self.__key2ind_cache = {}
+
+
 class UVData(UVBase):
     """
     A class for defining a radio interferometer dataset.
@@ -255,15 +266,6 @@ class UVData(UVBase):
             tols=uvutils.RADIAN_TOL,
         )
 
-        def clear_antpair2ind_cache(self):
-            """Clear the antpair2ind cache."""
-            self.__antpair2ind_cache = {}
-            self.__key2ind_cache = {}
-
-        def clear_key2ind_cache(self):
-            """Clear the antpair2ind cache."""
-            self.__key2ind_cache = {}
-
         desc = (
             "Array of numbers for the first antenna, which is matched to that in "
             "the antenna_numbers attribute. Shape (Nblts), type = int."
@@ -274,7 +276,7 @@ class UVData(UVBase):
             expected_type=int,
             form=("Nblts",),
             acceptable_range=(0, 2147483647),
-            setter=clear_antpair2ind_cache,
+            setter=_clear_antpair2ind_cache,
         )
 
         desc = (
@@ -287,7 +289,7 @@ class UVData(UVBase):
             expected_type=int,
             form=("Nblts",),
             acceptable_range=(0, 2147483647),
-            setter=clear_antpair2ind_cache,
+            setter=_clear_antpair2ind_cache,
         )
 
         desc = (
@@ -336,7 +338,7 @@ class UVData(UVBase):
             expected_type=int,
             acceptable_vals=list(np.arange(-8, 5)),
             form=("Npols",),
-            setter=clear_key2ind_cache,
+            setter=_clear_key2ind_cache,
         )
 
         desc = (
@@ -3892,23 +3894,9 @@ class UVData(UVBase):
                 raise KeyError(f"Polarization {orig_pol} not found in data.")
 
         # Convert to slices if possible
-        def slicify(ind):
-            if ind is None or isinstance(ind, slice):
-                return ind
-            if len(ind) == 0:
-                return None
-
-            if len(set(np.ediff1d(ind))) <= 1:
-                return slice(
-                    ind[0], ind[-1] + 1, ind[1] - ind[0] if len(ind) > 1 else 1
-                )
-            else:
-                # can't slicify
-                return ind
-
-        blt_ind1 = slicify(blt_ind1)
-        blt_ind2 = slicify(blt_ind2)
-        pol_ind = (slicify(pol_ind[0]), slicify(pol_ind[1]))
+        blt_ind1 = uvutils.slicify(blt_ind1)
+        blt_ind2 = uvutils.slicify(blt_ind2)
+        pol_ind = (uvutils.slicify(pol_ind[0]), uvutils.slicify(pol_ind[1]))
 
         self.__key2ind_cache[key] = (blt_ind1, blt_ind2, pol_ind)
         return (blt_ind1, blt_ind2, pol_ind)
@@ -4000,7 +3988,7 @@ class UVData(UVBase):
             Array of unique antennas with data associated with them.
         """
         if self.blts_are_rectangular:
-            if self.blt_order == ("baseline", "time"):
+            if self.time_axis_faster_than_bls:
                 ant1 = self.ant_1_array[:: self.Ntimes]
                 ant2 = self.ant_2_array[:: self.Ntimes]
             else:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -110,17 +110,6 @@ def _warn_old_phase_attr(__name):
     warnings.warn(warn_str, DeprecationWarning)
 
 
-def _clear_antpair2ind_cache(self):
-    """Clear the antpair2ind cache."""
-    self.__antpair2ind_cache = {}
-    self.__key2ind_cache = {}
-
-
-def _clear_key2ind_cache(self):
-    """Clear the antpair2ind cache."""
-    self.__key2ind_cache = {}
-
-
 class UVData(UVBase):
     """
     A class for defining a radio interferometer dataset.
@@ -275,7 +264,7 @@ class UVData(UVBase):
             expected_type=int,
             form=("Nblts",),
             acceptable_range=(0, 2147483647),
-            setter=_clear_antpair2ind_cache,
+            setter=self._clear_antpair2ind_cache,
         )
 
         desc = (
@@ -288,7 +277,7 @@ class UVData(UVBase):
             expected_type=int,
             form=("Nblts",),
             acceptable_range=(0, 2147483647),
-            setter=_clear_antpair2ind_cache,
+            setter=self._clear_antpair2ind_cache,
         )
 
         desc = (
@@ -337,7 +326,7 @@ class UVData(UVBase):
             expected_type=int,
             acceptable_vals=list(np.arange(-8, 5)),
             form=("Npols",),
-            setter=_clear_key2ind_cache,
+            setter=self._clear_key2ind_cache,
         )
 
         desc = (
@@ -784,6 +773,17 @@ class UVData(UVBase):
         self.__key2ind_cache = {}
 
         super(UVData, self).__init__()
+
+    @staticmethod
+    def _clear_antpair2ind_cache(obj):
+        """Clear the antpair2ind cache."""
+        obj.__antpair2ind_cache = {}
+        obj.__key2ind_cache = {}
+
+    @staticmethod
+    def _clear_key2ind_cache(obj):
+        """Clear the antpair2ind cache."""
+        obj.__key2ind_cache = {}
 
     @staticmethod
     @combine_docstrings(new_uvdata, style=DocstringStyle.NUMPYDOC)
@@ -3657,7 +3657,13 @@ class UVData(UVBase):
             ant1, ant2, Nants_telescope=self.Nants_telescope, attempt256=attempt256
         )
 
-    def antpair2ind(self, ant1, ant2=None, *, ordered=True) -> np.ndarray | slice:
+    def antpair2ind(
+        self,
+        ant1: int | tuple[int, int],
+        ant2: int | None = None,
+        *,
+        ordered: bool = True,
+    ) -> np.ndarray | slice | None:
         """
         Get indices along the baseline-time axis for a given antenna pair.
 
@@ -3678,7 +3684,8 @@ class UVData(UVBase):
         inds : ndarray of int-64 or slice
             If possible, returns a slice object that can be used to index the blt
             axis and get back the data associated with antpair. If not, returns indices
-            of the antpair along the baseline-time axis.
+            of the antpair along the baseline-time axis. If the antpair does not exist
+            in the data, returns None.
         """
         # check for expanded antpair or key
         if ant2 is None:
@@ -3784,11 +3791,16 @@ class UVData(UVBase):
             Note if a cross-pol baseline is requested, the polarization will
             also be reversed so the appropriate correlations are returned.
             e.g. asking for (1, 2, 'xy') may return conj(2, 1, 'yx'), which
-            is equivalent to the requesting baseline. See utils.conj_pol() for
+            is equivalent to the requested baseline. See utils.conj_pol() for
             complete conjugation mapping.
-        pol_ind : tuple of ndarray of int
+        pol_ind : tuple of ndarray of int or slice or None
             polarization indices for blt_ind1 and blt_ind2
 
+        Raises
+        ------
+        KeyError
+            If the requested key is not in the data at all (either in given form
+            or its conjugate).
         """
         orig_key = key
 
@@ -4753,9 +4765,7 @@ class UVData(UVBase):
                 self.ant_1_array[index_array], self.ant_2_array[index_array]
             )
             self.Nbls = np.unique(self.baseline_array).size
-
-            self.__antpair2ind_cache = {}
-            self._key2ind_cache = {}
+            self._clear_antpair2ind_cache(self)
 
     def reorder_pols(
         self,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -4019,7 +4019,7 @@ class UVData(UVBase):
             Array of unique baselines with data associated with them.
         """
         if self.blts_are_rectangular:
-            if self.blt_order == ("baseline", "time"):
+            if self.time_axis_faster_than_bls:
                 return self.baseline_array[:: self.Ntimes]
             else:
                 return self.baseline_array[: self.Nbls]
@@ -7464,6 +7464,8 @@ class UVData(UVBase):
             this.filename = uvutils._combine_filenames(this.filename, obj.filename)
         if this.filename is not None:
             this._filename.form = len(this.filename)
+
+        this.set_rectangularity(force=True)
 
         # Check final object is self-consistent
         if run_check:

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -34,7 +34,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 allowed_cat_types = ["sidereal", "ephem", "unprojected", "driftscan"]
-EMPTY_INDX = np.array([], dtype=np.int64)
 
 reporting_request = (
     " Please report this in our issue log, we have not been able to find a file with "

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,8 @@ description_file = README.md
 # require 3.10.
 # B907 wants us to not have quotes inside fstrings. We decided they helped with readability.
 # B028 wants us to set the stacklevel for warnings, we decided that was unnecessary
-ignore = W503, E203, N806, B905, B907, B028
+# B038 checks for mutating iterators, but seems like a buggy check
+ignore = W503, E203, N806, B905, B907, B028, B038
 max-line-length = 88
 per-file-ignores =
     pyuvdata/tests/*.py: D


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This improves performance for `antpair2ind()` and `_key2inds` in a couple of ways:

1. It caches the results, with some extra logic in there for better cache-invalidation
2. It uses the `blt_ordering` and whether the blts are "rectangular" to enable faster indexing if relevant. These functions now return slices wherever possible, instead of int arrays, which cuts down on memory usage (and is much faster to index by). This has necessitated some fixing up of tests that used the outputs of these assuming they are numpy arrays.

Other than these results being slightly different, there should be no other breaking changes here,  just extra speed if you want it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Indexing the data can be slow, this should speed it up. I'll report back with performance metrics soon.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change

Performance enhancement?

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

