### PR TITLE
Clean up freq_range and freq_array handling in UVCal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ tolerance value to be user-specified.
 `antenna_positions` and `telescope_location` together for `UVData`, `UVCal`, and `UVFlag`.
 Additionally, failing this check results in a warning (was an error).
 
+### Deprecated
+- Having `freq_range` defined on non-wide-band gain style UVCal objects.
+- Having `freq_array` and `channel_width` defined on wide-band UVCal objects.
+
+### Fixed
+- A couple of small bugs related to handling of the `freq_range` parameter in the
+`reorder_freqs` and `__add__` methods on `UVCal`.
+
 ## [2.4.1] - 2023-10-13
 
 ### Added

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -594,11 +594,10 @@ class CALFITS(UVCal):
             self.gain_scale = hdr.pop("GNSCALE", None)
             self.x_orientation = hdr.pop("XORIENT")
             self.cal_type = hdr.pop("CALTYPE")
+
+            # old files might have a freq range for gain types but we don't want them
             if self.cal_type == "delay":
                 self.freq_range = list(map(float, hdr.pop("FRQRANGE").split(",")))
-            else:
-                if "FRQRANGE" in hdr:
-                    self.freq_range = list(map(float, hdr.pop("FRQRANGE").split(",")))
 
             self.cal_style = hdr.pop("CALSTYLE")
             if self.cal_style == "sky":


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We should really only have one of `freq_array` or `freq_range` defined on a UVCal object in the future (e.g. in version 3.0). This is along the lines of what we decided for time_range vs time_array (see #1306).

This is very clear in v 3.0+ because of the move to the `wide_band` structure. It's a bit muddier before that because of the support for flag arrays that have a frequency axis in delay-type calibrations.

So this PR just adds deprecation warnings for the clear cases so users can know what's coming in v3.0. To be clear:
- `freq_range` should not be set on non-wide-band gain style objects (which have a frequency axis)
- `freq_array` and `channel_width` should not be set on wide-band objects (which do not have a frequency axis)

It also fixes a couple of small bugs I found in testing related to handling of the `freq_range` parameter in the `reorder_freqs` and `__add__` methods.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
I stumbled on this while working on improvements to UVCal methods that I'm implementing as part of developing the `calH5` format. I thought we should get the deprecation warnings in ASAP to give users as much heads up as possible. But I don't actually expect many users to run into this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Breaking change checklist:
- [x] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [x] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

