### PR TITLE
Fix docstrings for shape of waterfall-type UVFlag objects

### DIFF
--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -275,7 +275,7 @@ class UVFlag(UVBase):
             "future_array_shapes=True. For 'antenna' type objects, the shape is "
             "(Nants_data, 1, Nfreqs, Ntimes, Npols) or "
             "(Nants_data, Nfreqs, Ntimes, Npols) if future_array_shapes=True. "
-            "For 'waterfall' type objects, the shape is (Nfreq, Ntimes, Npols)."
+            "For 'waterfall' type objects, the shape is (Ntimes, Nfreq, Npols)."
         )
         self._metric_array = uvp.UVParameter(
             "metric_array",
@@ -293,7 +293,7 @@ class UVFlag(UVBase):
             "future_array_shapes=True. For 'antenna' type objects, the shape is "
             "(Nants_data, 1, Nfreqs, Ntimes, Npols) or "
             "(Nants_data, Nfreqs, Ntimes, Npols) if future_array_shapes=True. "
-            "For 'waterfall' type objects, the shape is (Nfreq, Ntimes, Npols)."
+            "For 'waterfall' type objects, the shape is (Ntimes, Nfreq, Npols)."
         )
         self._flag_array = uvp.UVParameter(
             "flag_array",
@@ -311,7 +311,7 @@ class UVFlag(UVBase):
             "future_array_shapes=True. For 'antenna' type objects, the shape is "
             "(Nants_data, 1, Nfreqs, Ntimes, Npols) or "
             "(Nants_data, Nfreqs, Ntimes, Npols) if future_array_shapes=True. "
-            "For 'waterfall' type objects, the shape is (Nfreq, Ntimes, Npols)."
+            "For 'waterfall' type objects, the shape is (Ntimes, Nfreq, Npols)."
         )
         self._weights_array = uvp.UVParameter(
             "weights_array",


### PR DESCRIPTION
Nfreq and Ntimes were transposed from what the object is actually doing.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Breaking change checklist:
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Documentation change checklist:
- [x] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
