### PR TITLE
MS writer improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,19 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Added a `check_surface_based_positions` positions method for verifying antenna
-positions are near surface of whatever celestial body their positions are referenced to
-(either the Earth or Moon, currently).
 - Added a switch to `UVData.write_ms` called `flip_conj`, which allows a user to write
 out data with the baseline conjugation scheme flipped from the standard `UVData`
 convention.
 - Added the `utils.determine_pol_order` method for determining polarization
 order based on a specified scheme ("AIPS" or "CASA").
+- Added a `check_surface_based_positions` positions method for verifying antenna
+positions are near surface of whatever celestial body their positions are referenced to
+(either the Earth or Moon, currently).
 
 ### Changed
+- Changed `UVData.write_ms` to sort polarizations based on CASA-preferred ordering.
+- Added some functionality to the `utils._convert_to_slices` method to enable quick
+assessment of whether an indexing array can be replaced by a single slice.
 - Increased the tolerance to 75 mas (equivalent to 5 ms time error) for a warning about
 values in `lst_array` not conforming to expectations for `UVData`, `UVCal`, and `UVFlag`
 (was 1 mas) inside of `check`. Additionally, added a keyword to `check` enable the
@@ -21,9 +24,6 @@ tolerance value to be user-specified.
 - Changed the behavior of checking of telescope location to look at the combination of
 `antenna_positions` and `telescope_location` together for `UVData`, `UVCal`, and `UVFlag`.
 Additionally, failing this check results in a warning (was an error).
-- Changed `UVData.write_ms` to sort polarizations based on CASA-preferred ordering.
-- Added some functionality to the `utils._convert_to_slices` method to enable quick
-assessment of whether an indexing array can be replaced by a single slice.
 
 ## [2.4.1] - 2023-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 - Added a `check_surface_based_positions` positions method for verifying antenna
 positions are near surface of whatever celestial body their positions are referenced to
 (either the Earth or Moon, currently).
+- Added a switch to `UVData.write_ms` called `flip_conj`, which allows a user to write
+out data with the baseline conjugation scheme flipped from the standard `UVData`
+convention.
+- Added the `utils.determine_pol_order` method for determining polarization
+order based on a specified scheme ("AIPS" or "CASA").
 
 ### Changed
 - Increased the tolerance to 75 mas (equivalent to 5 ms time error) for a warning about
@@ -16,6 +21,9 @@ tolerance value to be user-specified.
 - Changed the behavior of checking of telescope location to look at the combination of
 `antenna_positions` and `telescope_location` together for `UVData`, `UVCal`, and `UVFlag`.
 Additionally, failing this check results in a warning (was an error).
+- Changed `UVData.write_ms` to sort polarizations based on CASA-preferred ordering.
+- Added some functionality to the `utils._convert_to_slices` method to enable quick
+assessment of whether an indexing array can be replaced by a single slice.
 
 ## [2.4.1] - 2023-10-13
 

--- a/pyuvdata/tests/test_telescopes.py
+++ b/pyuvdata/tests/test_telescopes.py
@@ -79,7 +79,7 @@ def test_extra_parameter_iter():
     for prop in telescope_obj.extra():
         extra.append(prop)
     for a in extra_parameters:
-        a in extra, "expected attribute " + a + " not returned in extra iterator"
+        assert a in extra, "expected attribute " + a + " not returned in extra iterator"
 
 
 def test_unexpected_parameters():

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -2819,7 +2819,7 @@ def test_strict_cliques():
     adj_link[-1] = frozenset({5, 6, 7, 8, 1})
 
     with pytest.raises(ValueError, match="Non-isolated cliques found in graph."):
-        uvutils._find_cliques(adj_link, strict=True),
+        uvutils._find_cliques(adj_link, strict=True)
 
 
 def test_reorder_conj_pols_non_list():

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -5847,7 +5847,10 @@ def _convert_to_slices(
         max_nslice = max_nslice_frac * Ninds
     check = len(slices) <= max_nslice
 
-    return [indices] if (not check and return_index_on_fail) else slices, check
+    if return_index_on_fail and not check:
+        return [indices], check
+    else:
+        return slices, check
 
 
 def _get_slice_len(s, axlen):

--- a/pyuvdata/uvbeam/tests/test_cst_beam.py
+++ b/pyuvdata/uvbeam/tests/test_cst_beam.py
@@ -209,7 +209,7 @@ def test_read_yaml_override(cst_efield_2freq_mod):
             beam_type="efield",
             telescope_name="test",
             use_future_array_shapes=True,
-        ),
+        )
 
     assert beam1 == beam2
 

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -176,7 +176,7 @@ def test_mir_raw_data(mir_data, tmp_path):
 
     mir_data._write_cross_data(filepath)
     # Sub out the file we need to read from
-    mir_data._file_dict = {filepath: item for item in mir_data._file_dict.values()}
+    mir_data._file_dict = {filepath: list(mir_data._file_dict.values())[0]}
     raw_data = mir_data._read_data("cross", return_vis=False)
 
     assert raw_data.keys() == mir_data.raw_data.keys()
@@ -201,7 +201,7 @@ def test_mir_auto_data(mir_data, tmp_path):
     mir_data._write_auto_data(filepath)
     # Sub out the file we need to read from, and fix a couple of attributes that changed
     # since we are no longer spoofing values (after reading in data from old-style file)
-    mir_data._file_dict = {filepath: item for item in mir_data._file_dict.values()}
+    mir_data._file_dict = {filepath: list(mir_data._file_dict.values())[0]}
     mir_data._file_dict[filepath]["auto"]["filetype"] = "ach_read"
     int_dict, mir_data._ac_dict = mir_data.ac_data._generate_recpos_dict(reindex=True)
     mir_data._file_dict[filepath]["auto"]["int_dict"] = int_dict

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -9539,7 +9539,7 @@ def test_frequency_average_nsample_precision(casa_uvfits):
     uvobj.nsample_array = uvobj.nsample_array.astype(np.float16)
 
     with uvtest.check_warnings(UserWarning, "eq_coeffs vary by frequency"):
-        uvobj.frequency_average(n_chan_to_avg=2),
+        uvobj.frequency_average(n_chan_to_avg=2)
 
     assert uvobj.Nfreqs == (uvobj2.Nfreqs / 2)
 

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -926,7 +926,7 @@ def test_readwriteread_error_single_time(tmp_path, casa_uvfits):
                 "The integration time is not specified and only one time",
             ],
         ):
-            uv_out.read(write_file2, use_future_array_shapes=True),
+            uv_out.read(write_file2, use_future_array_shapes=True)
 
     return
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds some functionality to the `write_ms` method, which enforces that CASA-preferred polarization ordering is used on write, and allows the user to specify whether to flip the baseline conjugation scheme used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This addresses some issues that LWA users were running into when passing data through puvdata. Two issues in particular were identified in #1355. First, some CASA tasks clearly want the polarization order to be set up in a particular way, so the writer now always writes out in "CASA order". Second, there's an open question as to if some methods and functions (both internal and external to the CASA package) require different baseline conventions, which would be understandable given the conflicting documentation. Though I believe the pyuvdata standard is correct for most applications, I've added a switch that users can use to flip the convention.

In the course of addressing the above, I did make a few small tweaks to the writer and added/modified a couple of functions in `utils` to help with polarization ordering and to make indexing faster under most circumstances via use of slices.

Closes #1355.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
