### PR TITLE
Better time_range vs time_array handling in UVCal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- A `UVCal.get_time_array` method that either returns the mean of the start and stop
+time for each time range or the time_array (if there's a time_array and no time_range).
+
+### Changed
+- Only one of `time_array` and `time_range` (and similarly `lst_array` and `lst_range`)
+can be set on a UVCal object.
+- If `time_range` is set it must be 2D with a shape of (Ntimes, 2) where the first axis
+gives the number of different time solutions and the second axis gives the start/stop
+times for those solutions.
+
 ### Fixed
 - Fixed a bug in `utils.calc_app_coords` that occurred when supplying an astropy `Time`
 object for the `time_array` argument.

--- a/docs/uvcal_tutorial.rst
+++ b/docs/uvcal_tutorial.rst
@@ -26,6 +26,16 @@ guaranteed to have calibration solutions associated with them in the ``gain_arra
 calibration solution is held in the ``ant_array`` attribute (which has the same length
 as the ``gain_array`` or ``delay_array`` along the antenna axis).
 
+Calibration solutions can be described as either applying at a particular time (when
+calibrations were calculated for each integration), in which case the ``time_array``
+attribute will be set, or over a time range (when one solution was calculated over a
+range of integration times), in which case the ``time_range`` attribute will be set.
+Only one of ``time_array`` and ``time_range`` should be set on a UVCal object. If set,
+the ``time_range`` attribute should have shape (``Ntimes``, 2) where the second axis
+gives the beginning and end of the time range. The local sidereal times follow a similar
+pattern, UVCal objects should have either an ``lst_array`` or an ``lst_range`` attribute
+set.
+
 For most users, the convenience methods for quick data access (see
 `UVCal: Quick data access`_) are the easiest way to get data for particular antennas.
 Those methods take the antenna numbers (i.e. numbers listed in ``antenna_numbers``)
@@ -253,8 +263,9 @@ a) Calibration of UVData by UVCal
 UVCal: Selecting data
 ---------------------
 The :meth:`pyuvdata.UVCal.select` method lets you select specific antennas
-(by number or name), frequencies (in Hz or by channel number), times or jones components
-(by number or string) to keep in the object while removing others.
+(by number or name), frequencies (in Hz or by channel number), times (either exact
+times or times covered by a time range) or jones components (by number or string) to keep
+in the object while removing others.
 
 a) Select antennas to keep on UVCal object using the antenna number.
 ********************************************************************
@@ -315,6 +326,7 @@ d) Select times
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
   >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal2 = cal.copy()
 
   >>> # print all the times in the original file
   >>> print(cal.time_array)
@@ -326,6 +338,11 @@ d) Select times
   >>> cal.select(times=cal.time_array[0:3])
 
   >>> print(cal.time_array)
+  [2458098.45677626 2458098.45690053 2458098.45702481]
+
+  >>> # Or select using a time range
+  >>> cal2.select(time_range=[2458098.4567, 2458098.4571])
+  >>> print(cal2.time_array)
   [2458098.45677626 2458098.45690053 2458098.45702481]
 
 d) Select Jones components

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -3673,9 +3673,9 @@ def test_uvcalibrate_single_time_types(uvcalibrate_data, time_range):
         warn += [DeprecationWarning] * 2
         warn_msg += [
             "The time_array and time_range attributes are both set, but only one "
-            "should be set. This will become an error in version 2.5.",
+            "should be set. This will become an error in version 3.0.",
             "The lst_array and lst_range attributes are both set, but only one "
-            "should be set. This will become an error in version 2.5.",
+            "should be set. This will become an error in version 3.0.",
         ]
     with uvtest.check_warnings(warn, match=warn_msg):
         uvdcal = uvutils.uvcalibrate(uvd, uvc, inplace=False, time_check=False)

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -3303,7 +3303,7 @@ def test_uvcalibrate_delay_oldfiles(uvd_future_shapes, uvc_future_shapes):
 @pytest.mark.parametrize("uvd_future_shapes", [True, False])
 @pytest.mark.parametrize("flip_gain_conj", [False, True])
 @pytest.mark.parametrize("gain_convention", ["divide", "multiply"])
-@pytest.mark.parametrize("time_range", [True, False])
+@pytest.mark.parametrize("time_range", [None, "Ntimes", 3])
 def test_uvcalibrate(
     uvcalibrate_data,
     uvc_future_shapes,
@@ -3319,10 +3319,20 @@ def test_uvcalibrate(
     if not uvc_future_shapes:
         uvc.use_current_array_shapes()
 
-    if time_range:
+    if time_range is not None:
         tstarts = uvc.time_array - uvc.integration_time / (86400 * 2)
         tends = uvc.time_array + uvc.integration_time / (86400 * 2)
-        uvc.time_range = np.stack((tstarts, tends), axis=1)
+        if time_range == "Ntimes":
+            uvc.time_range = np.stack((tstarts, tends), axis=1)
+        else:
+            nt_per_range = int(np.ceil(uvc.Ntimes / time_range))
+            tstart_inds = np.array(np.arange(time_range) * nt_per_range)
+            tstarts_use = tstarts[tstart_inds]
+            tend_inds = np.array((np.arange(time_range) + 1) * nt_per_range - 1)
+            tend_inds[-1] = -1
+            tends_use = tends[tend_inds]
+            uvc.select(times=uvc.time_array[0:time_range])
+            uvc.time_range = np.stack((tstarts_use, tends_use), axis=1)
         uvc.time_array = None
         uvc.lst_array = None
         uvc.set_lsts_from_time_array()
@@ -3349,6 +3359,14 @@ def test_uvcalibrate(
         gain_product = (uvc.get_gains(ant1).conj() * uvc.get_gains(ant2)).T
     else:
         gain_product = (uvc.get_gains(ant1) * uvc.get_gains(ant2).conj()).T
+
+    if time_range is not None and time_range != "Ntimes":
+        gain_product = gain_product[:, np.newaxis]
+        gain_product = np.repeat(gain_product, nt_per_range, axis=1)
+        current_shape = gain_product.shape
+        new_shape = (current_shape[0] * current_shape[1], current_shape[-1])
+        gain_product = gain_product.reshape(new_shape)
+        gain_product = gain_product[: uvd.Ntimes]
 
     if gain_convention == "divide":
         np.testing.assert_array_almost_equal(
@@ -3568,11 +3586,13 @@ def test_uvcalibrate_time_mismatch(uvcalibrate_data, time_range):
     # change times to get warnings
     if time_range:
         uvc.time_range = uvc.time_range + 1
+        uvc.set_lsts_from_time_array()
         expected_err = "Time_ranges on UVCal do not cover all UVData times."
         with pytest.raises(ValueError, match=expected_err):
             uvutils.uvcalibrate(uvd, uvc, inplace=False)
     else:
         uvc.time_array = uvc.time_array + 1
+        uvc.set_lsts_from_time_array()
         expected_err = {
             f"Time {this_time} exists on UVData but not on UVCal."
             for this_time in np.unique(uvd.time_array)
@@ -3588,6 +3608,7 @@ def test_uvcalibrate_time_mismatch(uvcalibrate_data, time_range):
         uvc.time_range[0, 1] = uvc.time_range[0, 0] + uvc.integration_time[0] / (
             86400 * 4
         )
+        uvc.set_lsts_from_time_array()
         with pytest.raises(ValueError, match=expected_err):
             uvutils.uvcalibrate(uvd, uvc, inplace=False)
 
@@ -3632,6 +3653,7 @@ def test_uvcalibrate_single_time_types(uvcalibrate_data, time_range):
 
         # then change time_range to get warnings
         uvc.time_range = np.array(uvc.time_range) + 1
+        uvc.set_lsts_from_time_array()
 
     if time_range:
         msg_start = "Time_range on UVCal does not cover all UVData times"

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -3227,7 +3227,12 @@ def test_uvcalibrate_apply_gains_oldfiles():
 
     uvc.select(times=uvc.time_array[0])
 
-    with uvtest.check_warnings(UserWarning, match=ants_expected):
+    time_expected = [
+        "Times do not match between UVData and UVCal but time_check is False, so "
+        "calibration will be applied anyway."
+    ]
+
+    with uvtest.check_warnings(UserWarning, match=ants_expected + time_expected):
         with pytest.raises(ValueError, match=freq_expected):
             uvutils.uvcalibrate(
                 uvd, uvc, prop_flags=True, ant_check=False, time_check=False
@@ -3274,6 +3279,8 @@ def test_uvcalibrate_delay_oldfiles(uvd_future_shapes, uvc_future_shapes):
         "All antenna names with data on UVData are missing "
         "on UVCal. Since ant_check is False, calibration will "
         "proceed but all data will be flagged.",
+        "Times do not match between UVData and UVCal but time_check is False, so "
+        "calibration will be applied anyway.",
         r"UVData object does not have `x_orientation` specified but UVCal does",
     ]
     with uvtest.check_warnings(UserWarning, match=ant_expected):
@@ -3296,12 +3303,14 @@ def test_uvcalibrate_delay_oldfiles(uvd_future_shapes, uvc_future_shapes):
 @pytest.mark.parametrize("uvd_future_shapes", [True, False])
 @pytest.mark.parametrize("flip_gain_conj", [False, True])
 @pytest.mark.parametrize("gain_convention", ["divide", "multiply"])
+@pytest.mark.parametrize("time_range", [True, False])
 def test_uvcalibrate(
     uvcalibrate_data,
     uvc_future_shapes,
     uvd_future_shapes,
     flip_gain_conj,
     gain_convention,
+    time_range,
 ):
     uvd, uvc = uvcalibrate_data
 
@@ -3309,6 +3318,14 @@ def test_uvcalibrate(
         uvd.use_current_array_shapes()
     if not uvc_future_shapes:
         uvc.use_current_array_shapes()
+
+    if time_range:
+        tstarts = uvc.time_array - uvc.integration_time / (86400 * 2)
+        tends = uvc.time_array + uvc.integration_time / (86400 * 2)
+        uvc.time_range = np.stack((tstarts, tends), axis=1)
+        uvc.time_array = None
+        uvc.lst_array = None
+        uvc.set_lsts_from_time_array()
 
     uvc.gain_convention = gain_convention
 
@@ -3535,21 +3552,44 @@ def test_uvcalibrate_antenna_names_mismatch(uvcalibrate_init_data, future_shapes
     assert np.all(uvdcal.flag_array)  # assert completely flagged
 
 
-def test_uvcalibrate_time_mismatch(uvcalibrate_data):
+@pytest.mark.parametrize("time_range", [True, False])
+def test_uvcalibrate_time_mismatch(uvcalibrate_data, time_range):
     uvd, uvc = uvcalibrate_data
 
+    if time_range:
+        tstarts = uvc.time_array - uvc.integration_time / (86400 * 2)
+        tends = uvc.time_array + uvc.integration_time / (86400 * 2)
+        original_time_range = np.stack((tstarts, tends), axis=1)
+        uvc.time_range = original_time_range
+        uvc.time_array = None
+        uvc.lst_array = None
+        uvc.set_lsts_from_time_array()
+
     # change times to get warnings
-    uvc.time_array = uvc.time_array + 1
-    uvc.set_lsts_from_time_array()
+    if time_range:
+        uvc.time_range = uvc.time_range + 1
+        expected_err = "Time_ranges on UVCal do not cover all UVData times."
+        with pytest.raises(ValueError, match=expected_err):
+            uvutils.uvcalibrate(uvd, uvc, inplace=False)
+    else:
+        uvc.time_array = uvc.time_array + 1
+        expected_err = {
+            f"Time {this_time} exists on UVData but not on UVCal."
+            for this_time in np.unique(uvd.time_array)
+        }
 
-    expected_err = {
-        f"Time {this_time} exists on UVData but not on UVCal."
-        for this_time in np.unique(uvd.time_array)
-    }
+        with pytest.raises(ValueError) as errinfo:
+            uvutils.uvcalibrate(uvd, uvc, inplace=False)
+        assert str(errinfo.value) in expected_err
 
-    with pytest.raises(ValueError) as errinfo:
-        uvutils.uvcalibrate(uvd, uvc, inplace=False)
-    assert str(errinfo.value) in expected_err
+    # for time_range, make the time ranges not cover some UVData times
+    if time_range:
+        uvc.time_range = original_time_range
+        uvc.time_range[0, 1] = uvc.time_range[0, 0] + uvc.integration_time[0] / (
+            86400 * 4
+        )
+        with pytest.raises(ValueError, match=expected_err):
+            uvutils.uvcalibrate(uvd, uvc, inplace=False)
 
 
 def test_uvcalibrate_time_wrong_size(uvcalibrate_data):
@@ -3565,16 +3605,20 @@ def test_uvcalibrate_time_wrong_size(uvcalibrate_data):
         uvutils.uvcalibrate(uvd, uvc, inplace=False)
 
 
-@pytest.mark.parametrize("len_time_range", [0, 1])
-def test_uvcalibrate_time_types(uvcalibrate_data, len_time_range):
+@pytest.mark.filterwarnings("ignore:The time_array and time_range attributes")
+@pytest.mark.filterwarnings("ignore:The lst_array and lst_range attributes")
+@pytest.mark.parametrize("time_range", [True, False])
+def test_uvcalibrate_single_time_types(uvcalibrate_data, time_range):
     uvd, uvc = uvcalibrate_data
 
     # only one time
     uvc.select(times=uvc.time_array[0])
-    if len_time_range == 0:
-        uvc.time_range = None
-    else:
+    if time_range:
         # check cal runs fine with a good time range
+        uvc.time_range = np.reshape(
+            np.array([np.min(uvd.time_array), np.max(uvd.time_array)]), (1, 2)
+        )
+        uvc.set_lsts_from_time_array()
         uvdcal = uvutils.uvcalibrate(uvd, uvc, inplace=False)
 
         key = (1, 13, "xx")
@@ -3589,24 +3633,29 @@ def test_uvcalibrate_time_types(uvcalibrate_data, len_time_range):
         # then change time_range to get warnings
         uvc.time_range = np.array(uvc.time_range) + 1
 
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Times do not match between UVData and UVCal. "
-            "Set time_check=False to apply calibration anyway."
-        ),
-    ):
+    if time_range:
+        msg_start = "Time_range on UVCal does not cover all UVData times"
+    else:
+        msg_start = "Times do not match between UVData and UVCal"
+    err_msg = msg_start + ". Set time_check=False to apply calibration anyway."
+    warn_msg = [
+        msg_start + " but time_check is False, so calibration will be applied anyway."
+    ]
+
+    with pytest.raises(ValueError, match=err_msg):
         uvutils.uvcalibrate(uvd, uvc, inplace=False)
 
     # set time_check=False to test the user warning
-    with uvtest.check_warnings(
-        UserWarning,
-        match=(
-            "Times do not match between UVData and UVCal "
-            "but time_check is False, so calibration "
-            "will be applied anyway."
-        ),
-    ):
+    warn = [UserWarning]
+    if time_range:
+        warn += [DeprecationWarning] * 2
+        warn_msg += [
+            "The time_array and time_range attributes are both set, but only one "
+            "should be set. This will become an error in version 2.5.",
+            "The lst_array and lst_range attributes are both set, but only one "
+            "should be set. This will become an error in version 2.5.",
+        ]
+    with uvtest.check_warnings(warn, match=warn_msg):
         uvdcal = uvutils.uvcalibrate(uvd, uvc, inplace=False, time_check=False)
 
     key = (1, 13, "xx")

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -3943,6 +3943,8 @@ def get_lst_for_time(
         # Convert from hours back to rad
         lst_array *= np.pi / 12.0
 
+    lst_array = np.reshape(lst_array, jd_array.shape)
+
     return lst_array
 
 
@@ -4573,10 +4575,44 @@ def uvcalibrate(
                         "flag the data from missing antennas, set ant_check=False."
                     )
 
-    uvdata_times = np.unique(uvdata.time_array)
+    uvdata_times, uvd_time_ri = np.unique(uvdata.time_array, return_inverse=True)
     downselect_cal_times = False
-    if uvcal.Ntimes > 1:
-        if uvcal.Ntimes < uvdata.Ntimes:
+    # time_range supercedes time_array.
+    if uvcal.time_range is not None:
+        if np.min(uvdata_times) < np.min(uvcal.time_range[:, 0]) or np.max(
+            uvdata_times
+        ) > np.max(uvcal.time_range[:, 1]):
+            if not time_check and uvcal.Ntimes == 1:
+                warnings.warn(
+                    "Time_range on UVCal does not cover all UVData times "
+                    "but time_check is False, so calibration "
+                    "will be applied anyway."
+                )
+            else:
+                msg = "Time_ranges on UVCal do not cover all UVData times."
+                if uvcal.Ntimes == 1:
+                    msg = (
+                        "Time_range on UVCal does not cover all UVData times. "
+                        "Set time_check=False to apply calibration anyway."
+                    )
+                else:
+                    msg = "Time_ranges on UVCal do not cover all UVData times."
+                raise ValueError(msg)
+
+        # now check in detail that all UVData times fall in a UVCal time range.
+        # also create the indexing array to match UVData blts to UVCal time inds
+        if uvcal.Ntimes > 1:
+            trange_ind_arr = np.full_like(uvdata.time_array, -1, dtype=int)
+            for tr_ind, trange in enumerate(uvcal.time_range):
+                time_inds = np.nonzero(
+                    (uvdata_times >= trange[0]) & (uvdata_times <= trange[1])
+                )[0]
+                for tind in time_inds:
+                    trange_ind_arr[np.nonzero(uvd_time_ri == tind)[0]] = tr_ind
+            if np.any(trange_ind_arr < 0):
+                raise ValueError("Time_ranges on UVCal do not cover all UVData times.")
+    else:
+        if uvcal.Ntimes > 1 and uvcal.Ntimes < uvdata.Ntimes:
             raise ValueError(
                 "The uvcal object has more than one time but fewer than the "
                 "number of unique times on the uvdata object."
@@ -4593,64 +4629,38 @@ def uvcalibrate(
             time_arr_match = False
 
         if not time_arr_match:
-            # check more carefully
-            uvcal_times_to_keep = []
-            for this_time in uvdata_times:
-                wh_time_match = np.nonzero(
-                    np.isclose(
-                        uvcal.time_array - this_time,
-                        0,
-                        atol=uvdata._time_array.tols[1],
-                        rtol=uvdata._time_array.tols[0],
+            if uvcal.Ntimes == 1:
+                if not time_check:
+                    warnings.warn(
+                        "Times do not match between UVData and UVCal "
+                        "but time_check is False, so calibration "
+                        "will be applied anyway."
                     )
-                )
-                if wh_time_match[0].size > 0:
-                    uvcal_times_to_keep.append(uvcal.time_array[wh_time_match][0])
                 else:
                     raise ValueError(
-                        f"Time {this_time} exists on UVData but not on UVCal."
+                        "Times do not match between UVData and UVCal. "
+                        "Set time_check=False to apply calibration anyway. "
                     )
-            if len(uvcal_times_to_keep) < uvcal.Ntimes:
-                downselect_cal_times = True
-
-    elif uvcal.time_range is None:
-        # only one UVCal time, no time_range.
-        # This cannot match if UVData.Ntimes > 1.
-        # If they are both NTimes = 1, then check if they're close.
-        if uvdata.Ntimes > 1 or not np.isclose(
-            uvdata_times,
-            uvcal.time_array,
-            atol=uvdata._time_array.tols[1],
-            rtol=uvdata._time_array.tols[0],
-        ):
-            if not time_check:
-                warnings.warn(
-                    "Times do not match between UVData and UVCal "
-                    "but time_check is False, so calibration "
-                    "will be applied anyway."
-                )
             else:
-                raise ValueError(
-                    "Times do not match between UVData and UVCal. "
-                    "Set time_check=False to apply calibration anyway."
-                )
-    else:
-        # time_array is length 1 and time_range exists: check uvdata_times in time_range
-        if (
-            np.min(uvdata_times) < uvcal.time_range[0]
-            or np.max(uvdata_times) > uvcal.time_range[1]
-        ):
-            if not time_check:
-                warnings.warn(
-                    "Times do not match between UVData and UVCal "
-                    "but time_check is False, so calibration "
-                    "will be applied anyway."
-                )
-            else:
-                raise ValueError(
-                    "Times do not match between UVData and UVCal. "
-                    "Set time_check=False to apply calibration anyway. "
-                )
+                # check more carefully
+                uvcal_times_to_keep = []
+                for this_time in uvdata_times:
+                    wh_time_match = np.nonzero(
+                        np.isclose(
+                            uvcal.time_array - this_time,
+                            0,
+                            atol=uvdata._time_array.tols[1],
+                            rtol=uvdata._time_array.tols[0],
+                        )
+                    )
+                    if wh_time_match[0].size > 0:
+                        uvcal_times_to_keep.append(uvcal.time_array[wh_time_match][0])
+                    else:
+                        raise ValueError(
+                            f"Time {this_time} exists on UVData but not on UVCal."
+                        )
+                if len(uvcal_times_to_keep) < uvcal.Ntimes:
+                    downselect_cal_times = True
 
     downselect_cal_freq = False
     if uvcal.freq_array is not None:
@@ -4814,6 +4824,10 @@ def uvcalibrate(
                     * np.conj(uvcal_use.get_gains(uvcal_key2))
                 ).T  # tranpose to match uvdata shape
             flag = (uvcal_use.get_flags(uvcal_key1) | uvcal_use.get_flags(uvcal_key2)).T
+
+            if uvcal.time_range is not None and uvcal.Ntimes > 1:
+                gain = gain[trange_ind_arr[blt_inds], :]
+                flag = flag[trange_ind_arr[blt_inds], :]
 
             # propagate flags
             if prop_flags:

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -138,6 +138,11 @@ class CALFITS(UVCal):
                         ),
                     )
                     time_spacing = rounded_spacing[0]
+            if self.time_range is not None:
+                raise ValueError(
+                    "The calfits file format does not support time_range when there is "
+                    "more than one time."
+                )
             else:
                 if np.isclose(
                     time_spacing[0], self.integration_time / (24.0 * 60.0**2)

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -111,6 +111,11 @@ class CALFITS(UVCal):
                 delta_freq_array = 1.0
 
         if self.Ntimes > 1:
+            if self.time_range is not None:
+                raise ValueError(
+                    "The calfits file format does not support time_range when there is "
+                    "more than one time."
+                )
             if not uvutils._test_array_constant_spacing(self._time_array):
                 raise ValueError(
                     "The times are not evenly spaced (probably "
@@ -138,11 +143,6 @@ class CALFITS(UVCal):
                         ),
                     )
                     time_spacing = rounded_spacing[0]
-            if self.time_range is not None:
-                raise ValueError(
-                    "The calfits file format does not support time_range when there is "
-                    "more than one time."
-                )
             else:
                 if np.isclose(
                     time_spacing[0], self.integration_time / (24.0 * 60.0**2)
@@ -164,6 +164,10 @@ class CALFITS(UVCal):
                 time_spacing = self.integration_time[0] / (24.0 * 60.0**2)
             else:
                 time_spacing = self.integration_time / (24.0 * 60.0**2)
+        if self.time_array is None:
+            time_zero = np.mean(self.time_range)
+        else:
+            time_zero = self.time_array[0]
 
         if self.Njones > 1:
             if not uvutils._test_array_constant_spacing(self._jones_array):
@@ -238,7 +242,7 @@ class CALFITS(UVCal):
             prihdr["FRQRANGE"] = ",".join(map(str, freq_range_use))
 
         if self.time_range is not None:
-            prihdr["TMERANGE"] = ",".join(map(str, self.time_range))
+            prihdr["TMERANGE"] = ",".join(map(str, self.time_range[0, :]))
 
         if self.observer:
             prihdr["OBSERVER"] = self.observer
@@ -280,7 +284,7 @@ class CALFITS(UVCal):
         prihdr["CTYPE3"] = ("TIME", "Time axis.")
         prihdr["CUNIT3"] = ("JD", "Time in julian date format")
         prihdr["CRPIX3"] = 1
-        prihdr["CRVAL3"] = self.time_array[0]
+        prihdr["CRVAL3"] = time_zero
         prihdr["CDELT3"] = time_spacing
 
         # freq axis
@@ -389,7 +393,7 @@ class CALFITS(UVCal):
             sechdr["CTYPE3"] = ("TIME", "Time axis.")
             sechdr["CUNIT3"] = ("JD", "Time in julian date format")
             sechdr["CRPIX3"] = 1
-            sechdr["CRVAL3"] = self.time_array[0]
+            sechdr["CRVAL3"] = time_zero
             sechdr["CDELT3"] = time_spacing
 
             sechdr["CTYPE4"] = ("FREQS", "Valid frequencies to apply delay.")
@@ -459,7 +463,7 @@ class CALFITS(UVCal):
             totqualhdr["CTYPE2"] = ("TIME", "Time axis.")
             totqualhdr["CUNIT2"] = ("JD", "Time in julian date format")
             totqualhdr["CRPIX2"] = 1
-            totqualhdr["CRVAL2"] = self.time_array[0]
+            totqualhdr["CRVAL2"] = time_zero
             totqualhdr["CDELT2"] = time_spacing
 
             totqualhdr["CTYPE3"] = ("FREQS", "Valid frequencies to apply delay.")
@@ -611,11 +615,6 @@ class CALFITS(UVCal):
 
                 self.history += self.pyuvdata_version_str
 
-            time_range = hdr.pop("TMERANGE", None)
-            if time_range is not None:
-                self.time_range = np.asarray(
-                    list(map(np.float64, time_range.split(",")))
-                )
             self.gain_convention = hdr.pop("GNCONVEN")
             self.gain_scale = hdr.pop("GNSCALE", None)
             self.x_orientation = hdr.pop("XORIENT")
@@ -651,7 +650,17 @@ class CALFITS(UVCal):
             self.Njones = hdr.pop("NAXIS2")
             self.jones_array = uvutils._fits_gethduaxis(fname[0], 2)
             self.Ntimes = hdr.pop("NAXIS3")
-            self.time_array = uvutils._fits_gethduaxis(fname[0], 3)
+            main_hdr_time_array = uvutils._fits_gethduaxis(fname[0], 3)
+
+            # needs to come after Ntimes is defined.
+            time_range = hdr.pop("TMERANGE", None)
+            if time_range is not None and self.Ntimes == 1:
+                self.time_range = np.asarray(
+                    list(map(np.float64, time_range.split(",")))
+                )
+                self.time_range = self.time_range[np.newaxis, :]
+            else:
+                self.time_array = main_hdr_time_array
 
             if self.telescope_location is not None:
                 proc = self.set_lsts_from_time_array(background=background_lsts)
@@ -701,7 +710,7 @@ class CALFITS(UVCal):
                 time_array = uvutils._fits_gethduaxis(sechdu, 3)
                 if not np.allclose(
                     time_array,
-                    self.time_array,
+                    main_hdr_time_array,
                     rtol=self._time_array.tols[0],
                     atol=self._time_array.tols[0],
                 ):
@@ -787,7 +796,7 @@ class CALFITS(UVCal):
                     time_array = uvutils._fits_gethduaxis(totqualhdu, 2)
                     if not np.allclose(
                         time_array,
-                        self.time_array,
+                        main_hdr_time_array,
                         rtol=self._time_array.tols[0],
                         atol=self._time_array.tols[0],
                     ):

--- a/pyuvdata/uvcal/fhd_cal.py
+++ b/pyuvdata/uvcal/fhd_cal.py
@@ -130,7 +130,9 @@ class FHDCal(UVCal):
         time_use = bl_info["time_use"][0]
 
         time_array_use = time_array[np.where(time_use > 0)]
-        self.time_range = np.asarray([np.min(time_array_use), np.max(time_array_use)])
+        self.time_range = np.reshape(
+            np.asarray([np.min(time_array_use), np.max(time_array_use)]), (1, 2)
+        )
 
         self.telescope_name = obs_data["instrument"][0].decode("utf8")
         latitude = np.deg2rad(float(obs_data["LAT"][0]))

--- a/pyuvdata/uvcal/fhd_cal.py
+++ b/pyuvdata/uvcal/fhd_cal.py
@@ -114,8 +114,6 @@ class FHDCal(UVCal):
         self.Ntimes = 1
         time_array = bl_info["jdate"][0]
 
-        self.time_array = np.array([np.mean(time_array)])
-
         # this is generated in FHD by subtracting the JD of neighboring
         # integrations. This can have limited accuracy, so it can be slightly
         # off the actual value.

--- a/pyuvdata/uvcal/fhd_cal.py
+++ b/pyuvdata/uvcal/fhd_cal.py
@@ -130,8 +130,17 @@ class FHDCal(UVCal):
         time_use = bl_info["time_use"][0]
 
         time_array_use = time_array[np.where(time_use > 0)]
+        # extend the range by half the integration time in each direction
+        # to make sure that the original data times are covered by the range.
+        intime_jd = self.integration_time / (24.0 * 3600.0)
         self.time_range = np.reshape(
-            np.asarray([np.min(time_array_use), np.max(time_array_use)]), (1, 2)
+            np.asarray(
+                [
+                    np.min(time_array_use) - intime_jd / 2.0,
+                    np.max(time_array_use) + intime_jd / 2.0,
+                ]
+            ),
+            (1, 2),
         )
 
         self.telescope_name = obs_data["instrument"][0].decode("utf8")

--- a/pyuvdata/uvcal/initializers.py
+++ b/pyuvdata/uvcal/initializers.py
@@ -21,7 +21,6 @@ from ..uvdata.initializers import (
 
 def new_uvcal(
     *,
-    time_array: np.ndarray,
     antenna_positions: np.ndarray | dict[str | int, np.ndarray],
     telescope_location: Locations,
     telescope_name: str,
@@ -29,6 +28,8 @@ def new_uvcal(
     gain_convention: Literal["divide", "multiply"],
     jones_array: np.ndarray | str,
     x_orientation: Literal["east", "north", "e", "n", "ew", "ns"],
+    time_array: np.ndarray | None = None,
+    time_range: np.ndarray | None = None,
     freq_array: np.ndarray | None = None,
     freq_range: np.ndarray | None = None,
     cal_type: Literal["delay", "gain"] | None = None,
@@ -51,7 +52,13 @@ def new_uvcal(
     Parameters
     ----------
     time_array : ndarray of float
-        Array of times in Julian Date.
+        Array of times of the center of the integrations, in Julian Date. Only
+        one of time_array or time_range should be supplied.
+    time_range : ndarray of float
+        Array of start and stop times for calibrations solutions, in Julian Date. A
+        two-dimensional array with shape (Ntimes, 2) where the second axis gives
+        the start time and stop time (in that order). Only one of time_array or
+        time_range should be supplied.
     antenna_positions : ndarray of float or dict of ndarray of float
         Array of antenna positions in ECEF coordinates in meters.
         If a dict, keys can either be antenna numbers or antenna names, and values are
@@ -83,11 +90,14 @@ def new_uvcal(
         ``freq_array`` is given, and by *default* set to 'delay' if not.
     integration_time : float or ndarray of float, optional
         Integration time in seconds. If not provided, it will be derived from the
-        time_array, as the difference between successive times (with the last time-diff
-        appended). If not provided and the number of unique times is one, then
-        a warning will be raised and the integration time set to 1 second.
+        time_array or time_range. If derived from the time_array, it will be the
+        difference between successive times (with the last time-diff appended), if
+        the number of unique times is one, then a warning will be raised and
+        the integration time set to 1 second. If derived from the time_range it will be
+        the difference between the start and stop times for each range.
         If a float is provided, it will be used for all integrations.
-        If an ndarray is provided, it must have the same shape as time_array.
+        If an ndarray is provided, it must have the same shape as time_array or the
+        first axis of time_range.
     channel_width : float or ndarray of float, optional
         Channel width in Hz. If not provided, it will be derived from the freq_array,
         as the difference between successive frequencies (with the last frequency-diff
@@ -158,9 +168,14 @@ def new_uvcal(
                 f"The following ants are not in antenna_numbers: {missing}"
             )
 
-    lst_array, integration_time = get_time_params(
-        telescope_location, time_array, integration_time
-    )
+    if time_array is not None:
+        lst_array, integration_time = get_time_params(
+            telescope_location, time_array, integration_time
+        )
+    if time_range is not None:
+        lst_range, integration_time = get_time_params(
+            telescope_location, time_range, integration_time
+        )
 
     if (freq_range is not None) and (
         freq_array is not None
@@ -230,8 +245,14 @@ def new_uvcal(
         ]
     )
     uvc.telescope_name = telescope_name
-    uvc.time_array = time_array
-    uvc.lst_array = lst_array
+    if time_array is not None:
+        uvc.time_array = time_array
+        uvc.lst_array = lst_array
+        uvc.Ntimes = len(time_array)
+    if time_range is not None:
+        uvc.time_range = time_range
+        uvc.lst_range = lst_range
+        uvc.Ntimes = time_range.shape[0]
     uvc.integration_time = integration_time
     uvc.channel_width = channel_width
     uvc.antenna_names = antenna_names
@@ -265,7 +286,6 @@ def new_uvcal(
     uvc.Nants_telescope = len(antenna_numbers)
     uvc.Nfreqs = len(freq_array) if freq_array is not None else 1
 
-    uvc.Ntimes = len(time_array)
     uvc.Nspws = len(spw_array)
     uvc.Njones = len(jones_array)
 
@@ -364,9 +384,10 @@ def new_uvcal_from_uvdata(
         wide_band = True
 
     # If any time-length params are in kwargs, we can't use ANY of them from the UVData
-    if "integration_time" in kwargs or "time_array" in kwargs:
+    if "integration_time" in kwargs or "time_array" or "time_range" in kwargs:
         integration_time = kwargs.pop("integration_time", None)
         time_array = kwargs.pop("time_array", None)
+        time_range = kwargs.pop("time_range", None)
     else:
         indx = np.unique(uvdata.time_array, return_index=True)[1]
         integration_time = uvdata.integration_time[indx]
@@ -508,6 +529,7 @@ def new_uvcal_from_uvdata(
         freq_range=freq_range,
         cal_type=cal_type,
         time_array=time_array,
+        time_range=time_range,
         antenna_positions=antenna_positions,
         antenna_names=antenna_names,
         antenna_numbers=antenna_numbers,

--- a/pyuvdata/uvcal/initializers.py
+++ b/pyuvdata/uvcal/initializers.py
@@ -384,7 +384,7 @@ def new_uvcal_from_uvdata(
         wide_band = True
 
     # If any time-length params are in kwargs, we can't use ANY of them from the UVData
-    if "integration_time" in kwargs or "time_array" or "time_range" in kwargs:
+    if "integration_time" in kwargs or "time_array" in kwargs or "time_range" in kwargs:
         integration_time = kwargs.pop("integration_time", None)
         time_array = kwargs.pop("time_array", None)
         time_range = kwargs.pop("time_range", None)
@@ -392,6 +392,7 @@ def new_uvcal_from_uvdata(
         indx = np.unique(uvdata.time_array, return_index=True)[1]
         integration_time = uvdata.integration_time[indx]
         time_array = uvdata.time_array[indx]
+        time_range = None
 
     # Get frequency-type info from kwargs and uvdata
     if cal_type == "gain" and not wide_band:

--- a/pyuvdata/uvcal/tests/__init__.py
+++ b/pyuvdata/uvcal/tests/__init__.py
@@ -1,3 +1,18 @@
 # -*- mode: python; coding: utf-8 -*-
 # Copyright (c) 2019 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
+
+import numpy as np
+
+
+def time_array_to_time_range(calobj_in, keep_time_array=False):
+    calobj = calobj_in.copy()
+    tstarts = calobj.time_array - calobj.integration_time / (86400 * 2)
+    tends = calobj.time_array + calobj.integration_time / (86400 * 2)
+    calobj.time_range = np.stack((tstarts, tends), axis=1)
+    if not keep_time_array:
+        calobj.time_array = None
+        calobj.lst_array = None
+    calobj.set_lsts_from_time_array()
+
+    return calobj

--- a/pyuvdata/uvcal/tests/test_fhd_cal.py
+++ b/pyuvdata/uvcal/tests/test_fhd_cal.py
@@ -375,10 +375,19 @@ def test_read_multi(tmp_path, concat_method, read_method):
                 use_future_array_shapes=True,
             )
 
+    # calfits doesn't support multiple time ranges, so this errors
+    # TODO: add back a roundtrip check when we have an hdf5 file format
     outfile = str(tmp_path / "outtest_FHDcal_1061311664.calfits")
-    fhd_cal.write_calfits(outfile, clobber=True)
-    calfits_cal = UVCal.from_file(outfile, use_future_array_shapes=True)
-    assert fhd_cal == calfits_cal
+    with pytest.raises(
+        ValueError,
+        match=(
+            "The calfits file format does not support time_range when there is more "
+            "than one time."
+        ),
+    ):
+        fhd_cal.write_calfits(outfile, clobber=True)
+    # calfits_cal = UVCal.from_file(outfile, use_future_array_shapes=True)
+    # assert fhd_cal == calfits_cal
 
 
 @pytest.mark.parametrize(

--- a/pyuvdata/uvcal/tests/test_initializers.py
+++ b/pyuvdata/uvcal/tests/test_initializers.py
@@ -52,6 +52,28 @@ def test_new_uvcal_simplest(uvc_kw):
     assert uvc.Ntimes == 12
 
 
+def test_new_uvcal_time_range(uvc_kw):
+    tdiff = np.mean(np.diff(uvc_kw["time_array"]))
+    tstarts = uvc_kw["time_array"] - tdiff / 2
+    tends = uvc_kw["time_array"] + tdiff / 2
+    uvc_kw["time_range"] = np.stack((tstarts, tends), axis=1)
+    del uvc_kw["time_array"]
+
+    UVCal.new(**uvc_kw)
+
+    uvc_kw["integration_time"] = tdiff * 86400
+    uvc = UVCal.new(**uvc_kw)
+    assert uvc.Ntimes == 12
+
+    uvc_kw["integration_time"] = np.full((5,), tdiff * 86400)
+    with pytest.raises(
+        ValueError,
+        match="integration_time must be the same length as the first axis of "
+        "time_range.",
+    ):
+        uvc = UVCal.new(**uvc_kw)
+
+
 def test_new_uvcal_bad_inputs(uvc_kw):
     with pytest.raises(
         ValueError, match="The following ants are not in antenna_numbers"

--- a/pyuvdata/uvcal/tests/test_uvcal.py
+++ b/pyuvdata/uvcal/tests/test_uvcal.py
@@ -19,6 +19,7 @@ import pyuvdata.tests as uvtest
 import pyuvdata.utils as uvutils
 from pyuvdata import UVCal
 from pyuvdata.data import DATA_PATH
+from pyuvdata.uvcal.tests import time_array_to_time_range
 from pyuvdata.uvcal.uvcal import _future_array_shapes_warning
 
 pytestmark = pytest.mark.filterwarnings(
@@ -47,7 +48,6 @@ def uvcal_data():
         "spw_array",
         "flex_spw",
         "jones_array",
-        "time_array",
         "integration_time",
         "gain_convention",
         "flag_array",
@@ -63,6 +63,7 @@ def uvcal_data():
         "telescope_location",
         "antenna_positions",
         "lst_array",
+        "lst_range",
         "gain_array",
         "delay_array",
         "sky_field",
@@ -73,6 +74,7 @@ def uvcal_data():
         "diffuse_model",
         "input_flag_array",
         "time_range",
+        "time_array",
         "freq_range",
         "flex_spw_id_array",
         "observer",
@@ -390,6 +392,53 @@ def test_check_flag_array(gain_data):
         gain_data.check()
 
 
+def test_check_time_range_errors(gain_data):
+    calobj = time_array_to_time_range(gain_data)
+    original_range = copy.copy(calobj.time_range)
+
+    calobj.time_range[1, 1] = calobj.time_range[0, 0]
+    print(calobj.time_range[:, 1] - calobj.time_range[:, 0])
+    with pytest.raises(
+        ValueError,
+        match="The time ranges are not well-formed, some stop times are after start "
+        "times.",
+    ):
+        calobj.check()
+
+    calobj.time_range = original_range
+    calobj.time_range[0, 1] = calobj.time_range[1, 1]
+    with pytest.raises(ValueError, match="Some time_ranges overlap"):
+        calobj.check()
+
+
+@pytest.mark.parametrize("time_range", [True, False])
+def test_check_lst(gain_data, time_range):
+    gain_time_range = time_array_to_time_range(gain_data)
+    if time_range:
+        calobj = gain_time_range
+        tparam = "time_range"
+        lst_param = "lst_range"
+        calobj.lst_range = None
+    else:
+        calobj = gain_data
+        tparam = "time_array"
+        lst_param = "lst_array"
+        calobj.lst_array = None
+
+    with pytest.raises(ValueError, match="Either lst_array or lst_range must be set."):
+        calobj.check()
+
+    if time_range:
+        calobj.lst_array = gain_data.lst_array
+    else:
+        calobj.lst_range = gain_time_range.lst_range
+
+    with pytest.raises(
+        ValueError, match=f"If {tparam} is present, {lst_param} must also be present."
+    ):
+        calobj.check()
+
+
 @pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 def test_future_array_shape(caltype, gain_data, delay_data_inputflag):
@@ -544,6 +593,18 @@ def test_future_array_shape_errors(
 
         with pytest.raises(ValueError, match="The frequencies are not evenly spaced"):
             calobj2._check_freq_spacing()
+
+
+def test_get_time_array(gain_data):
+    calobj = gain_data
+    orig_time_array = copy.copy(calobj.time_array)
+
+    time_array = calobj.get_time_array()
+    assert np.allclose(time_array, orig_time_array)
+
+    calobj = time_array_to_time_range(calobj)
+    time_array = calobj.get_time_array()
+    assert np.allclose(time_array, orig_time_array)
 
 
 def test_unknown_telescopes(gain_data, tmp_path):
@@ -1055,13 +1116,21 @@ def test_select_antennas(
 @pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.parametrize("future_shapes", [True, False])
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
+@pytest.mark.parametrize("time_range", [True, False])
 def test_select_times(
-    future_shapes, caltype, gain_data, delay_data_inputflag, tmp_path
+    future_shapes, caltype, time_range, gain_data, delay_data_inputflag, tmp_path
 ):
     if caltype == "gain":
         calobj = gain_data
     else:
         calobj = delay_data_inputflag
+
+    orig_time_array = calobj.time_array
+    times_to_keep = orig_time_array[2:5]
+    time_range_to_keep = [np.min(times_to_keep), np.max(times_to_keep)]
+
+    if time_range:
+        calobj = time_array_to_time_range(calobj)
 
     if not future_shapes:
         calobj.use_current_array_shapes()
@@ -1069,45 +1138,89 @@ def test_select_times(
     calobj2 = calobj.copy()
 
     old_history = calobj.history
-    times_to_keep = calobj.time_array[2:5]
 
     calobj2.select(times=times_to_keep)
 
     assert len(times_to_keep) == calobj2.Ntimes
-    for t in times_to_keep:
-        assert t in calobj2.time_array
-    for t in np.unique(calobj2.time_array):
-        assert t in times_to_keep
+    if time_range:
+        for t in times_to_keep:
+            time_in_range = np.nonzero(
+                np.logical_and(
+                    (calobj2.time_range[:, 0] <= t), (calobj2.time_range[:, 1] >= t)
+                )
+            )[0]
+            assert time_in_range.size > 0
+    else:
+        for t in times_to_keep:
+            assert t in calobj2.time_array
+        for t in np.unique(calobj2.time_array):
+            assert t in times_to_keep
 
     assert uvutils._check_histories(
         old_history + "  Downselected to specific times using pyuvdata.",
         calobj2.history,
     )
 
+    # check same answer with time_range parameter
+    calobj3 = calobj.copy()
+    calobj3.select(time_range=time_range_to_keep)
+    assert calobj2 == calobj3
+
     write_file_calfits = str(tmp_path / "select_test.calfits")
     # test writing calfits with only one time
     calobj2 = calobj.copy()
-    times_to_keep = calobj.time_array[[1]]
+    times_to_keep = times_to_keep[0]
+    time_range_to_keep = [np.min(times_to_keep), np.max(times_to_keep)]
     calobj2.select(times=times_to_keep)
+
+    # check same answer with time_range parameter
+    calobj3 = calobj.copy()
+    calobj3.select(time_range=time_range_to_keep)
+    assert calobj2 == calobj3
+
     calobj2.write_calfits(write_file_calfits, clobber=True)
 
     # check for errors associated with times not included in data
-    pytest.raises(
-        ValueError,
-        calobj.select,
-        times=[np.min(calobj.time_array) - calobj.integration_time],
-    )
+    early_time = np.min(orig_time_array) - np.max(calobj.integration_time)
+    if time_range:
+        msg = "No times or time_ranges matching requested times."
+    else:
+        msg = f"Time {early_time} is not present in the time_array"
+    with pytest.raises(ValueError, match=msg):
+        calobj.select(times=[early_time])
+
+    with pytest.raises(
+        ValueError, match="Only one of times and time_range can be provided."
+    ):
+        calobj.select(times=times_to_keep, time_range=time_range_to_keep)
 
     # check for warnings and errors associated with unevenly spaced times
     calobj2 = calobj.copy()
-    warn_type = [UserWarning]
-    msg = ["Selected times are not evenly spaced"]
+    warn_type = []
+    msg = []
+    if not time_range:
+        warn_type += [UserWarning]
+        msg += ["Selected times are not evenly spaced"]
     if caltype == "delay":
         warn_type += [DeprecationWarning]
         msg += ["The input_flag_array is deprecated and will be removed in version 2.5"]
+    if len(warn_type) == 0:
+        warn_type = None
+        msg = ""
     with uvtest.check_warnings(warn_type, match=msg):
-        calobj2.select(times=calobj2.time_array[[0, 2, 3]])
-    pytest.raises(ValueError, calobj2.write_calfits, write_file_calfits)
+        calobj2.select(times=orig_time_array[[0, 2, 3]])
+    if time_range:
+        msg = (
+            "The calfits file format does not support time_range when there is more "
+            "than one time."
+        )
+    else:
+        msg = (
+            "The times are not evenly spaced (probably because of a select operation). "
+            "The calfits format does not support unevenly spaced times."
+        )
+    with pytest.raises(ValueError, match=re.escape(msg)):
+        calobj2.write_calfits(write_file_calfits)
 
 
 @pytest.mark.filterwarnings("ignore:The input_flag_array is deprecated")
@@ -1976,8 +2089,9 @@ def test_reorder_freqs_errors(gain_data, multi_spw_delay):
 @pytest.mark.parametrize("future_shapes", [True, False])
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 @pytest.mark.parametrize("metadata_only", [True, False])
+@pytest.mark.parametrize("time_range", [True, False])
 def test_reorder_times(
-    future_shapes, caltype, metadata_only, gain_data, delay_data_inputflag
+    future_shapes, caltype, metadata_only, time_range, gain_data, delay_data_inputflag
 ):
     if caltype == "gain":
         calobj = gain_data
@@ -1989,6 +2103,9 @@ def test_reorder_times(
         calobj.check()
     else:
         calobj = delay_data_inputflag
+
+    if time_range:
+        calobj = time_array_to_time_range(calobj)
 
     if not future_shapes:
         calobj.use_current_array_shapes()
@@ -2002,7 +2119,10 @@ def test_reorder_times(
     assert calobj == calobj2
 
     calobj2.reorder_times(order="-time")
-    time_diff = np.diff(calobj2.time_array)
+    if time_range:
+        time_diff = np.diff(calobj2.time_range[:, 0])
+    else:
+        time_diff = np.diff(calobj2.time_array)
     assert np.all(time_diff < 0)
 
     if caltype == "gain" and not metadata_only:
@@ -2037,6 +2157,15 @@ def test_reorder_times_errors(gain_data):
         "without duplicates.",
     ):
         gain_data.reorder_times(order=np.arange(7))
+
+    gain_data = time_array_to_time_range(gain_data, keep_time_array=True)
+    with uvtest.check_warnings(
+        DeprecationWarning,
+        match="The time_array and time_range attributes are both set. "
+        "Defaulting to using time_range to determine sorting. This will "
+        "become an error in version 2.5.",
+    ):
+        gain_data.reorder_times()
 
 
 @pytest.mark.filterwarnings("ignore:The input_flag_array is deprecated")
@@ -2737,13 +2866,24 @@ def test_add_spw_wideband(axis, caltype, method, multi_spw_delay, wideband_gain)
 @pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.parametrize("future_shapes", [True, False])
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
+@pytest.mark.parametrize("time_range", [True, False])
 @pytest.mark.parametrize("method", ["__iadd__", "fast_concat"])
-def test_add_times(future_shapes, caltype, method, gain_data, delay_data_inputflag):
+def test_add_times(
+    future_shapes, caltype, time_range, method, gain_data, delay_data_inputflag
+):
     """Test adding times between two UVCal objects"""
     if caltype == "gain":
         calobj = gain_data
     else:
         calobj = delay_data_inputflag
+
+    n_times2 = calobj.Ntimes // 2
+    times1 = calobj.time_array[:n_times2]
+    times2 = calobj.time_array[n_times2:]
+
+    if time_range:
+        keep_time_array = caltype == "gain"
+        calobj = time_array_to_time_range(calobj, keep_time_array=keep_time_array)
 
     if not future_shapes:
         calobj.use_current_array_shapes()
@@ -2751,17 +2891,58 @@ def test_add_times(future_shapes, caltype, method, gain_data, delay_data_inputfl
     calobj2 = calobj.copy()
 
     calobj_full = calobj.copy()
-    n_times2 = calobj.Ntimes // 2
-    times1 = calobj.time_array[:n_times2]
-    times2 = calobj.time_array[n_times2:]
-    calobj.select(times=times1)
-    calobj2.select(times=times2)
+    if time_range and caltype == "gain":
+        check_warn = [DeprecationWarning] * 2
+        check_msg = [
+            "The time_array and time_range attributes are both set, but only one "
+            "should be set. This will become an error in version 2.5.",
+            "The lst_array and lst_range attributes are both set, but only one should "
+            "be set. This will become an error in version 2.5.",
+        ]
+        select_warn = check_warn + [DeprecationWarning]
+        select_msg = check_msg + [
+            "The time_array and time_range attributes are both set. "
+            "Defaulting to using time_range to determine time selection. "
+            "This will become an error in version 2.5."
+        ]
+
+        add_warn = check_warn * 3
+        add_msg = check_msg * 3
+        if method != "fast_concat":
+            add_warn += [DeprecationWarning]
+            add_msg += [
+                "The time_array and time_range attributes are both set. Defaulting to "
+                "using time_range to determine time matching between objects. "
+                "This will become an error in version 2.5."
+            ]
+    elif caltype == "delay":
+        check_warn = [DeprecationWarning]
+        check_msg = [
+            "The input_flag_array is deprecated and will be removed in version 2.5"
+        ]
+        select_warn = check_warn
+        select_msg = check_msg
+        add_warn = check_warn * 3
+        add_msg = check_msg * 3
+    else:
+        check_warn = None
+        check_msg = ""
+        select_warn = None
+        select_msg = ""
+        add_warn = None
+        add_msg = ""
+    with uvtest.check_warnings(select_warn, match=select_msg):
+        calobj.select(time_range=[np.min(times1), np.max(times1)])
+    with uvtest.check_warnings(select_warn, match=select_msg):
+        calobj2.select(time_range=[np.min(times2), np.max(times2)])
 
     if method == "fast_concat":
         kwargs = {"axis": "time", "inplace": True}
     else:
         kwargs = {}
-    getattr(calobj, method)(calobj2, **kwargs)
+
+    with uvtest.check_warnings(add_warn, match=add_msg):
+        getattr(calobj, method)(calobj2, **kwargs)
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
         calobj_full.history + "  Downselected to specific "
@@ -2773,7 +2954,8 @@ def test_add_times(future_shapes, caltype, method, gain_data, delay_data_inputfl
     assert calobj == calobj_full
 
     # test for when total_quality_array is present in first file but not second
-    calobj.select(times=times1)
+    with uvtest.check_warnings(select_warn, match=select_msg):
+        calobj.select(time_range=[np.min(times1), np.max(times1)])
     tqa = np.ones(calobj._total_quality_array.expected_shape(calobj))
     tqa2 = np.zeros(calobj2._total_quality_array.expected_shape(calobj2))
     if future_shapes:
@@ -2781,7 +2963,8 @@ def test_add_times(future_shapes, caltype, method, gain_data, delay_data_inputfl
     else:
         tot_tqa = np.concatenate([tqa, tqa2], axis=2)
     calobj.total_quality_array = tqa
-    getattr(calobj, method)(calobj2, **kwargs)
+    with uvtest.check_warnings(add_warn, match=add_msg):
+        getattr(calobj, method)(calobj2, **kwargs)
     assert np.allclose(
         calobj.total_quality_array,
         tot_tqa,
@@ -2790,7 +2973,8 @@ def test_add_times(future_shapes, caltype, method, gain_data, delay_data_inputfl
     )
 
     # test for when total_quality_array is present in second file but not first
-    calobj.select(times=times1)
+    with uvtest.check_warnings(select_warn, match=select_msg):
+        calobj.select(time_range=[np.min(times1), np.max(times1)])
     tqa = np.zeros(calobj._total_quality_array.expected_shape(calobj))
     tqa2 = np.ones(calobj2._total_quality_array.expected_shape(calobj2))
     if future_shapes:
@@ -2799,7 +2983,8 @@ def test_add_times(future_shapes, caltype, method, gain_data, delay_data_inputfl
         tot_tqa = np.concatenate([tqa, tqa2], axis=2)
     calobj.total_quality_array = None
     calobj2.total_quality_array = tqa2
-    getattr(calobj, method)(calobj2, **kwargs)
+    with uvtest.check_warnings(add_warn, match=add_msg):
+        getattr(calobj, method)(calobj2, **kwargs)
     assert np.allclose(
         calobj.total_quality_array,
         tot_tqa,
@@ -2808,7 +2993,8 @@ def test_add_times(future_shapes, caltype, method, gain_data, delay_data_inputfl
     )
 
     # test for when total_quality_array is present in both
-    calobj.select(times=times1)
+    with uvtest.check_warnings(select_warn, match=select_msg):
+        calobj.select(time_range=[np.min(times1), np.max(times1)])
     tqa = np.ones(calobj._total_quality_array.expected_shape(calobj))
     tqa2 = np.ones(calobj2._total_quality_array.expected_shape(calobj2))
     tqa *= 2
@@ -2818,7 +3004,8 @@ def test_add_times(future_shapes, caltype, method, gain_data, delay_data_inputfl
         tot_tqa = np.concatenate([tqa, tqa2], axis=2)
     calobj.total_quality_array = tqa
     calobj2.total_quality_array = tqa2
-    getattr(calobj, method)(calobj2, **kwargs)
+    with uvtest.check_warnings(add_warn, match=add_msg):
+        getattr(calobj, method)(calobj2, **kwargs)
     assert np.allclose(
         calobj.total_quality_array,
         tot_tqa,
@@ -2829,7 +3016,8 @@ def test_add_times(future_shapes, caltype, method, gain_data, delay_data_inputfl
     if caltype == "delay":
         # test for when input_flag_array & quality_array is present in first file but
         # not in second
-        calobj.select(times=times1)
+        with uvtest.check_warnings(select_warn, match=select_msg):
+            calobj.select(time_range=[np.min(times1), np.max(times1)])
         ifa = np.zeros(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool_)
         ifa2 = np.ones(calobj2._input_flag_array.expected_shape(calobj2)).astype(
             np.bool_
@@ -2847,12 +3035,14 @@ def test_add_times(future_shapes, caltype, method, gain_data, delay_data_inputfl
         calobj2.input_flag_array = None
         calobj.quality_array = qa
         calobj2.quality_array = None
-        getattr(calobj, method)(calobj2, **kwargs)
+        with uvtest.check_warnings(add_warn[1:], match=add_msg[1:]):
+            getattr(calobj, method)(calobj2, **kwargs)
         assert np.allclose(calobj.input_flag_array, tot_ifa)
         assert np.allclose(calobj.quality_array, tot_qa)
 
         # test for when input_flag_array is present in second file but not first
-        calobj.select(times=times1)
+        with uvtest.check_warnings(select_warn, match=select_msg):
+            calobj.select(time_range=[np.min(times1), np.max(times1)])
         ifa = np.ones(calobj._input_flag_array.expected_shape(calobj)).astype(np.bool_)
         ifa2 = np.zeros(calobj2._input_flag_array.expected_shape(calobj2)).astype(
             np.bool_
@@ -2866,20 +3056,34 @@ def test_add_times(future_shapes, caltype, method, gain_data, delay_data_inputfl
         calobj2.input_flag_array = ifa2
         calobj.quality_array = None
         calobj2.quality_array = qa2
-        getattr(calobj, method)(calobj2, **kwargs)
+        with uvtest.check_warnings(add_warn[1:], match=add_msg[1:]):
+            getattr(calobj, method)(calobj2, **kwargs)
         assert np.allclose(calobj.input_flag_array, tot_ifa)
         assert np.allclose(calobj.quality_array, tot_qa)
 
     # Out of order - times
     calobj = calobj_full.copy()
     calobj2 = calobj.copy()
-    calobj.select(times=times2)
-    calobj2.select(times=times1)
-    getattr(calobj, method)(calobj2, **kwargs)
+    with uvtest.check_warnings(select_warn, match=select_msg):
+        calobj.select(time_range=[np.min(times2), np.max(times2)])
+    with uvtest.check_warnings(select_warn, match=select_msg):
+        calobj2.select(time_range=[np.min(times1), np.max(times1)])
+    with uvtest.check_warnings(add_warn, match=add_msg):
+        getattr(calobj, method)(calobj2, **kwargs)
     calobj.history = calobj_full.history
     if method == "fast_concat":
         # need to sort object first
-        calobj.reorder_times()
+        warn = check_warn
+        warn_msg = check_msg
+        if time_range and caltype == "gain":
+            warn += [DeprecationWarning]
+            warn_msg += [
+                "The time_array and time_range attributes are both set. Defaulting to "
+                "using time_range to determine sorting. This will become an error in "
+                "version 2.5."
+            ]
+        with uvtest.check_warnings(warn, match=warn_msg):
+            calobj.reorder_times()
     assert calobj == calobj_full
 
 
@@ -3296,15 +3500,19 @@ def test_add_multiple_axes(gain_data, ant, freq, time, jones, in_order):
 @pytest.mark.filterwarnings("ignore:The input_flag_array is deprecated")
 @pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
+@pytest.mark.parametrize("time_range", [True, False])
 @pytest.mark.parametrize("method", ["__add__", "fast_concat"])
 def test_add_errors(
-    caltype, method, gain_data, delay_data, multi_spw_gain, wideband_gain
+    caltype, time_range, method, gain_data, delay_data, multi_spw_gain, wideband_gain
 ):
     """Test behavior that will raise errors"""
     if caltype == "gain":
-        calobj = gain_data
+        calobj = gain_data.copy()
     else:
-        calobj = delay_data
+        calobj = delay_data.copy()
+
+    if time_range:
+        calobj = time_array_to_time_range(calobj)
 
     calobj2 = calobj.copy()
 
@@ -3325,10 +3533,12 @@ def test_add_errors(
 
     else:
         # test addition of two identical objects
-        with pytest.raises(
-            ValueError,
-            match="These objects have overlapping data and cannot be combined.",
-        ):
+        if time_range:
+            msg = "A time_range overlaps in the two objects."
+        else:
+            msg = "These objects have overlapping data and cannot be combined."
+
+        with pytest.raises(ValueError, match=msg):
             calobj + calobj2
 
     # test addition of UVCal and non-UVCal object
@@ -3369,6 +3579,29 @@ def test_add_errors(
         match="To combine these data, wide_band must be set to the same value",
     ):
         getattr(gain_data, method)(wideband_gain, **kwargs)
+
+    # test time_range, time_array mismatch
+    calobj2 = calobj.copy()
+    if time_range:
+        calobj2.time_array = gain_data.time_array
+        calobj2.time_range = None
+        calobj2.lst_range = None
+    else:
+        calobj2 = time_array_to_time_range(calobj2)
+
+    calobj2.set_lsts_from_time_array()
+
+    if method == "fast_concat":
+        kwargs = {"axis": "time", "inplace": True}
+    else:
+        kwargs = {}
+
+    with pytest.raises(
+        ValueError,
+        match="Some objects have a time_array while others do not. All objects must "
+        "either have or not have a time_array.",
+    ):
+        getattr(calobj, method)(calobj2, **kwargs)
 
 
 @pytest.mark.filterwarnings("ignore:The input_flag_array is deprecated")
@@ -3959,10 +4192,6 @@ def test_init_from_uvdata(
     if not uvcal_future_shapes:
         uvc.use_current_array_shapes()
 
-    # uvc has a time_range which it shouldn't really have because Ntimes > 1,
-    # but that requirement is not enforced. Set it to None for this test
-    uvc.time_range = None
-
     uvc2 = uvc.copy(metadata_only=True)
 
     uvc_new = UVCal.initialize_from_uvdata(
@@ -4020,10 +4249,6 @@ def test_init_from_uvdata_setfreqs(
 
     if not uvcal_future_shapes:
         uvc.use_current_array_shapes()
-
-    # uvc has a time_range which it shouldn't really have because Ntimes > 1,
-    # but that requirement is not enforced. Set it to None for this test
-    uvc.time_range = None
 
     uvc2 = uvc.copy(metadata_only=True)
 
@@ -4137,7 +4362,6 @@ def test_init_from_uvdata_settimes(
         metadata_only=metadata_only,
         time_array=times_use,
         integration_time=integration_time,
-        time_range=uvc.time_range,
     )
 
     with pytest.warns(
@@ -4152,7 +4376,6 @@ def test_init_from_uvdata_settimes(
             metadata_only=metadata_only,
             times=times_use,
             integration_time=integration_time,
-            time_range=uvc.time_range,
         )
     # antenna positions are different by ~6cm or less. The ones in the uvcal file
     # derive from info on our telescope object while the ones in the uvdata file
@@ -4193,9 +4416,6 @@ def test_init_from_uvdata_settimes(
 def test_init_from_uvdata_setjones(uvcalibrate_data):
     uvd, uvc = uvcalibrate_data
     uvc._set_flex_spw()
-    # uvc has a time_range which it shouldn't really have because Ntimes > 1,
-    # but that requirement is not enforced. Set it to None for this test
-    uvc.time_range = None
 
     uvc2 = uvc.copy(metadata_only=True)
 
@@ -4245,10 +4465,6 @@ def test_init_from_uvdata_setjones(uvcalibrate_data):
 def test_init_single_pol(uvcalibrate_data, pol):
     uvd, uvc = uvcalibrate_data
     uvc._set_flex_spw()
-
-    # uvc has a time_range which it shouldn't really have because Ntimes > 1,
-    # but that requirement is not enforced. Set it to None for this test
-    uvc.time_range = None
 
     if pol in ["ll", "rr"]:
         # convert to circular pol
@@ -4301,10 +4517,6 @@ def test_init_from_uvdata_circular_pol(uvcalibrate_data):
     uvd.polarization_array = np.array([-1, -2, -3, -4])
     uvc.jones_array = np.array([-1, -2])
 
-    # uvc has a time_range which it shouldn't really have because Ntimes > 1,
-    # but that requirement is not enforced. Set it to None for this test
-    uvc.time_range = None
-
     uvc2 = uvc.copy(metadata_only=True)
 
     uvc_new = UVCal.initialize_from_uvdata(uvd, uvc.gain_convention, uvc.cal_style)
@@ -4354,10 +4566,6 @@ def test_init_from_uvdata_sky(
 
     if not uvcal_future_shapes:
         uvc.use_current_array_shapes()
-
-    # uvc has a time_range which it shouldn't really have because Ntimes > 1,
-    # but that requirement is not enforced. Set it to None for this test
-    uvc.time_range = None
 
     # make cal object be a sky cal type
     uvc._set_sky()
@@ -4443,10 +4651,6 @@ def test_init_from_uvdata_delay(
 
     if not uvdata_future_shapes:
         uvd.use_current_array_shapes()
-
-    # uvc has a time_range which it shouldn't really have because Ntimes > 1,
-    # but that requirement is not enforced. Set it to None for this test
-    uvc.time_range = None
 
     # make cal object be a delay cal type
     uvc2 = uvc.copy(metadata_only=True)
@@ -4555,10 +4759,6 @@ def test_init_from_uvdata_wideband(
     if not uvdata_future_shapes:
         uvd.use_current_array_shapes()
 
-    # uvc has a time_range which it shouldn't really have because Ntimes > 1,
-    # but that requirement is not enforced. Set it to None for this test
-    uvc.time_range = None
-
     # make cal object be a wide-band cal
     uvc2 = uvc.copy(metadata_only=True)
     uvc2._set_wide_band()
@@ -4647,9 +4847,6 @@ def test_init_from_uvdata_wideband(
 def test_init_from_uvdata_basic_errors(uvcalibrate_data):
     uvd, uvc = uvcalibrate_data
     uvc._set_flex_spw()
-    # uvc has a time_range which it shouldn't really have because Ntimes > 1,
-    # but that requirement is not enforced. Set it to None for this test
-    uvc.time_range = None
 
     with pytest.raises(ValueError, match="uvdata must be a UVData object."):
         UVCal.initialize_from_uvdata(uvc, uvc.gain_convention, uvc.cal_style)

--- a/pyuvdata/uvcal/tests/test_uvcal.py
+++ b/pyuvdata/uvcal/tests/test_uvcal.py
@@ -2163,7 +2163,7 @@ def test_reorder_times_errors(gain_data):
         DeprecationWarning,
         match="The time_array and time_range attributes are both set. "
         "Defaulting to using time_range to determine sorting. This will "
-        "become an error in version 2.5.",
+        "become an error in version 3.0.",
     ):
         gain_data.reorder_times()
 
@@ -2895,15 +2895,15 @@ def test_add_times(
         check_warn = [DeprecationWarning] * 2
         check_msg = [
             "The time_array and time_range attributes are both set, but only one "
-            "should be set. This will become an error in version 2.5.",
+            "should be set. This will become an error in version 3.0.",
             "The lst_array and lst_range attributes are both set, but only one should "
-            "be set. This will become an error in version 2.5.",
+            "be set. This will become an error in version 3.0.",
         ]
         select_warn = check_warn + [DeprecationWarning]
         select_msg = check_msg + [
             "The time_array and time_range attributes are both set. "
             "Defaulting to using time_range to determine time selection. "
-            "This will become an error in version 2.5."
+            "This will become an error in version 3.0."
         ]
 
         add_warn = check_warn * 3
@@ -2913,7 +2913,7 @@ def test_add_times(
             add_msg += [
                 "The time_array and time_range attributes are both set. Defaulting to "
                 "using time_range to determine time matching between objects. "
-                "This will become an error in version 2.5."
+                "This will become an error in version 3.0."
             ]
     elif caltype == "delay":
         check_warn = [DeprecationWarning]
@@ -3080,7 +3080,7 @@ def test_add_times(
             warn_msg += [
                 "The time_array and time_range attributes are both set. Defaulting to "
                 "using time_range to determine sorting. This will become an error in "
-                "version 2.5."
+                "version 3.0."
             ]
         with uvtest.check_warnings(warn, match=warn_msg):
             calobj.reorder_times()

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -354,10 +354,6 @@ class UVCal(UVBase):
             required=False,
         )
 
-        # TODO:
-        #  - update uvcalibrate to handle multiple time ranges
-        #  - consider using python_ranges package
-
         desc = (
             "Integration time of a time bin, units seconds. "
             "If future_array_shapes=False, then it is a single value of type = float, "

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -1366,7 +1366,7 @@ class UVCal(UVBase):
             ):
                 warnings.warn(
                     f"The {pair[0]} and {pair[1]} attributes are both set, but only "
-                    "one should be set. This will become an error in version 2.5.",
+                    "one should be set. This will become an error in version 3.0.",
                     DeprecationWarning,
                 )
             elif getattr(self, pair[0]) is None and getattr(self, pair[1]) is None:
@@ -2015,7 +2015,7 @@ class UVCal(UVBase):
                 warnings.warn(
                     "The time_array and time_range attributes are both set. "
                     "Defaulting to using time_range to determine sorting. This will "
-                    "become an error in version 2.5.",
+                    "become an error in version 3.0.",
                     DeprecationWarning,
                 )
 
@@ -2516,7 +2516,7 @@ class UVCal(UVBase):
             warnings.warn(
                 "The time_array and time_range attributes are both set. "
                 "Defaulting to using time_range to determine time matching between "
-                "objects. This will become an error in version 2.5.",
+                "objects. This will become an error in version 3.0.",
                 DeprecationWarning,
             )
         if this.time_range is not None:
@@ -4259,7 +4259,7 @@ class UVCal(UVBase):
             warnings.warn(
                 "The time_array and time_range attributes are both set. "
                 "Defaulting to using time_range to determine time selection. "
-                "This will become an error in version 2.5.",
+                "This will become an error in version 3.0.",
                 DeprecationWarning,
             )
 

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -30,6 +30,60 @@ _future_array_shapes_warning = (
 )
 
 
+def _check_time_range_overlap(time_range):
+    """
+    Detect if any time ranges in an array overlap.
+
+    Parameters
+    ----------
+    time_range : np.array of float
+        Array of time ranges, shape (Ntimes, 2).
+
+    Returns
+    -------
+    bool
+        True if any time range overlaps.
+    """
+    # first check that time ranges are well formed (stop is >= than start)
+    if np.any((time_range[:, 1] - time_range[:, 0]) < 0):
+        raise ValueError(
+            "The time_ranges are not well-formed, some stop times are after start "
+            "times."
+        )
+
+    # Sort by start time
+    sorted_ranges = time_range[np.argsort(time_range[:, 0]), :]
+
+    # then check if adjacent pairs overlap
+    for ind in range(sorted_ranges.shape[0] - 1):
+        range1 = sorted_ranges[ind]
+        range2 = sorted_ranges[ind + 1]
+        if range2[0] < range1[1]:
+            return True
+
+
+def _time_param_check(this, other):
+    """Check if any time parameter is defined in this but not in other or vice-versa."""
+    if not isinstance(other):
+        other = [other]
+    time_params = ["time_array", "time_range"]
+    for param in time_params:
+        if getattr(this, time_params) is not None:
+            for obj in other:
+                if obj.time_array is None:
+                    raise ValueError(
+                        f"Some objects have a {param} while others do not. All "
+                        f"objects must either have or not have a {param}."
+                    )
+        else:
+            for obj in other:
+                if obj.time_array is not None:
+                    raise ValueError(
+                        f"Some objects have a {param} while others do not. All "
+                        f"objects must either have or not have a {param}."
+                    )
+
+
 class UVCal(UVBase):
     """
     A class defining calibration solutions for interferometric data.
@@ -238,16 +292,25 @@ class UVCal(UVBase):
         )
 
         desc = (
-            "Time range (in JD) that cal solutions are valid for."
-            "list: [start_time, end_time] in JD. Should only be set if Ntimes is 1."
+            "Time range (in JD) that cal solutions are valid for. This should be an "
+            "array with shape (Ntimes, 2) where the second axis gives the start_time "
+            "and end_time (in that order) in JD. Should only be set if the cal "
+            "solutions apply over a range of times. Only one of time_range and "
+            "time_array should be set."
         )
         self._time_range = uvp.UVParameter(
-            "time_range", description=desc, form=2, expected_type=float, required=False
+            "time_range",
+            description=desc,
+            form=("Ntimes", 2),
+            expected_type=float,
+            required=False,
         )
 
         desc = (
-            "Array of calibration solution times, center of integration, "
-            "shape (Ntimes), units Julian Date"
+            "Array of calibration solution times, center of integration, shape "
+            "(Ntimes), units Julian Date. Should only be set cal solutions were "
+            "calculated per integration (rather than over a range of integrations). "
+            "Only one of time_range and time_array should be set."
         )
         self._time_array = uvp.UVParameter(
             "time_array",
@@ -255,6 +318,7 @@ class UVCal(UVBase):
             form=("Ntimes",),
             expected_type=float,
             tols=1e-3 / (60.0 * 60.0 * 24.0),
+            required=False,
         )
 
         # standard angle tolerance: 1 mas in radians.
@@ -267,6 +331,13 @@ class UVCal(UVBase):
             tols=uvutils.RADIAN_TOL,
             required=True,
         )
+
+        # TODO: what should we do about the lst_array if we have a time_range rather
+        # than a time? 3 options occur to me:
+        #   1) add an lst_range parameter to match the time_range
+        #   2) make the lst_array have the lst of the starts of the time_ranges
+        #   3) dynamically change the expected shape of the lst_array to (Ntimes, 2)
+        #      if we have a time_range and not a time_array
 
         desc = (
             "Integration time of a time bin, units seconds. "
@@ -1253,6 +1324,20 @@ class UVCal(UVBase):
                 "2.5",
                 DeprecationWarning,
             )
+        # deprecate having both time_array and time_range set
+        if self.time_array is not None and self.time_range is not None:
+            warnings.warn(
+                "The time_array and time_range attributes are both set, but only one "
+                "should be set. This will become an error in version 2.5.",
+                DeprecationWarning,
+            )
+        elif self.time_array is None and self.time_range is None:
+            raise ValueError("Either time_array or time_range must be set.")
+
+        # check that time ranges are well formed and do not overlap
+        if self.time_range is not None:
+            if _check_time_range_overlap(self.time_range):
+                raise ValueError("Some time_ranges overlap.")
 
         # first run the basic check from UVBase
         super(UVCal, self).check(
@@ -1829,8 +1914,8 @@ class UVCal(UVBase):
         order: str or array like of int
             If a string, allowed value is "time" or "-time" to sort on the time in
             ascending or descending order respectively. An array of integers of length
-            Ntimes representing indexes along the existing `time_array` can also be
-            supplied to sort in any desired order.
+            Ntimes representing indexes along the existing `time_array` or `time_range`
+            can also be supplied to sort in any desired order.
 
         Returns
         -------
@@ -1860,7 +1945,18 @@ class UVCal(UVBase):
                     "index array of length Ntimes"
                 )
 
-            index_array = np.argsort(self.time_array)
+            if self.time_array is not None and self.time_range is not None:
+                warnings.warn(
+                    "The time_array and time_range attributes are both set. "
+                    "Defaulting to using time_range to determine sorting. This will "
+                    "become an error in version 2.5.",
+                    DeprecationWarning,
+                )
+
+            if self.time_range is not None:
+                index_array = np.argsort(self.time_range[:, 0])
+            else:
+                index_array = np.argsort(self.time_array)
 
             if order[0] == "-":
                 index_array = np.flip(index_array)
@@ -1870,7 +1966,10 @@ class UVCal(UVBase):
             return
 
         # update all the relevant arrays
-        self.time_array = self.time_array[index_array]
+        if self.time_array is not None:
+            self.time_array = self.time_array[index_array]
+        if self.time_range is not None:
+            self.time_range = self.time_range[index_array]
         self.lst_array = self.lst_array[index_array]
         if self.future_array_shapes:
             self.integration_time = self.integration_time[index_array]
@@ -2297,6 +2396,9 @@ class UVCal(UVBase):
                 "object will have it set."
             )
 
+        # check that both either have or don't have time_array and time_range
+        _time_param_check(this, other)
+
         # Check objects are compatible
         compatibility_params = [
             "_cal_type",
@@ -2340,9 +2442,27 @@ class UVCal(UVBase):
         both_jones, this_jones_ind, other_jones_ind = np.intersect1d(
             this.jones_array, other.jones_array, return_indices=True
         )
-        both_times, this_times_ind, other_times_ind = np.intersect1d(
-            this.time_array, other.time_array, return_indices=True
-        )
+
+        if self.time_array is not None and self.time_range is not None:
+            warnings.warn(
+                "The time_array and time_range attributes are both set. "
+                "Defaulting to using time_range to determine time matching between "
+                "objects. This will become an error in version 2.5.",
+                DeprecationWarning,
+            )
+        if this.time_range is not None:
+            if _check_time_range_overlap(
+                np.concatenate((this.time_range, other.time_range), axis=0)
+            ):
+                raise ValueError("A time_range overlaps in the two objects.")
+            both_times, this_times_ind, other_times_ind = np.intersect1d(
+                this.time_range[:, 0], other.time_range[:, 0], return_indices=True
+            )
+        else:
+            both_times, this_times_ind, other_times_ind = np.intersect1d(
+                this.time_array, other.time_array, return_indices=True
+            )
+
         if this.cal_type != "delay" and not this.wide_band:
             # With flexible spectral window, the handling here becomes a bit funky,
             # because we are allowed to have channels with the same frequency *if* they
@@ -2478,7 +2598,12 @@ class UVCal(UVBase):
         else:
             anew_inds = []
 
-        temp = np.nonzero(~np.in1d(other.time_array, this.time_array))[0]
+        if this.time_range is not None:
+            temp = np.nonzero(~np.in1d(other.time_range[:, 0], this.time_range[:, 0]))[
+                0
+            ]
+        else:
+            temp = np.nonzero(~np.in1d(other.time_array, this.time_array))[0]
         if len(temp) > 0:
             tnew_inds = temp
             if n_axes > 0:
@@ -2863,13 +2988,21 @@ class UVCal(UVBase):
 
         t_order = None
         if len(tnew_inds) > 0:
-            this.time_array = np.concatenate(
-                [this.time_array, other.time_array[tnew_inds]]
-            )
+            if this.time_array is not None:
+                this.time_array = np.concatenate(
+                    [this.time_array, other.time_array[tnew_inds]]
+                )
+            if this.time_range is not None:
+                this.time_range = np.concatenate(
+                    [this.time_range, other.time_range[tnew_inds]]
+                )
             this.lst_array = np.concatenate(
                 [this.lst_array, other.lst_array[tnew_inds]]
             )
-            t_order = np.argsort(this.time_array)
+            if this.time_range is not None:
+                t_order = np.argsort(this.time_range[:, 0])
+            else:
+                t_order = np.argsort(this.time_array)
             if self.future_array_shapes:
                 this.integration_time = np.concatenate(
                     [this.integration_time, other.integration_time[tnew_inds]]
@@ -3159,7 +3292,10 @@ class UVCal(UVBase):
         # Now populate the data
         if not self.metadata_only:
             jones_t2o = np.nonzero(np.in1d(this.jones_array, other.jones_array))[0]
-            times_t2o = np.nonzero(np.in1d(this.time_array, other.time_array))[0]
+            if this.time_range is not None:
+                times_t2o = np.nonzero(np.in1d(this.time_range, other.time_range))[0]
+            else:
+                times_t2o = np.nonzero(np.in1d(this.time_array, other.time_array))[0]
             if self.wide_band:
                 freqs_t2o = np.nonzero(np.in1d(this.spw_array, other.spw_array))[0]
             elif self.future_array_shapes:
@@ -3286,7 +3422,10 @@ class UVCal(UVBase):
                 if this.flex_spw_id_array is not None:
                     this.flex_spw_id_array = this.flex_spw_id_array[f_order]
         if len(tnew_inds) > 0:
-            this.time_array = this.time_array[t_order]
+            if this.time_array is not None:
+                this.time_array = this.time_array[t_order]
+            if this.time_range is not None:
+                this.time_range = this.time_range[t_order]
             this.lst_array = this.lst_array[t_order]
             if self.future_array_shapes:
                 this.integration_time = this.integration_time[t_order]
@@ -3295,7 +3434,10 @@ class UVCal(UVBase):
 
         # Update N parameters (e.g. Njones)
         this.Njones = this.jones_array.shape[0]
-        this.Ntimes = this.time_array.shape[0]
+        if this.time_range is not None:
+            this.Ntimes = this.time_range.shape[0]
+        else:
+            this.Ntimes = this.time_array.shape[0]
         if this.cal_type == "gain" and not this.wide_band:
             this.Nfreqs = this.freq_array.size
         this.Nspws = this.spw_array.size
@@ -3572,6 +3714,7 @@ class UVCal(UVBase):
             ]
             if not this.future_array_shapes:
                 compatibility_params += ["_integration_time"]
+            _time_param_check(this, other)
 
         history_update_string += " axis using pyuvdata."
         histories_match = []
@@ -3739,9 +3882,14 @@ class UVCal(UVBase):
             axis_num = 1
         elif axis == "time":
             this.Ntimes = sum([this.Ntimes] + [obj.Ntimes for obj in other])
-            this.time_array = np.concatenate(
-                [this.time_array] + [obj.time_array for obj in other]
-            )
+            if this.time_array is not None:
+                this.time_array = np.concatenate(
+                    [this.time_array] + [obj.time_array for obj in other]
+                )
+            if this.time_range is not None:
+                this.time_range = np.concatenate(
+                    [this.time_range] + [obj.time_range for obj in other], axis=0
+                )
             if this.future_array_shapes:
                 this.integration_time = np.concatenate(
                     [this.integration_time] + [obj.integration_time for obj in other]
@@ -3886,6 +4034,7 @@ class UVCal(UVBase):
         freq_chans=None,
         spws=None,
         times=None,
+        time_range=None,
         jones=None,
         run_check=True,
         check_extra=True,
@@ -3922,8 +4071,13 @@ class UVCal(UVBase):
             that match any of the specifications will be kept (i.e. the selections will
             be OR'ed together).
         times : array_like of float, optional
-            The times to keep in the object, each value passed here should
-            exist in the time_array.
+            The times to keep in the object, each value passed here should exist in
+            the time_array or be a start time in the time_range (i.e. be in
+            time_range[:, 0]).
+        time_range : array_like of float, optional
+            The time range in Julian Date to keep in the object, must be
+            length 2. Some of the times in the object should fall between the
+            first and last elements. Cannot be used with `times`.
         jones : array_like of int or str, optional
             The antenna polarizations numbers to keep in the object, each value
             passed here should exist in the jones_array. If passing strings, the
@@ -4009,6 +4163,19 @@ class UVCal(UVBase):
                     )
                     cal_object.total_quality_array = None
 
+        if times is not None and time_range is not None:
+            raise ValueError("Cannot set both `times` and `time_range`.")
+
+        if (times is not None or time_range is not None) and (
+            cal_object.time_array is not None and cal_object.time_range is not None
+        ):
+            warnings.warn(
+                "The time_array and time_range attributes are both set. "
+                "Defaulting to using time_range to determine time selection. "
+                "This will become an error in version 2.5.",
+                DeprecationWarning,
+            )
+
         if times is not None:
             times = uvutils._get_iterable(times)
             if n_selects > 0:
@@ -4018,25 +4185,30 @@ class UVCal(UVBase):
             n_selects += 1
 
             time_inds = np.zeros(0, dtype=np.int64)
+            if cal_object.time_range is not None:
+                time_param = "time_range"
+                times_compare = cal_object.time_range[:, 0]
+            else:
+                time_param = "time_array"
+                times_compare = cal_object.time_array
             for jd in times:
                 if jd in cal_object.time_array:
-                    time_inds = np.append(
-                        time_inds, np.where(cal_object.time_array == jd)[0]
-                    )
+                    time_inds = np.append(time_inds, np.where(times_compare == jd)[0])
                 else:
-                    raise ValueError(
-                        "Time {t} is not present in the time_array".format(t=jd)
-                    )
+                    raise ValueError(f"Time {jd} is not present in the {time_param}")
 
             time_inds = sorted(set(time_inds))
             cal_object.Ntimes = len(time_inds)
-            cal_object.time_array = cal_object.time_array[time_inds]
+            if cal_object.time_array is not None:
+                cal_object.time_array = cal_object.time_array[time_inds]
+            if cal_object.time_range is not None:
+                cal_object.time_range = cal_object.time_range[time_inds]
             if cal_object.lst_array is not None:
                 cal_object.lst_array = cal_object.lst_array[time_inds]
             if self.future_array_shapes:
                 cal_object.integration_time = cal_object.integration_time[time_inds]
 
-            if cal_object.Ntimes > 1:
+            if cal_object.Ntimes > 1 and self.time_array is not None:
                 if not uvutils._test_array_constant_spacing(cal_object._time_array):
                     warnings.warn(
                         "Selected times are not evenly spaced. This "
@@ -4431,6 +4603,8 @@ class UVCal(UVBase):
             param = getattr(self, p)
             setattr(other_obj, p, param)
         return other_obj
+
+    # TODO: update the initializers module and read methods for proper time_range handling.
 
     @classmethod
     @combine_docstrings(initializers.new_uvcal_from_uvdata)

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -66,20 +66,20 @@ def _check_range_overlap(val_range, range_type="time"):
 
 def _time_param_check(this, other):
     """Check if any time parameter is defined in this but not in other or vice-versa."""
-    if not isinstance(other):
+    if not isinstance(other, list):
         other = [other]
     time_params = ["time_array", "time_range"]
     for param in time_params:
-        if getattr(this, time_params) is not None:
+        if getattr(this, param) is not None:
             for obj in other:
-                if obj.time_array is None:
+                if getattr(obj, param) is None:
                     raise ValueError(
                         f"Some objects have a {param} while others do not. All "
                         f"objects must either have or not have a {param}."
                     )
         else:
             for obj in other:
-                if obj.time_array is not None:
+                if getattr(obj, param) is not None:
                     raise ValueError(
                         f"Some objects have a {param} while others do not. All "
                         f"objects must either have or not have a {param}."
@@ -1351,7 +1351,13 @@ class UVCal(UVBase):
                 "2.5",
                 DeprecationWarning,
             )
+        # first run the basic check from UVBase
+        super(UVCal, self).check(
+            check_extra=check_extra, run_check_acceptability=run_check_acceptability
+        )
+
         # deprecate having both time_array and time_range set
+        # check that corresponding lst parameters are set
         time_like_pairs = [("time_array", "time_range"), ("lst_array", "lst_range")]
         for pair in time_like_pairs:
             if (
@@ -1366,30 +1372,19 @@ class UVCal(UVBase):
             elif getattr(self, pair[0]) is None and getattr(self, pair[1]) is None:
                 raise ValueError(f"Either {pair[0]} or {pair[1]} must be set.")
 
-        # this can go away in version 2.5
-        if self.time_array is not None:
-            if self.lst_array is None:
+        for tp_ind, param in enumerate(time_like_pairs[0]):
+            lst_param = time_like_pairs[1][tp_ind]
+            if getattr(self, param) is not None and getattr(self, lst_param) is None:
                 raise ValueError(
-                    "If time_array is present, lst_array must also be present."
+                    f"If {param} is present, {lst_param} must also be present."
                 )
 
         # check that time ranges are well formed and do not overlap
         if self.time_range is not None:
-            if self.lst_range is None:
-                raise ValueError(
-                    "If time_range is present, lst_range must also be present."
-                )
             if _check_range_overlap(self.time_range):
                 raise ValueError("Some time_ranges overlap.")
-
-        if self.lst_range is not None:
-            if _check_range_overlap(self.lst_range, range_type="lst"):
-                raise ValueError("Some lst_range overlap.")
-
-        # first run the basic check from UVBase
-        super(UVCal, self).check(
-            check_extra=check_extra, run_check_acceptability=run_check_acceptability
-        )
+            # note: do not check lst range overlap because of branch cut.
+            # Assume they are ok if time_ranges are ok.
 
         # require that all entries in ant_array exist in antenna_numbers
         if not all(ant in self.antenna_numbers for ant in self.ant_array):
@@ -3372,7 +3367,10 @@ class UVCal(UVBase):
         if not self.metadata_only:
             jones_t2o = np.nonzero(np.in1d(this.jones_array, other.jones_array))[0]
             if this.time_range is not None:
-                times_t2o = np.nonzero(np.in1d(this.time_range, other.time_range))[0]
+                times_t2o = np.nonzero(
+                    (np.in1d(this.time_range[:, 0], other.time_range[:, 0]))
+                    & (np.in1d(this.time_range[:, 1], other.time_range[:, 1]))
+                )[0]
             else:
                 times_t2o = np.nonzero(np.in1d(this.time_array, other.time_array))[0]
             if self.wide_band:
@@ -4253,7 +4251,7 @@ class UVCal(UVBase):
                     cal_object.total_quality_array = None
 
         if times is not None and time_range is not None:
-            raise ValueError("Cannot set both `times` and `time_range`.")
+            raise ValueError("Only one of times and time_range can be provided.")
 
         if (times is not None or time_range is not None) and (
             cal_object.time_array is not None and cal_object.time_range is not None
@@ -4284,13 +4282,13 @@ class UVCal(UVBase):
                                     (cal_object.time_range[:, 0] <= jd),
                                     (cal_object.time_range[:, 1] >= jd),
                                 )
-                            ),
+                            )[0],
                         )
                 else:
                     for jd in times:
                         if jd in cal_object.time_array:
                             time_inds = np.append(
-                                time_inds, np.where(cal_object.time_array == jd)[0]
+                                time_inds, np.nonzero(cal_object.time_array == jd)[0]
                             )
                         else:
                             raise ValueError(
@@ -4302,23 +4300,26 @@ class UVCal(UVBase):
                         if _check_range_overlap(np.stack((trange, time_range), axis=0)):
                             time_inds = np.append(time_inds, tind)
                 else:
-                    time_inds = (
-                        np.nonzero(
-                            np.logical_and(
-                                (cal_object.time_array >= time_range[0]),
-                                (cal_object.time_array <= time_range[1]),
-                            )
-                        ),
-                    )
+                    time_inds = np.nonzero(
+                        np.logical_and(
+                            (cal_object.time_array >= time_range[0]),
+                            (cal_object.time_array <= time_range[1]),
+                        )
+                    )[0]
 
-            time_inds = sorted(set(time_inds))
-            cal_object.Ntimes = len(time_inds)
+            if time_inds.size == 0:
+                raise ValueError("No times or time_ranges matching requested times.")
+
+            time_inds = np.array(sorted(set(time_inds.tolist())))
+            cal_object.Ntimes = time_inds.size
             if cal_object.time_array is not None:
                 cal_object.time_array = cal_object.time_array[time_inds]
             if cal_object.time_range is not None:
                 cal_object.time_range = cal_object.time_range[time_inds]
             if cal_object.lst_array is not None:
                 cal_object.lst_array = cal_object.lst_array[time_inds]
+            if cal_object.lst_range is not None:
+                cal_object.lst_range = cal_object.lst_range[time_inds]
             if self.future_array_shapes:
                 cal_object.integration_time = cal_object.integration_time[time_inds]
 

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -355,8 +355,6 @@ class UVCal(UVBase):
         )
 
         # TODO:
-        #  - consider allowing a time_array even if you have a time_range to carry the
-        #     center of times? Talk to Dara.
         #  - update uvcalibrate to handle multiple time ranges
         #  - consider using python_ranges package
 
@@ -1714,6 +1712,20 @@ class UVCal(UVBase):
         return self._slice_array(
             self._parse_key(ant, jpol=jpol), self.quality_array, squeeze_pol=squeeze_pol
         )
+
+    def get_time_array(self):
+        """
+        Get a time array of calibration solution times.
+
+        Times are for the center of the integration, shape (Ntimes), units in Julian
+        Date. If a time_range is defined on the object, the times are the mean of the
+        start and stop times for each range. Otherwise return the time_array (which can
+        be None).
+        """
+        if self.time_range is not None:
+            return np.mean(self.time_range, axis=1)
+        else:
+            return self.time_array
 
     def reorder_antennas(
         self,
@@ -4705,9 +4717,6 @@ class UVCal(UVBase):
             param = getattr(self, p)
             setattr(other_obj, p, param)
         return other_obj
-
-    # TODO: update the initializers module and read methods for proper time_range
-    # handling.
 
     @classmethod
     @combine_docstrings(initializers.new_uvcal_from_uvdata)

--- a/pyuvdata/uvdata/initializers.py
+++ b/pyuvdata/uvdata/initializers.py
@@ -108,27 +108,39 @@ def get_time_params(
     )
 
     if integration_time is None:
-        utimes = np.sort(list(set(time_array)))
-        if len(utimes) > 1:
-            integration_time = np.diff(utimes) * 86400
-            integration_time = np.concatenate([integration_time, integration_time[-1:]])
+        if time_array.ndim == 2:
+            np.diff(time_array, axis=1)
         else:
-            warnings.warn(
-                "integration_time not provided, and cannot be inferred from time_array,"
-                " setting to 1 second"
-            )
-            integration_time = np.array([1.0])
+            utimes = np.sort(list(set(time_array)))
+            if len(utimes) > 1:
+                integration_time = np.diff(utimes) * 86400
+                integration_time = np.concatenate(
+                    [integration_time, integration_time[-1:]]
+                )
+            else:
+                warnings.warn(
+                    "integration_time not provided, and cannot be inferred from "
+                    "time_array, setting to 1 second"
+                )
+                integration_time = np.array([1.0])
 
     if np.isscalar(integration_time):
-        integration_time = np.full_like(time_array, integration_time)
+        if time_array.ndim == 2:
+            integration_time = np.full_like(time_array[:, 0], integration_time)
+        else:
+            integration_time = np.full_like(time_array, integration_time)
 
     try:
         integration_time = np.asarray(integration_time, dtype=float)
     except TypeError as e:
         raise TypeError("integration_time must be array_like of floats") from e
 
-    if integration_time.shape != time_array.shape:
-        raise ValueError("integration_time must be the same shape as time_array.")
+    if time_array.ndim == 2:
+        if integration_time.size != time_array.shape[0]:
+            raise ValueError("integration_time must be the same shape as time_array.")
+    else:
+        if integration_time.shape != time_array.shape:
+            raise ValueError("integration_time must be the same shape as time_array.")
 
     return lst_array, integration_time
 

--- a/pyuvdata/uvdata/initializers.py
+++ b/pyuvdata/uvdata/initializers.py
@@ -109,7 +109,7 @@ def get_time_params(
 
     if integration_time is None:
         if time_array.ndim == 2:
-            np.diff(time_array, axis=1)
+            integration_time = np.squeeze(np.diff(time_array, axis=1) * 86400)
         else:
             utimes = np.sort(list(set(time_array)))
             if len(utimes) > 1:
@@ -137,7 +137,10 @@ def get_time_params(
 
     if time_array.ndim == 2:
         if integration_time.size != time_array.shape[0]:
-            raise ValueError("integration_time must be the same shape as time_array.")
+            raise ValueError(
+                "integration_time must be the same length as the first axis of "
+                "time_range."
+            )
     else:
         if integration_time.shape != time_array.shape:
             raise ValueError("integration_time must be the same shape as time_array.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Improve the way `time_range` is handled in UVCal. It exists to support calibration approaches that solve for cal solutions over a range of times rather than per integration. This PR makes the following changes:
- Deprecate having both a `time_array` and a `time_range` defined.
- Make `time_range` be 2D with a shape of (Ntimes, 2) where the first axis gives the number of different time solutions and the second axis gives the start/stop times for those solutions. This allows different calibration solutions that apply over ranges of times to be properly combined in a single object.
- Add a `get_time_array` method that either returns the mean of the start and stop time for each time range or the time_array (if there's a time_array and no time_range)

**Note**: this is actually a breaking change in the following ways:
- It changes the shape of the `time_range` in the object.
- It makes it so that `time_range` is not defined on an object read from a calfits file with more than one time, even if the file has a `time_range` entry in the header. This is because the header `time_range` is a single range, it doesn't have a length Ntimes axis, so it doesn't have the right shape for the new `time_range` shape.
- If a calfits file is read in with one time and it has a `time_range` entry in the header, only the `time_range` will be defined, not the `time_array`. This could be changed but it would result in many deprecation warnings because having both a `time_range` and a `time_array` is deprecated. We could add a parameter to `read_calfits` to only have it define one or the other.
- If and fhd cal file is read in (which by definition has only one time), only the `time_range` will be defined, not the `time_array`. This could be changed but it would result in many deprecation warnings because having both a `time_range` and a `time_array` is deprecated. We could add a parameter to the `read_fhd` method to only have it define one or the other.

I see how to fix the third  & fourth items above in a way that supports deprecation, but I don't see a path for allowing for a deprecation period for the first two items. So we decided to push this into version 3.0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Closes #851 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Breaking change checklist:
- [x] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to reflect my changes (if appropriate).
- [x] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
