### PR TITLE
Minor bug fix for `tests.WarningChecker` when IERS is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ fully tested and didn't work properly.
 - Having `freq_array` and `channel_width` defined on wide-band UVCal objects.
 
 ### Fixed
+- A small bug (mostly affecting continuous integration) that threw an error when the
+IERS service was down and when tests were using `test.check_warnings` to look for no
+warnings thrown (i.e., where `match=None`).
 - A couple of small bugs related to handling of the `freq_range` parameter in the
 `reorder_freqs` and `__add__` methods on `UVCal`.
 

--- a/pyuvdata/tests/__init__.py
+++ b/pyuvdata/tests/__init__.py
@@ -126,11 +126,12 @@ class WarningsChecker(warnings.catch_warnings):
             warnings.filterwarnings("ignore", message="time is out of IERS range")
 
             test_message = []
-            for message in self.match:
-                if message is None:
-                    test_message.append(False)
-                else:
-                    test_message.append(message.startswith("LST values stored in "))
+            if self.match is not None:
+                for message in self.match:
+                    if message is None:
+                        test_message.append(False)
+                    else:
+                        test_message.append(message.startswith("LST values stored in "))
             if not any(test_message):
                 warnings.filterwarnings("ignore", message="LST values stored in ")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes testing bug.

## Description
<!--- Describe your changes in detail -->
I've updated the `WarningChecker` class inside of `pyuvdata.tests` to handle when the IERS service is down and when `check_warnings` is being called with the expected warning and text match being set to `None` (which effectively ensures that no warnings are being thrown).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
There are about half a dozen tests which use `check_warnings` to make sure no warnings are being thrown, which were failing due to the previously uncaught behavior.  This sems to be a fairly rare occurence that's popped up recently due to what appear to be IERS server issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
