### PR TITLE
MS support broken for legacy array shape [Issue #1379]

### DIFF
--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1211,7 +1211,7 @@ class MS(UVData):
                 if self.future_array_shapes:
                     temp_vals = getattr(self, attr)[:, :, pol_order]
                 else:
-                    temp_vals = getattr(self, attr)[:, 0, :, pol_order]
+                    temp_vals = getattr(self, attr)[:, 0, :][..., pol_order]
 
                 if flip_conj and (attr == "data_array"):
                     temp_vals = np.conj(temp_vals)

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -70,6 +70,17 @@ def nrao_uv(nrao_uv_main):
 
     return
 
+@pytest.fixture(scope="function")
+def nrao_uv_legacy():
+    """Make function level NRAO ms object, legacy array shapes."""
+    uvobj = UVData()
+    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.ms")
+    uvobj.read(testfile, use_future_array_shapes=False)
+
+    yield uvobj
+
+    del uvobj
+
 
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 @pytest.mark.filterwarnings("ignore:ITRF coordinate frame detected,")
@@ -1063,3 +1074,13 @@ def test_flip_conj_multispw(sma_mir, tmp_path):
     sma_mir.filename = ms_uv.filename = None
 
     assert sma_mir == ms_uv
+
+def test_read_ms_write_miriad(nrao_uv, nrao_uv_legacy, tmp_path):
+    """
+    write ms from future and legacy array shapes.
+    """
+    testfile_l = os.path.join(tmp_path, "outtest_legacy.ms")
+    testfile_f = os.path.join(tmp_path, "outtest_future.ms")
+
+    nrao_uv.write_ms(testfile_l)
+    nrao_uv_legacy.write_ms(testfile_f)


### PR DESCRIPTION
A fix for #1379: On main branch, commit [7790d06](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/commit/7790d0650a6407bd2d59277a208c92471dad2e52), MS writing fails if use_future_array_shapes=False is set.

## Description
See #1379

## Motivation and Context
Fixes #1379

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Breaking change checklist:
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
