### PR TITLE
Fix `write_ms` handling of history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed a bug in `utils.calc_app_coords` that occurred when supplying an astropy `Time`
 object for the `time_array` argument.
+- Fixed a bug in `UVData.write_ms` that caused the writer to crash if prior measurement
+set history was not formatted in the currently expected fashion.
 
 ## [2.4] - 2023-07-12
 

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -938,3 +938,47 @@ def test_timescale_handling():
     assert (
         np.round(Time(uvobj.time_array[0], format="jd").gps, decimals=5) == 1090008642.0
     )
+
+
+def test_ms_bad_history(sma_mir, tmp_path):
+    # Adding history string that rlbryne (Issue 1324) reported as throwing a particular
+    # bug on write.
+    sma_mir.history = (
+        "Begin measurement set history\nAPP_PARAMS;CLI_COMMAND;APPLICATION;MESSAGE;"
+        "OBJECT_ID;OBSERVATION_ID;ORIG\nIN;PRIORITY;TIME\nEnd measurement set history."
+        "\n  Read/written with pyuvdata version: 2.1.2. Combined data along baselin\ne-"
+        "time axis using pyuvdata. Combined data along baseline-time axis using\n "
+        "pyuvdata. Combined data along baseline-time axis using pyuvdata. Combin\ned "
+        "data along baseline-time axis using pyuvdata. Combined data along bas\neline-"
+        "time axis using pyuvdata. Combined data along baseline-time axis u\nsing "
+        "pyuvdata. Combined data along baseline-time axis using pyuvdata. Co\nmbined "
+        "data along baseline-time axis using pyuvdata. Combined data along\n baseline-"
+        "time axis using pyuvdata. Combined data along baseline-time ax\nis using "
+        "pyuvdata. Combined data along baseline-time axis using pyuvdata\n. Combined "
+        "data along baseline-time axis using pyuvdata. Combined data a\nlong baseline-"
+        "time axis using pyuvdata. Combined data along baseline-tim\ne axis using "
+        "pyuvdata. Combined data along baseline-time axis using pyuv\ndata. Combined "
+        "data along baseline-time axis using pyuvdata. Combined da\nta along baseline-"
+        "time axis using pyuvdata. Combined data along baseline\n-time axis using "
+        "pyuvdata. Combined data along baseline-time axis using\npyuvdata. Combined "
+        "data along baseline-time axis using pyuvdata. Combine\nd data along baseline-"
+        "time axis using pyuvdata. Combined data along base\nline-time axis using "
+        "pyuvdata. Combined data along baseline-time axis us\ning pyuvdata. Combined "
+        "data along baseline-time axis using pyuvdata. Com\nbined data along baseline-"
+        "time axis using pyuvdata. Combined data along\nbaseline-time axis using "
+        "pyuvdata. Combined data along baseline-time axi\ns using pyuvdata. Combined "
+        "data along baseline-time axis using pyuvdata.\n Combined data along baseline-"
+        "time axis using pyuvdata.\nFlagged with pyuvdata.utils.apply_uvflags.  "
+        "Downselected to specific tim\nes using pyuvdata.\n  Read/written with pyuvdata"
+        "version: 2.3.2.\nCalibrated with pyuvdata.utils.uvcalibrate."
+    )
+
+    filename = os.path.join(tmp_path, "bad_history.ms")
+    with uvtest.check_warnings(
+        UserWarning, match="Failed to parse prior history of MS file,"
+    ):
+        sma_mir.write_ms(filename)
+
+    # Make sure the history is actually preserved correctly.
+    sma_ms = UVData.from_file(filename, use_future_array_shapes=True)
+    assert sma_mir.history in sma_ms.history


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a minor bug in `write_ms`.
## Description
<!--- Describe your changes in detail -->
Adds some robustness to how `write_ms` handles `UVData.history` when containing MS file history that is not formatted as expected. When encountered, `write_ms` will not simply write out the history line-by-line in the MS file, as it does for any other bit of the history for a `UVData` object.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
When reading/writing history containing information from MS files, the `write_ms` method expects `UVData.history` to be formatted in the exact way it currently reads it in. However, external programs interacting with individual files (as well as older versions of various file writers for `UVData`) may not always preserve this history.

Closes #1324

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).