### PR TITLE
Add options for astrometry library to object methods, round-trip telescope frame through UVH5, UVFITS and MS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Support for setting the astrometry library for various object methods including `set_lsts_from_time_array`, file read methods and others.
+- Properly round-trip the telescope frame through UVH5, UVFITS and MS files.
+
 ### Fixed
 - Fixed a bug in `utils.calc_app_coords` that occurred when supplying an astropy `Time`
 object for the `time_array` argument.

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -3947,23 +3947,16 @@ def get_lst_for_time(
 
 
 def check_lsts_against_times(
-    *,
-    jd_array,
-    lst_array,
-    latitude,
-    longitude,
-    altitude,
-    lst_tols,
-    astrometry_library=None,
-    frame="itrs",
+    *, jd_array, lst_array, latitude, longitude, altitude, lst_tols, frame="itrs"
 ):
     """Check that LSTs consistent with the time_array and telescope location."""
+    # Don't worry about passing the astrometry library because we test that they agree
+    # to better than our standard lst tolerances.
     lsts = get_lst_for_time(
         jd_array=jd_array,
         latitude=latitude,
         longitude=longitude,
         altitude=altitude,
-        astrometry_library=astrometry_library,
         frame=frame,
     )
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1527,7 +1527,7 @@ def ECEF_from_ENU(enu, latitude, longitude, altitude, frame="ITRS"):
     longitude : float
         Longitude of center of ENU coordinates in radians.
     altitude : float
-        Altitude of center of ENU coordinates in radians.
+        Altitude of center of ENU coordinates in meters.
     frame : str
         Coordinate frame of xyz.
         Valid options are ITRS (default) or MCMF.

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -7,8 +7,10 @@ import warnings
 
 import numpy as np
 from astropy.io import fits
+from docstring_parser import DocstringStyle
 
 from .. import utils as uvutils
+from ..docstrings import copy_replace_short_description
 from .uvcal import UVCal, _future_array_shapes_warning
 
 __all__ = ["CALFITS"]
@@ -510,6 +512,7 @@ class CALFITS(UVCal):
         hdulist.writeto(filename, overwrite=clobber)
         hdulist.close()
 
+    @copy_replace_short_description(UVCal.read_calfits, style=DocstringStyle.NUMPYDOC)
     def read_calfits(
         self,
         filename,
@@ -519,33 +522,9 @@ class CALFITS(UVCal):
         check_extra=True,
         run_check_acceptability=True,
         use_future_array_shapes=False,
+        astrometry_library=None,
     ):
-        """
-        Read data from a calfits file.
-
-        Parameters
-        ----------
-        filename : str
-            The calfits file to read from.
-        read_data : bool
-            Read in the gains or delays, quality arrays and flag arrays.
-            If set to False, only the metadata will be read in. Setting read_data to
-            False results in a metadata only object.
-        background_lsts : bool
-            When set to True, the lst_array is calculated in a background thread.
-        run_check : bool
-            Option to check for the existence and proper shapes of
-            parameters after reading in the file.
-        check_extra : bool
-            Option to check optional parameters as well as required ones.
-        run_check_acceptability : bool
-            Option to check acceptable range of the values of
-            parameters after reading in the file.
-        use_future_array_shapes : bool
-            Option to convert to the future planned array shapes before the changes go
-            into effect by removing the spectral window axis.
-
-        """
+        """Read data from a calfits file."""
         # update filename attribute
         basename = os.path.basename(filename)
         self.filename = [basename]
@@ -649,7 +628,9 @@ class CALFITS(UVCal):
             self.time_array = uvutils._fits_gethduaxis(fname[0], 3)
 
             if self.telescope_location is not None:
-                proc = self.set_lsts_from_time_array(background=background_lsts)
+                proc = self.set_lsts_from_time_array(
+                    background=background_lsts, astrometry_library=astrometry_library
+                )
             else:
                 proc = None
 

--- a/pyuvdata/uvcal/fhd_cal.py
+++ b/pyuvdata/uvcal/fhd_cal.py
@@ -7,9 +7,11 @@ import os
 import warnings
 
 import numpy as np
+from docstring_parser import DocstringStyle
 from scipy.io import readsav
 
 from .. import utils as uvutils
+from ..docstrings import copy_replace_short_description
 from ..uvdata.fhd import get_fhd_history, get_fhd_layout_info
 from .uvcal import UVCal, _future_array_shapes_warning
 
@@ -25,6 +27,7 @@ class FHDCal(UVCal):
 
     """
 
+    @copy_replace_short_description(UVCal.read_fhd_cal, style=DocstringStyle.NUMPYDOC)
     def read_fhd_cal(
         self,
         cal_file,
@@ -39,46 +42,9 @@ class FHDCal(UVCal):
         check_extra=True,
         run_check_acceptability=True,
         use_future_array_shapes=False,
+        astrometry_library=None,
     ):
-        """
-        Read data from an FHD cal.sav file.
-
-        Parameters
-        ----------
-        cal_file : str
-            The cal.sav file to read from.
-        obs_file : str
-            The obs.sav file to read from.
-        layout_file : str
-            The FHD layout file. Required for antenna_positions to be set.
-        settings_file : str, optional
-            The settings_file to read from. Optional, but very useful for provenance.
-        raw : bool
-            Option to use the raw (per antenna, per frequency) solution or
-            to use the fitted (polynomial over phase/amplitude) solution.
-            Default is True (meaning use the raw solutions).
-        read_data : bool
-            Read in the gains, quality array and flag data. If set to False, only
-            the metadata will be read in. Setting read_data to False results in
-            a metadata only object. If read_data is False, a settings file must be
-            provided.
-        background_lsts : bool
-            When set to True, the lst_array is calculated in a background thread.
-        extra_history : str or list of str, optional
-            String(s) to add to the object's history parameter.
-        run_check : bool
-            Option to check for the existence and proper shapes of
-            parameters after reading in the file.
-        check_extra : bool
-            Option to check optional parameters as well as required ones.
-        run_check_acceptability : bool
-            Option to check acceptable range of the values of
-            parameters after reading in the file.
-        use_future_array_shapes : bool
-            Option to convert to the future planned array shapes before the changes go
-            into effect by removing the spectral window axis.
-
-        """
+        """Read data from an FHD cal.sav file."""
         if not read_data and settings_file is None:
             raise ValueError("A settings_file must be provided if read_data is False.")
 
@@ -202,7 +168,9 @@ class FHDCal(UVCal):
 
         # need to make sure telescope location is defined properly before this call
         if self.telescope_location is not None:
-            proc = self.set_lsts_from_time_array(background=background_lsts)
+            proc = self.set_lsts_from_time_array(
+                background=background_lsts, astrometry_library=astrometry_library
+            )
 
         self._set_sky()
         self.gain_convention = "divide"

--- a/pyuvdata/uvcal/initializers.py
+++ b/pyuvdata/uvcal/initializers.py
@@ -43,6 +43,7 @@ def new_uvcal(
     sky_catalog: str | None = None,
     empty: bool = False,
     data: dict[str, np.ndarray] | None = None,
+    astrometry_library: str | None = None,
     history: str = "",
     **kwargs,
 ):
@@ -132,6 +133,12 @@ def new_uvcal(
     history : str, optional
         History string to be added to the object. Default is a simple string
         containing the date and time and pyuvdata version.
+    astrometry_library : str
+        Library used for calculating LSTs. Allowed options are 'erfa' (which uses
+        the pyERFA), 'novas' (which uses the python-novas library), and 'astropy'
+        (which uses the astropy utilities). Default is erfa unless the
+        telescope_location frame is MCMF (on the moon), in which case the default
+        is astropy.
     \*\*kwargs
         All other keyword arguments are added to the object as attributes.
 
@@ -159,7 +166,10 @@ def new_uvcal(
             )
 
     lst_array, integration_time = get_time_params(
-        telescope_location, time_array, integration_time
+        telescope_location,
+        time_array,
+        integration_time,
+        astrometry_library=astrometry_library,
     )
 
     if (freq_range is not None) and (

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -1160,7 +1160,7 @@ class UVCal(UVBase):
         if self.flex_spw:
             uvutils._check_flex_spw_contiguous(self.spw_array, self.flex_spw_id_array)
 
-    def _check_freq_spacing(self, raise_errors=True, astrometry_library="erfa"):
+    def _check_freq_spacing(self, raise_errors=True):
         """
         Check if frequencies are evenly spaced and separated by their channel width.
 
@@ -1194,11 +1194,7 @@ class UVCal(UVBase):
         )
 
     def check(
-        self,
-        check_extra=True,
-        run_check_acceptability=True,
-        check_freq_spacing=False,
-        astrometry_library=None,
+        self, check_extra=True, run_check_acceptability=True, check_freq_spacing=False
     ):
         """
         Add some extra checks on top of checks on UVBase class.
@@ -1216,12 +1212,6 @@ class UVCal(UVBase):
             Option to check if frequencies are evenly spaced and the spacing is
             equal to their channel_width. This is not required for UVCal
             objects in general but is required to write to calfits files.
-        astrometry_library : str
-            Library used for running the LST acceptability check. Allowed options are
-            'erfa' (which uses the pyERFA), 'novas' (which uses the python-novas
-            library), and 'astropy' (which uses the astropy utilities). Default is erfa
-            unless the telescope_location frame is MCMF (on the moon), in which case the
-            default is astropy.
 
         Returns
         -------
@@ -1327,7 +1317,6 @@ class UVCal(UVBase):
                 longitude=lon,
                 altitude=alt,
                 lst_tols=self._lst_array.tols,
-                astrometry_library=astrometry_library,
                 frame=self._telescope_location.frame,
             )
 

--- a/pyuvdata/uvdata/fhd.py
+++ b/pyuvdata/uvdata/fhd.py
@@ -8,10 +8,12 @@ import warnings
 
 import numpy as np
 from astropy import constants as const
+from docstring_parser import DocstringStyle
 from scipy.io import readsav
 
 from .. import telescopes as uvtel
 from .. import utils as uvutils
+from ..docstrings import copy_replace_short_description
 from .uvdata import UVData, _future_array_shapes_warning
 
 __all__ = ["get_fhd_history", "get_fhd_layout_info", "FHD"]
@@ -311,6 +313,7 @@ class FHD(UVData):
     method on the UVData class.
     """
 
+    @copy_replace_short_description(UVData.read_fhd, style=DocstringStyle.NUMPYDOC)
     def read_fhd(
         self,
         filelist,
@@ -324,64 +327,9 @@ class FHD(UVData):
         check_autos=True,
         fix_autos=True,
         use_future_array_shapes=False,
+        astrometry_library=None,
     ):
-        """
-        Read in data from a list of FHD files.
-
-        Parameters
-        ----------
-        filelist : array_like of str
-            The list/array of FHD save files to read from. Must include at
-            least one polarization file, a params file, a layout file and a flag file.
-            An obs file is also required if `read_data` is False.
-        use_model : bool
-            Option to read in the model visibilities rather than the dirty
-            visibilities (the default is False, meaning the dirty visibilities
-            will be read).
-        background_lsts : bool
-            When set to True, the lst_array is calculated in a background thread.
-        read_data : bool
-            Read in the visibility, nsample and flag data. If set to False, only
-            the metadata will be read in. Setting read_data to False results in
-            a metadata only object. If read_data is False, an obs file must be
-            included in the filelist. Note that if read_data is False, Npols is
-            derived from the obs file and reflects the number of polarizations
-            used in the FHD run. If read_data is True, Npols is given by the
-            number of visibility data files provided in `filelist`.
-        run_check : bool
-            Option to check for the existence and proper shapes of parameters
-            after after reading in the file (the default is True,
-            meaning the check will be run).
-        check_extra : bool
-            Option to check optional parameters as well as required ones (the
-            default is True, meaning the optional parameters will be checked).
-        run_check_acceptability : bool
-            Option to check acceptable range of the values of parameters after
-            reading in the file (the default is True, meaning the acceptable
-            range check will be done).
-        strict_uvw_antpos_check : bool
-            Option to raise an error rather than a warning if the check that
-            uvws match antenna positions does not pass.
-        check_autos : bool
-            Check whether any auto-correlations have non-zero imaginary values in
-            data_array (which should not mathematically exist). Default is True.
-        fix_autos : bool
-            If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only in data_array. Default is False.
-        use_future_array_shapes : bool
-            Option to convert to the future planned array shapes before the changes go
-            into effect by removing the spectral window axis.
-
-        Raises
-        ------
-        IOError
-            If root file directory doesn't exist.
-        ValueError
-            If required files are missing or multiple files for any polarization
-            are included in filelist.
-            If there is no recognized key for visibility weights in the flags_file.
-
-        """
+        """Read in data from a list of FHD files."""
         datafiles = {}
         params_file = None
         obs_file = None
@@ -617,7 +565,9 @@ class FHD(UVData):
             self.Nants_telescope = len(self.antenna_names)
 
         # need to make sure telescope location is defined properly before this call
-        proc = self.set_lsts_from_time_array(background=background_lsts)
+        proc = self.set_lsts_from_time_array(
+            background=background_lsts, astrometry_library=astrometry_library
+        )
 
         if not np.isclose(obs["OBSRA"][0], obs["PHASERA"][0]) or not np.isclose(
             obs["OBSDEC"][0], obs["PHASEDEC"][0]

--- a/pyuvdata/uvdata/initializers.py
+++ b/pyuvdata/uvdata/initializers.py
@@ -94,6 +94,7 @@ def get_time_params(
     telescope_location: Locations,
     time_array: np.ndarray,
     integration_time: float | np.ndarray | None = None,
+    astrometry_library: str | None = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Configure time parameters for new UVData object."""
     if not isinstance(time_array, np.ndarray):
@@ -105,6 +106,7 @@ def get_time_params(
         longitude=telescope_location.lon.deg,
         altitude=telescope_location.height.to_value("m"),
         frame="itrs" if isinstance(telescope_location, EarthLocation) else "mcmf",
+        astrometry_library=astrometry_library,
     )
 
     if integration_time is None:
@@ -352,6 +354,7 @@ def new_uvdata(
     phase_center_catalog: dict[str, Any] | None = None,
     phase_center_id_array: np.ndarray | None = None,
     x_orientation: Literal["east", "north", "e", "n", "ew", "ns"] | None = None,
+    astrometry_library: str | None = None,
     **kwargs,
 ):
     """Initialize a new UVData object from keyword arguments.
@@ -461,6 +464,12 @@ def new_uvdata(
         id found in ``phase_center_catalog``. It must have shape ``(Nblts,)``.
     x_orientation : str
         Orientation of the x-axis. Options are 'east', 'north', 'e', 'n', 'ew', 'ns'.
+    astrometry_library : str
+        Library used for calculating LSTs. Allowed options are 'erfa' (which uses
+        the pyERFA), 'novas' (which uses the python-novas library), and 'astropy'
+        (which uses the astropy utilities). Default is erfa unless the
+        telescope_location frame is MCMF (on the moon), in which case the default
+        is astropy.
 
     Other Parameters
     ----------------
@@ -481,7 +490,10 @@ def new_uvdata(
     )
 
     lst_array, integration_time = get_time_params(
-        telescope_location, times, integration_time
+        telescope_location,
+        times,
+        integration_time,
+        astrometry_library=astrometry_library,
     )
 
     if antpairs is None:

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -9,9 +9,11 @@ import warnings
 import numpy as np
 from astropy.coordinates import angular_separation
 from astropy.time import Time
+from docstring_parser import DocstringStyle
 
 from .. import get_telescope
 from .. import utils as uvutils
+from ..docstrings import copy_replace_short_description
 from . import mir_parser
 from .uvdata import UVData
 
@@ -27,6 +29,7 @@ class Mir(UVData):
     instead use the read_mir and write_mir methods on the UVData class.
     """
 
+    @copy_replace_short_description(UVData.read_mir, style=DocstringStyle.NUMPYDOC)
     def read_mir(
         self,
         filepath,
@@ -52,102 +55,9 @@ class Mir(UVData):
         strict_uvw_antpos_check=False,
         allow_flex_pol=True,
         check_autos=True,
-        fix_autos=False,
+        fix_autos=True,
     ):
-        """
-        Read in data from an SMA MIR file, and map to a UVData object.
-
-        Note that with the exception of filename, most of the remaining parameters are
-        used to sub-select a range of data.
-
-        Parameters
-        ----------
-        filepath : str
-            The file path to the MIR folder to read from.
-        antenna_nums : array_like of int, optional
-            The antennas numbers to include when reading data into the object
-            (antenna positions and names for the removed antennas will be retained
-            unless `keep_all_metadata` is False). This cannot be provided if
-            `antenna_names` is also provided.
-        antenna_names : array_like of str, optional
-            The antennas names to include when reading data into the object
-            (antenna positions and names for the removed antennas will be retained
-            unless `keep_all_metadata` is False). This cannot be provided if
-            `antenna_nums` is also provided.
-        bls : list of tuple, optional
-            A list of antenna number tuples (e.g. [(0, 1), (3, 2)]) specifying baselines
-            to include when reading data in to the object.
-        time_range : array_like of float, optional
-            The time range in Julian Date to include when reading data into
-            the object, must be length 2. Some of the times in the file should
-            fall between the first and last elements.
-        lst_range : array_like of float, optional
-            The local sidereal time (LST) range in radians to keep in the
-            object, must be of length 2. Some of the LSTs in the object should
-            fall between the first and last elements. If the second value is
-            smaller than the first, the LSTs are treated as having phase-wrapped
-            around LST = 2*pi = 0, and the LSTs kept on the object will run from
-            the larger value, through 0, and end at the smaller value.
-        polarizations : array_like of int, optional
-            The polarizations numbers to include when reading data into the
-            object, each value passed here should exist in the polarization_array.
-        catalog_names : str or array-like of str
-            The names of the phase centers (sources) to include when reading data into
-            the object, which should match exactly in spelling and capitalization.
-        corrchunk : int or array-like of int
-            Correlator "chunk" (spectral window) to include when reading data into the
-            object, where 0 corresponds to the pseudo-continuum channel.
-        receivers : str or array-like of str
-            The names of the receivers ("230", "240", "345", "400") to include when
-            reading data into the object.
-        sidebands : str or array-like of str
-            The names of the sidebands ("l" for lower, "u" for upper) to include when
-            reading data into the object.
-        select_where : tuple or list of tuples, optional
-            Argument to pass to the `MirParser.select` method, which will downselect
-            which data is read into the object.
-        apply_flags : bool
-            If set to True, apply "wideband" flags to the visibilities, which are
-            recorded by the realtime system to denote when data are expected to be bad
-            (e.g., antennas not on source, dewar warm). Default it true.
-        apply_tsys : bool
-            If set to False, data are returned as correlation coefficients (normalized
-            by the auto-correlations). Default is True, which instead scales the raw
-            visibilities and forward-gain of the antenna to produce values in Jy
-            (uncalibrated).
-        apply_dedoppler : bool
-            If set to True, data will be corrected for any doppler-tracking performed
-            during observations, and brought into the topocentric rest frame (default
-            for UVData objects). Default is False.
-        pseudo_cont : boolean
-            Read in only pseudo-continuum values. Default is false.
-        rechunk : int
-            Number of channels to average over when reading in the dataset. Optional
-            argument, typically required to be a power of 2.
-        run_check : bool
-            Option to check for the existence and proper shapes of parameters
-            before writing the file.
-        check_extra : bool
-            Option to check optional parameters as well as required ones.
-        run_check_acceptability : bool
-            Option to check acceptable range of the values of parameters before
-            writing the file.
-        strict_uvw_antpos_check : bool
-            Option to raise an error rather than a warning if the check that
-            uvw coordinates match antenna positions does not pass.
-        allow_flex_pol : bool
-            If only one polarization per spectral window is read (and the polarization
-            differs from window to window), allow for the `UVData` object to use
-            "flexible polarization", which compresses the polarization-axis of various
-            attributes to be of length 1, sets the `flex_spw_polarization_array`
-            attribute to define the polarization per spectral window. Default is True.
-        check_autos : bool
-            Check whether any auto-correlations have non-zero imaginary values in
-            data_array (which should not mathematically exist). Default is True.
-        fix_autos : bool
-            If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only in data_array. Default is False.
-        """
+        """Read in data from an SMA MIR file, and map to a UVData object."""
         # Use the mir_parser to read in metadata, which can be used to select data.
         mir_data = mir_parser.MirParser(filepath)
 

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -1672,6 +1672,11 @@ class Miriad(UVData):
         """
         from . import aipy_extracts
 
+        if self._telescope_location.frame != "itrs":
+            raise ValueError(
+                "Only ITRS telescope locations are supported in Miriad files."
+            )
+
         # change time_array and lst_array to mark beginning of integration,
         # per Miriad format
         miriad_time_array = self.time_array - self.integration_time / (24 * 3600.0) / 2

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -12,8 +12,10 @@ import warnings
 
 import numpy as np
 from astropy.time import Time
+from docstring_parser import DocstringStyle
 
 from .. import utils as uvutils
+from ..docstrings import copy_replace_short_description
 from .uvdata import UVData, _future_array_shapes_warning, reporting_request
 
 __all__ = ["MS"]
@@ -1879,6 +1881,7 @@ class MS(UVData):
 
         return spw_list, field_list, pol_list, flex_pol
 
+    @copy_replace_short_description(UVData.read_ms, style=DocstringStyle.NUMPYDOC)
     def read_ms(
         self,
         filepath,
@@ -1896,85 +1899,9 @@ class MS(UVData):
         check_autos=True,
         fix_autos=True,
         use_future_array_shapes=False,
+        astrometry_library=None,
     ):
-        """
-        Read in a casa measurement set.
-
-        Parameters
-        ----------
-        filepath : str
-            The measurement set root directory to read from.
-        data_column : str
-            name of CASA data column to read into data_array. Options are:
-            'DATA', 'MODEL', or 'CORRECTED_DATA'
-        pol_order : str
-            Option to specify polarizations order convention, options are
-            'CASA' or 'AIPS'.
-        background_lsts : bool
-            When set to True, the lst_array is calculated in a background thread.
-        run_check : bool
-            Option to check for the existence and proper shapes of parameters
-            after after reading in the file (the default is True,
-            meaning the check will be run).
-        check_extra : bool
-            Option to check optional parameters as well as required ones (the
-            default is True, meaning the optional parameters will be checked).
-        run_check_acceptability : bool
-            Option to check acceptable range of the values of parameters after
-            reading in the file (the default is True, meaning the acceptable
-            range check will be done).
-        strict_uvw_antpos_check : bool
-            Option to raise an error rather than a warning if the check that
-            uvws match antenna positions does not pass.
-        ignore_single_chan : bool
-            Some measurement sets (e.g., those from ALMA) use single channel spectral
-            windows for recording pseudo-continuum channels or storing other metadata
-            in the track when the telescopes are not on source. Because of the way
-            the object is strutured (where all spectral windows are assumed to be
-            simultaneously recorded), this can significantly inflate the size and memory
-            footprint of UVData objects. By default, single channel windows are ignored
-            to avoid this issue, although they can be included if setting this parameter
-            equal to True.
-        raise_error : bool
-            The measurement set format allows for different spectral windows and
-            polarizations to have different metdata for the same time-baseline
-            combination, but UVData objects do not. It also allows for timescales that
-            are not supported by astropy. If any of these problems are detected, by
-            default the reader will throw an error. However, if set to False, the reader
-            will simply give a warning and try to do the best it can. If the problem is
-            with differing metadata, it will use the first value read in the file as the
-            "correct" metadata in the UVData object. If the problem is with the
-            timescale, it will just assume UTC.
-        read_weights : bool
-            Read in the weights from the MS file, default is True. If false, the method
-            will set the `nsamples_array` to the same uniform value (namely 1.0).
-        allow_flex_pol : bool
-            If only one polarization per spectral window is read (and the polarization
-            differs from window to window), allow for the `UVData` object to use
-            "flexible polarization", which compresses the polarization-axis of various
-            attributes to be of length 1, sets the `flex_spw_polarization_array`
-            attribute to define the polarization per spectral window.  Default is True.
-        check_autos : bool
-            Check whether any auto-correlations have non-zero imaginary values in
-            data_array (which should not mathematically exist). Default is True.
-        fix_autos : bool
-            If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only in data_array. Default is True.
-        use_future_array_shapes : bool
-            Option to convert to the future planned array shapes before the changes go
-            into effect by removing the spectral window axis.
-
-        Raises
-        ------
-        IOError
-            If root file directory doesn't exist.
-        ValueError
-            If the `data_column` is not set to an allowed value.
-            If the data are have multiple subarrays or are multi source or have
-            multiple spectral windows.
-            If the data have multiple data description ID values.
-
-        """
+        """Read in a casa measurement set."""
         if not casa_present:  # pragma: no cover
             raise ImportError(no_casa_message) from casa_error
 
@@ -2180,7 +2107,9 @@ class MS(UVData):
         tb_ant.close()
 
         # set LST array from times and itrf
-        proc = self.set_lsts_from_time_array(background=background_lsts)
+        proc = self.set_lsts_from_time_array(
+            background=background_lsts, astrometry_library=astrometry_library
+        )
 
         tb_field = tables.table(filepath + "/FIELD", ack=False)
 

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -834,7 +834,18 @@ def test_readwriteread_missing_info(tmp_path, casa_uvfits, lat_lon_alt):
         hdulist = fits.HDUList(hdus=[vis_hdu, ant_hdu, source_hdu])
         hdulist.writeto(write_file2, overwrite=True)
 
-    uv_out.read(write_file2, use_future_array_shapes=True)
+    with uvtest.check_warnings(
+        UserWarning,
+        match=[
+            "The telescope frame is set to '????', which generally indicates "
+            "ignorance. Defaulting the frame to 'itrs', but this may lead to other "
+            "warnings or errors.",
+            "Telescope EVLA is not in known_telescopes.",
+            "The uvw_array does not match the expected values given the antenna "
+            "positions.",
+        ],
+    ):
+        uv_out.read(write_file2, use_future_array_shapes=True)
     assert uv_out.telescope_name == "EVLA"
     assert uv_out.timesys == time_sys
 

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -221,6 +221,9 @@ def test_read_uvfits_write_uvh5_read_uvh5(casa_uvfits, tmp_path, telescope_frame
     uv_in.write_uvh5(testfile, clobber=True)
     uv_out.read(testfile, use_future_array_shapes=True)
 
+    # clean up
+    os.remove(testfile)
+
     assert uv_out._telescope_location.frame == telescope_frame
 
     # make sure filenames are what we expect

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -230,12 +230,8 @@ def test_read_uvfits_write_uvh5_read_uvh5(casa_uvfits, tmp_path, telescope_frame
 
     assert uv_in == uv_out
 
-    # clean up
-    os.remove(testfile)
-
     # also test writing double-precision data_array
     fname = f"outtest_{telescope_frame}2_uvfits.uvh5"
-    testfile = str(tmp_path / fname)
 
     uv_in.data_array = uv_in.data_array.astype(np.complex128)
     uv_in.write_uvh5(testfile, clobber=True)

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -596,10 +596,10 @@ class UVData(UVBase):
         )
 
         desc = (
-            "Array giving coordinates of antennas relative to "
-            "telescope_location (ITRF frame), shape (Nants_telescope, 3), "
-            "units meters. See the tutorial page in the documentation "
-            "for an example of how to convert this to topocentric frame."
+            "Array giving coordinates of antennas relative to telescope_location "
+            "(in frame _telescope_location.frame), shape (Nants_telescope, 3), units "
+            "meters. See the UVData tutorial page in the documentation for an example "
+            "of how to convert this to topocentric frame."
         )
         self._antenna_positions = uvp.UVParameter(
             "antenna_positions",

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -3208,7 +3208,6 @@ class UVData(UVBase):
         allow_flip_conj=False,
         check_autos=False,
         fix_autos=False,
-        astrometry_library=None,
     ):
         """
         Add some extra checks on top of checks on UVBase class.
@@ -3241,12 +3240,6 @@ class UVData(UVBase):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is True.
-        astrometry_library : str
-            Library used for running the LST acceptability check. Allowed options are
-            'erfa' (which uses the pyERFA), 'novas' (which uses the python-novas
-            library), and 'astropy' (which uses the astropy utilities). Default is erfa
-            unless the telescope_location frame is MCMF (on the moon), in which case the
-            default is astropy.
 
         Returns
         -------
@@ -3390,7 +3383,6 @@ class UVData(UVBase):
                 longitude=lon,
                 altitude=alt,
                 lst_tols=self._lst_array.tols,
-                astrometry_library=astrometry_library,
                 frame=self._telescope_location.frame,
             )
 

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -71,7 +71,6 @@ class UVFITS(UVData):
                 longitude=longitude,
                 altitude=altitude,
                 lst_tols=self._lst_array.tols,
-                astrometry_library=astrometry_library,
                 frame=self._telescope_location.frame,
             )
 
@@ -569,6 +568,11 @@ class UVFITS(UVData):
                 elif ant_hdu.header["FRAME"] == "????":
                     # default to itrs, but use the lat/lon/alt to set the location
                     # if they are available.
+                    warnings.warn(
+                        "The telescope frame is set to '????', which generally "
+                        "indicates ignorance. Defaulting the frame to 'itrs', but this "
+                        "may lead to other warnings or errors."
+                    )
                     prefer_lat_lon_alt = True
                     self._telescope_location.frame = "itrs"
                 else:

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -1448,7 +1448,9 @@ class UVH5(UVData):
         if isinstance(filename, FastUVH5Meta):
             meta = filename
             filename = str(meta.path)
+            close_meta = False
         else:
+            close_meta = True
             meta = FastUVH5Meta(
                 filename,
                 blt_order=blt_order,
@@ -1492,6 +1494,8 @@ class UVH5(UVData):
                 keep_all_metadata,
                 multidim_index,
             )
+        if close_meta:
+            meta.close()
 
         # Finally, backfill the apparent coords if they aren't in the original datafile
         add_app_coords = (

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -919,9 +919,7 @@ class UVFlag(UVBase):
         if not self.future_array_shapes:
             self._freq_array.form = ("Nfreqs",)
 
-    def check(
-        self, check_extra=True, run_check_acceptability=True, astrometry_library=None
-    ):
+    def check(self, check_extra=True, run_check_acceptability=True):
         """
         Add some extra checks on top of checks on UVBase class.
 
@@ -934,12 +932,6 @@ class UVFlag(UVBase):
             If true, check all parameters, otherwise only check required parameters.
         run_check_acceptability : bool
             Option to check if values in parameters are acceptable.
-        astrometry_library : str
-            Library used for running the LST acceptability check. Allowed options are
-            'erfa' (which uses the pyERFA), 'novas' (which uses the python-novas
-            library), and 'astropy' (which uses the astropy utilities). Default is erfa
-            unless the telescope_location frame is MCMF (on the moon), in which case the
-            default is astropy.
 
         Returns
         -------
@@ -1028,7 +1020,6 @@ class UVFlag(UVBase):
                 longitude=lon,
                 altitude=alt,
                 lst_tols=self._lst_array.tols,
-                astrometry_library=astrometry_library,
                 frame=self._telescope_location.frame,
             )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There's a choice of astrometry library for several of the utility methods (e.g. `get_lst_for_time`) that was inaccessible from the various class methods that call it. This pipes that option through to all the relevant methods.

This required updating some docstrings, so I also reduced the duplication of docstrings between the file-type objects and UVData while I was at it using docstring parser to copy the docstrings as appropriate. I also shifted to using `kwargs` in the cases where e.g. read methods were just calling a method with all the same parameters. This should make it easier to maintain docstrings and code.

Finally, there were some places where the telescope frame was not being used properly and not round tripped through file read/writes. I added support for it in uvh5, uvfits and ms files and added an error in write_miriad if the frame is not "itrs" because it appears that the miriad format implicitly only supports the ITRS frame. I also added errors on read for the uvh5, uvfits and ms formats if the telescope frame is not "itrs" or "mcmf" because otherwise there are unclear errors later related to calculating LSTs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

