### PR TITLE
Replacing deprecated scipy `simps` method in MWA code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ positions are near surface of whatever celestial body their positions are refere
 (either the Earth or Moon, currently).
 
 ### Changed
+- Changed `MWACorrFits.corrcorrect_simps` method to use the `scipy.integrate.simpson`
+method rather than the `scipy.integrate.simps` method to fix deprecation warnings.
 - added support for python 3.12, dropped support for python 3.8.
 - Updated minimum dependency versions: pyyaml>=5.3
 - Changed `UVData.write_ms` to sort polarizations based on CASA-preferred ordering.

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -310,7 +310,7 @@ def corrcorrect_simps(rho, sig1, sig2):
     x = np.linspace(0, rho, 11, dtype=np.float64)
     khat = np.zeros((11, rho.size), dtype=np.float64)
     khat = _corr_fits.get_khat(x, sig1, sig2)
-    integrated_khat = simpson(khat, x, axis=0)
+    integrated_khat = simpson(khat, x=x, axis=0)
     return integrated_khat
 
 

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -14,8 +14,14 @@ from astropy import constants as const
 from astropy.io import fits
 from astropy.time import Time
 from docstring_parser import DocstringStyle
-from scipy.integrate import simpson
 from scipy.special import erf
+
+try:
+    # TODO: Make this the only line we use once scipy >= 1.11 is required.
+    from scipy.integrate import simpson
+except ImportError:
+    # Fallback to simps if working with an older version of scipy
+    from scipy.integrate import simps as simpson
 
 from pyuvdata.data import DATA_PATH
 

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -14,7 +14,7 @@ from astropy import constants as const
 from astropy.io import fits
 from astropy.time import Time
 from docstring_parser import DocstringStyle
-from scipy.integrate import simps
+from scipy.integrate import simpson
 from scipy.special import erf
 
 from pyuvdata.data import DATA_PATH
@@ -304,7 +304,7 @@ def corrcorrect_simps(rho, sig1, sig2):
     x = np.linspace(0, rho, 11, dtype=np.float64)
     khat = np.zeros((11, rho.size), dtype=np.float64)
     khat = _corr_fits.get_khat(x, sig1, sig2)
-    integrated_khat = simps(khat, x, axis=0)
+    integrated_khat = simpson(khat, x, axis=0)
     return integrated_khat
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Swaps deprecated code.

## Description
<!--- Describe your changes in detail -->
I've swapped the `scipy.integrate.simpson` method in place for the previously used `scipy.integrate.simps` method due to a fresh set of deprecation warnings (as of v1.12.0 of scipy, it seems) that are now breaking tests. According to the scipy docs, `simps` method is simply an alias for the `simpson` function, so there should be absolutely no change in functionality here.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
New deprecation warnings were causing significant test breakage. And if there's one thing I can't stand, it's new warnings causing test failures.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
