### PR TITLE
Add warnings in check if lst_array doesn't match expectations

### DIFF
--- a/pyuvdata/conftest.py
+++ b/pyuvdata/conftest.py
@@ -5,12 +5,12 @@
 """Testing environment setup and teardown for pytest."""
 import os
 
-import numpy as np
 import pytest
 from astropy.coordinates import EarthLocation
 from astropy.time import Time
 from astropy.utils import iers
 
+import pyuvdata.tests as uvtest
 from pyuvdata import UVCal, UVData
 from pyuvdata.data import DATA_PATH
 
@@ -76,10 +76,25 @@ def uvcalibrate_data_main(uvcalibrate_init_data_main):
     uvdata = uvdata_in.copy()
     uvcal = uvcal_in.copy()
 
-    # fix the antenna names in the uvcal object to match the uvdata object
-    uvcal.antenna_names = np.array(
-        [name.replace("ant", "HH") for name in uvcal.antenna_names]
-    )
+    with uvtest.check_warnings(
+        UserWarning,
+        match=[
+            "telescope_location is not set. Using known values for HERA.",
+            "antenna_positions, antenna_names, antenna_numbers, Nants_telescope are "
+            "not set or are being overwritten. Using known values for HERA.",
+        ],
+    ):
+        uvcal.set_telescope_params(overwrite=True)
+
+    with uvtest.check_warnings(
+        UserWarning,
+        match=[
+            "Nants_telescope, antenna_diameters, antenna_names, antenna_numbers, "
+            "antenna_positions, telescope_location, telescope_name are not set or are "
+            "being overwritten. Using known values for HERA."
+        ],
+    ):
+        uvdata.set_telescope_params(overwrite=True)
 
     yield uvdata, uvcal
 

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -3988,6 +3988,7 @@ def test_read_slicing():
         ("ant1",),
         ("ant2",),
         (),
+        ([0, 2, 6, 4, 8, 10, 12, 14, 16, 1, 3, 5, 7, 9, 11, 13, 15, 17]),
     ],
 )
 def test_determine_blt_order(blt_order):
@@ -4017,7 +4018,9 @@ def test_determine_blt_order(blt_order):
         BASELINE = getbl(ANT1, ANT2)
 
         lc = locals()
-        if blt_order:
+        if isinstance(blt_order, list):
+            inds = np.array(blt_order)
+        elif blt_order:
             inds = np.lexsort(tuple(lc[k.upper()] for k in blt_order[::-1]))
         else:
             inds = np.arange(len(TIME))
@@ -4026,15 +4029,12 @@ def test_determine_blt_order(blt_order):
 
     # time, bl
     TIME, ANT1, ANT2, BL = gettimebls(blt_order)
-    print(blt_order)
-    print("TIME: ", TIME)
-    print("ANT1: ", ANT1)
-    print("ANT2: ", ANT2)
-    print("BL: ", BL)
     order = uvutils.determine_blt_order(
         TIME, ANT1, ANT2, BL, Nbls=nant**2, Ntimes=ntime
     )
-    if blt_order:
+    if isinstance(blt_order, list):
+        assert order is None
+    elif blt_order:
         assert order == blt_order
     else:
         assert order is None
@@ -4045,6 +4045,9 @@ def test_determine_blt_order(blt_order):
     if blt_order in [("ant1", "time"), ("ant2", "time")]:
         # sorting by ant1/ant2 then time means we split the other ant into a
         # separate group
+        assert not is_rect
+        assert not time_first
+    elif isinstance(blt_order, list):
         assert not is_rect
         assert not time_first
     else:

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -33,13 +33,7 @@ ref_xyz_moon = (1581421.16194946, 718462.9979381, 20843.20350155)
 
 pytestmark = pytest.mark.filterwarnings(
     "ignore:telescope_location is not set. Using known values",
-    "ignore:antenna_positions is not set. Using known values",
-)
-
-
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:telescope_location is not set. Using known values for HERA.",
-    "ignore:antenna_positions is not set. Using known values for HERA.",
+    "ignore:antenna_positions are not set or are being overwritten. Using known values",
 )
 
 
@@ -3413,8 +3407,6 @@ def test_uvcalibrate_flag_propagation(
         uvd.get_data(0, 12, "xx"), uvdcal.get_data(0, 12, "xx")
     )
 
-    uvc.set_telescope_params(overwrite=True)
-
     uvc_sub = uvc.select(antenna_nums=[1, 12], inplace=False)
 
     uvdata_unique_nums = np.unique(np.append(uvd.ant_1_array, uvd.ant_2_array))
@@ -3548,6 +3540,7 @@ def test_uvcalibrate_time_mismatch(uvcalibrate_data):
 
     # change times to get warnings
     uvc.time_array = uvc.time_array + 1
+    uvc.set_lsts_from_time_array()
 
     expected_err = {
         f"Time {this_time} exists on UVData but not on UVCal."
@@ -3632,6 +3625,7 @@ def test_uvcalibrate_extra_cal_times(uvcalibrate_data):
 
     uvc2 = uvc.copy()
     uvc2.time_array = uvc.time_array + 1
+    uvc2.set_lsts_from_time_array()
     uvc_use = uvc + uvc2
 
     uvdcal = uvutils.uvcalibrate(uvd, uvc_use, inplace=False)

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -73,6 +73,9 @@ __all__ = [
     "and_collapse",
 ]
 
+# standard angle tolerance: 1 mas in radians.
+RADIAN_TOL = 1 * 2 * np.pi * 1e-3 / (60.0 * 60.0 * 360.0)
+
 # fmt: off
 # polarization constants
 # maps polarization strings to polarization integers
@@ -3941,6 +3944,35 @@ def get_lst_for_time(
         lst_array *= np.pi / 12.0
 
     return lst_array
+
+
+def check_lsts_against_times(
+    *,
+    jd_array,
+    lst_array,
+    latitude,
+    longitude,
+    altitude,
+    lst_tols,
+    astrometry_library=None,
+    frame="itrs",
+):
+    """Check that LSTs consistent with the time_array and telescope location."""
+    lsts = get_lst_for_time(
+        jd_array=jd_array,
+        latitude=latitude,
+        longitude=longitude,
+        altitude=altitude,
+        astrometry_library=astrometry_library,
+        frame=frame,
+    )
+
+    if not np.allclose(lst_array, lsts, rtol=lst_tols[0], atol=lst_tols[1]):
+        warnings.warn(
+            "The lst_array is not self-consistent with the time_array and "
+            "telescope location. Consider recomputing with the "
+            "`set_lsts_from_time_array` method."
+        )
 
 
 def _adj_list(vecs, tol, n_blocks=None):

--- a/pyuvdata/uvcal/tests/conftest.py
+++ b/pyuvdata/uvcal/tests/conftest.py
@@ -18,7 +18,15 @@ from pyuvdata.data import DATA_PATH
 def gain_data_main():
     """Read in gain calfits file."""
     gainfile = os.path.join(DATA_PATH, "zen.2457698.40355.xx.gain.calfits")
-    gain_object = UVCal.from_file(gainfile, use_future_array_shapes=True)
+    with uvtest.check_warnings(
+        UserWarning,
+        match=[
+            "telescope_location is not set. Using known values for HERA.",
+            "antenna_positions are not set or are being overwritten. Using known "
+            "values for HERA.",
+        ],
+    ):
+        gain_object = UVCal.from_file(gainfile, use_future_array_shapes=True)
     gain_object.freq_range = None
 
     yield gain_object
@@ -44,7 +52,8 @@ def delay_data_main():
         UserWarning,
         match=[
             "telescope_location is not set. Using known values for HERA.",
-            "antenna_positions is not set. Using known values for HERA.",
+            "antenna_positions are not set or are being overwritten. Using known "
+            "values for HERA.",
             "When converting a delay-style cal to future array shapes the flag_array"
             " (and input_flag_array if it exists) must drop the frequency axis",
         ],

--- a/pyuvdata/uvcal/tests/test_calfits.py
+++ b/pyuvdata/uvcal/tests/test_calfits.py
@@ -19,7 +19,7 @@ from pyuvdata.uvcal.uvcal import _future_array_shapes_warning
 
 pytestmark = pytest.mark.filterwarnings(
     "ignore:telescope_location is not set. Using known values",
-    "ignore:antenna_positions is not set. Using known values",
+    "ignore:antenna_positions are not set or are being overwritten. Using known values",
 )
 
 

--- a/pyuvdata/uvdata/fhd.py
+++ b/pyuvdata/uvdata/fhd.py
@@ -13,7 +13,6 @@ from scipy.io import readsav
 from .. import telescopes as uvtel
 from .. import utils as uvutils
 from .uvdata import UVData, _future_array_shapes_warning
-from .uvdata import radian_tol as default_radian_tol
 
 __all__ = ["get_fhd_history", "get_fhd_layout_info", "FHD"]
 
@@ -592,7 +591,7 @@ class FHD(UVData):
                 latitude,
                 longitude,
                 altitude,
-                default_radian_tol,
+                uvutils.RADIAN_TOL,
                 self._telescope_location.tols,
                 obs_tile_names,
                 run_check_acceptability=True,

--- a/pyuvdata/uvdata/tests/conftest.py
+++ b/pyuvdata/uvdata/tests/conftest.py
@@ -104,7 +104,13 @@ def sma_mir_main():
     # read in test file for the resampling in time functions
     uv_object = UVData()
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
-    uv_object.read(testfile, use_future_array_shapes=True)
+    with uvtest.check_warnings(
+        UserWarning,
+        match="The lst_array is not self-consistent with the time_array and telescope "
+        "location. Consider recomputing with the `set_lsts_from_time_array` method.",
+    ):
+        uv_object.read(testfile, use_future_array_shapes=True)
+    uv_object.set_lsts_from_time_array()
 
     yield uv_object
 

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -87,8 +87,8 @@ def test_cotter_ms():
         [UserWarning] * 3 + [DeprecationWarning],
         match=[
             "Warning: select on read keyword set",
-            "telescope_location are not set or being overwritten. Using known values "
-            "for MWA.",
+            "telescope_location are not set or are being overwritten. Using known "
+            "values for MWA.",
             "UVW orientation appears to be flipped,",
             _future_array_shapes_warning,
         ],

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -2135,9 +2135,8 @@ def test_select_lsts_too_big(casa_uvfits, tmp_path):
         match=warn_msg
         + [
             "Telescope EVLA is not in known_telescopes.",
-            "LST values stored in this file are not self-consistent with "
-            "time_array and telescope location. Consider recomputing with "
-            "the `set_lsts_from_time_array` method.",
+            "The lst_array is not self-consistent with the time_array and telescope "
+            "location. Consider recomputing with the `set_lsts_from_time_array` method",
         ],
     ):
         UVData.from_file(test_filename, use_future_array_shapes=True)

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -1979,6 +1979,8 @@ def test_uvh5_lst_array(casa_uvfits, tmp_path):
             f"LST values stored in {testfile} are not self-consistent",
             "The uvw_array does not match the expected values given the antenna "
             "positions.",
+            "The lst_array is not self-consistent with the time_array and telescope "
+            "location. Consider recomputing with the `set_lsts_from_time_array` method",
         ],
     ):
         uv_out.read_uvh5(testfile, use_future_array_shapes=True)

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -1976,12 +1976,14 @@ def test_uvh5_lst_array(casa_uvfits, tmp_path):
     with uvtest.check_warnings(
         UserWarning,
         [
-            f"LST values stored in {testfile} are not self-consistent",
             "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            "positions."
+        ]
+        + [
             "The lst_array is not self-consistent with the time_array and telescope "
-            "location. Consider recomputing with the `set_lsts_from_time_array` method",
-        ],
+            "location. Consider recomputing with the `set_lsts_from_time_array` method"
+        ]
+        * 2,
     ):
         uv_out.read_uvh5(testfile, use_future_array_shapes=True)
     uv_out.lst_array = lst_array

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3482,7 +3482,7 @@ class TestFastUVH5Meta:
         uvd.write_uvh5(self.fl_singlebl)
 
         time_keep = np.min(uvd.time_array)
-        uvd2 = UVData.from_file(self.fl, times=time_keep)
+        uvd2 = UVData.from_file(self.fl, times=time_keep, use_future_array_shapes=True)
         self.fl_singletime = os.path.join(self.tmp_path.name, "singletime.uvh5")
         uvd2.write_uvh5(self.fl_singletime)
 

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -69,10 +69,9 @@ class UVFITS(UVData):
                     )
                 ):
                     warnings.warn(
-                        "LST values stored in this file are not "
-                        "self-consistent with time_array and telescope "
-                        "location. Consider recomputing with "
-                        "utils.get_lst_for_time."
+                        "LST values stored in this file are not self-consistent with "
+                        "time_array and telescope location. Consider recomputing with "
+                        "the `set_lsts_from_time_array` method."
                     )
 
         else:

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -57,22 +57,15 @@ class UVFITS(UVData):
                     longitude,
                     altitude,
                 ) = self.telescope_location_lat_lon_alt_degrees
-                lst_array = uvutils.get_lst_for_time(
-                    self.time_array, latitude, longitude, altitude
-                )
-                if not np.all(
-                    np.isclose(
-                        self.lst_array,
-                        lst_array,
-                        rtol=self._lst_array.tols[0],
-                        atol=self._lst_array.tols[1],
-                    )
-                ):
-                    warnings.warn(
-                        "LST values stored in this file are not self-consistent with "
-                        "time_array and telescope location. Consider recomputing with "
-                        "the `set_lsts_from_time_array` method."
-                    )
+            uvutils.check_lsts_against_times(
+                jd_array=self.time_array,
+                lst_array=self.lst_array,
+                latitude=latitude,
+                longitude=longitude,
+                altitude=altitude,
+                lst_tols=self._lst_array.tols,
+                frame=self._telescope_location.frame,
+            )
 
         else:
             proc = self.set_lsts_from_time_array(background=background_lsts)

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -699,7 +699,7 @@ class FastUVH5Meta:
             warnings.warn(
                 f"LST values stored in {self.path} are not self-consistent "
                 "with time_array and telescope location. Consider "
-                "recomputing with utils.get_lst_for_time."
+                "recomputing with UVData.set_lsts_from_time_array."
             )
 
     @cached_property

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -632,19 +632,13 @@ class FastUVH5Meta:
     def lsts(self) -> np.ndarray:
         """The unique LSTs in the file."""
         h = self.header
-        if "lst_array" in h:
-            if self.blts_are_rectangular:
-                if self.time_axis_faster_than_bls:
-                    return h["lst_array"][: self.Ntimes]
-                else:
-                    return h["lst_array"][:: self.Nbls]
+        if "lst_array" in h and self.blts_are_rectangular:
+            if self.time_axis_faster_than_bls:
+                return h["lst_array"][: self.Ntimes]
             else:
-                return np.unique(self.lst_array)
-
-        # If lst_array not there, compute ourselves.
-        return uvutils.get_lst_for_time(
-            self.times, *self.telescope_location_lat_lon_alt_degrees
-        )
+                return h["lst_array"][:: self.Nbls]
+        else:
+            return np.unique(self.lst_array)
 
     @cached_property
     def lst_array(self) -> np.ndarray:

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -804,6 +804,7 @@ def test_from_uvdata_error():
 
 
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 @pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.parametrize("read_future_shapes", [True, False])
 @pytest.mark.parametrize("write_future_shapes", [True, False])
@@ -832,6 +833,7 @@ def test_init_list_files_weights(read_future_shapes, write_future_shapes, tmpdir
     assert np.all(uvf2.weights_array == np.concatenate([wts1, wts2], axis=0))
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_init_posix():
     # Test that weights are preserved when reading list of files
     testfile_posix = pathlib.Path(test_f_file)
@@ -905,6 +907,7 @@ def test_read_write_loop_missing_shapes(uvdata_obj, test_outfile, future_shapes)
     assert uvf2.filename == [os.path.basename(test_outfile)]
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 @pytest.mark.parametrize(
     ["uvf_type", "param_list", "warn_type", "msg", "uv_mod"],
     [
@@ -923,31 +926,49 @@ def test_read_write_loop_missing_shapes(uvdata_obj, test_outfile, future_shapes)
             "baseline",
             ["telescope_location"],
             UserWarning,
-            "telescope_location are not set or are being overwritten. Using known",
+            [
+                "telescope_location are not set or are being overwritten. Using known",
+                "The lst_array is not self-consistent with the time_array",
+            ],
             "reset_telescope_params",
         ),
         (
             "baseline",
             ["antenna_names"],
             UserWarning,
-            "antenna_names are not set or are being overwritten. Using known values",
+            [
+                "antenna_names are not set or are being overwritten. Using known",
+                "The lst_array is not self-consistent with the time_array",
+            ],
             "reset_telescope_params",
         ),
         (
             "baseline",
             ["antenna_numbers"],
             UserWarning,
-            "antenna_numbers are not set or are being overwritten. Using known values",
+            [
+                "antenna_numbers are not set or are being overwritten. Using known",
+                "The lst_array is not self-consistent with the time_array",
+            ],
             "reset_telescope_params",
         ),
         (
             "baseline",
             ["antenna_positions"],
             UserWarning,
-            "antenna_positions are not set or are being overwritten. Using known",
+            [
+                "antenna_positions are not set or are being overwritten. Using known",
+                "The lst_array is not self-consistent with the time_array",
+            ],
             "reset_telescope_params",
         ),
-        ("baseline", ["Nants_telescope"], None, "", "reset_telescope_params"),
+        (
+            "baseline",
+            ["Nants_telescope"],
+            UserWarning,
+            "The lst_array is not self-consistent with the time_array",
+            "reset_telescope_params",
+        ),
         (
             "waterfall",
             ["Nants_telescope", "telescope_name", "antenna_numbers"],
@@ -991,8 +1012,11 @@ def test_read_write_loop_missing_shapes(uvdata_obj, test_outfile, future_shapes)
             "baseline",
             ["antenna_names", "antenna_numbers", "antenna_positions"],
             UserWarning,
-            "Nants_telescope, antenna_names, antenna_numbers, antenna_positions are "
-            "not set or are being overwritten. Using known values for HERA.",
+            [
+                "Nants_telescope, antenna_names, antenna_numbers, antenna_positions "
+                "are not set or are being overwritten. Using known values for HERA.",
+                "The lst_array is not self-consistent with the time_array",
+            ],
             "reset_telescope_params",
         ),
         (
@@ -1214,6 +1238,7 @@ def test_read_write_loop_waterfall(uvdata_obj, test_outfile, spw_axis):
     assert uvf.__eq__(uvf2, check_history=True)
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_read_write_loop_ret_wt_sq(test_outfile):
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.weights_array = 2 * np.ones_like(uvf.weights_array)
@@ -1381,6 +1406,7 @@ def test_read_write_extra_keywords(uvdata_obj, test_outfile):
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_init_list(uvdata_obj):
     uv = uvdata_obj
     uv.time_array -= 1
@@ -1418,6 +1444,7 @@ def test_init_list(uvdata_obj):
 
 
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 @pytest.mark.parametrize("write_future_shapes", [True, False])
 @pytest.mark.parametrize("read_future_shapes", [True, False])
 def test_read_multiple_files(
@@ -1429,11 +1456,14 @@ def test_read_multiple_files(
     uvf = UVFlag(uv, use_future_array_shapes=write_future_shapes)
     uvf.write(test_outfile, clobber=True)
 
-    warn_msg = []
-    warn_type = None
+    warn_msg = [
+        "The lst_array is not self-consistent with the time_array and telescope "
+        "location. Consider recomputing with the `set_lsts_from_time_array` method."
+    ] * 2
+    warn_type = [UserWarning] * 2
     if not read_future_shapes:
-        warn_msg = [_future_array_shapes_warning] * 2
-        warn_type = DeprecationWarning
+        warn_msg += [_future_array_shapes_warning] * 2
+        warn_type += [DeprecationWarning] * 2
 
     with uvtest.check_warnings(warn_type, match=warn_msg):
         uvf.read(
@@ -1474,6 +1504,7 @@ def test_read_error():
         UVFlag("foo")
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_read_change_type(uvcal_obj, test_outfile):
     uvc = uvcal_obj
     uvf = UVFlag(uvc, use_future_array_shapes=True)
@@ -1498,6 +1529,7 @@ def test_read_change_type(uvcal_obj, test_outfile):
     assert uvf.ant_2_array is None
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_read_change_mode(uvdata_obj, test_outfile):
     uv = uvdata_obj
     uvf = UVFlag(uv, mode="flag", use_future_array_shapes=True)
@@ -1515,6 +1547,7 @@ def test_read_change_mode(uvdata_obj, test_outfile):
     assert uvf.metric_array is None
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_write_no_clobber():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     with pytest.raises(ValueError, match=re.escape("File " + test_f_file + " exists")):
@@ -1571,6 +1604,7 @@ def test_set_telescope_params(uvdata_obj):
 
 
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_add(future_shapes):
     uv1 = UVFlag(test_f_file, use_future_array_shapes=future_shapes)
@@ -1613,6 +1647,7 @@ def test_add(future_shapes):
     assert "Data combined along time axis. " in uv3.history
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_collapsed_pols():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -1628,6 +1663,7 @@ def test_add_collapsed_pols():
     uvf4.check()
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_add_version_str():
     uv1 = UVFlag(test_f_file, use_future_array_shapes=True)
     uv1.history = uv1.history.replace(pyuvdata_version_str, "")
@@ -1641,6 +1677,7 @@ def test_add_add_version_str():
     assert pyuvdata_version_str in uv3.history
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_baseline():
     uv1 = UVFlag(test_f_file, use_future_array_shapes=True)
     uv2 = uv1.copy()
@@ -1698,6 +1735,7 @@ def test_add_antenna(uvcal_obj):
     assert "Data combined along antenna axis. " in uv3.history
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_frequency():
     uv1 = UVFlag(test_f_file, use_future_array_shapes=True)
     uv2 = uv1.copy()
@@ -1707,8 +1745,12 @@ def test_add_frequency():
 
     with uvtest.check_warnings(
         UserWarning,
-        match="One object has the flex_spw_id_array set and one does not. Combined "
-        "object will have it set.",
+        match=[
+            "One object has the flex_spw_id_array set and one does not. Combined "
+            "object will have it set.",
+            "The lst_array is not self-consistent with the time_array and telescope "
+            "location. Consider recomputing with the `set_lsts_from_time_array` method",
+        ],
     ):
         uv3 = uv1.__add__(uv2, axis="frequency")
     assert np.array_equal(
@@ -1732,6 +1774,7 @@ def test_add_frequency():
     assert "Data combined along frequency axis. " in uv3.history
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 @pytest.mark.parametrize("split_spw", [True, False])
 def test_add_frequency_multi_spw(split_spw):
     uv1 = UVFlag(test_f_file, use_future_array_shapes=True)
@@ -1760,10 +1803,13 @@ def test_add_frequency_multi_spw(split_spw):
         assert uv2.Nfreqs == uv_full.Nfreqs // 2
 
         with uvtest.check_warnings(
-            DeprecationWarning,
+            [DeprecationWarning, UserWarning] * 2,
             match=[
                 "flex_spw_id_array is not set. It will be required starting in "
-                "version 3.0"
+                "version 3.0",
+                "The lst_array is not self-consistent with the time_array and "
+                "telescope location. Consider recomputing with the "
+                "`set_lsts_from_time_array` method.",
             ]
             * 2,
         ):
@@ -1777,6 +1823,7 @@ def test_add_frequency_multi_spw(split_spw):
     assert uv3 == uv_full
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_frequency_with_weights_square():
     # Same test as above, just checking an optional parameter (also in waterfall mode)
     uvf1 = UVFlag(test_f_file, use_future_array_shapes=True)
@@ -1791,6 +1838,7 @@ def test_add_frequency_with_weights_square():
     )
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_frequency_mix_weights_square():
     # Same test as above, checking some error handling
     uvf1 = UVFlag(test_f_file, use_future_array_shapes=True)
@@ -1806,6 +1854,7 @@ def test_add_frequency_mix_weights_square():
         uvf1.__add__(uvf2, axis="frequency", inplace=True)
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_pol():
     uv1 = UVFlag(test_f_file, use_future_array_shapes=True)
     uv2 = uv1.copy()
@@ -1913,6 +1962,7 @@ def test_add_errors(uvdata_obj, uvcal_obj):
         uv2.__add__(uv2, axis="baseline")
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_inplace_add():
     uv1a = UVFlag(test_f_file, use_future_array_shapes=True)
     uv1b = uv1a.copy()
@@ -1923,6 +1973,7 @@ def test_inplace_add():
     assert uv1a.__eq__(uv1b + uv2)
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_clear_unused_attributes():
     uv = UVFlag(test_f_file, use_future_array_shapes=True)
     assert hasattr(uv, "baseline_array")
@@ -1956,6 +2007,7 @@ def test_clear_unused_attributes():
     assert uv.flag_array is None
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_not_equal():
     uvf1 = UVFlag(test_f_file, use_future_array_shapes=True)
     # different class
@@ -1978,6 +2030,7 @@ def test_not_equal():
     assert not uvf1.__eq__(uvf2, check_history=True)
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_waterfall_bl():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -1991,6 +2044,7 @@ def test_to_waterfall_bl():
     assert uvf.weights_array.shape == uvf.metric_array.shape
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_waterfall_add_version_str():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -2002,6 +2056,7 @@ def test_to_waterfall_add_version_str():
 
 
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_to_waterfall_bl_multi_pol(future_shapes):
     uvf = UVFlag(test_f_file, use_future_array_shapes=future_shapes)
@@ -2030,6 +2085,7 @@ def test_to_waterfall_bl_multi_pol(future_shapes):
     )
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_waterfall_bl_ret_wt_sq():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     Nbls = uvf.Nbls
@@ -2042,6 +2098,7 @@ def test_to_waterfall_bl_ret_wt_sq():
     assert uvf.weights_square_array is None
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_collapse_pol(test_outfile):
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -2074,6 +2131,7 @@ def test_collapse_pol(test_outfile):
     os.remove(test_outfile)
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_collapse_pol_add_pol_axis():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -2087,6 +2145,7 @@ def test_collapse_pol_add_pol_axis():
     assert str(cm.value).startswith("Two UVFlag objects with their")
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_collapse_pol_or():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_flag()
@@ -2106,6 +2165,7 @@ def test_collapse_pol_or():
     assert uvf2.metric_array is None
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_collapse_pol_add_version_str():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_flag()
@@ -2123,6 +2183,7 @@ def test_collapse_pol_add_version_str():
     assert pyuvdata_version_str in uvf2.history
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_collapse_single_pol():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -2132,6 +2193,7 @@ def test_collapse_single_pol():
     assert uvf == uvf2
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_collapse_pol_flag():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_flag()
@@ -2151,6 +2213,7 @@ def test_collapse_pol_flag():
     assert uvf2.flag_array is None
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_waterfall_bl_flags():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_flag()
@@ -2166,6 +2229,7 @@ def test_to_waterfall_bl_flags():
     assert len(uvf.lst_array) == len(uvf.time_array)
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_waterfall_bl_flags_or():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_flag()
@@ -2209,6 +2273,7 @@ def test_to_waterfall_ant(uvcal_obj, future_shapes):
     assert len(uvf.lst_array) == len(uvf.time_array)
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_waterfall_waterfall():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.weights_array = np.ones_like(uvf.weights_array)
@@ -2442,6 +2507,7 @@ def test_to_baseline_from_antenna(
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 @pytest.mark.parametrize("uv_future_shapes", [True, False])
 @pytest.mark.parametrize("method", ["to_antenna", "to_baseline"])
 def test_to_baseline_antenna_errors(uvdata_obj, uvcal_obj, method, uv_future_shapes):
@@ -2747,6 +2813,7 @@ def test_to_antenna_metric_force_pol(uvcal_obj):
     )
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_copy():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf2 = uvf.copy()
@@ -2756,6 +2823,7 @@ def test_copy():
     assert uvf != uvf2
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_or():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_flag()
@@ -2770,6 +2838,7 @@ def test_or():
     assert np.all(uvf3.flag_array[2:])
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_or_add_version_str():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_flag()
@@ -2786,6 +2855,7 @@ def test_or_add_version_str():
     assert pyuvdata_version_str in uvf3.history
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_or_error():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf2 = uvf.copy()
@@ -2795,6 +2865,7 @@ def test_or_error():
     assert str(cm.value).startswith('UVFlag object must be in "flag" mode')
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_or_add_history():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_flag()
@@ -2806,6 +2877,7 @@ def test_or_add_history():
     assert "Flags OR'd with:" in uvf3.history
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_ior():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_flag()
@@ -2820,6 +2892,7 @@ def test_ior():
     assert np.all(uvf.flag_array[2:])
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_flag():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_flag()
@@ -2830,6 +2903,7 @@ def test_to_flag():
     assert 'Converted to mode "flag"' in uvf.history
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_flag_add_version_str():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.history = uvf.history.replace(pyuvdata_version_str, "")
@@ -2839,6 +2913,7 @@ def test_to_flag_add_version_str():
     assert pyuvdata_version_str in uvf.history
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_flag_threshold():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.metric_array = np.zeros_like(uvf.metric_array)
@@ -2853,6 +2928,7 @@ def test_to_flag_threshold():
     assert 'Converted to mode "flag"' in uvf.history
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_flag_to_flag():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_flag()
@@ -2861,6 +2937,7 @@ def test_flag_to_flag():
     assert uvf == uvf2
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_flag_unknown_mode():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.mode = "foo"
@@ -2869,6 +2946,7 @@ def test_to_flag_unknown_mode():
     assert str(cm.value).startswith("Unknown UVFlag mode: foo")
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 @pytest.mark.parametrize("future_shapes", [True, False])
 def test_to_metric_baseline(future_shapes):
@@ -2897,6 +2975,7 @@ def test_to_metric_baseline(future_shapes):
         assert np.isclose(uvf.weights_array[:, :, 10], 0.0).all()
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_metric_add_version_str():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_flag()
@@ -2914,6 +2993,7 @@ def test_to_metric_add_version_str():
     assert pyuvdata_version_str in uvf.history
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_metric_waterfall():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_waterfall()
@@ -2945,6 +3025,7 @@ def test_to_metric_antenna(uvcal_obj, future_shapes):
         assert np.isclose(uvf.weights_array[15, :, 3, :, :], 0.0).all()
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_metric_to_metric():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf2 = uvf.copy()
@@ -2952,6 +3033,7 @@ def test_metric_to_metric():
     assert uvf == uvf2
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_metric_unknown_mode():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.mode = "foo"
@@ -2960,6 +3042,7 @@ def test_to_metric_unknown_mode():
     assert str(cm.value).startswith("Unknown UVFlag mode: foo")
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_antpair2ind():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     ind = uvf.antpair2ind(uvf.ant_1_array[0], uvf.ant_2_array[0])
@@ -2967,6 +3050,7 @@ def test_antpair2ind():
     assert np.all(uvf.ant_2_array[ind] == uvf.ant_2_array[0])
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_antpair2ind_nonbaseline():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     uvf.to_waterfall()
@@ -2980,6 +3064,7 @@ def test_antpair2ind_nonbaseline():
     )
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_baseline_to_antnums():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     a1, a2 = uvf.baseline_to_antnums(uvf.baseline_array[0])
@@ -2987,12 +3072,14 @@ def test_baseline_to_antnums():
     assert a2 == uvf.ant_2_array[0]
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_get_baseline_nums():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     bls = uvf.get_baseline_nums()
     assert np.array_equal(bls, np.unique(uvf.baseline_array))
 
 
+@pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_get_antpairs():
     uvf = UVFlag(test_f_file, use_future_array_shapes=True)
     antpairs = uvf.get_antpairs()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a check that the LSTs have their expected values in the `check` methods of UVData, UVCal and UVFlag. It only issues a UserWarning, not an error, and it is only run if `run_check_acceptability=True`. This is implemented via a new utility method to check the LSTs which is now called in all the places.

In moving this to the utility module, I also realized that the standard radian tolerance was being redefined in several separate places and that the one in UVFlag had not been updated when we reduced that tolerance. So I moved it to be defined in the utility module as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
I recently realized (as I was fixing up test files for `hera_qm` and `hera_cal`) that there was only a check that the LSTs had their expected values when reading in UVH5 and uvfits files but not on reading in any other files. I think this is a useful check, so I added it the UVData, UVCal and UVFlag `check` methods. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
