### PR TITLE
Better handing of discrepancies for LSTs and telescope position in `check`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ positions are near surface of whatever celestial body their positions are refere
 
 ### Changed
 - Increased the tolerance to 75 mas (equivalent to 5 ms time error) for a warning about
-values in `lst_array` not conforming to exceptations for `UVData`, `UVCal`, and `UVFlag`
+values in `lst_array` not conforming to expectations for `UVData`, `UVCal`, and `UVFlag`
 (was 1 mas) inside of `check`. Additionally, added a keyword to `check` enable the
 tolerance value to be user-specified.
 - Changed the behavior of checking of telescope location to look at the combination of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 ## [2.4.1] - 2023-10-13
 
 ### Added
+- Added a `check_surface_based_positions` positions method for verifying antenna
+positions are near surface of whatever celestial body their positions are referenced to
+(either the Earth or Moon, currently).
 - Added a `uvw_track_generator` method within `utils` for calculating the expected
 uvws (and a few other values) without needing to instantiate a whole `UVData` object.
 - Added a convenience function called `compare_value` in `UVParameter` that enables
@@ -19,6 +22,14 @@ file to the new `mwa_metafits_file` parameter.
 - Support for recarrays in `UVParameter` objects and in `UVBase`, needed for pyradiosky.
 - Support for setting the astrometry library for various object methods including `set_lsts_from_time_array`, file read methods and others.
 - Properly round-trip the telescope frame through UVH5, UVFITS and MS files.
+
+### Changed
+- Increased the tolerance to 15 mas for a warning about values in `lst_array` not conforming
+to exceptations for `UVData`, `UVCal`, and `UVFlag` (was 1 mas) inside of `check`, additionally
+adding a keyword to enable the tolerance value to be specified.
+- Changed the behavior of checking of telescope location to look at the combination of
+`antenna_positions` and `telescope_location` together for `UVData`, `UVCal`, and `UVFlag`.
+Additionally, failing this check results in a warning (was an error).
 
 ### Fixed
 - A bug in apparent coordinate calculation that resulted in small errors/loss of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [2.4.1] - 2023-10-13
-
 ### Added
 - Added a `check_surface_based_positions` positions method for verifying antenna
 positions are near surface of whatever celestial body their positions are referenced to
 (either the Earth or Moon, currently).
+
+### Changed
+- Increased the tolerance to 75 mas (equivalent to 5 ms time error) for a warning about
+values in `lst_array` not conforming to exceptations for `UVData`, `UVCal`, and `UVFlag`
+(was 1 mas) inside of `check`. Additionally, added a keyword to `check` enable the
+tolerance value to be user-specified.
+- Changed the behavior of checking of telescope location to look at the combination of
+`antenna_positions` and `telescope_location` together for `UVData`, `UVCal`, and `UVFlag`.
+Additionally, failing this check results in a warning (was an error).
+
+## [2.4.1] - 2023-10-13
+
+### Added
 - Added a `uvw_track_generator` method within `utils` for calculating the expected
 uvws (and a few other values) without needing to instantiate a whole `UVData` object.
 - Added a convenience function called `compare_value` in `UVParameter` that enables
@@ -22,14 +33,6 @@ file to the new `mwa_metafits_file` parameter.
 - Support for recarrays in `UVParameter` objects and in `UVBase`, needed for pyradiosky.
 - Support for setting the astrometry library for various object methods including `set_lsts_from_time_array`, file read methods and others.
 - Properly round-trip the telescope frame through UVH5, UVFITS and MS files.
-
-### Changed
-- Increased the tolerance to 15 mas for a warning about values in `lst_array` not conforming
-to exceptations for `UVData`, `UVCal`, and `UVFlag` (was 1 mas) inside of `check`, additionally
-adding a keyword to enable the tolerance value to be specified.
-- Changed the behavior of checking of telescope location to look at the combination of
-`antenna_positions` and `telescope_location` together for `UVData`, `UVCal`, and `UVFlag`.
-Additionally, failing this check results in a warning (was an error).
 
 ### Fixed
 - A bug in apparent coordinate calculation that resulted in small errors/loss of

--- a/pyuvdata/parameter.py
+++ b/pyuvdata/parameter.py
@@ -895,8 +895,6 @@ class LocationParameter(UVParameter):
 
     """
 
-    _range_dict = {"itrs": (6.35e6, 6.39e6), "mcmf": (1717100.0, 1757100.0)}
-
     def __init__(
         self,
         name,
@@ -905,7 +903,7 @@ class LocationParameter(UVParameter):
         spoof_val=None,
         description="",
         frame="itrs",
-        acceptable_range=-1,
+        acceptable_range=None,
         tols=1e-3,
     ):
         super(LocationParameter, self).__init__(
@@ -920,21 +918,6 @@ class LocationParameter(UVParameter):
             tols=tols,
         )
         self.frame = frame
-
-        # If acceptable_range is set, set it now. Has to be done after frame is set
-        # because setting the frame changes the acceptable_range.
-        if acceptable_range != -1:
-            self.acceptable_range = acceptable_range
-
-    def __setattr__(self, name, value):
-        """Ensure that acceptable_range is set properly when frame is changed."""
-        if name == "frame":
-            if value in self._range_dict.keys():
-                self.acceptable_range = self._range_dict[value]
-            else:
-                self.acceptable_range = None
-
-        return super().__setattr__(name, value)
 
     def lat_lon_alt(self):
         """Get value in (latitude, longitude, altitude) tuple in radians."""

--- a/pyuvdata/tests/test_parameter.py
+++ b/pyuvdata/tests/test_parameter.py
@@ -397,6 +397,17 @@ def test_location_set_lat_lon_alt_degrees_none():
     assert param1.value is None
 
 
+def test_location_acceptability():
+    """Test check_acceptability with LocationParameters"""
+    val = np.array([0.5, 0.5, 0.5])
+    param1 = uvp.LocationParameter("p1", value=val, acceptable_range=[0, 1])
+    assert param1.check_acceptability()[0]
+
+    val += 0.5
+    param1 = uvp.LocationParameter("p1", value=val, acceptable_range=[0, 1])
+    assert not param1.check_acceptability()[0]
+
+
 def test_location_acceptable_none():
     param1 = uvp.LocationParameter(name="p2", value=1, acceptable_range=None)
 

--- a/pyuvdata/tests/test_parameter.py
+++ b/pyuvdata/tests/test_parameter.py
@@ -408,33 +408,6 @@ def test_location_acceptable_none():
     assert param1.check_acceptability()[0]
 
 
-def test_location_mcmf_acceptability():
-    loc = np.array([1717200.0, 0.0, 0.0])
-    param1 = uvp.LocationParameter(name="p2", value=loc, frame="mcmf")
-    assert param1.acceptable_range == (1717100.0, 1757100.0)
-    assert param1.check_acceptability()[0]
-
-    # test that the acceptable range is changed when the frame is changed
-    param1.frame = "itrs"
-    assert param1.acceptable_range == (6.35e6, 6.39e6)
-    assert not param1.check_acceptability()[0]
-
-    param1.frame = "foo"
-    assert param1.acceptable_range is None
-    assert param1.check_acceptability()[0]
-
-    param1.frame = "mcmf"
-    assert param1.acceptable_range == (1717100.0, 1757100.0)
-    assert param1.check_acceptability()[0]
-
-    # check that if you set the acceptable range on init that it is used
-    param1 = uvp.LocationParameter(
-        name="p2", value=loc, acceptable_range=(1717100.0, 1717150.0), frame="mcmf"
-    )
-    assert param1.acceptable_range == (1717100.0, 1717150.0)
-    assert not param1.check_acceptability()[0]
-
-
 @pytest.mark.parametrize(
     "sky2",
     [

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4261,3 +4261,78 @@ def test_uvw_track_generator_moon():
 
     # Check that the total lengths all match 1
     assert np.allclose((gen_results["uvw"] ** 2.0).sum(1), 2.0)
+
+
+@pytest.mark.parametrize("err_state", ["err", "warn", "none"])
+@pytest.mark.parametrize("tel_loc", ["Center", "Moon", "Earth", "Space"])
+@pytest.mark.parametrize("check_frame", ["Moon", "Earth"])
+@pytest.mark.parametrize("del_tel_loc", [False, None, True])
+def test_check_surface_based_positions(err_state, tel_loc, check_frame, del_tel_loc):
+    tel_loc_dict = {
+        "Center": np.array([0, 0, 0]),
+        "Moon": np.array([0, 0, 1.737e6]),
+        "Earth": np.array([0, 6.37e6, 0]),
+        "Space": np.array([4.22e7, 0, 0]),
+    }
+    tel_frame_dict = {"Moon": "mcmf", "Earth": "itrs"}
+
+    ant_pos = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    )
+    if del_tel_loc:
+        ant_pos += tel_loc_dict[tel_loc]
+
+    fail_type = err_msg = err_type = None
+    err_check = uvtest.check_warnings
+    if (tel_loc != check_frame) and (err_state != "none"):
+        if tel_loc == "Center":
+            fail_type = "below"
+        elif tel_loc == "Space":
+            fail_type = "above"
+        else:
+            fail_type = "above" if tel_loc == "Earth" else "below"
+
+    if fail_type is not None:
+        err_msg = (
+            f"{tel_frame_dict[check_frame]} position vector magnitudes must be "
+            f"on the order of the radius of {check_frame} -- they appear to lie well "
+            f"{fail_type} this."
+        )
+        if err_state == "err":
+            err_type = ValueError
+            err_check = pytest.raises
+        else:
+            err_type = UserWarning
+
+        with err_check(err_type, match=err_msg):
+            status = uvutils.check_surface_based_positions(
+                telescope_loc=None if (del_tel_loc) else tel_loc_dict[tel_loc],
+                antenna_positions=None if (del_tel_loc is None) else ant_pos,
+                telescope_frame=tel_frame_dict[check_frame],
+                raise_error=err_state == "err",
+                raise_warning=err_state == "warn",
+            )
+
+        assert (err_state == "err") or (status == (tel_loc == check_frame))
+
+
+@pytest.mark.skipif(not hasmoon, reason="lunarsky not installed")
+@pytest.mark.parametrize("tel_loc", ["Earth", "Moon"])
+@pytest.mark.parametrize("check_frame", ["Earth", "Moon"])
+def test_check_surface_based_positions_earthmoonloc(tel_loc, check_frame):
+    frame = "mcmf" if (check_frame == "Moon") else "itrs"
+
+    if tel_loc == "Earth":
+        loc = EarthLocation.from_geodetic(0, 0, 0)
+    else:
+        loc = MoonLocation.from_selenodetic(0, 0, 0)
+
+    if tel_loc == check_frame:
+        assert uvutils.check_surface_based_positions(
+            telescope_loc=loc, telescope_frame=frame
+        )
+    else:
+        with pytest.raises(ValueError, match=(f"{frame} position vector")):
+            uvutils.check_surface_based_positions(
+                telescope_loc=loc, telescope_frame=frame
+            )

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -75,8 +75,11 @@ __all__ = [
 
 # standard angle tolerance: 1 mas in radians.
 RADIAN_TOL = 1 * 2 * np.pi * 1e-3 / (60.0 * 60.0 * 360.0)
-# standard lst time tolerance: 1 ms (15 mas in radians)
-LST_RAD_TOL = 1 * 2 * np.pi * 1e-3 / (86400.0)
+# standard lst time tolerance: 5 ms (75 mas in radians), based on an expected RMS
+# accuracy of 1 ms at 7 days out from issuance of Bulletin A (which are issued once a
+# week with rapidly determined parameters and forecasted values of DUT1), the exact
+# formula for which is t_err = 0.00025 (MJD-<Bulletin A Release Data>)**0.75 (in secs).
+LST_RAD_TOL = 2 * np.pi * 5e-3 / (86400.0)
 
 # fmt: off
 # polarization constants

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -120,8 +120,6 @@ POL_TO_FEED_DICT = {"xx": ["x", "x"], "yy": ["y", "y"],
                     "rr": ["r", "r"], "ll": ["l", "l"],
                     "rl": ["r", "l"], "lr": ["l", "r"]}
 
-ANGLE_TIME_EQUIV = [(units.s, units.arcsec, lambda x: x * 15.0, lambda x: x / 15.0)]
-
 _range_dict = {
     "itrs": (6.35e6, 6.39e6, "Earth"), "mcmf": (1717100.0, 1757100.0, "Moon")
 }

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -120,7 +120,7 @@ POL_TO_FEED_DICT = {"xx": ["x", "x"], "yy": ["y", "y"],
 ANGLE_TIME_EQUIV = [(units.s, units.arcsec, lambda x: x * 15.0, lambda x: x / 15.0)]
 
 _range_dict = {
-    "itrs": (6.35e6, 6.39e6, "Earth"), "mcmf": (1717100.0, 1757100.0, "Earth")
+    "itrs": (6.35e6, 6.39e6, "Earth"), "mcmf": (1717100.0, 1757100.0, "Moon")
 }
 
 
@@ -4105,7 +4105,7 @@ def check_surface_based_positions(
     whereas for theMoon the range is 1717.1 to 1757.1 km.
 
     telescope_loc : tuple or EarthLocation or MoonLocation
-        Telescope location, specified as a 3-elemnemt tuple (specifying geocentric
+        Telescope location, specified as a 3-element tuple (specifying geo/selenocentric
         position in meters) or as an astropy EarthLocation (or lunarsky MoonLocation).
     telescope_frame : str, optional
         Reference frame for latitude/longitude/altitude. Options are itrs (default) or
@@ -4138,7 +4138,7 @@ def check_surface_based_positions(
         antenna_positions = antenna_positions + (
             telescope_loc.x.to("m").value,
             telescope_loc.y.to("m").value,
-            telescope_loc.x.to("m").value,
+            telescope_loc.z.to("m").value,
         )
     elif telescope_loc is not None:
         antenna_positions = antenna_positions + telescope_loc
@@ -4155,7 +4155,7 @@ def check_surface_based_positions(
         return True
 
     err_msg = (
-        f"{telescope_frame} antenna position vector magnitudes must be on the order of "
+        f"{telescope_frame} position vector magnitudes must be on the order of "
         f"the radius of {world} -- they appear to lie well {err_type} this."
     )
 

--- a/pyuvdata/uvcal/tests/test_uvcal.py
+++ b/pyuvdata/uvcal/tests/test_uvcal.py
@@ -3990,13 +3990,7 @@ def test_init_from_uvdata(
     # of precision in the processing pipeline.
     assert uvc_new._time_array == uvc2._time_array
     uvc_new.time_array = uvc2.time_array
-    with uvtest.check_warnings(
-        UserWarning,
-        match="The lst_array is not self-consistent with the time_array and "
-        "telescope location. Consider recomputing with the "
-        "`set_lsts_from_time_array` method.",
-    ):
-        uvc_new.check()
+    uvc_new.check()
 
     uvc_new.set_lsts_from_time_array()
 

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -1216,9 +1216,11 @@ class UVCal(UVBase):
             Tolerance level at which to test LSTs against their expected values. If
             provided as a float, must be in units of radians. If set to None, the
             default precision tolerance from the `lst_array` parameter is used (1 mas).
-            Default value is 15 mas,  which is set by the predictive uncertainty in IERS
-            calculations of DUT1 (of order 1 ms), which for some observatories sets the
-            precision with which these values are written.
+            Default value is 75 mas,  which is set by the predictive uncertainty in IERS
+            calculations of DUT1 (RMS is of order 1 ms, with with a 5-sigma threshold
+            for detection is used to prevent false issues from being reported), which
+            for some observatories sets the precision with which these values are
+            written.
 
         Returns
         -------

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -456,7 +456,12 @@ class Miriad(UVData):
                     rel_ecef_antpos = ecef_antpos
             else:
                 self.telescope_location = np.mean(ecef_antpos[good_antpos, :], axis=0)
-                valid_location = self._telescope_location.check_acceptability()[0]
+                valid_location = uvutils.check_surface_based_positions(
+                    telescope_loc=self.telescope_location,
+                    telescope_frame=self._telescope_location.frame,
+                    raise_error=False,
+                    raise_warning=False,
+                )
 
                 # check to see if this could be a valid telescope_location
                 if valid_location:

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -5514,8 +5514,13 @@ def test_telescope_loc_xyz_check(paper_uvh5, tmp_path):
     uv.read(fname, run_check=False, use_future_array_shapes=True)
 
     # try to read without checks: assert it fails
-    with pytest.raises(
-        ValueError, match="UVParameter _telescope_location has unacceptable values."
+    with uvtest.check_warnings(
+        UserWarning,
+        [
+            "The uvw_array does not match the expected",
+            "itrs antenna position vector magnitudes must be on the order "
+            "of the radius of Earth -- they appear to lie well below this.",
+        ],
     ):
         uv.read(fname, use_future_array_shapes=True)
 

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -5518,7 +5518,7 @@ def test_telescope_loc_xyz_check(paper_uvh5, tmp_path):
         UserWarning,
         [
             "The uvw_array does not match the expected",
-            "itrs antenna position vector magnitudes must be on the order "
+            "itrs position vector magnitudes must be on the order "
             "of the radius of Earth -- they appear to lie well below this.",
         ],
     ):

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -3241,9 +3241,11 @@ class UVData(UVBase):
             Tolerance level at which to test LSTs against their expected values. If
             provided as a float, must be in units of radians. If set to None, the
             default precision tolerance from the `lst_array` parameter is used (1 mas).
-            Default value is 15 mas,  which is set by the predictive uncertainty in IERS
-            calculations of DUT1 (of order 1 ms), which for some observatories sets the
-            precision with which these values are written.
+            Default value is 75 mas,  which is set by the predictive uncertainty in IERS
+            calculations of DUT1 (RMS is of order 1 ms, with with a 5-sigma threshold
+            for detection is used to prevent false issues from being reported), which
+            for some observatories sets the precision with which these values are
+            written.
 
         Returns
         -------

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -70,7 +70,7 @@ class UVFITS(UVData):
                 latitude=latitude,
                 longitude=longitude,
                 altitude=altitude,
-                lst_tols=self._lst_array.tols,
+                lst_tols=(0, uvutils.LST_RAD_TOL),
                 frame=self._telescope_location.frame,
             )
 

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -934,7 +934,7 @@ class UVH5(UVData):
                 latitude=lat,
                 longitude=lon,
                 altitude=alt,
-                lst_tols=(0, uvutils.RADIAN_TOL),
+                lst_tols=(0, uvutils.LST_RAD_TOL),
                 frame=self._telescope_location.frame,
             )
 

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -917,20 +917,14 @@ def test_read_write_loop_missing_shapes(uvdata_obj, test_outfile, future_shapes)
             "baseline",
             ["telescope_location"],
             UserWarning,
-            [
-                "telescope_location are not set or are being overwritten. Using known",
-                "The lst_array is not self-consistent with the time_array",
-            ],
+            ["telescope_location are not set or are being overwritten. Using known"],
             "reset_telescope_params",
         ),
         (
             "baseline",
             ["antenna_names"],
             UserWarning,
-            [
-                "antenna_names are not set or are being overwritten. Using known",
-                "The lst_array is not self-consistent with the time_array",
-            ],
+            ["antenna_names are not set or are being overwritten. Using known"],
             "reset_telescope_params",
         ),
         (
@@ -948,29 +942,17 @@ def test_read_write_loop_missing_shapes(uvdata_obj, test_outfile, future_shapes)
             "baseline",
             ["antenna_numbers"],
             UserWarning,
-            [
-                "antenna_numbers are not set or are being overwritten. Using known",
-                "The lst_array is not self-consistent with the time_array",
-            ],
+            ["antenna_numbers are not set or are being overwritten. Using known"],
             "reset_telescope_params",
         ),
         (
             "baseline",
             ["antenna_positions"],
             UserWarning,
-            [
-                "antenna_positions are not set or are being overwritten. Using known",
-                "The lst_array is not self-consistent with the time_array",
-            ],
+            ["antenna_positions are not set or are being overwritten. Using known"],
             "reset_telescope_params",
         ),
-        (
-            "baseline",
-            ["Nants_telescope"],
-            UserWarning,
-            "The lst_array is not self-consistent with the time_array",
-            "reset_telescope_params",
-        ),
+        ("baseline", ["Nants_telescope"], None, [], "reset_telescope_params"),
         (
             "waterfall",
             ["Nants_telescope", "telescope_name", "antenna_numbers"],
@@ -1019,8 +1001,7 @@ def test_read_write_loop_missing_shapes(uvdata_obj, test_outfile, future_shapes)
             UserWarning,
             [
                 "Nants_telescope, antenna_names, antenna_numbers, antenna_positions "
-                "are not set or are being overwritten. Using known values for HERA.",
-                "The lst_array is not self-consistent with the time_array",
+                "are not set or are being overwritten. Using known values for HERA."
             ],
             "reset_telescope_params",
         ),
@@ -1164,7 +1145,7 @@ def test_read_write_loop_missing_telescope_info(
     if "telescope_name" in param_list:
         run_check = False
 
-    with uvtest.check_warnings(warn_type, match=msg):
+    with uvtest.check_warnings(warn_type, match=None if warn_type is None else msg):
         uvf2 = UVFlag(test_outfile, use_future_array_shapes=True, run_check=run_check)
 
     if uv_mod is None:
@@ -1191,7 +1172,7 @@ def test_read_write_loop_missing_telescope_info(
     if "Nants_telescope" in param_list and "telescope_name" not in param_list:
         with uvtest.check_warnings(
             UserWarning,
-            match=[msg]
+            match=([] if warn_type is None else [msg])
             + [
                 "Telescope_name parameter is set to foo, which overrides the telescope "
                 "name in the file (HERA)."
@@ -1568,11 +1549,8 @@ def test_read_multiple_files(
     uvf = UVFlag(uv, use_future_array_shapes=write_future_shapes)
     uvf.write(test_outfile, clobber=True)
 
-    warn_msg = [
-        "The lst_array is not self-consistent with the time_array and telescope "
-        "location. Consider recomputing with the `set_lsts_from_time_array` method."
-    ] * 2
-    warn_type = [UserWarning] * 2
+    warn_msg = []
+    warn_type = []
     if not read_future_shapes:
         warn_msg += [_future_array_shapes_warning] * 2
         warn_type += [DeprecationWarning] * 2
@@ -1857,12 +1835,10 @@ def test_add_frequency():
 
     with uvtest.check_warnings(
         UserWarning,
-        match=[
+        match=(
             "One object has the flex_spw_id_array set and one does not. Combined "
-            "object will have it set.",
-            "The lst_array is not self-consistent with the time_array and telescope "
-            "location. Consider recomputing with the `set_lsts_from_time_array` method",
-        ],
+            "object will have it set."
+        ),
     ):
         uv3 = uv1.__add__(uv2, axis="frequency")
     assert np.array_equal(
@@ -1915,13 +1891,10 @@ def test_add_frequency_multi_spw(split_spw):
         assert uv2.Nfreqs == uv_full.Nfreqs // 2
 
         with uvtest.check_warnings(
-            [DeprecationWarning, UserWarning] * 2,
+            [DeprecationWarning] * 2,
             match=[
                 "flex_spw_id_array is not set. It will be required starting in "
-                "version 3.0",
-                "The lst_array is not self-consistent with the time_array and "
-                "telescope location. Consider recomputing with the "
-                "`set_lsts_from_time_array` method.",
+                "version 3.0"
             ]
             * 2,
         ):

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -948,9 +948,11 @@ class UVFlag(UVBase):
             Tolerance level at which to test LSTs against their expected values. If
             provided as a float, must be in units of radians. If set to None, the
             default precision tolerance from the `lst_array` parameter is used (1 mas).
-            Default value is 15 mas,  which is set by the predictive uncertainty in IERS
-            calculations of DUT1 (of order 1 ms), which for some observatories sets the
-            precision with which these values are written.
+            Default value is 75 mas,  which is set by the predictive uncertainty in IERS
+            calculations of DUT1 (RMS is of order 1 ms, with with a 5-sigma threshold
+            for detection is used to prevent false issues from being reported), which
+            for some observatories sets the precision with which these values are
+            written.
 
         Returns
         -------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates handling of `lst_array` and `telescope_position` in terms of when warnings and errors get issued inside of `check` for `UVData`, `UVCal`, and `UVFlag`. More specifically, the tolerance for when the warning about "LSTs not set correctly" has been increased to 15 milliarcsec, to better reflect the typical uncertainty in these values at the time of observation (due to the ever-changing DUT1 ). Additionally, `check` now looks at the combination of telescope location _and_ antenna positions in determining whether or not a given set of positions are "reasonable", and when a discrepancy is discovered, a warning is now issued instead of an error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Relevant issues below, but in both cases, the prior behavior in `check` was resulting in undesired behavior. In the case of the LSTs, a lot of spurious warnings were being generated that were confusing/concerning some users in situations where the "issues" were totally benign. In the case of the telescope position handing, it was breaking support for VLBA/VLBI-generated UVFITS file (without disabling parts of `check`), whose telescope location (phase reference center) is not neccessarily on the surface of the Earth.

Closes #1348
Closes #1352

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
