### PR TITLE
better error message if az_za_grid set but no az_array or za_array

### DIFF
--- a/pyuvdata/uvbeam/tests/test_uvbeam.py
+++ b/pyuvdata/uvbeam/tests/test_uvbeam.py
@@ -1233,6 +1233,12 @@ def test_spatial_interpolation_errors(cst_power_2freq_cut):
             az_array=az_interp_vals, za_array=za_interp_vals, freq_array=np.array([100])
         )
 
+    # test errors if frequency interp values outside range
+    with pytest.raises(
+        ValueError,
+        match="If az_za_grid is set to True, az_array and za_array must be provided.",
+    ):
+        uvbeam.interp(az_za_grid=True, freq_array=freq_interp_vals)
     # test errors if positions outside range
     with pytest.raises(
         ValueError,

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -2311,6 +2311,11 @@ class UVBeam(UVBase):
                 kind_use = "nearest"
 
         if az_za_grid:
+            if az_array is None or za_array is None:
+                raise ValueError(
+                    "If az_za_grid is set to True, az_array and za_array must be "
+                    "provided."
+                )
             az_array_use, za_array_use = np.meshgrid(az_array, za_array)
             az_array_use = az_array_use.flatten()
             za_array_use = za_array_use.flatten()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Give users a better error message if they set `az_za_grid=True` in UVBeam.interp but do not provide both the `az_array` and `za_array`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

