### PR TITLE
fix: error when setting freq_interp_kind to an integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Compatibility with Python 3.11
 
 ### Fixed
+- Error when setting `UVBeam.freq_interp_kind` to an integer.
 - Error when reading `mwa_corr_fits` files from the new MWAX correlator
 
 ## [2.3.3] - 2023-05-25

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -2468,11 +2468,11 @@ class UVBeam(UVBase):
                 new_uvb.ordering = "ring"
 
             history_update_string += (
-                " using pyuvdata with interpolation_function = " + interp_func_name
+                f" using pyuvdata with interpolation_function = {interp_func_name}"
             )
             if freq_array is not None:
                 history_update_string += (
-                    " and freq_interp_kind = " + new_uvb.freq_interp_kind
+                    f" and freq_interp_kind = {new_uvb.freq_interp_kind}"
                 )
             history_update_string += "."
             new_uvb.history = new_uvb.history + history_update_string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a bug where setting `freq_interp_kind` to an integer causes an error in `UVBeam.interp()`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes #1303 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

