### PR TITLE
Miriad support (UVFITS and UV file writing) and MS write with legacy array shape

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -33,7 +33,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
-          CIBW_TEST_REQUIRES: packaging pytest pytest-cov pytest-cases
+          CIBW_TEST_REQUIRES: packaging pytest<8.0 pytest-cov pytest-cases
           CIBW_TEST_COMMAND: "python -m pytest --pyargs pyuvdata"
           CIBW_TEST_SKIP: "*-macosx_arm64"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Fixed a bug when trying to write a MS with a legacy array shape (but note legacy shape 
+will be deprecated in upcoming releases).
+- Improved support for MIRIAD UV files, and added `use_miriad_convention` flag to the
+UVFITS writer code, so files with the MIRIAD `BASELINE` convention can be created.
 - A new `freq_interp_kind` parameter to `UVBeam.interp`, `UVBeam._interp_az_za_rect_spline`
 and `UVBeam._interp_healpix_bilinear` to allow the frequency interpolation
 specification to be passed into the methods. Note this defaults to "cubic" rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Fixed a bug when trying to write a MS with a legacy array shape (but note legacy shape 
+- Fixed a bug when trying to write a MS with a legacy array shape (but note legacy shape
 will be deprecated in upcoming releases).
 - Improved support for MIRIAD UV files, and added `use_miriad_convention` flag to the
 UVFITS writer code, so files with the MIRIAD `BASELINE` convention can be created.

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -9,7 +9,7 @@ dependencies:
   - numpy>=1.20.*
   - pyerfa>=2.0
   - coverage
-  - pytest>=6.2.0
+  - pytest>=6.2.0,<8.0
   - pytest-cases>=3.6.9
   - pytest-cov
   - pytest-xdist

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -15,7 +15,7 @@ dependencies:
   - pyyaml>=5.3
   - scipy>=1.5
   - coverage
-  - pytest>=6.2.0
+  - pytest>=6.2.0,<8.0
   - pytest-cases>=3.6.9
   - pytest-cov
   - pytest-xdist

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -14,7 +14,7 @@ dependencies:
   - pyyaml>=5.3
   - scipy>=1.5
   - coverage
-  - pytest>=6.2.0
+  - pytest>=6.2.0,<8.0
   - pytest-cases>=3.6.9
   - pytest-cov
   - pytest-xdist

--- a/environment.yaml
+++ b/environment.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pre-commit
   - pyerfa>=2.0
   - pypandoc
-  - pytest>=6.2.0
+  - pytest>=6.2.0,<8.0
   - pytest-cases>=3.6.9
   - pytest-cov
   - pytest-xdist

--- a/pyuvdata/__init__.py
+++ b/pyuvdata/__init__.py
@@ -17,7 +17,7 @@ try:  # pragma: nocover
 
     __version__ = version_str
 
-except (LookupError, ImportError):
+except (LookupError, ImportError): # pragma: no cover
     try:
         # Set the version automatically from the package details.
         __version__ = version("pyuvdata")

--- a/pyuvdata/__init__.py
+++ b/pyuvdata/__init__.py
@@ -17,7 +17,7 @@ try:  # pragma: nocover
 
     __version__ = version_str
 
-except (LookupError, ImportError): # pragma: no cover
+except (LookupError, ImportError):  # pragma: no cover
     try:
         # Set the version automatically from the package details.
         __version__ = version("pyuvdata")

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4158,9 +4158,9 @@ def test_determine_blt_order_size_1():
 
 
 def test_antnums_to_baseline_miriad_convention():
-    ant1 = np.array([0, 1, 2, 3, 0, 0]) + 1      # Ant1 array should be 1-based
+    ant1 = np.array([0, 1, 2, 3, 0, 0]) + 1  # Ant1 array should be 1-based
     ant2 = np.array([0, 1, 2, 3, 255, 256]) + 1  # Ant2 array should be 1-based
-    bl_gold = np.array([ 257, 514, 771, 1028, 67840, 67841], dtype='uint64')
+    bl_gold = np.array([257, 514, 771, 1028, 67840, 67841], dtype="uint64")
     n_ant = 256
     bl = uvutils.antnums_to_baseline(ant1, ant2, n_ant, use_miriad_convention=True)
     assert np.allclose(bl, bl_gold)

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4157,6 +4157,15 @@ def test_determine_blt_order_size_1():
     assert time_first
 
 
+def test_antnums_to_baseline_miriad_convention():
+    ant1 = np.array([0, 1, 2, 3, 0, 0]) + 1      # Ant1 array should be 1-based
+    ant2 = np.array([0, 1, 2, 3, 255, 256]) + 1  # Ant2 array should be 1-based
+    bl_gold = np.array([ 257, 514, 771, 1028, 67840, 67841], dtype='uint64')
+    n_ant = 256
+    bl = uvutils.antnums_to_baseline(ant1, ant2, n_ant, use_miriad_convention=True)
+    assert np.allclose(bl, bl_gold)
+
+
 def test_determine_rect_time_first():
     times = np.linspace(2458119.5, 2458120.5, 10)
     ant1 = np.arange(3)

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -799,7 +799,7 @@ def baseline_to_antnums(baseline, Nants_telescope):
         return ant1.item(0), ant2.item(0)
 
 
-def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False):
+def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False, use_miriad_convention=False):
     """
     Get the baseline number corresponding to two given antenna numbers.
 
@@ -817,6 +817,13 @@ def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False):
         standard will be used unless there are antenna numbers >= 2048
         or Nants_telescope > 2048. In that case, the 2147483648 standard
         will be used. Default is False.
+    use_miriad_convention : bool
+        Option to use the MIRIAD convention where BASELINE id is
+            if ant2 < 256:
+                bl = 256 * ant1 + ant2 
+            else:
+                bl = 2048 * ant1 + ant2 + 2**16
+        Note antennas should be 1-indexed (start at 1, not 0)
 
     Returns
     -------
@@ -850,6 +857,7 @@ def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False):
         np.ascontiguousarray(ant2, dtype=np.uint64),
         attempt256=attempt256,
         nants_less2048=nants_less2048,
+        use_miriad_convention=use_miriad_convention
     )
     if return_array:
         return baseline

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -821,10 +821,8 @@ def antnums_to_baseline(
         will be used. Default is False.
     use_miriad_convention : bool
         Option to use the MIRIAD convention where BASELINE id is
-            if ant2 < 256:
-                bl = 256 * ant1 + ant2
-            else:
-                bl = 2048 * ant1 + ant2 + 2**16
+        `bl = 256 * ant1 + ant2` if `ant2 < 256`, otherwise
+        `bl = 2048 * ant1 + ant2 + 2**16`.
         Note antennas should be 1-indexed (start at 1, not 0)
 
     Returns

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1444,11 +1444,13 @@ def rotECEF_from_ECEF(xyz, longitude):
 
     """
     angle = -1 * longitude
-    rot_matrix = np.array([
-        [np.cos(angle), -1 * np.sin(angle), 0],
-        [np.sin(angle), np.cos(angle), 0],
-        [0, 0, 1],
-    ])
+    rot_matrix = np.array(
+        [
+            [np.cos(angle), -1 * np.sin(angle), 0],
+            [np.sin(angle), np.cos(angle), 0],
+            [0, 0, 1],
+        ]
+    )
     return rot_matrix.dot(xyz.T).T
 
 
@@ -1471,11 +1473,13 @@ def ECEF_from_rotECEF(xyz, longitude):
 
     """
     angle = longitude
-    rot_matrix = np.array([
-        [np.cos(angle), -1 * np.sin(angle), 0],
-        [np.sin(angle), np.cos(angle), 0],
-        [0, 0, 1],
-    ])
+    rot_matrix = np.array(
+        [
+            [np.cos(angle), -1 * np.sin(angle), 0],
+            [np.sin(angle), np.cos(angle), 0],
+            [0, 0, 1],
+        ]
+    )
     return rot_matrix.dot(xyz.T).T
 
 
@@ -4950,16 +4954,20 @@ def uvcalibrate(
     # have associated data in the UVCal object
     uvdata_unique_nums = np.unique(np.append(uvdata.ant_1_array, uvdata.ant_2_array))
     uvdata.antenna_names = np.asarray(uvdata.antenna_names)
-    uvdata_used_antnames = np.array([
-        uvdata.antenna_names[np.where(uvdata.antenna_numbers == antnum)][0]
-        for antnum in uvdata_unique_nums
-    ])
+    uvdata_used_antnames = np.array(
+        [
+            uvdata.antenna_names[np.where(uvdata.antenna_numbers == antnum)][0]
+            for antnum in uvdata_unique_nums
+        ]
+    )
     uvcal_unique_nums = np.unique(uvcal.ant_array)
     uvcal.antenna_names = np.asarray(uvcal.antenna_names)
-    uvcal_used_antnames = np.array([
-        uvcal.antenna_names[np.where(uvcal.antenna_numbers == antnum)][0]
-        for antnum in uvcal_unique_nums
-    ])
+    uvcal_used_antnames = np.array(
+        [
+            uvcal.antenna_names[np.where(uvcal.antenna_numbers == antnum)][0]
+            for antnum in uvcal_unique_nums
+        ]
+    )
 
     ant_arr_match = uvcal_used_antnames.tolist() == uvdata_used_antnames.tolist()
 
@@ -6059,19 +6067,21 @@ def determine_blt_order(
             if not on_bl_boundary:
                 time_b = False
 
-        if not any((
-            time_bl,
-            time_a,
-            time_b,
-            time_bl,
-            bl_time,
-            a_time,
-            b_time,
-            bl_order,
-            a_order,
-            b_order,
-            time_order,
-        )):
+        if not any(
+            (
+                time_bl,
+                time_a,
+                time_b,
+                time_bl,
+                bl_time,
+                a_time,
+                b_time,
+                bl_order,
+                a_order,
+                b_order,
+                time_order,
+            )
+        ):
             break
 
     if Nbls > 1 and Ntimes > 1:

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1446,13 +1446,11 @@ def rotECEF_from_ECEF(xyz, longitude):
 
     """
     angle = -1 * longitude
-    rot_matrix = np.array(
-        [
-            [np.cos(angle), -1 * np.sin(angle), 0],
-            [np.sin(angle), np.cos(angle), 0],
-            [0, 0, 1],
-        ]
-    )
+    rot_matrix = np.array([
+        [np.cos(angle), -1 * np.sin(angle), 0],
+        [np.sin(angle), np.cos(angle), 0],
+        [0, 0, 1],
+    ])
     return rot_matrix.dot(xyz.T).T
 
 
@@ -1475,13 +1473,11 @@ def ECEF_from_rotECEF(xyz, longitude):
 
     """
     angle = longitude
-    rot_matrix = np.array(
-        [
-            [np.cos(angle), -1 * np.sin(angle), 0],
-            [np.sin(angle), np.cos(angle), 0],
-            [0, 0, 1],
-        ]
-    )
+    rot_matrix = np.array([
+        [np.cos(angle), -1 * np.sin(angle), 0],
+        [np.sin(angle), np.cos(angle), 0],
+        [0, 0, 1],
+    ])
     return rot_matrix.dot(xyz.T).T
 
 
@@ -2176,8 +2172,7 @@ def calc_uvw(
             )
         if telescope_lat is None:
             raise ValueError(
-                "Must include telescope_lat to calculate baselines "
-                "in ENU coordinates!"
+                "Must include telescope_lat to calculate baselines in ENU coordinates!"
             )
     else:
         if ((app_ra is None) or (app_dec is None)) and frame_pa is None:
@@ -4011,8 +4006,7 @@ def get_lst_for_time(
     else:
         if not astrometry_library == "astropy":
             raise NotImplementedError(
-                "The MCMF frame is only supported with the 'astropy' astrometry "
-                "library"
+                "The MCMF frame is only supported with the 'astropy' astrometry library"
             )
         TimeClass = LTime
 
@@ -4024,8 +4018,7 @@ def get_lst_for_time(
             np.isin(status, (iers.TIME_BEFORE_IERS_RANGE, iers.TIME_BEYOND_IERS_RANGE))
         ):
             warnings.warn(
-                "time is out of IERS range, setting delta ut1 utc to "
-                "extrapolated value"
+                "time is out of IERS range, setting delta ut1 utc to extrapolated value"
             )
             times.delta_ut1_utc = delta
     if astrometry_library == "erfa":
@@ -4959,20 +4952,16 @@ def uvcalibrate(
     # have associated data in the UVCal object
     uvdata_unique_nums = np.unique(np.append(uvdata.ant_1_array, uvdata.ant_2_array))
     uvdata.antenna_names = np.asarray(uvdata.antenna_names)
-    uvdata_used_antnames = np.array(
-        [
-            uvdata.antenna_names[np.where(uvdata.antenna_numbers == antnum)][0]
-            for antnum in uvdata_unique_nums
-        ]
-    )
+    uvdata_used_antnames = np.array([
+        uvdata.antenna_names[np.where(uvdata.antenna_numbers == antnum)][0]
+        for antnum in uvdata_unique_nums
+    ])
     uvcal_unique_nums = np.unique(uvcal.ant_array)
     uvcal.antenna_names = np.asarray(uvcal.antenna_names)
-    uvcal_used_antnames = np.array(
-        [
-            uvcal.antenna_names[np.where(uvcal.antenna_numbers == antnum)][0]
-            for antnum in uvcal_unique_nums
-        ]
-    )
+    uvcal_used_antnames = np.array([
+        uvcal.antenna_names[np.where(uvcal.antenna_numbers == antnum)][0]
+        for antnum in uvcal_unique_nums
+    ])
 
     ant_arr_match = uvcal_used_antnames.tolist() == uvdata_used_antnames.tolist()
 
@@ -5661,8 +5650,9 @@ def parse_ants(uv, ant_str, print_toggle=False, x_orientation=None):
 
     if len(warned_pols) > 0:
         warnings.warn(
-            "Warning: Polarization {p} is not present in "
-            "the polarization_array".format(p=(",").join(warned_pols).upper())
+            "Warning: Polarization {p} is not present in the polarization_array".format(
+                p=(",").join(warned_pols).upper()
+            )
         )
 
     return ant_pairs_nums, polarizations
@@ -6071,21 +6061,19 @@ def determine_blt_order(
             if not on_bl_boundary:
                 time_b = False
 
-        if not any(
-            (
-                time_bl,
-                time_a,
-                time_b,
-                time_bl,
-                bl_time,
-                a_time,
-                b_time,
-                bl_order,
-                a_order,
-                b_order,
-                time_order,
-            )
-        ):
+        if not any((
+            time_bl,
+            time_a,
+            time_b,
+            time_bl,
+            bl_time,
+            a_time,
+            b_time,
+            bl_order,
+            a_order,
+            b_order,
+            time_order,
+        )):
             break
 
     if Nbls > 1 and Ntimes > 1:

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -799,7 +799,9 @@ def baseline_to_antnums(baseline, Nants_telescope):
         return ant1.item(0), ant2.item(0)
 
 
-def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False, use_miriad_convention=False):
+def antnums_to_baseline(
+    ant1, ant2, Nants_telescope, attempt256=False, use_miriad_convention=False
+):
     """
     Get the baseline number corresponding to two given antenna numbers.
 
@@ -820,7 +822,7 @@ def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False, use_miria
     use_miriad_convention : bool
         Option to use the MIRIAD convention where BASELINE id is
             if ant2 < 256:
-                bl = 256 * ant1 + ant2 
+                bl = 256 * ant1 + ant2
             else:
                 bl = 2048 * ant1 + ant2 + 2**16
         Note antennas should be 1-indexed (start at 1, not 0)
@@ -857,7 +859,7 @@ def antnums_to_baseline(ant1, ant2, Nants_telescope, attempt256=False, use_miria
         np.ascontiguousarray(ant2, dtype=np.uint64),
         attempt256=attempt256,
         nants_less2048=nants_less2048,
-        use_miriad_convention=use_miriad_convention
+        use_miriad_convention=use_miriad_convention,
     )
     if return_array:
         return baseline

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -176,7 +176,7 @@ cdef inline void _antnum_to_bl_2048_miriad(
     if ant2[i] >= 255:
       baselines[i] = 2048 * (ant1[i]) + (ant2[i]) + 2 ** 16
     else:
-      baselines[i] = 256 * (ant1[i]) + (ant2[i]) 
+      baselines[i] = 256 * (ant1[i]) + (ant2[i])
   return
 
 @cython.boundscheck(False)
@@ -217,7 +217,7 @@ cpdef numpy.ndarray[dtype=numpy.uint64_t] antnums_to_baseline(
     arraymax(ant2),
   ) < 2048
 
-  # Some UVFITS readers (e.g. MWA and AAVS) expect the 
+  # Some UVFITS readers (e.g. MWA and AAVS) expect the
   # MIRIAD baseline convention.
   if use_miriad_convention:
       _antnum_to_bl_2048_miriad(ant1, ant2, _bl, nbls)

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -173,10 +173,10 @@ cdef inline void _antnum_to_bl_2048_miriad(
   cdef Py_ssize_t i
 
   for i in range(nbls):
-    if ant2[i] >= 256:
-      baselines[i] = 2048 * (ant1[i]) + (ant2[i]) + 2 ** 16
+    if ant2[i] >= 255:
+      baselines[i] = 2048 * (ant1[i] + 1) + (ant2[i] + 1) + 2 ** 16
     else:
-      baselines[i] = 256 * (ant1[i]) + (ant2[i]) 
+      baselines[i] = 256 * (ant1[i] + 1) + (ant2[i] + 1) 
   return
 
 @cython.boundscheck(False)

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -174,9 +174,9 @@ cdef inline void _antnum_to_bl_2048_miriad(
 
   for i in range(nbls):
     if ant2[i] >= 255:
-      baselines[i] = 2048 * (ant1[i] + 1) + (ant2[i] + 1) + 2 ** 16
+      baselines[i] = 2048 * (ant1[i]) + (ant2[i]) + 2 ** 16
     else:
-      baselines[i] = 256 * (ant1[i] + 1) + (ant2[i] + 1) 
+      baselines[i] = 256 * (ant1[i]) + (ant2[i]) 
   return
 
 @cython.boundscheck(False)

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -147,6 +147,7 @@ class Miriad(UVData):
             "cable",
             "dazim",
             "delev",
+            "jyperk",
             "jyperka",
             "phaselo1",
             "phaselo2",
@@ -1794,23 +1795,23 @@ class Miriad(UVData):
         uv["longitu"] = self.telescope_location_lat_lon_alt[1].astype(np.double)
         uv.add_var("nants", "i")
         
-        
         # DCP 2024.01.12 - Adding defaults required for basic imaging
         #############################################################
         miriad_defaults = {
             "restfreq": ("d", np.float64(0.0)),
-            "jyperk":   ("r", np.float32(1.0)),
-            "systemp":  ("r", np.float32(1.0)),
-            "veldop":   ("r", np.float32(0.0)),
-            "vsource":  ("r", np.float32(0.0))
+            "jyperk": ("r", np.float32(1.0)),
+            "systemp": ("r", np.float32(1.0)),
+            "veldop": ("r", np.float32(0.0)),
+            "vsource": ("r", np.float32(0.0))
         }
 
         for key, (miriad_dtype, val) in miriad_defaults.items():
             uv.add_var(key, miriad_dtype)
             uv[key] = val
 
-        warnings.warn("writing default values for restfreq, vsource, veldop, jyperk, and systemp")
-
+        warnings.warn("writing default values for restfreq, vsource, "
+                      "veldop, jyperk, and systemp"
+                      )
 
         if self.antenna_diameters is not None:
             if not np.allclose(self.antenna_diameters, self.antenna_diameters[0]):

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -1794,7 +1794,7 @@ class Miriad(UVData):
         uv.add_var("longitu", "d")
         uv["longitu"] = self.telescope_location_lat_lon_alt[1].astype(np.double)
         uv.add_var("nants", "i")
-        
+
         # DCP 2024.01.12 - Adding defaults required for basic imaging
         #############################################################
         miriad_defaults = {
@@ -1802,16 +1802,17 @@ class Miriad(UVData):
             "jyperk": ("r", np.float32(1.0)),
             "systemp": ("r", np.float32(1.0)),
             "veldop": ("r", np.float32(0.0)),
-            "vsource": ("r", np.float32(0.0))
+            "vsource": ("r", np.float32(0.0)),
         }
 
         for key, (miriad_dtype, val) in miriad_defaults.items():
             uv.add_var(key, miriad_dtype)
             uv[key] = val
 
-        warnings.warn("writing default values for restfreq, vsource, "
-                      "veldop, jyperk, and systemp"
-                      )
+        warnings.warn(
+            "writing default values for restfreq, vsource, "
+            "veldop, jyperk, and systemp"
+        )
 
         if self.antenna_diameters is not None:
             if not np.allclose(self.antenna_diameters, self.antenna_diameters[0]):

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -1946,7 +1946,7 @@ class Miriad(UVData):
         uv.add_var("source", "a")
         uv.add_var("ra", "d")
         uv.add_var("dec", "d")
-        uv.add_var("inttime", "d")
+        uv.add_var("inttime", "r")
 
         uv.add_var("epoch", "r")
         uv.add_var("phsframe", "a")  # Non-standard MIRIAD keyword
@@ -2027,7 +2027,7 @@ class Miriad(UVData):
             this_j = self.ant_2_array[viscnt]
 
             uv["lst"] = miriad_lsts[viscnt].astype(np.double)
-            uv["inttime"] = self.integration_time[viscnt].astype(np.double)
+            uv["inttime"] = self.integration_time[viscnt].astype(np.float32)
 
             cat_id = self.phase_center_id_array[viscnt]
             uv["source"] = self.phase_center_catalog[cat_id]["cat_name"]

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -1797,14 +1797,18 @@ class Miriad(UVData):
         
         # DCP 2024.01.12 - Adding defaults required for basic imaging
         #############################################################
-        for k in ("restfreq", "vsource", "veldop"):
-            uv.add_var(k, "d")
-            uv[k] = 0.0
-        
-        for k in ("jyperk", "systemp"):
-            uv.add_var(k, "r")
-            uv[k] = 1.0
-        
+        miriad_defaults = {
+            "restfreq": ("d", np.float64(0.0)),
+            "jyperk":   ("r", np.float32(1.0)),
+            "systemp":  ("r", np.float32(1.0)),
+            "veldop":   ("r", np.float32(0.0)),
+            "vsource":  ("r", np.float32(0.0))
+        }
+
+        for key, (miriad_dtype, val) in miriad_defaults.items():
+            uv.add_var(key, miriad_dtype)
+            uv[key] = val
+
         warnings.warn("writing default values for restfreq, vsource, veldop, jyperk, and systemp")
 
 

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -508,25 +508,25 @@ class Miriad(UVData):
                             warn_string += (
                                 "latitude and longitude values do not "
                                 "match file values so they are not used "
-                                "for altiude."
+                                "for altitude."
                             )
                         elif not mean_lat_close:
                             warn_string += (
                                 "latitude value does not "
                                 "match file values so they are not used "
-                                "for altiude."
+                                "for altitude."
                             )
                         else:
                             warn_string += (
                                 "longitude value does not "
                                 "match file values so they are not used "
-                                "for altiude."
+                                "for altitude."
                             )
                         warnings.warn(warn_string)
 
                 else:
                     # This does not give a valid telescope_location. Instead
-                    # calculate it from the file lat/lon and sea level for altiude
+                    # calculate it from the file lat/lon and sea level for altitude
                     self.telescope_location_lat_lon_alt = (latitude, longitude, 0)
                     warn_string = (
                         "Telescope location is set at sealevel at "
@@ -1817,7 +1817,7 @@ class Miriad(UVData):
         if self.antenna_diameters is not None:
             if not np.allclose(self.antenna_diameters, self.antenna_diameters[0]):
                 warnings.warn(
-                    "Antenna diameters are not uniform, but miriad only"
+                    "Antenna diameters are not uniform, but miriad only "
                     "supports a single diameter. Skipping."
                 )
             else:

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -1786,8 +1786,6 @@ class Miriad(UVData):
             # same to our tolerances
             uv["sdf"] = np.median(self.channel_width) * freq_dir / 1e9  # Hz -> GHz
 
-        # NB: restfreq should go in here at some point
-        #####################################################
         uv.add_var("telescop", "a")
         uv["telescop"] = self.telescope_name
         uv.add_var("latitud", "d")
@@ -1795,6 +1793,20 @@ class Miriad(UVData):
         uv.add_var("longitu", "d")
         uv["longitu"] = self.telescope_location_lat_lon_alt[1].astype(np.double)
         uv.add_var("nants", "i")
+        
+        
+        # DCP 2024.01.12 - Adding defaults required for basic imaging
+        #############################################################
+        for k in ("restfreq", "vsource", "veldop"):
+            uv.add_var(k, "d")
+            uv[k] = 0.0
+        
+        for k in ("jyperk", "systemp"):
+            uv.add_var(k, "r")
+            uv[k] = 1.0
+        
+        warnings.warn("writing default values for restfreq, vsource, veldop, jyperk, and systemp")
+
 
         if self.antenna_diameters is not None:
             if not np.allclose(self.antenna_diameters, self.antenna_diameters[0]):

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -2067,7 +2067,7 @@ class MS(UVData):
         if (spw_list is None) and (field_list is None) and (pol_list is None):
             raise ValueError(
                 "No valid data available in the MS file. If this file contains "
-                "single channel data, set ignore_single_channel=True when calling "
+                "single channel data, set ignore_single_chan=False when calling "
                 "read_ms."
             )
 

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1211,7 +1211,7 @@ class MS(UVData):
                 if self.future_array_shapes:
                     temp_vals = getattr(self, attr)[:, :, pol_order]
                 else:
-                    temp_vals = getattr(self, attr)[:, 0, :][..., pol_order]
+                    temp_vals = np.squeeze(getattr(self, attr), axis=1)[..., pol_order]
 
                 if flip_conj and (attr == "data_array"):
                     temp_vals = np.conj(temp_vals)

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -1211,7 +1211,7 @@ class MS(UVData):
                 if self.future_array_shapes:
                     temp_vals = getattr(self, attr)[:, :, pol_order]
                 else:
-                    temp_vals = getattr(self, attr)[:, 0, :, pol_order]
+                    temp_vals = getattr(self, attr)[:, 0, :][..., pol_order]
 
                 if flip_conj and (attr == "data_array"):
                     temp_vals = np.conj(temp_vals)

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -471,21 +471,22 @@ def test_flex_pol_roundtrip(sma_mir_filt, filetype, future_shapes, tmp_path):
     uvd3.remove_flex_pol(combine_spws=False)
     assert uvd2 != uvd3
 
-
     exp_warning = None
     warn_str = ""
 
     if filetype in ["uvfits", "miriad"]:
         warn_str = [
-            ("combine_spws is True but there are not matched spws for all "
-            "polarizations, so spws will not be combined.")
+            (
+                "combine_spws is True but there are not matched spws for all "
+                "polarizations, so spws will not be combined."
+            )
         ]
         exp_warning = UserWarning
 
     if filetype == "miriad":
         warn_str.append(
             "writing default values for restfreq, vsource, veldop, jyperk, and systemp"
-       )
+        )
 
     with uvtest.check_warnings(exp_warning, warn_str):
         if filetype == "uvfits":

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -471,17 +471,23 @@ def test_flex_pol_roundtrip(sma_mir_filt, filetype, future_shapes, tmp_path):
     uvd3.remove_flex_pol(combine_spws=False)
     assert uvd2 != uvd3
 
-    if filetype in ["uvfits", "miriad"]:
-        warn_str = (
-            "combine_spws is True but there are not matched spws for all "
-            "polarizations, so spws will not be combined."
-        )
-        exp_warning = UserWarning
-    else:
-        exp_warning = None
-        warn_str = ""
 
-    with uvtest.check_warnings(exp_warning, match=warn_str):
+    exp_warning = None
+    warn_str = ""
+
+    if filetype in ["uvfits", "miriad"]:
+        warn_str = [
+            ("combine_spws is True but there are not matched spws for all "
+            "polarizations, so spws will not be combined.")
+        ]
+        exp_warning = UserWarning
+
+    if filetype == "miriad":
+        warn_str.append(
+            "writing default values for restfreq, vsource, veldop, jyperk, and systemp"
+       )
+
+    with uvtest.check_warnings(exp_warning, warn_str):
         if filetype == "uvfits":
             sma_mir_filt.write_uvfits(testfile)
         else:

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -47,65 +47,65 @@ paper_miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
 # This is a dictionary of warning strings to aid warning checks
 warn_dict = {
     "default_vals": "writing default values for restfreq, vsource, veldop, "
-                    "jyperk, and systemp",
+    "jyperk, and systemp",
     "uvw_mismatch": "The uvw_array does not match the expected values "
-                    "given the antenna positions",
+    "given the antenna positions",
     "driftscan": "This object has a driftscan phase center. Miriad does not really ",
     "long_key": "key test_long_key in extra_keywords is longer than 8 characters.",
     "ant_diameters": "Antenna diameters are not uniform, but miriad "
-                         "only supports a single diameter.",
+    "only supports a single diameter.",
     "time_mismatch": "Some visibility times did not match ephem times so the ra and dec "
-                     "values for those visibilities were interpolated or set to "
-                     "the closest time if they would have required extrapolation.",  
+    "values for those visibilities were interpolated or set to "
+    "the closest time if they would have required extrapolation.",
     "altitude_missing_miriad": "Altitude is not present in Miriad file, and telescope",
     "altitude_missing_lat_long": "Altitude is not present in file and latitude and longitude "
-                        "values do not match",
+    "values do not match",
     "altitude_missing_long": "Altitude is not present in file and longitude value does not match",
     "altitude_missing_lat": "Altitude is not present in file and latitude value does not match",
     "altitude_missing_foo": "Altitude is not present in Miriad file, and "
-                        "telescope foo is not in known_telescopes. "
-                        "Telescope location will be set using antenna positions.",
+    "telescope foo is not in known_telescopes. "
+    "Telescope location will be set using antenna positions.",
     "no_telescope_loc": "Telescope location is not set, but antenna "
-                        "positions are present. Mean antenna latitude "
-                        "and longitude values match file values, so "
-                        "telescope_position will be set using the mean "
-                        "of the antenna altitudes",
+    "positions are present. Mean antenna latitude "
+    "and longitude values match file values, so "
+    "telescope_position will be set using the mean "
+    "of the antenna altitudes",
     "unknown_telescope_foo": "Telescope foo is not in known_telescopes.",
     "unclear_projection": "It is not clear from the file if the data are "
-                          "projected or not.",
+    "projected or not.",
     "telescope_at_sealevel": "Telescope location is set at sealevel at the file lat/lon "
-                            "coordinates. Antenna positions are present, but the mean antenna "
-                            "position does not give a telescope_location on the surface of the "
-                            "earth. Antenna positions do not appear to be on the surface of the "
-                            "earth and will be treated as relative.",
+    "coordinates. Antenna positions are present, but the mean antenna "
+    "position does not give a telescope_location on the surface of the "
+    "earth. Antenna positions do not appear to be on the surface of the "
+    "earth and will be treated as relative.",
     "telescope_at_sealevel_lat": "Telescope location is set at sealevel at the file lat/lon coordinates. "
-                                 "Antenna positions are present, but the mean antenna latitude value does " 
-                                 "not match file values so they are not used for altitude.",
+    "Antenna positions are present, but the mean antenna latitude value does "
+    "not match file values so they are not used for altitude.",
     "telescope_at_sealevel_lat_long": "Telescope location is set at sealevel at the file lat/lon coordinates. "
-                                      "Antenna positions are present, but the mean antenna latitude and longitude values do not match file values "
-                                      "so they are not used for altitude.",
+    "Antenna positions are present, but the mean antenna latitude and longitude values do not match file values "
+    "so they are not used for altitude.",
     "telescope_at_sealevel_foo": "Altitude is not present in Miriad file, and telescope foo is not in known_telescopes.",
     "phase_type_deprecated": "The phase_type parameter is deprecated, use the projected parameter "
-                             "instead.",
+    "instead.",
     "no_telescope_loc": "Telescope location is not set, but antenna positions are "
-                        "present. Mean antenna latitude and longitude values match file "
-                        "values, so telescope_position will be set using the mean of the "
-                        "antenna altitudes",
+    "present. Mean antenna latitude and longitude values match file "
+    "values, so telescope_position will be set using the mean of the "
+    "antenna altitudes",
     "projection_false_offset": "projected is False, but RA, Dec is off from lst, latitude by more than "
-                               "1.0 deg",
-    }
+    "1.0 deg",
+}
 
 
-def _write_miriad(uv: UVData, filename: str, warn: str=None, **kwargs):
-    """ Write miriad file, capturing warnings for pytest 
-    
+def _write_miriad(uv: UVData, filename: str, warn: str = None, **kwargs):
+    """Write miriad file, capturing warnings for pytest
+
     Parameters:
     -----------
     uv: UVData
         uvdata object to call write_miriad on
     filename: str
         Name of file to write to
-    warn: str or None  
+    warn: str or None
         warnings to catch. Defaults to catch 'writing default values ...'
     """
     if warn is None:
@@ -427,7 +427,7 @@ def test_miriad_read_warning_lat_lon_corrected():
         [
             "Altitude is not present in Miriad file, using known location "
             "altitude value for PAPER and lat/lon from file.",
-            warn_dict["uvw_mismatch"]
+            warn_dict["uvw_mismatch"],
         ],
     ):
         miriad_uv.read(
@@ -519,7 +519,7 @@ def test_wronglatlon():
             warn_dict["altitude_missing_long"],
             warn_dict["projection_false_offset"],
             warn_dict["uvw_mismatch"],
-            warn_dict["unclear_projection"]
+            warn_dict["unclear_projection"],
         ],
     ):
         uv_in.read(lonfile, use_future_array_shapes=True)
@@ -541,7 +541,7 @@ def test_wronglatlon():
             warn_dict["altitude_missing_miriad"],
             warn_dict["no_telescope_loc"],
             warn_dict["unknown_telescope_foo"],
-            warn_dict["unclear_projection"]
+            warn_dict["unclear_projection"],
         ],
     ):
         uv_in.read(telescopefile, run_check=False, use_future_array_shapes=True)
@@ -590,7 +590,7 @@ def test_miriad_location_handling(paper_miriad_main, tmp_path):
         UserWarning,
         [
             warn_dict["altitude_missing_foo"],
-            warn_dict["altitude_missing_foo"], # raised twice
+            warn_dict["altitude_missing_foo"],  # raised twice
             warn_dict["no_telescope_loc"],
             warn_dict["unknown_telescope_foo"],
             warn_dict["uvw_mismatch"],
@@ -624,7 +624,7 @@ def test_miriad_location_handling(paper_miriad_main, tmp_path):
             warn_dict["telescope_at_sealevel_foo"],
             warn_dict["projection_false_offset"],
             warn_dict["unknown_telescope_foo"],
-            warn_dict["uvw_mismatch"]
+            warn_dict["uvw_mismatch"],
         ],
     ):
         uv_out.read(testfile, use_future_array_shapes=True)
@@ -777,10 +777,7 @@ def test_singletimeselect_unprojected(uv_in_paper):
     # also check that setting phase_type works
     with uvtest.check_warnings(
         [DeprecationWarning, UserWarning],
-        match=[
-            warn_dict["phase_type_deprecated"],
-            warn_dict["uvw_mismatch"],
-        ],
+        match=[warn_dict["phase_type_deprecated"], warn_dict["uvw_mismatch"]],
     ):
         uv_out.read(testfile, phase_type="drift", use_future_array_shapes=True)
         assert uv_in == uv_out
@@ -946,9 +943,13 @@ def test_miriad_ephem(tmp_path, casa_uvfits, cut_ephem_pts, extrapolate):
         uv_in.phase_center_catalog[1]["cat_dist"] = uv_in.phase_center_catalog[1][
             "cat_dist"
         ][0]
-    
-    _write_miriad(uv_in, testfile, clobber=True, 
-                  warn=[warn_dict["default_vals"], warn_dict["time_mismatch"]])
+
+    _write_miriad(
+        uv_in,
+        testfile,
+        clobber=True,
+        warn=[warn_dict["default_vals"], warn_dict["time_mismatch"]],
+    )
     uv2 = UVData.from_file(testfile, use_future_array_shapes=True)
 
     uv2._update_phase_center_id(0, 1)
@@ -1106,11 +1107,21 @@ def test_miriad_extra_keywords_errors(
 
     if errstr is not None:
         with pytest.raises(TypeError, match=errstr):
-            _write_miriad(uv_in, testfile, clobber=True, run_check=False, 
-                          warn=[errstr, warn_dict["default_vals"]])
+            _write_miriad(
+                uv_in,
+                testfile,
+                clobber=True,
+                run_check=False,
+                warn=[errstr, warn_dict["default_vals"]],
+            )
     else:
-        _write_miriad(uv_in, testfile, clobber=True, run_check=False, 
-                      warn=[warn_dict["default_vals"], warn_dict["long_key"]])
+        _write_miriad(
+            uv_in,
+            testfile,
+            clobber=True,
+            run_check=False,
+            warn=[warn_dict["default_vals"], warn_dict["long_key"]],
+        )
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
@@ -1179,7 +1190,13 @@ def test_breakread_miriad(uv_in_paper, tmp_path):
 
     uv_in_copy = uv_in.copy()
     uv_in_copy.Nblts += 10
-    _write_miriad(uv_in_copy, testfile, clobber=True, run_check=False, warn=warn_dict["default_vals"])
+    _write_miriad(
+        uv_in_copy,
+        testfile,
+        clobber=True,
+        run_check=False,
+        warn=warn_dict["default_vals"],
+    )
     with uvtest.check_warnings(
         UserWarning, "Nblts does not match the number of unique blts in the data"
     ):
@@ -1187,7 +1204,13 @@ def test_breakread_miriad(uv_in_paper, tmp_path):
 
     uv_in_copy = uv_in.copy()
     uv_in_copy.Nbls += 10
-    _write_miriad(uv_in_copy, testfile, clobber=True, run_check=False, warn=warn_dict["default_vals"])
+    _write_miriad(
+        uv_in_copy,
+        testfile,
+        clobber=True,
+        run_check=False,
+        warn=warn_dict["default_vals"],
+    )
     with uvtest.check_warnings(
         UserWarning, "Nbls does not match the number of unique baselines in the data"
     ):
@@ -1195,7 +1218,13 @@ def test_breakread_miriad(uv_in_paper, tmp_path):
 
     uv_in_copy = uv_in.copy()
     uv_in_copy.Ntimes += 10
-    _write_miriad(uv_in_copy, testfile, clobber=True, run_check=False, warn=warn_dict["default_vals"])
+    _write_miriad(
+        uv_in_copy,
+        testfile,
+        clobber=True,
+        run_check=False,
+        warn=warn_dict["default_vals"],
+    )
     with uvtest.check_warnings(
         UserWarning, "Ntimes does not match the number of unique times in the data"
     ):
@@ -1276,10 +1305,16 @@ def test_miriad_antenna_diameters(uv_in_paper):
         np.zeros((uv_in.Nants_telescope,), dtype=np.float32) + 14.0
     )
     uv_in.antenna_diameters[1] = 15.0
-    _write_miriad(uv_in, write_file, clobber=True, 
-                      warn=[warn_dict["uvw_mismatch"], 
-                            warn_dict["default_vals"], 
-                            warn_dict["ant_diameters"]])
+    _write_miriad(
+        uv_in,
+        write_file,
+        clobber=True,
+        warn=[
+            warn_dict["uvw_mismatch"],
+            warn_dict["default_vals"],
+            warn_dict["ant_diameters"],
+        ],
+    )
     uv_out.read(write_file, use_future_array_shapes=True)
     assert uv_out.antenna_diameters is None
     uv_out.antenna_diameters = uv_in.antenna_diameters
@@ -1785,7 +1820,13 @@ def test_rwr_miriad_antpos_issues(uv_in_paper, tmp_path):
 
     uv_in_copy = uv_in.copy()
     uv_in_copy.antenna_positions = None
-    _write_miriad(uv_in_copy, write_file, clobber=True, run_check=False, warn=warn_dict["default_vals"])
+    _write_miriad(
+        uv_in_copy,
+        write_file,
+        clobber=True,
+        run_check=False,
+        warn=warn_dict["default_vals"],
+    )
     with uvtest.check_warnings(
         UserWarning, "Antenna positions are not present in the file.", nwarnings=2
     ):
@@ -1803,14 +1844,15 @@ def test_rwr_miriad_antpos_issues(uv_in_paper, tmp_path):
     ants_with_data = list(set(uv_in_copy.ant_1_array).union(uv_in_copy.ant_2_array))
     ant_ind = np.where(uv_in_copy.antenna_numbers == ants_with_data[0])[0]
     uv_in_copy.antenna_positions[ant_ind, :] = [0, 0, 0]
-    _write_miriad(uv_in_copy, write_file, clobber=True, no_antnums=True, 
-                  warn=[warn_dict["default_vals"], warn_dict["uvw_mismatch"]])
+    _write_miriad(
+        uv_in_copy,
+        write_file,
+        clobber=True,
+        no_antnums=True,
+        warn=[warn_dict["default_vals"], warn_dict["uvw_mismatch"]],
+    )
     with uvtest.check_warnings(
-        UserWarning,
-        [
-            "antenna number",
-            warn_dict["uvw_mismatch"],
-        ],
+        UserWarning, ["antenna number", warn_dict["uvw_mismatch"]]
     ):
         uv_out.read(write_file, use_future_array_shapes=True)
 
@@ -1833,8 +1875,14 @@ def test_rwr_miriad_antpos_issues(uv_in_paper, tmp_path):
     uv_in.antenna_numbers = np.array(new_nums)
     uv_in.antenna_names = new_names
     uv_in.Nants_telescope = len(uv_in.antenna_numbers)
-    _write_miriad(uv_in, write_file, clobber=True, no_antnums=True, run_check=False, 
-                  warn=warn_dict["default_vals"])
+    _write_miriad(
+        uv_in,
+        write_file,
+        clobber=True,
+        no_antnums=True,
+        run_check=False,
+        warn=warn_dict["default_vals"],
+    )
     with uvtest.check_warnings(
         UserWarning, "Antenna positions are not present in the file.", nwarnings=2
     ):

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -282,8 +282,10 @@ def test_read_write_read_carma(tmp_path):
     for item in list(uv_in.extra_keywords.keys()):
         if isinstance(uv_in.extra_keywords[item], dict):
             uv_in.extra_keywords.pop(item)
+
         elif isinstance(uv_in.extra_keywords[item], list):
             uv_in.extra_keywords.pop(item)
+
         elif isinstance(uv_in.extra_keywords[item], np.ndarray):
             uv_in.extra_keywords.pop(item)
 
@@ -746,6 +748,7 @@ def test_miriad_location_handling(paper_miriad_main, tmp_path):
     rot_antpos = uvutils.rotECEF_from_ECEF(ecef_antpos[rot_ants, :], longitude + np.pi)
     modified_antpos = uvutils.rotECEF_from_ECEF(ecef_antpos, longitude)
     modified_antpos[rot_ants, :] = rot_antpos
+
     # zero out bad locations (these are checked on read)
     modified_antpos[np.where(antpos_length == 0), :] = [0, 0, 0]
     modified_antpos = modified_antpos.T.flatten() / const.c.to("m/ns").value

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -999,13 +999,14 @@ def test_driftscan(tmp_path, paper_miriad):
         cat_type="driftscan",
         cat_name="drift_alt80",
     )
-    warn_str_list = ["This object has a driftscan phase center. Miriad does not really ",
-                     "writing default values for restfreq, vsource, veldop, jyperk, and systemp"
-                     ]
+    warn_list = ["This object has a driftscan phase center. Miriad does not really ",
+                 "writing default values for restfreq, vsource, veldop,"
+                 " jyperk, and systemp"
+                ]
     
     with uvtest.check_warnings(
         UserWarning,
-        match=warn_str_list,
+        match=warn_list,
     ):
         uv2.write_miriad(testfile, clobber=True)
 
@@ -1087,15 +1088,13 @@ def test_miriad_extra_keywords_errors(
     uv_in, _, testfile = uv_in_paper
 
     uvw_warn_str = "The uvw_array does not match the expected values"
-    def_warn_str = "writing default values for restfreq, vsource, veldop, jyperk, and systemp"
+   
     # check for warnings & errors with extra_keywords that are dicts, lists or arrays
     uv_in.extra_keywords[kwd_name] = kwd_value
     if warnstr is None:
         warnstr_list = [uvw_warn_str]
     else:
         warnstr_list = [warnstr, uvw_warn_str]
-
-
 
     with uvtest.check_warnings(UserWarning, warnstr_list):
         uv_in.check()
@@ -1104,7 +1103,11 @@ def test_miriad_extra_keywords_errors(
         with pytest.raises(TypeError, match=errstr):
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
     else:
-        with uvtest.check_warnings(UserWarning, [warnstr, def_warn_str]):
+        warn_str_list = [
+            warnstr,
+            "writing default values for restfreq, vsource, veldop, jyperk, and systemp"
+        ]
+        with uvtest.check_warnings(UserWarning, warn_str_list):
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
 
 

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -929,11 +929,16 @@ def test_miriad_ephem(tmp_path, casa_uvfits, cut_ephem_pts, extrapolate):
             "cat_dist"
         ][0]
 
-    with uvtest.check_warnings(
-        UserWarning,
-        match="Some visibility times did not match ephem times so the ra and dec "
+    warn_str = [
+        "Some visibility times did not match ephem times so the ra and dec "
         "values for those visibilities were interpolated or set to the closest time "
         "if they would have required extrapolation.",
+        "writing default values for restfreq, vsource, veldop," " jyperk, and systemp"        
+    ]
+
+    with uvtest.check_warnings(
+        UserWarning,
+        match=warn_str
     ):
         uv_in.write_miriad(testfile, clobber=True)
     uv2 = UVData.from_file(testfile, use_future_array_shapes=True)

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -999,15 +999,12 @@ def test_driftscan(tmp_path, paper_miriad):
         cat_type="driftscan",
         cat_name="drift_alt80",
     )
-    warn_list = ["This object has a driftscan phase center. Miriad does not really ",
-                 "writing default values for restfreq, vsource, veldop,"
-                 " jyperk, and systemp"
-                ]
-    
-    with uvtest.check_warnings(
-        UserWarning,
-        match=warn_list,
-    ):
+    warn_list = [
+        "This object has a driftscan phase center. Miriad does not really ",
+        "writing default values for restfreq, vsource, veldop," " jyperk, and systemp",
+    ]
+
+    with uvtest.check_warnings(UserWarning, match=warn_list):
         uv2.write_miriad(testfile, clobber=True)
 
     uv3 = UVData.from_file(testfile, use_future_array_shapes=True)
@@ -1088,7 +1085,7 @@ def test_miriad_extra_keywords_errors(
     uv_in, _, testfile = uv_in_paper
 
     uvw_warn_str = "The uvw_array does not match the expected values"
-   
+
     # check for warnings & errors with extra_keywords that are dicts, lists or arrays
     uv_in.extra_keywords[kwd_name] = kwd_value
     if warnstr is None:
@@ -1105,7 +1102,7 @@ def test_miriad_extra_keywords_errors(
     else:
         warn_str_list = [
             warnstr,
-            "writing default values for restfreq, vsource, veldop, jyperk, and systemp"
+            "writing default values for restfreq, vsource, veldop, jyperk, and systemp",
         ]
         with uvtest.check_warnings(UserWarning, warn_str_list):
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
@@ -1279,7 +1276,7 @@ def test_miriad_antenna_diameters(uv_in_paper):
         match=[
             "The uvw_array does not match the expected values",
             "Antenna diameters are not uniform",
-            "writing default values for restfreq, vsource, veldop, jyperk, and systemp"
+            "writing default values for restfreq, vsource, veldop, jyperk, and systemp",
         ],
     ):
         uv_in.write_miriad(write_file, clobber=True)

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -1964,8 +1964,7 @@ def test_multi_files(casa_uvfits, tmp_path):
 
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis using"
         " pyuvdata.",
@@ -1991,8 +1990,7 @@ def test_multi_files(casa_uvfits, tmp_path):
     uv1.read([testfile1, testfile2], axis="freq", use_future_array_shapes=True)
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis using"
         " pyuvdata.",

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -999,9 +999,13 @@ def test_driftscan(tmp_path, paper_miriad):
         cat_type="driftscan",
         cat_name="drift_alt80",
     )
+    warn_str_list = ["This object has a driftscan phase center. Miriad does not really ",
+                     "writing default values for restfreq, vsource, veldop, jyperk, and systemp"
+                     ]
+    
     with uvtest.check_warnings(
         UserWarning,
-        match="This object has a driftscan phase center. Miriad does not really ",
+        match=warn_str_list,
     ):
         uv2.write_miriad(testfile, clobber=True)
 
@@ -1083,12 +1087,15 @@ def test_miriad_extra_keywords_errors(
     uv_in, _, testfile = uv_in_paper
 
     uvw_warn_str = "The uvw_array does not match the expected values"
+    def_warn_str = "writing default values for restfreq, vsource, veldop, jyperk, and systemp"
     # check for warnings & errors with extra_keywords that are dicts, lists or arrays
     uv_in.extra_keywords[kwd_name] = kwd_value
     if warnstr is None:
         warnstr_list = [uvw_warn_str]
     else:
         warnstr_list = [warnstr, uvw_warn_str]
+
+
 
     with uvtest.check_warnings(UserWarning, warnstr_list):
         uv_in.check()
@@ -1097,7 +1104,7 @@ def test_miriad_extra_keywords_errors(
         with pytest.raises(TypeError, match=errstr):
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
     else:
-        with uvtest.check_warnings(UserWarning, warnstr):
+        with uvtest.check_warnings(UserWarning, [warnstr, def_warn_str]):
             uv_in.write_miriad(testfile, clobber=True, run_check=False)
 
 
@@ -1269,6 +1276,7 @@ def test_miriad_antenna_diameters(uv_in_paper):
         match=[
             "The uvw_array does not match the expected values",
             "Antenna diameters are not uniform",
+            "writing default values for restfreq, vsource, veldop, jyperk, and systemp"
         ],
     ):
         uv_in.write_miriad(write_file, clobber=True)

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -46,53 +46,81 @@ paper_miriad_file = os.path.join(DATA_PATH, "zen.2456865.60537.xy.uvcRREAA")
 
 # This is a dictionary of warning strings to aid warning checks
 warn_dict = {
-    "default_vals": "writing default values for restfreq, vsource, veldop, "
-    "jyperk, and systemp",
-    "uvw_mismatch": "The uvw_array does not match the expected values "
-    "given the antenna positions",
+    "default_vals": (
+        "writing default values for restfreq, vsource, veldop, jyperk, and systemp"
+    ),
+    "uvw_mismatch": (
+        "The uvw_array does not match the expected values given the antenna positions"
+    ),
     "driftscan": "This object has a driftscan phase center. Miriad does not really ",
     "long_key": "key test_long_key in extra_keywords is longer than 8 characters.",
-    "ant_diameters": "Antenna diameters are not uniform, but miriad "
-    "only supports a single diameter.",
-    "time_mismatch": "Some visibility times did not match ephem times so the ra and dec "
-    "values for those visibilities were interpolated or set to "
-    "the closest time if they would have required extrapolation.",
+    "ant_diameters": (
+        "Antenna diameters are not uniform, but miriad only supports a single diameter."
+    ),
+    "time_mismatch": (
+        "Some visibility times did not match ephem times so the ra and dec "
+        "values for those visibilities were interpolated or set to "
+        "the closest time if they would have required extrapolation."
+    ),
     "altitude_missing_miriad": "Altitude is not present in Miriad file, and telescope",
-    "altitude_missing_lat_long": "Altitude is not present in file and latitude and longitude "
-    "values do not match",
-    "altitude_missing_long": "Altitude is not present in file and longitude value does not match",
-    "altitude_missing_lat": "Altitude is not present in file and latitude value does not match",
-    "altitude_missing_foo": "Altitude is not present in Miriad file, and "
-    "telescope foo is not in known_telescopes. "
-    "Telescope location will be set using antenna positions.",
-    "no_telescope_loc": "Telescope location is not set, but antenna "
-    "positions are present. Mean antenna latitude "
-    "and longitude values match file values, so "
-    "telescope_position will be set using the mean "
-    "of the antenna altitudes",
+    "altitude_missing_lat_long": (
+        "Altitude is not present in file and latitude and longitude values do not match"
+    ),
+    "altitude_missing_long": (
+        "Altitude is not present in file and longitude value does not match"
+    ),
+    "altitude_missing_lat": (
+        "Altitude is not present in file and latitude value does not match"
+    ),
+    "altitude_missing_foo": (
+        "Altitude is not present in Miriad file, and "
+        "telescope foo is not in known_telescopes. "
+        "Telescope location will be set using antenna positions."
+    ),
+    "no_telescope_loc": (
+        "Telescope location is not set, but antenna "
+        "positions are present. Mean antenna latitude "
+        "and longitude values match file values, so "
+        "telescope_position will be set using the mean "
+        "of the antenna altitudes"
+    ),
     "unknown_telescope_foo": "Telescope foo is not in known_telescopes.",
-    "unclear_projection": "It is not clear from the file if the data are "
-    "projected or not.",
-    "telescope_at_sealevel": "Telescope location is set at sealevel at the file lat/lon "
-    "coordinates. Antenna positions are present, but the mean antenna "
-    "position does not give a telescope_location on the surface of the "
-    "earth. Antenna positions do not appear to be on the surface of the "
-    "earth and will be treated as relative.",
-    "telescope_at_sealevel_lat": "Telescope location is set at sealevel at the file lat/lon coordinates. "
-    "Antenna positions are present, but the mean antenna latitude value does "
-    "not match file values so they are not used for altitude.",
-    "telescope_at_sealevel_lat_long": "Telescope location is set at sealevel at the file lat/lon coordinates. "
-    "Antenna positions are present, but the mean antenna latitude and longitude values do not match file values "
-    "so they are not used for altitude.",
-    "telescope_at_sealevel_foo": "Altitude is not present in Miriad file, and telescope foo is not in known_telescopes.",
-    "phase_type_deprecated": "The phase_type parameter is deprecated, use the projected parameter "
-    "instead.",
-    "no_telescope_loc": "Telescope location is not set, but antenna positions are "
-    "present. Mean antenna latitude and longitude values match file "
-    "values, so telescope_position will be set using the mean of the "
-    "antenna altitudes",
-    "projection_false_offset": "projected is False, but RA, Dec is off from lst, latitude by more than "
-    "1.0 deg",
+    "unclear_projection": (
+        "It is not clear from the file if the data are projected or not."
+    ),
+    "telescope_at_sealevel": (
+        "Telescope location is set at sealevel at the file lat/lon "
+        "coordinates. Antenna positions are present, but the mean antenna "
+        "position does not give a telescope_location on the surface of the "
+        "earth. Antenna positions do not appear to be on the surface of the "
+        "earth and will be treated as relative."
+    ),
+    "telescope_at_sealevel_lat": (
+        "Telescope location is set at sealevel at the file lat/lon coordinates. "
+        "Antenna positions are present, but the mean antenna latitude value does "
+        "not match file values so they are not used for altitude."
+    ),
+    "telescope_at_sealevel_lat_long": (
+        "Telescope location is set at sealevel at the file lat/lon coordinates. Antenna"
+        " positions are present, but the mean antenna latitude and longitude values do"
+        " not match file values so they are not used for altitude."
+    ),
+    "telescope_at_sealevel_foo": (
+        "Altitude is not present in Miriad file, and telescope foo is not in"
+        " known_telescopes."
+    ),
+    "phase_type_deprecated": (
+        "The phase_type parameter is deprecated, use the projected parameter instead."
+    ),
+    "no_telescope_loc": (
+        "Telescope location is not set, but antenna positions are "
+        "present. Mean antenna latitude and longitude values match file "
+        "values, so telescope_position will be set using the mean of the "
+        "antenna altitudes"
+    ),
+    "projection_false_offset": (
+        "projected is False, but RA, Dec is off from lst, latitude by more than 1.0 deg"
+    ),
 }
 
 
@@ -152,8 +180,10 @@ def test_read_write_read_atca(tmp_path, future_shapes):
     with uvtest.check_warnings(
         [UserWarning] * 6 + [DeprecationWarning],
         [
-            "Altitude is not present in Miriad file, and "
-            "telescope ATCA is not in known_telescopes. ",
+            (
+                "Altitude is not present in Miriad file, and "
+                "telescope ATCA is not in known_telescopes. "
+            ),
             "Telescope ATCA is not in known_telescopes.",
             "Altitude is not present",
             warn_dict["telescope_at_sealevel"],
@@ -232,8 +262,10 @@ def test_read_write_read_carma(tmp_path):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "Altitude is not present in Miriad file, "
-            "using known location values for SZA.",
+            (
+                "Altitude is not present in Miriad file, "
+                "using known location values for SZA."
+            ),
             warn_dict["uvw_mismatch"],
             "pamatten in extra_keywords is a list, array or dict",
             "psys in extra_keywords is a list, array or dict",
@@ -305,8 +337,10 @@ def test_read_carma_miriad_write_ms(tmp_path):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "Altitude is not present in Miriad file, "
-            "using known location values for SZA.",
+            (
+                "Altitude is not present in Miriad file, "
+                "using known location values for SZA."
+            ),
             warn_dict["uvw_mismatch"],
             "pamatten in extra_keywords is a list, array or dict",
             "psys in extra_keywords is a list, array or dict",
@@ -425,8 +459,10 @@ def test_miriad_read_warning_lat_lon_corrected():
     with uvtest.check_warnings(
         UserWarning,
         [
-            "Altitude is not present in Miriad file, using known location "
-            "altitude value for PAPER and lat/lon from file.",
+            (
+                "Altitude is not present in Miriad file, using known location "
+                "altitude value for PAPER and lat/lon from file."
+            ),
             warn_dict["uvw_mismatch"],
         ],
     ):
@@ -653,10 +689,12 @@ def test_miriad_location_handling(paper_miriad_main, tmp_path):
         [
             warn_dict["altitude_missing_foo"],
             warn_dict["altitude_missing_foo"],
-            "Telescope location is set at sealevel at the "
-            "file lat/lon coordinates. Antenna positions "
-            "are present, but the mean antenna longitude "
-            "value does not match",
+            (
+                "Telescope location is set at sealevel at the "
+                "file lat/lon coordinates. Antenna positions "
+                "are present, but the mean antenna longitude "
+                "value does not match"
+            ),
             warn_dict["projection_false_offset"],
             warn_dict["unknown_telescope_foo"],
             warn_dict["uvw_mismatch"],
@@ -730,15 +768,19 @@ def test_miriad_location_handling(paper_miriad_main, tmp_path):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "Altitude is not present in Miriad file, and "
-            "telescope foo is not in known_telescopes. "
-            "Telescope location will be set using antenna positions.",
+            (
+                "Altitude is not present in Miriad file, and "
+                "telescope foo is not in known_telescopes. "
+                "Telescope location will be set using antenna positions."
+            ),
             "Altitude is not present ",
-            "Telescope location is set at sealevel at the "
-            "file lat/lon coordinates. Antenna positions "
-            "are present, but the mean antenna position "
-            "does not give a telescope_location on the "
-            "surface of the earth.",
+            (
+                "Telescope location is set at sealevel at the "
+                "file lat/lon coordinates. Antenna positions "
+                "are present, but the mean antenna position "
+                "does not give a telescope_location on the "
+                "surface of the earth."
+            ),
             warn_dict["unknown_telescope_foo"],
             warn_dict["uvw_mismatch"],
         ],
@@ -1922,7 +1964,8 @@ def test_multi_files(casa_uvfits, tmp_path):
 
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis using"
         " pyuvdata.",
@@ -1948,7 +1991,8 @@ def test_multi_files(casa_uvfits, tmp_path):
     uv1.read([testfile1, testfile2], axis="freq", use_future_array_shapes=True)
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis using"
         " pyuvdata.",
@@ -2032,17 +2076,23 @@ def test_file_with_bad_extra_words():
     fname = os.path.join(DATA_PATH, "test_miriad_changing_extra.uv")
     uv = UVData()
     warn_message = [
-        "Altitude is not present in Miriad file, "
-        "using known location values for PAPER.",
+        (
+            "Altitude is not present in Miriad file, "
+            "using known location values for PAPER."
+        ),
         "Mean of empty slice.",
         "invalid value encountered",
         "npols=4 but found 1 pols in data file",
         "Mean of empty slice.",
         "invalid value encountered",
-        "antenna number 0 has visibilities associated with it, but it has a "
-        "position of (0,0,0)",
-        "antenna number 26 has visibilities associated with it, "
-        "but it has a position of (0,0,0)",
+        (
+            "antenna number 0 has visibilities associated with it, but it has a "
+            "position of (0,0,0)"
+        ),
+        (
+            "antenna number 26 has visibilities associated with it, "
+            "but it has a position of (0,0,0)"
+        ),
     ]
     warn_category = (
         [UserWarning]

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -100,8 +100,10 @@ def test_cotter_ms():
         [UserWarning] * 3 + [DeprecationWarning],
         match=[
             "Warning: select on read keyword set",
-            "telescope_location are not set or are being overwritten. Using known "
-            "values for MWA.",
+            (
+                "telescope_location are not set or are being overwritten. Using known "
+                "values for MWA."
+            ),
             "UVW orientation appears to be flipped,",
             _future_array_shapes_warning,
         ],
@@ -363,7 +365,10 @@ def test_read_ms_write_miriad(nrao_uv, tmp_path):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna"
+                " positions."
+            ),
             "writing default values for restfreq, vsource, veldop, jyperk, and systemp",
         ],
     ):
@@ -695,10 +700,14 @@ def test_ms_scannumber_multiphasecenter(tmp_path, multi_frame):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "Altitude is not present in Miriad file, "
-            "using known location values for SZA.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "Altitude is not present in Miriad file, "
+                "using known location values for SZA."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
             "pamatten in extra_keywords is a list, array or dict",
             "psys in extra_keywords is a list, array or dict",
             "psysattn in extra_keywords is a list, array or dict",
@@ -875,8 +884,10 @@ def test_ms_weights(sma_mir, tmp_path, onewin):
             "TEL_LOC",
             None,
             ValueError,
-            "Telescope frame in file is abc. Only 'itrs' and 'mcmf' are currently "
-            "supported.",
+            (
+                "Telescope frame in file is abc. Only 'itrs' and 'mcmf' are currently "
+                "supported."
+            ),
         ],
         [
             "timescale",
@@ -1085,7 +1096,7 @@ def test_flip_conj_multispw(sma_mir, tmp_path):
 
 
 @pytest.mark.filterwarnings(
-    "ignore:Writing in the MS file that the units " "of the data are"
+    "ignore:Writing in the MS file that the units of the data are"
 )
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -1075,7 +1075,7 @@ def test_flip_conj_multispw(sma_mir, tmp_path):
 
     assert sma_mir == ms_uv
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-def test_read_ms_write_miriad(nrao_uv, nrao_uv_legacy, tmp_path):
+def test_read_ms_write_miriad_legacy(nrao_uv, nrao_uv_legacy, tmp_path):
     """
     write ms from future and legacy array shapes.
     """

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -1077,7 +1077,8 @@ def test_flip_conj_multispw(sma_mir, tmp_path):
     assert sma_mir == ms_uv
 
 
-@pytest.mark.filterwarnings("ignore:"Writing in the MS file that the units of the data")
+@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units "
+                            "of the data are")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 def test_read_ms_write_miriad_legacy(nrao_uv, nrao_uv_legacy, tmp_path):

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -1074,7 +1074,7 @@ def test_flip_conj_multispw(sma_mir, tmp_path):
     sma_mir.filename = ms_uv.filename = None
 
     assert sma_mir == ms_uv
-
+@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 def test_read_ms_write_miriad(nrao_uv, nrao_uv_legacy, tmp_path):
     """
     write ms from future and legacy array shapes.

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -70,6 +70,17 @@ def nrao_uv(nrao_uv_main):
 
     return
 
+@pytest.fixture(scope="function")
+def nrao_uv_legacy():
+    """Make function level NRAO ms object, legacy array shapes."""
+    uvobj = UVData()
+    testfile = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.ms")
+    uvobj.read(testfile, use_future_array_shapes=False)
+
+    yield uvobj
+
+    del uvobj
+
 
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 @pytest.mark.filterwarnings("ignore:ITRF coordinate frame detected,")
@@ -1063,3 +1074,13 @@ def test_flip_conj_multispw(sma_mir, tmp_path):
     sma_mir.filename = ms_uv.filename = None
 
     assert sma_mir == ms_uv
+
+def test_read_ms_write_miriad(nrao_uv, nrao_uv_legacy, tmp_path):
+    """
+    write ms from future and legacy array shapes.
+    """
+    testfile_l = os.path.join(tmp_path, "outtest_legacy.ms")
+    testfile_f = os.path.join(tmp_path, "outtest_future.ms")
+
+    nrao_uv.write_ms(testfile_l)
+    nrao_uv_legacy.write_ms(testfile_f)

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -1074,6 +1074,9 @@ def test_flip_conj_multispw(sma_mir, tmp_path):
     sma_mir.filename = ms_uv.filename = None
 
     assert sma_mir == ms_uv
+
+
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 def test_read_ms_write_miriad_legacy(nrao_uv, nrao_uv_legacy, tmp_path):
     """

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -360,7 +360,14 @@ def test_read_ms_write_miriad(nrao_uv, tmp_path):
     ms_uv = nrao_uv
     miriad_uv = UVData()
     testfile = os.path.join(tmp_path, "outtest_miriad")
-    ms_uv.write_miriad(testfile)
+    with uvtest.check_warnings(
+        UserWarning,
+        [
+            "The uvw_array does not match the expected values given the antenna positions.",
+            "writing default values for restfreq, vsource, veldop, jyperk, and systemp",
+        ],
+    ):
+        ms_uv.write_miriad(testfile)
     miriad_uv.read(testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
@@ -1077,11 +1084,12 @@ def test_flip_conj_multispw(sma_mir, tmp_path):
     assert sma_mir == ms_uv
 
 
-@pytest.mark.filterwarnings("ignore:Writing in the MS file that the units "
-                            "of the data are")
+@pytest.mark.filterwarnings(
+    "ignore:Writing in the MS file that the units " "of the data are"
+)
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-def test_read_ms_write_miriad_legacy(nrao_uv, nrao_uv_legacy, tmp_path):
+def test_read_ms_write_ms_legacy(nrao_uv, nrao_uv_legacy, tmp_path):
     """
     write ms from future and legacy array shapes.
     """

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -70,6 +70,7 @@ def nrao_uv(nrao_uv_main):
 
     return
 
+
 @pytest.fixture(scope="function")
 def nrao_uv_legacy():
     """Make function level NRAO ms object, legacy array shapes."""

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -1077,6 +1077,7 @@ def test_flip_conj_multispw(sma_mir, tmp_path):
     assert sma_mir == ms_uv
 
 
+@pytest.mark.filterwarnings("ignore:"Writing in the MS file that the units of the data")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 def test_read_ms_write_miriad_legacy(nrao_uv, nrao_uv_legacy, tmp_path):

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -1442,8 +1442,7 @@ def test_select_phase_center_id(tmp_path, carma_miriad):
 
     uv_sum = uv1 + uv2
     assert uvutils._check_histories(
-        uv_obj.history
-        + "  Downselected to specific phase center IDs using pyuvdata.  "
+        uv_obj.history + "  Downselected to specific phase center IDs using pyuvdata.  "
         "Combined data along baseline-time axis using pyuvdata.",
         uv_sum.history,
     )
@@ -2703,12 +2702,14 @@ def test_select(casa_uvfits, future_shapes):
         for (a1, a2) in zip(uv_object.ant_1_array, uv_object.ant_2_array)
     ]
     blts_time_select = [t in times_to_keep for t in uv_object.time_array]
-    Nblts_select = np.sum([
-        bi & (ai & pi) & ti
-        for (bi, ai, pi, ti) in zip(
-            blts_blt_select, blts_ant_select, blts_pair_select, blts_time_select
-        )
-    ])
+    Nblts_select = np.sum(
+        [
+            bi & (ai & pi) & ti
+            for (bi, ai, pi, ti) in zip(
+                blts_blt_select, blts_ant_select, blts_pair_select, blts_time_select
+            )
+        ]
+    )
 
     uv_object2 = uv_object.copy()
     uv_object2.select(
@@ -2742,8 +2743,7 @@ def test_select(casa_uvfits, future_shapes):
         assert p in pols_to_keep
 
     assert uvutils._check_histories(
-        old_history
-        + "  Downselected to "
+        old_history + "  Downselected to "
         "specific baseline-times, antennas, "
         "baselines, times, frequencies, "
         "polarizations using pyuvdata.",
@@ -2810,12 +2810,14 @@ def test_select_with_lst(casa_uvfits, future_shapes):
         for (a1, a2) in zip(uv_object.ant_1_array, uv_object.ant_2_array)
     ]
     blts_lst_select = [lst in lsts_to_keep for lst in uv_object.lst_array]
-    Nblts_select = np.sum([
-        bi & (ai & pi) & li
-        for (bi, ai, pi, li) in zip(
-            blts_blt_select, blts_ant_select, blts_pair_select, blts_lst_select
-        )
-    ])
+    Nblts_select = np.sum(
+        [
+            bi & (ai & pi) & li
+            for (bi, ai, pi, li) in zip(
+                blts_blt_select, blts_ant_select, blts_pair_select, blts_lst_select
+            )
+        ]
+    )
 
     uv_object2 = uv_object.copy()
     uv_object2.select(
@@ -2849,8 +2851,7 @@ def test_select_with_lst(casa_uvfits, future_shapes):
         assert p in pols_to_keep
 
     assert uvutils._check_histories(
-        old_history
-        + "  Downselected to "
+        old_history + "  Downselected to "
         "specific baseline-times, antennas, "
         "baselines, lsts, frequencies, "
         "polarizations using pyuvdata.",
@@ -2874,8 +2875,7 @@ def test_select_not_inplace(casa_uvfits):
     uv1 = uv_object.select(freq_chans=np.arange(32), inplace=False)
     uv1 += uv_object.select(freq_chans=np.arange(32, 64), inplace=False)
     assert uvutils._check_histories(
-        old_history
-        + "  Downselected to "
+        old_history + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis "
         "using pyuvdata.",
@@ -3483,8 +3483,7 @@ def test_sum_vis(casa_uvfits, future_shapes):
 
     assert np.array_equal(uv_summed.data_array, uv_full.data_array)
     assert uvutils._check_histories(
-        uv_half.history
-        + " Visibilities summed using pyuvdata. Unique part of second "
+        uv_half.history + " Visibilities summed using pyuvdata. Unique part of second "
         "object history follows.  testing the history.",
         uv_summed.history,
     )
@@ -3616,8 +3615,7 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv1 += uv2
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis "
         "using pyuvdata.",
@@ -3656,8 +3654,7 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(polarizations=uv2.polarization_array[2:4])
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific polarizations using pyuvdata. "
         "Combined data along polarization axis "
         "using pyuvdata.",
@@ -3683,8 +3680,7 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(times=times[len(times) // 2 :])
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific times using pyuvdata. "
         "Combined data along baseline-time axis "
         "using pyuvdata.",
@@ -3704,8 +3700,7 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(blt_inds=ind2)
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific baseline-times using pyuvdata. "
         "Combined data along baseline-time axis "
         "using pyuvdata.",
@@ -3742,8 +3737,7 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv1 += uv3
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific baseline-times using pyuvdata. "
         "Combined data along baseline-time axis "
         "using pyuvdata. Combined data along "
@@ -3766,24 +3760,27 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     )
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific times, polarizations using "
         "pyuvdata. Combined data along "
         "baseline-time, polarization axis "
         "using pyuvdata.",
         uv1.history,
     )
-    blt_ind1 = np.array([
-        ind
-        for ind in range(uv_full.Nblts)
-        if uv_full.time_array[ind] in times[0 : len(times) // 2]
-    ])
-    blt_ind2 = np.array([
-        ind
-        for ind in range(uv_full.Nblts)
-        if uv_full.time_array[ind] in times[len(times) // 2 :]
-    ])
+    blt_ind1 = np.array(
+        [
+            ind
+            for ind in range(uv_full.Nblts)
+            if uv_full.time_array[ind] in times[0 : len(times) // 2]
+        ]
+    )
+    blt_ind2 = np.array(
+        [
+            ind
+            for ind in range(uv_full.Nblts)
+            if uv_full.time_array[ind] in times[len(times) // 2 :]
+        ]
+    )
     # Zero out missing data in reference object
     if future_shapes:
         uv_ref.data_array[blt_ind1, :, 2:] = 0.0
@@ -3811,24 +3808,27 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(times=times[len(times) // 2 :], freq_chans=np.arange(32, 64))
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific times, frequencies using "
         "pyuvdata. Combined data along "
         "baseline-time, frequency axis using "
         "pyuvdata.",
         uv1.history,
     )
-    blt_ind1 = np.array([
-        ind
-        for ind in range(uv_full.Nblts)
-        if uv_full.time_array[ind] in times[0 : len(times) // 2]
-    ])
-    blt_ind2 = np.array([
-        ind
-        for ind in range(uv_full.Nblts)
-        if uv_full.time_array[ind] in times[len(times) // 2 :]
-    ])
+    blt_ind1 = np.array(
+        [
+            ind
+            for ind in range(uv_full.Nblts)
+            if uv_full.time_array[ind] in times[0 : len(times) // 2]
+        ]
+    )
+    blt_ind2 = np.array(
+        [
+            ind
+            for ind in range(uv_full.Nblts)
+            if uv_full.time_array[ind] in times[len(times) // 2 :]
+        ]
+    )
     # Zero out missing data in reference object
     if future_shapes:
         uv_ref.data_array[blt_ind1, 32:, :] = 0.0
@@ -3855,8 +3855,7 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(times=times[len(times) // 2 :])
     uv1 = uv1 + uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific times using pyuvdata. "
         "Combined data along baseline-time "
         "axis using pyuvdata.",
@@ -3969,8 +3968,7 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.history += " testing the history. AIPS WTSCAL = 1.0"
     uv_new = uv1 + uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to specific polarizations using pyuvdata. "
+        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
         "Combined data along polarization axis using pyuvdata. Unique part of next "
         "object history follows.  testing the history.",
         uv_new.history,
@@ -3980,11 +3978,9 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
 
     uv_new = uv1.__add__(uv2, verbose_history=True)
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to specific polarizations using pyuvdata. "
+        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
         "Combined data along polarization axis using pyuvdata. Next object history "
-        "follows.  "
-        + uv2.history,
+        "follows.  " + uv2.history,
         uv_new.history,
     )
 
@@ -4014,8 +4010,7 @@ def test_add_unprojected(casa_uvfits):
     uv1 += uv2
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency "
         "axis using pyuvdata.",
@@ -4031,8 +4026,7 @@ def test_add_unprojected(casa_uvfits):
     uv2.select(polarizations=uv2.polarization_array[2:4])
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific polarizations using pyuvdata. "
         "Combined data along polarization "
         "axis using pyuvdata.",
@@ -4049,8 +4043,7 @@ def test_add_unprojected(casa_uvfits):
     uv2.select(times=times[len(times) // 2 :])
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific times using pyuvdata. "
         "Combined data along baseline-time "
         "axis using pyuvdata.",
@@ -4070,8 +4063,7 @@ def test_add_unprojected(casa_uvfits):
     uv2.select(blt_inds=ind2)
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific baseline-times using pyuvdata. "
         "Combined data along baseline-time "
         "axis using pyuvdata.",
@@ -4093,24 +4085,27 @@ def test_add_unprojected(casa_uvfits):
     )
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific times, polarizations using "
         "pyuvdata. Combined data along "
         "baseline-time, polarization "
         "axis using pyuvdata.",
         uv1.history,
     )
-    blt_ind1 = np.array([
-        ind
-        for ind in range(uv_full.Nblts)
-        if uv_full.time_array[ind] in times[0 : len(times) // 2]
-    ])
-    blt_ind2 = np.array([
-        ind
-        for ind in range(uv_full.Nblts)
-        if uv_full.time_array[ind] in times[len(times) // 2 :]
-    ])
+    blt_ind1 = np.array(
+        [
+            ind
+            for ind in range(uv_full.Nblts)
+            if uv_full.time_array[ind] in times[0 : len(times) // 2]
+        ]
+    )
+    blt_ind2 = np.array(
+        [
+            ind
+            for ind in range(uv_full.Nblts)
+            if uv_full.time_array[ind] in times[len(times) // 2 :]
+        ]
+    )
     # Zero out missing data in reference object
     uv_ref.data_array[blt_ind1, :, 2:] = 0.0
     uv_ref.nsample_array[blt_ind1, :, 2:] = 0.0
@@ -4130,24 +4125,27 @@ def test_add_unprojected(casa_uvfits):
     uv2.select(times=times[len(times) // 2 :], freq_chans=np.arange(32, 64))
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific times, frequencies using "
         "pyuvdata. Combined data along "
         "baseline-time, frequency "
         "axis using pyuvdata.",
         uv1.history,
     )
-    blt_ind1 = np.array([
-        ind
-        for ind in range(uv_full.Nblts)
-        if uv_full.time_array[ind] in times[0 : len(times) // 2]
-    ])
-    blt_ind2 = np.array([
-        ind
-        for ind in range(uv_full.Nblts)
-        if uv_full.time_array[ind] in times[len(times) // 2 :]
-    ])
+    blt_ind1 = np.array(
+        [
+            ind
+            for ind in range(uv_full.Nblts)
+            if uv_full.time_array[ind] in times[0 : len(times) // 2]
+        ]
+    )
+    blt_ind2 = np.array(
+        [
+            ind
+            for ind in range(uv_full.Nblts)
+            if uv_full.time_array[ind] in times[len(times) // 2 :]
+        ]
+    )
     # Zero out missing data in reference object
     uv_ref.data_array[blt_ind1, 32:, :] = 0.0
     uv_ref.nsample_array[blt_ind1, 32:, :] = 0.0
@@ -4166,8 +4164,7 @@ def test_add_unprojected(casa_uvfits):
     uv2.select(times=times[len(times) // 2 :])
     uv1 = uv1 + uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific times using pyuvdata. "
         "Combined data along baseline-time "
         "axis using pyuvdata.",
@@ -4211,8 +4208,7 @@ def test_add_unprojected(casa_uvfits):
     uv2.history += " testing the history. AIPS WTSCAL = 1.0"
     uv_new = uv1 + uv2
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to specific polarizations using pyuvdata. "
+        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
         "Combined data along polarization axis using pyuvdata.  Unique part of next "
         "object history follows.  testing the history.",
         uv_new.history,
@@ -4222,11 +4218,9 @@ def test_add_unprojected(casa_uvfits):
 
     uv_new = uv1.__add__(uv2, verbose_history=True)
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to specific polarizations using pyuvdata. "
+        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
         "Combined data along polarization axis using pyuvdata. Next object history "
-        "follows."
-        + uv2.history,
+        "follows." + uv2.history,
         uv_new.history,
     )
 
@@ -4437,8 +4431,7 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv1.fast_concat([uv2, uv3], "freq", inplace=True)
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis "
         "using pyuvdata.",
@@ -4505,8 +4498,7 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv3.select(polarizations=uv3.polarization_array[3:4])
     uv1.fast_concat([uv2, uv3], "polarization", inplace=True)
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific polarizations using pyuvdata. "
         "Combined data along polarization axis "
         "using pyuvdata.",
@@ -4551,8 +4543,7 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv3.select(times=times[(len(times) // 3) * 2 :])
     uv1.fast_concat([uv2, uv3], "blt", inplace=True)
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific times using pyuvdata. "
         "Combined data along baseline-time axis "
         "using pyuvdata.",
@@ -4571,8 +4562,7 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(blt_inds=ind2)
     uv1.fast_concat(uv2, "blt", inplace=True)
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific baseline-times using pyuvdata. "
         "Combined data along baseline-time axis "
         "using pyuvdata.",
@@ -4624,8 +4614,7 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.fast_concat(uv1, "blt", inplace=True)
 
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific baseline-times using pyuvdata. "
         "Combined data along baseline-time "
         "axis using pyuvdata.",
@@ -4693,8 +4682,7 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(times=times[len(times) // 2 :])
     uv1 = uv1.fast_concat(uv2, "blt", inplace=False)
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific times using pyuvdata. "
         "Combined data along baseline-time "
         "axis using pyuvdata.",
@@ -4796,8 +4784,7 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.history += " testing the history. AIPS WTSCAL = 1.0"
     uv_new = uv1.fast_concat(uv2, "polarization")
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to specific polarizations using pyuvdata. "
+        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
         "Combined data along polarization axis using pyuvdata. Unique part of next "
         "object history follows. testing the history.",
         uv_new.history,
@@ -4807,11 +4794,9 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
 
     uv_new = uv1.fast_concat(uv2, "polarization", verbose_history=True)
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to specific polarizations using pyuvdata. "
+        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
         "Combined data along polarization axis using pyuvdata. Next object history "
-        "follows."
-        + uv2.history,
+        "follows." + uv2.history,
         uv_new.history,
     )
 
@@ -6441,9 +6426,12 @@ def test_redundancy_contract_expand(
         # the test file has groups that are either all not conjugated or all conjugated.
         # need to conjugate some so we have mixed groups to properly test the average
         # method.
-        (orig_red_gps, orig_centers, orig_lengths, orig_conjugates) = (
-            uv0.get_redundancies(tol, include_conjugates=True)
-        )
+        (
+            orig_red_gps,
+            orig_centers,
+            orig_lengths,
+            orig_conjugates,
+        ) = uv0.get_redundancies(tol, include_conjugates=True)
         blt_inds_to_conj = []
         for gp in orig_red_gps:
             if len(gp) > 1:
@@ -9060,12 +9048,14 @@ def test_frequency_average(casa_uvfits, future_shapes, flex_spw, sum_corr):
         # Make multiple spws
         uvobj._set_flex_spw()
         spw_nchan = int(uvobj.Nfreqs / 4)
-        uvobj.flex_spw_id_array = np.concatenate((
-            np.full(spw_nchan, 0, dtype=int),
-            np.full(spw_nchan, 1, dtype=int),
-            np.full(spw_nchan, 2, dtype=int),
-            np.full(spw_nchan, 3, dtype=int),
-        ))
+        uvobj.flex_spw_id_array = np.concatenate(
+            (
+                np.full(spw_nchan, 0, dtype=int),
+                np.full(spw_nchan, 1, dtype=int),
+                np.full(spw_nchan, 2, dtype=int),
+                np.full(spw_nchan, 3, dtype=int),
+            )
+        )
         uvobj.spw_array = np.arange(4)
         uvobj.Nspws = 4
         if not future_shapes:
@@ -9163,12 +9153,14 @@ def test_frequency_average_uneven(
         # Make multiple spws
         uvobj._set_flex_spw()
         spw_nchan = int(uvobj.Nfreqs / 4)
-        uvobj.flex_spw_id_array = np.concatenate((
-            np.full(spw_nchan, 0, dtype=int),
-            np.full(spw_nchan, 1, dtype=int),
-            np.full(spw_nchan, 2, dtype=int),
-            np.full(spw_nchan, 3, dtype=int),
-        ))
+        uvobj.flex_spw_id_array = np.concatenate(
+            (
+                np.full(spw_nchan, 0, dtype=int),
+                np.full(spw_nchan, 1, dtype=int),
+                np.full(spw_nchan, 2, dtype=int),
+                np.full(spw_nchan, 3, dtype=int),
+            )
+        )
         uvobj.spw_array = np.arange(4)
         uvobj.Nspws = 4
         if not future_shapes:
@@ -11318,9 +11310,9 @@ def test_fix_phase(hera_uvh5, tmp_path, future_shapes, use_ant_pos, phase_frame)
         uv_in_bad2.gst0 = None
         uv_in_bad2.rdate = None
         uv_in_bad2.timesys = None
-    uv_in_bad2.phase_center_catalog[1]["info_source"] = (
-        uv_in_bad_copy.phase_center_catalog[1]["info_source"]
-    )
+    uv_in_bad2.phase_center_catalog[1][
+        "info_source"
+    ] = uv_in_bad_copy.phase_center_catalog[1]["info_source"]
     uv_in_bad2.extra_keywords = uv_in_bad_copy.extra_keywords
     assert uv_in_bad2 == uv_in_bad_copy
 
@@ -12357,9 +12349,9 @@ def test_flex_pol_uvh5(future_shapes, multispw, sorting, uv_phase_comp, tmp_path
         for idx, spw in enumerate(uvd2.spw_array):
             new_spw = spw_renumber_dict[spw]
             new_spw_array[idx] = new_spw
-            uvd2.flex_spw_id_array[np.nonzero(uvd2.flex_spw_id_array == spw)[0]] = (
-                new_spw
-            )
+            uvd2.flex_spw_id_array[
+                np.nonzero(uvd2.flex_spw_id_array == spw)[0]
+            ] = new_spw
         uvd2.spw_array = new_spw_array
         uvd2.check()
 

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -545,9 +545,7 @@ def test_check_nbls(casa_uvfits):
     uvobj.Nbls += 1
     with pytest.raises(
         ValueError,
-        match=(
-            "Nbls must be equal to the number of unique baselines in the data_array"
-        ),
+        match="Nbls must be equal to the number of unique baselines in the data_array",
     ):
         uvobj.check()
 
@@ -558,7 +556,7 @@ def test_check_ntimes(casa_uvfits):
     uvobj.Ntimes += 1
     with pytest.raises(
         ValueError,
-        match=("Ntimes must be equal to the number of unique times in the time_array"),
+        match="Ntimes must be equal to the number of unique times in the time_array",
     ):
         uvobj.check()
     uvobj.Ntimes -= 1
@@ -578,8 +576,10 @@ def test_check_strict_uvw(casa_uvfits):
     uvobj = casa_uvfits
     with pytest.raises(
         ValueError,
-        match="The uvw_array does not match the expected values given the antenna "
-        "positions.",
+        match=(
+            "The uvw_array does not match the expected values given the antenna "
+            "positions."
+        ),
     ):
         uvobj.check(strict_uvw_antpos_check=True)
 
@@ -607,8 +607,7 @@ def test_check_uvw_array(hera_uvh5_xx):
     # make auto have non-zero uvw coords, assert ValueError
     uvd.uvw_array[auto_inds[0], 0] = 0.1
     with pytest.raises(
-        ValueError,
-        match=("Some auto-correlations have non-zero uvw_array coordinates."),
+        ValueError, match="Some auto-correlations have non-zero uvw_array coordinates."
     ):
         uvd.check()
 
@@ -616,8 +615,7 @@ def test_check_uvw_array(hera_uvh5_xx):
     uvd = hera_uvh5_xx.copy()
     uvd.uvw_array[cross_inds[0]][:] = 0.0
     with pytest.raises(
-        ValueError,
-        match=("Some cross-correlations have near-zero uvw_array magnitudes."),
+        ValueError, match="Some cross-correlations have near-zero uvw_array magnitudes."
     ):
         uvd.check()
 
@@ -647,8 +645,10 @@ def test_future_array_shape(casa_uvfits):
 
     with uvtest.check_warnings(
         DeprecationWarning,
-        match="This method will be removed in version 3.0 when the current array "
-        "shapes are no longer supported.",
+        match=(
+            "This method will be removed in version 3.0 when the current array "
+            "shapes are no longer supported."
+        ),
     ):
         uvobj.use_current_array_shapes()
     uvobj.check()
@@ -657,8 +657,10 @@ def test_future_array_shape(casa_uvfits):
     # test no-op:
     with uvtest.check_warnings(
         DeprecationWarning,
-        match="This method will be removed in version 3.0 when the current array "
-        "shapes are no longer supported.",
+        match=(
+            "This method will be removed in version 3.0 when the current array "
+            "shapes are no longer supported."
+        ),
     ):
         uvobj.use_current_array_shapes()
     assert uvobj == uvobj3
@@ -670,8 +672,10 @@ def test_future_array_shape(casa_uvfits):
 
     with uvtest.check_warnings(
         DeprecationWarning,
-        match="This method will be removed in version 3.0 when the current array "
-        "shapes are no longer supported.",
+        match=(
+            "This method will be removed in version 3.0 when the current array "
+            "shapes are no longer supported."
+        ),
     ):
         uvobj2.use_current_array_shapes()
     uvobj2.data_array = None
@@ -694,8 +698,10 @@ def test_future_array_shape(casa_uvfits):
     ):
         with uvtest.check_warnings(
             DeprecationWarning,
-            match="This method will be removed in version 3.0 when the current array "
-            "shapes are no longer supported.",
+            match=(
+                "This method will be removed in version 3.0 when the current array "
+                "shapes are no longer supported."
+            ),
         ):
             uvobj.use_current_array_shapes()
 
@@ -769,8 +775,10 @@ def test_baseline_to_antnums(uvdata_baseline):
 
     with pytest.raises(
         Exception,
-        match=f"error Nants={uvdata_baseline.uv_object2.Nants_telescope}>2147483648"
-        " not supported",
+        match=(
+            f"error Nants={uvdata_baseline.uv_object2.Nants_telescope}>2147483648"
+            " not supported"
+        ),
     ):
         uvdata_baseline.uv_object2.baseline_to_antnums(65536)
     with pytest.raises(ValueError, match="negative baseline numbers are not supported"):
@@ -823,21 +831,27 @@ def test_antnums_to_baselines(uvdata_baseline):
         uvdata_baseline.uv_object3.antnums_to_baseline(1112, 1111, attempt256=True)
     with pytest.raises(
         ValueError,
-        match="cannot convert ant1, ant2 to a baseline index with Nants={Nants}"
-        ">2147483648.".format(Nants=uvdata_baseline.uv_object2.Nants_telescope),
+        match=(
+            "cannot convert ant1, ant2 to a baseline index with Nants={Nants}"
+            ">2147483648.".format(Nants=uvdata_baseline.uv_object2.Nants_telescope)
+        ),
     ):
         uvdata_baseline.uv_object2.antnums_to_baseline(0, 0)
     # check for out of range antenna numbers
     with pytest.raises(
         ValueError,
-        match="cannot convert ant1, ant2 to a baseline index "
-        "with antenna numbers greater than 2147483647.",
+        match=(
+            "cannot convert ant1, ant2 to a baseline index "
+            "with antenna numbers greater than 2147483647."
+        ),
     ):
         uvdata_baseline.uv_object.antnums_to_baseline(2147483649, 2147483648)
     with pytest.raises(
         ValueError,
-        match="cannot convert ant1, ant2 to a baseline index "
-        "with antenna numbers less than zero.",
+        match=(
+            "cannot convert ant1, ant2 to a baseline index "
+            "with antenna numbers less than zero."
+        ),
     ):
         uvdata_baseline.uv_object.antnums_to_baseline(-10, 2047)
     # check a len-1 array returns as an array
@@ -874,8 +888,10 @@ def test_hera_diameters(paper_uvh5):
     uv_in.telescope_name = "HERA"
     with uvtest.check_warnings(
         UserWarning,
-        match="antenna_diameters are not set or are being overwritten. Using known "
-        "values for HERA.",
+        match=(
+            "antenna_diameters are not set or are being overwritten. Using known "
+            "values for HERA."
+        ),
     ):
         uv_in.set_telescope_params()
 
@@ -1162,11 +1178,15 @@ def test_phasing(uv_phase_comp, future_shapes, unphase_first, use_ant_pos):
         exp_warning = None
     else:
         warning_str = [
-            "The entry name UVCeti is not unique inside the phase center catalog, "
-            "adding anyways",
-            "The provided name UVCeti is already used but has different parameters. "
-            "Adding another entry with the same name but a different ID and "
-            "parameters.",
+            (
+                "The entry name UVCeti is not unique inside the phase center catalog, "
+                "adding anyways"
+            ),
+            (
+                "The provided name UVCeti is already used but has different parameters."
+                " Adding another entry with the same name but a different ID and"
+                " parameters."
+            ),
         ]
         exp_warning = UserWarning
 
@@ -1324,9 +1344,11 @@ def test_set_uvws(hera_uvh5):
     uv2.phase(ra=0.0, dec=0.0, cat_name="foo")
     with uvtest.check_warnings(
         UserWarning,
-        match="Recalculating uvw_array without adjusting visibility "
-        "phases -- this can introduce significant errors if used "
-        "incorrectly.",
+        match=(
+            "Recalculating uvw_array without adjusting visibility "
+            "phases -- this can introduce significant errors if used "
+            "incorrectly."
+        ),
     ):
         uv1.set_uvws_from_antenna_positions(update_vis=False)
     assert uv1._uvw_array == uv2._uvw_array
@@ -1420,7 +1442,8 @@ def test_select_phase_center_id(tmp_path, carma_miriad):
 
     uv_sum = uv1 + uv2
     assert uvutils._check_histories(
-        uv_obj.history + "  Downselected to specific phase center IDs using pyuvdata.  "
+        uv_obj.history
+        + "  Downselected to specific phase center IDs using pyuvdata.  "
         "Combined data along baseline-time axis using pyuvdata.",
         uv_sum.history,
     )
@@ -1701,8 +1724,8 @@ def test_select_bls(casa_uvfits):
         assert bl in sorted_bls_to_keep
 
     assert uvutils._check_histories(
-        old_history + "  Downselected to "
-        "specific baselines, polarizations using pyuvdata.",
+        old_history
+        + "  Downselected to specific baselines, polarizations using pyuvdata.",
         uv_object2.history,
     )
 
@@ -1999,8 +2022,10 @@ def test_select_lsts_casa(casa_uvfits, tmp_path, future_shapes, select_type):
     with uvtest.check_warnings(
         UserWarning,
         match=[
-            'select on read keyword set, but file_type is "ms" which does not '
-            "support select on read",
+            (
+                'select on read keyword set, but file_type is "ms" which does not '
+                "support select on read"
+            ),
             "The uvw_array does not match the expected values",
             "The uvw_array does not match the expected values",
         ],
@@ -2115,8 +2140,11 @@ def test_select_lsts_too_big(casa_uvfits, tmp_path):
         [
             "The lsts parameter contained a value greater than 2*pi",
             "The uvw_array does not match the expected values",
-            "The lst_array is not self-consistent with the time_array and telescope "
-            "location. Consider recomputing with the `set_lsts_from_time_array` method",
+            (
+                "The lst_array is not self-consistent with the time_array and telescope"
+                " location. Consider recomputing with the `set_lsts_from_time_array`"
+                " method"
+            ),
         ],
     ):
         uv_object2.select(lsts=lsts_to_keep)
@@ -2131,10 +2159,11 @@ def test_select_lsts_too_big(casa_uvfits, tmp_path):
     # check that it's detected in the uvfits reader
     test_filename = os.path.join(tmp_path, "test_bad_lsts.uvfits")
     warn_msg = [
-        "The lst_array is not self-consistent with the time_array and telescope "
-        "location. Consider recomputing with the `set_lsts_from_time_array` method",
-        "The uvw_array does not match the expected values given the antenna "
-        "positions.",
+        (
+            "The lst_array is not self-consistent with the time_array and telescope "
+            "location. Consider recomputing with the `set_lsts_from_time_array` method"
+        ),
+        "The uvw_array does not match the expected values given the antenna positions.",
     ]
     with uvtest.check_warnings(UserWarning, match=warn_msg):
         uv_object2.write_uvfits(test_filename)
@@ -2143,8 +2172,11 @@ def test_select_lsts_too_big(casa_uvfits, tmp_path):
         match=warn_msg
         + [
             "Telescope EVLA is not in known_telescopes.",
-            "The lst_array is not self-consistent with the time_array and telescope "
-            "location. Consider recomputing with the `set_lsts_from_time_array` method",
+            (
+                "The lst_array is not self-consistent with the time_array and telescope"
+                " location. Consider recomputing with the `set_lsts_from_time_array`"
+                " method"
+            ),
         ],
     ):
         UVData.from_file(test_filename, use_future_array_shapes=True)
@@ -2408,8 +2440,10 @@ def test_select_frequencies_writeerrors(casa_uvfits, future_shapes, tmp_path):
         UserWarning,
         [
             "Selected frequencies are not evenly spaced",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         if future_shapes:
@@ -2429,8 +2463,10 @@ def test_select_frequencies_writeerrors(casa_uvfits, future_shapes, tmp_path):
         UserWarning,
         [
             "Selected frequencies are not contiguous",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         if future_shapes:
@@ -2597,8 +2633,10 @@ def test_select_polarizations_errors(casa_uvfits, tmp_path):
         UserWarning,
         [
             "Selected polarization values are not evenly spaced",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv_object.select(polarizations=uv_object.polarization_array[[0, 1, 3]])
@@ -2665,14 +2703,12 @@ def test_select(casa_uvfits, future_shapes):
         for (a1, a2) in zip(uv_object.ant_1_array, uv_object.ant_2_array)
     ]
     blts_time_select = [t in times_to_keep for t in uv_object.time_array]
-    Nblts_select = np.sum(
-        [
-            bi & (ai & pi) & ti
-            for (bi, ai, pi, ti) in zip(
-                blts_blt_select, blts_ant_select, blts_pair_select, blts_time_select
-            )
-        ]
-    )
+    Nblts_select = np.sum([
+        bi & (ai & pi) & ti
+        for (bi, ai, pi, ti) in zip(
+            blts_blt_select, blts_ant_select, blts_pair_select, blts_time_select
+        )
+    ])
 
     uv_object2 = uv_object.copy()
     uv_object2.select(
@@ -2706,7 +2742,8 @@ def test_select(casa_uvfits, future_shapes):
         assert p in pols_to_keep
 
     assert uvutils._check_histories(
-        old_history + "  Downselected to "
+        old_history
+        + "  Downselected to "
         "specific baseline-times, antennas, "
         "baselines, times, frequencies, "
         "polarizations using pyuvdata.",
@@ -2773,14 +2810,12 @@ def test_select_with_lst(casa_uvfits, future_shapes):
         for (a1, a2) in zip(uv_object.ant_1_array, uv_object.ant_2_array)
     ]
     blts_lst_select = [lst in lsts_to_keep for lst in uv_object.lst_array]
-    Nblts_select = np.sum(
-        [
-            bi & (ai & pi) & li
-            for (bi, ai, pi, li) in zip(
-                blts_blt_select, blts_ant_select, blts_pair_select, blts_lst_select
-            )
-        ]
-    )
+    Nblts_select = np.sum([
+        bi & (ai & pi) & li
+        for (bi, ai, pi, li) in zip(
+            blts_blt_select, blts_ant_select, blts_pair_select, blts_lst_select
+        )
+    ])
 
     uv_object2 = uv_object.copy()
     uv_object2.select(
@@ -2814,7 +2849,8 @@ def test_select_with_lst(casa_uvfits, future_shapes):
         assert p in pols_to_keep
 
     assert uvutils._check_histories(
-        old_history + "  Downselected to "
+        old_history
+        + "  Downselected to "
         "specific baseline-times, antennas, "
         "baselines, lsts, frequencies, "
         "polarizations using pyuvdata.",
@@ -2838,7 +2874,8 @@ def test_select_not_inplace(casa_uvfits):
     uv1 = uv_object.select(freq_chans=np.arange(32), inplace=False)
     uv1 += uv_object.select(freq_chans=np.arange(32, 64), inplace=False)
     assert uvutils._check_histories(
-        old_history + "  Downselected to "
+        old_history
+        + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis "
         "using pyuvdata.",
@@ -3446,7 +3483,8 @@ def test_sum_vis(casa_uvfits, future_shapes):
 
     assert np.array_equal(uv_summed.data_array, uv_full.data_array)
     assert uvutils._check_histories(
-        uv_half.history + " Visibilities summed using pyuvdata. Unique part of second "
+        uv_half.history
+        + " Visibilities summed using pyuvdata. Unique part of second "
         "object history follows.  testing the history.",
         uv_summed.history,
     )
@@ -3465,8 +3503,9 @@ def test_sum_vis(casa_uvfits, future_shapes):
 
     assert np.array_equal(uv_summed.data_array, uv_full.data_array)
     assert uvutils._check_histories(
-        uv_half.history + " Visibilities summed using pyuvdata. Second object history "
-        "follows. " + uv_half_mod.history,
+        uv_half.history
+        + " Visibilities summed using pyuvdata. Second object history follows. "
+        + uv_half_mod.history,
         uv_summed.history,
     )
 
@@ -3489,14 +3528,22 @@ def test_sum_vis(casa_uvfits, future_shapes):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-            "Keyword SPECSYS in _extra_keywords is different in the two objects. "
-            "Taking the first object's entry.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
+            (
+                "Keyword SPECSYS in _extra_keywords is different in the two objects. "
+                "Taking the first object's entry."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv_merged_keys = uv_keys.sum_vis(uv_full)
@@ -3569,7 +3616,8 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv1 += uv2
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis "
         "using pyuvdata.",
@@ -3590,8 +3638,10 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
         [DeprecationWarning] + [UserWarning] * 4,
         match=[
             "flex_spw_id_array is not set. It will be required starting in version 3.0",
-            "One object has the flex_spw_id_array set and one does not. Combined "
-            "object will have it set.",
+            (
+                "One object has the flex_spw_id_array set and one does not. Combined "
+                "object will have it set."
+            ),
         ]
         + ["The uvw_array does not match the expected values"] * 3,
     ):
@@ -3606,7 +3656,8 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(polarizations=uv2.polarization_array[2:4])
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific polarizations using pyuvdata. "
         "Combined data along polarization axis "
         "using pyuvdata.",
@@ -3632,7 +3683,8 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(times=times[len(times) // 2 :])
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific times using pyuvdata. "
         "Combined data along baseline-time axis "
         "using pyuvdata.",
@@ -3652,7 +3704,8 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(blt_inds=ind2)
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific baseline-times using pyuvdata. "
         "Combined data along baseline-time axis "
         "using pyuvdata.",
@@ -3689,7 +3742,8 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv1 += uv3
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific baseline-times using pyuvdata. "
         "Combined data along baseline-time axis "
         "using pyuvdata. Combined data along "
@@ -3712,27 +3766,24 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     )
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific times, polarizations using "
         "pyuvdata. Combined data along "
         "baseline-time, polarization axis "
         "using pyuvdata.",
         uv1.history,
     )
-    blt_ind1 = np.array(
-        [
-            ind
-            for ind in range(uv_full.Nblts)
-            if uv_full.time_array[ind] in times[0 : len(times) // 2]
-        ]
-    )
-    blt_ind2 = np.array(
-        [
-            ind
-            for ind in range(uv_full.Nblts)
-            if uv_full.time_array[ind] in times[len(times) // 2 :]
-        ]
-    )
+    blt_ind1 = np.array([
+        ind
+        for ind in range(uv_full.Nblts)
+        if uv_full.time_array[ind] in times[0 : len(times) // 2]
+    ])
+    blt_ind2 = np.array([
+        ind
+        for ind in range(uv_full.Nblts)
+        if uv_full.time_array[ind] in times[len(times) // 2 :]
+    ])
     # Zero out missing data in reference object
     if future_shapes:
         uv_ref.data_array[blt_ind1, :, 2:] = 0.0
@@ -3760,27 +3811,24 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(times=times[len(times) // 2 :], freq_chans=np.arange(32, 64))
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific times, frequencies using "
         "pyuvdata. Combined data along "
         "baseline-time, frequency axis using "
         "pyuvdata.",
         uv1.history,
     )
-    blt_ind1 = np.array(
-        [
-            ind
-            for ind in range(uv_full.Nblts)
-            if uv_full.time_array[ind] in times[0 : len(times) // 2]
-        ]
-    )
-    blt_ind2 = np.array(
-        [
-            ind
-            for ind in range(uv_full.Nblts)
-            if uv_full.time_array[ind] in times[len(times) // 2 :]
-        ]
-    )
+    blt_ind1 = np.array([
+        ind
+        for ind in range(uv_full.Nblts)
+        if uv_full.time_array[ind] in times[0 : len(times) // 2]
+    ])
+    blt_ind2 = np.array([
+        ind
+        for ind in range(uv_full.Nblts)
+        if uv_full.time_array[ind] in times[len(times) // 2 :]
+    ])
     # Zero out missing data in reference object
     if future_shapes:
         uv_ref.data_array[blt_ind1, 32:, :] = 0.0
@@ -3807,7 +3855,8 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(times=times[len(times) // 2 :])
     uv1 = uv1 + uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific times using pyuvdata. "
         "Combined data along baseline-time "
         "axis using pyuvdata.",
@@ -3824,13 +3873,19 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
             "Combined frequencies are not evenly spaced",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv1.__add__(uv2)
@@ -3842,13 +3897,19 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
             "Combined frequencies are separated by more than their channel width.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv1.__iadd__(uv2)
@@ -3861,12 +3922,18 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv1.__iadd__(uv2)
@@ -3878,12 +3945,18 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv1.__iadd__(uv2)
@@ -3896,7 +3969,8 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.history += " testing the history. AIPS WTSCAL = 1.0"
     uv_new = uv1 + uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
+        uv_full.history
+        + "  Downselected to specific polarizations using pyuvdata. "
         "Combined data along polarization axis using pyuvdata. Unique part of next "
         "object history follows.  testing the history.",
         uv_new.history,
@@ -3906,9 +3980,11 @@ def test_add(casa_uvfits, hera_uvh5_xx, future_shapes):
 
     uv_new = uv1.__add__(uv2, verbose_history=True)
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
+        uv_full.history
+        + "  Downselected to specific polarizations using pyuvdata. "
         "Combined data along polarization axis using pyuvdata. Next object history "
-        "follows.  " + uv2.history,
+        "follows.  "
+        + uv2.history,
         uv_new.history,
     )
 
@@ -3938,7 +4014,8 @@ def test_add_unprojected(casa_uvfits):
     uv1 += uv2
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency "
         "axis using pyuvdata.",
@@ -3954,7 +4031,8 @@ def test_add_unprojected(casa_uvfits):
     uv2.select(polarizations=uv2.polarization_array[2:4])
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific polarizations using pyuvdata. "
         "Combined data along polarization "
         "axis using pyuvdata.",
@@ -3971,7 +4049,8 @@ def test_add_unprojected(casa_uvfits):
     uv2.select(times=times[len(times) // 2 :])
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific times using pyuvdata. "
         "Combined data along baseline-time "
         "axis using pyuvdata.",
@@ -3991,7 +4070,8 @@ def test_add_unprojected(casa_uvfits):
     uv2.select(blt_inds=ind2)
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific baseline-times using pyuvdata. "
         "Combined data along baseline-time "
         "axis using pyuvdata.",
@@ -4013,27 +4093,24 @@ def test_add_unprojected(casa_uvfits):
     )
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific times, polarizations using "
         "pyuvdata. Combined data along "
         "baseline-time, polarization "
         "axis using pyuvdata.",
         uv1.history,
     )
-    blt_ind1 = np.array(
-        [
-            ind
-            for ind in range(uv_full.Nblts)
-            if uv_full.time_array[ind] in times[0 : len(times) // 2]
-        ]
-    )
-    blt_ind2 = np.array(
-        [
-            ind
-            for ind in range(uv_full.Nblts)
-            if uv_full.time_array[ind] in times[len(times) // 2 :]
-        ]
-    )
+    blt_ind1 = np.array([
+        ind
+        for ind in range(uv_full.Nblts)
+        if uv_full.time_array[ind] in times[0 : len(times) // 2]
+    ])
+    blt_ind2 = np.array([
+        ind
+        for ind in range(uv_full.Nblts)
+        if uv_full.time_array[ind] in times[len(times) // 2 :]
+    ])
     # Zero out missing data in reference object
     uv_ref.data_array[blt_ind1, :, 2:] = 0.0
     uv_ref.nsample_array[blt_ind1, :, 2:] = 0.0
@@ -4053,27 +4130,24 @@ def test_add_unprojected(casa_uvfits):
     uv2.select(times=times[len(times) // 2 :], freq_chans=np.arange(32, 64))
     uv1 += uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific times, frequencies using "
         "pyuvdata. Combined data along "
         "baseline-time, frequency "
         "axis using pyuvdata.",
         uv1.history,
     )
-    blt_ind1 = np.array(
-        [
-            ind
-            for ind in range(uv_full.Nblts)
-            if uv_full.time_array[ind] in times[0 : len(times) // 2]
-        ]
-    )
-    blt_ind2 = np.array(
-        [
-            ind
-            for ind in range(uv_full.Nblts)
-            if uv_full.time_array[ind] in times[len(times) // 2 :]
-        ]
-    )
+    blt_ind1 = np.array([
+        ind
+        for ind in range(uv_full.Nblts)
+        if uv_full.time_array[ind] in times[0 : len(times) // 2]
+    ])
+    blt_ind2 = np.array([
+        ind
+        for ind in range(uv_full.Nblts)
+        if uv_full.time_array[ind] in times[len(times) // 2 :]
+    ])
     # Zero out missing data in reference object
     uv_ref.data_array[blt_ind1, 32:, :] = 0.0
     uv_ref.nsample_array[blt_ind1, 32:, :] = 0.0
@@ -4092,7 +4166,8 @@ def test_add_unprojected(casa_uvfits):
     uv2.select(times=times[len(times) // 2 :])
     uv1 = uv1 + uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific times using pyuvdata. "
         "Combined data along baseline-time "
         "axis using pyuvdata.",
@@ -4136,7 +4211,8 @@ def test_add_unprojected(casa_uvfits):
     uv2.history += " testing the history. AIPS WTSCAL = 1.0"
     uv_new = uv1 + uv2
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
+        uv_full.history
+        + "  Downselected to specific polarizations using pyuvdata. "
         "Combined data along polarization axis using pyuvdata.  Unique part of next "
         "object history follows.  testing the history.",
         uv_new.history,
@@ -4146,9 +4222,11 @@ def test_add_unprojected(casa_uvfits):
 
     uv_new = uv1.__add__(uv2, verbose_history=True)
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
+        uv_full.history
+        + "  Downselected to specific polarizations using pyuvdata. "
         "Combined data along polarization axis using pyuvdata. Next object history "
-        "follows." + uv2.history,
+        "follows."
+        + uv2.history,
         uv_new.history,
     )
 
@@ -4171,10 +4249,12 @@ def test_check_flex_spw_contiguous_error(sma_mir):
     sma_mir.flex_spw_id_array[0] = 1
     with pytest.raises(
         ValueError,
-        match="Channels from different spectral windows are interspersed with "
-        "one another, rather than being grouped together along the "
-        "frequency axis. Most file formats do not support such "
-        "non-grouping of data.",
+        match=(
+            "Channels from different spectral windows are interspersed with "
+            "one another, rather than being grouped together along the "
+            "frequency axis. Most file formats do not support such "
+            "non-grouping of data."
+        ),
     ):
         sma_mir._check_flex_spw_contiguous()
 
@@ -4357,7 +4437,8 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv1.fast_concat([uv2, uv3], "freq", inplace=True)
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis "
         "using pyuvdata.",
@@ -4385,8 +4466,10 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
         * 4
         + [
             "Combined frequencies are not evenly spaced",
-            "Some objects have the flex_spw_id_array set and some do not. Combined "
-            "object will have it set.",
+            (
+                "Some objects have the flex_spw_id_array set and some do not. Combined "
+                "object will have it set."
+            ),
             "flex_spw_id_array is not set. It will be required starting in version 3.0",
         ],
     ):
@@ -4422,7 +4505,8 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv3.select(polarizations=uv3.polarization_array[3:4])
     uv1.fast_concat([uv2, uv3], "polarization", inplace=True)
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific polarizations using pyuvdata. "
         "Combined data along polarization axis "
         "using pyuvdata.",
@@ -4467,7 +4551,8 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv3.select(times=times[(len(times) // 3) * 2 :])
     uv1.fast_concat([uv2, uv3], "blt", inplace=True)
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific times using pyuvdata. "
         "Combined data along baseline-time axis "
         "using pyuvdata.",
@@ -4486,7 +4571,8 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(blt_inds=ind2)
     uv1.fast_concat(uv2, "blt", inplace=True)
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific baseline-times using pyuvdata. "
         "Combined data along baseline-time axis "
         "using pyuvdata.",
@@ -4538,7 +4624,8 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.fast_concat(uv1, "blt", inplace=True)
 
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific baseline-times using pyuvdata. "
         "Combined data along baseline-time "
         "axis using pyuvdata.",
@@ -4606,7 +4693,8 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.select(times=times[len(times) // 2 :])
     uv1 = uv1.fast_concat(uv2, "blt", inplace=False)
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific times using pyuvdata. "
         "Combined data along baseline-time "
         "axis using pyuvdata.",
@@ -4623,13 +4711,19 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
             "Combined frequencies are not evenly spaced",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv1.fast_concat(uv1, "freq", inplace=True)
@@ -4641,13 +4735,19 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
             "Combined frequencies are separated by more than their channel width",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv1.fast_concat(uv2, "freq")
@@ -4659,8 +4759,7 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.freq_array += uv2._channel_width.tols[1] / 2.0
     with uvtest.check_warnings(
         UserWarning,
-        "The uvw_array does not match the expected values given the antenna "
-        "positions.",
+        "The uvw_array does not match the expected values given the antenna positions.",
         nwarnings=3,
     ):
         uv1.fast_concat(uv2, "freq")
@@ -4672,13 +4771,19 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
             "Combined polarizations are not evenly spaced",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv1.fast_concat(uv2, "polarization")
@@ -4691,7 +4796,8 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
     uv2.history += " testing the history. AIPS WTSCAL = 1.0"
     uv_new = uv1.fast_concat(uv2, "polarization")
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
+        uv_full.history
+        + "  Downselected to specific polarizations using pyuvdata. "
         "Combined data along polarization axis using pyuvdata. Unique part of next "
         "object history follows. testing the history.",
         uv_new.history,
@@ -4701,9 +4807,11 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx, future_shapes):
 
     uv_new = uv1.fast_concat(uv2, "polarization", verbose_history=True)
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to specific polarizations using pyuvdata. "
+        uv_full.history
+        + "  Downselected to specific polarizations using pyuvdata. "
         "Combined data along polarization axis using pyuvdata. Next object history "
-        "follows." + uv2.history,
+        "follows."
+        + uv2.history,
         uv_new.history,
     )
 
@@ -4830,7 +4938,7 @@ def test_key2inds(casa_uvfits):
     assert np.array_equal(np.arange(uv.Nblts), ind1)
     assert np.array_equal(np.array([]), ind2)
     assert np.array_equal(np.array([1]), indp[0])
-    ind1, ind2, indp = uv._key2inds(("LL"))
+    ind1, ind2, indp = uv._key2inds("LL")
     assert np.array_equal(np.arange(uv.Nblts), ind1)
     assert np.array_equal(np.array([]), ind2)
     assert np.array_equal(np.array([1]), indp[0])
@@ -4964,8 +5072,10 @@ def test_smart_slicing_err(casa_uvfits):
     # Test invalid squeeze
     with pytest.raises(
         ValueError,
-        match='"notasqueeze" is not a valid option for squeeze.Only "default", "none", '
-        'or "full" are allowed.',
+        match=(
+            '"notasqueeze" is not a valid option for squeeze.Only "default", "none", '
+            'or "full" are allowed.'
+        ),
     ):
         casa_uvfits._smart_slicing(
             casa_uvfits.data_array, [0, 4, 5], [], ([0, 1], []), squeeze="notasqueeze"
@@ -5526,8 +5636,10 @@ def test_telescope_loc_xyz_check(paper_uvh5, tmp_path):
         UserWarning,
         [
             "The uvw_array does not match the expected",
-            "itrs position vector magnitudes must be on the order "
-            "of the radius of Earth -- they appear to lie well below this.",
+            (
+                "itrs position vector magnitudes must be on the order "
+                "of the radius of Earth -- they appear to lie well below this."
+            ),
         ],
     ):
         uv.read(fname, use_future_array_shapes=True)
@@ -5637,8 +5749,10 @@ def test_parse_ants(casa_uvfits, hera_uvh5_xx):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "Warning: Antenna number 10 passed, but not present in the ant_1_array or "
-            "ant_2_array",
+            (
+                "Warning: Antenna number 10 passed, but not present in the ant_1_array"
+                " or ant_2_array"
+            ),
             "Warning: Polarization XX,XY is not present in the polarization_array",
         ],
     ):
@@ -5924,10 +6038,14 @@ def test_select_with_ant_str(casa_uvfits, hera_uvh5_xx):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "Warning: Antenna number 10 passed, but not present in the "
-            "ant_1_array or ant_2_array",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "Warning: Antenna number 10 passed, but not present in the "
+                "ant_1_array or ant_2_array"
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv.select(ant_str=ant_str, inplace=inplace)
@@ -5995,8 +6113,10 @@ def test_select_with_ant_str(casa_uvfits, hera_uvh5_xx):
         UserWarning,
         [
             "Warning: Polarization XX,XY is not present in the polarization_array",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv.select(ant_str=ant_str, inplace=inplace)
@@ -6015,8 +6135,10 @@ def test_select_with_ant_str(casa_uvfits, hera_uvh5_xx):
         UserWarning,
         [
             "Warning: Polarization XX,YX is not present in the polarization_array",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv2 = uv.select(ant_str=ant_str, inplace=inplace)
@@ -6034,10 +6156,14 @@ def test_select_with_ant_str(casa_uvfits, hera_uvh5_xx):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "Warning: Antenna number 10 passed, but not present in the "
-            "ant_1_array or ant_2_array",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "Warning: Antenna number 10 passed, but not present in the "
+                "ant_1_array or ant_2_array"
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv2 = uv.select(ant_str=ant_str, inplace=inplace)
@@ -6215,23 +6341,31 @@ def test_select_with_ant_str(casa_uvfits, hera_uvh5_xx):
     [
         (
             {"ant_str": "", "antenna_nums": []},
-            "Cannot provide ant_str with antenna_nums, antenna_names, bls, or "
-            "polarizations.",
+            (
+                "Cannot provide ant_str with antenna_nums, antenna_names, bls, or "
+                "polarizations."
+            ),
         ),
         (
             {"ant_str": "", "antenna_names": []},
-            "Cannot provide ant_str with antenna_nums, antenna_names, bls, or "
-            "polarizations.",
+            (
+                "Cannot provide ant_str with antenna_nums, antenna_names, bls, or "
+                "polarizations."
+            ),
         ),
         (
             {"ant_str": "", "bls": []},
-            "Cannot provide ant_str with antenna_nums, antenna_names, bls, or "
-            "polarizations.",
+            (
+                "Cannot provide ant_str with antenna_nums, antenna_names, bls, or "
+                "polarizations."
+            ),
         ),
         (
             {"ant_str": "", "polarizations": []},
-            "Cannot provide ant_str with antenna_nums, antenna_names, bls, or "
-            "polarizations.",
+            (
+                "Cannot provide ant_str with antenna_nums, antenna_names, bls, or "
+                "polarizations."
+            ),
         ),
         ({"ant_str": "auto"}, "There is no data matching ant_str=auto in this object."),
         (
@@ -6307,12 +6441,9 @@ def test_redundancy_contract_expand(
         # the test file has groups that are either all not conjugated or all conjugated.
         # need to conjugate some so we have mixed groups to properly test the average
         # method.
-        (
-            orig_red_gps,
-            orig_centers,
-            orig_lengths,
-            orig_conjugates,
-        ) = uv0.get_redundancies(tol, include_conjugates=True)
+        (orig_red_gps, orig_centers, orig_lengths, orig_conjugates) = (
+            uv0.get_redundancies(tol, include_conjugates=True)
+        )
         blt_inds_to_conj = []
         for gp in orig_red_gps:
             if len(gp) > 1:
@@ -6640,10 +6771,14 @@ def test_redundancy_contract_expand_nblts_not_nbls_times_ntimes(method, casa_uvf
         UserWarning,
         [
             "Missing some redundant groups. Filling in available data.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv2.inflate_by_redundancy(tol=tol)
@@ -6947,8 +7082,10 @@ def test_overlapping_data_add(casa_uvfits, tmp_path, future_shapes):
     uvfull += uv3
     with pytest.raises(
         ValueError,
-        match="To combine these data, please run the add operation again, but with "
-        "the object whose data is to be overwritten as the first object",
+        match=(
+            "To combine these data, please run the add operation again, but with "
+            "the object whose data is to be overwritten as the first object"
+        ),
     ):
         uv4.__iadd__(uvfull)
     with pytest.raises(
@@ -8212,10 +8349,12 @@ def test_downsample_in_time_errors(hera_uvh5):
     uv_object2.phase(ra=0, dec=0, phase_frame="icrs", select_mask=mask, cat_name="foo")
     with pytest.raises(
         ValueError,
-        match="Multiple phase centers included in a downsampling window. Use `phase` "
-        "to phase to a single phase center or decrease the `min_int_time` or "
-        "`n_times_to_avg` parameter to avoid multiple phase centers being included in "
-        "a downsampling window.",
+        match=(
+            "Multiple phase centers included in a downsampling window. Use `phase` to"
+            " phase to a single phase center or decrease the `min_int_time` or"
+            " `n_times_to_avg` parameter to avoid multiple phase centers being included"
+            " in a downsampling window."
+        ),
     ):
         uv_object2.downsample_in_time(n_times_to_avg=2)
 
@@ -8254,8 +8393,11 @@ def test_downsample_in_time_errors(hera_uvh5):
         UserWarning,
         match=[
             "There is a gap in the times of baseline",
-            "The lst_array is not self-consistent with the time_array and telescope "
-            "location. Consider recomputing with the `set_lsts_from_time_array` method",
+            (
+                "The lst_array is not self-consistent with the time_array and telescope"
+                " location. Consider recomputing with the `set_lsts_from_time_array`"
+                " method"
+            ),
         ],
     ):
         uv_object.downsample_in_time(min_int_time=min_integration_time)
@@ -8918,14 +9060,12 @@ def test_frequency_average(casa_uvfits, future_shapes, flex_spw, sum_corr):
         # Make multiple spws
         uvobj._set_flex_spw()
         spw_nchan = int(uvobj.Nfreqs / 4)
-        uvobj.flex_spw_id_array = np.concatenate(
-            (
-                np.full(spw_nchan, 0, dtype=int),
-                np.full(spw_nchan, 1, dtype=int),
-                np.full(spw_nchan, 2, dtype=int),
-                np.full(spw_nchan, 3, dtype=int),
-            )
-        )
+        uvobj.flex_spw_id_array = np.concatenate((
+            np.full(spw_nchan, 0, dtype=int),
+            np.full(spw_nchan, 1, dtype=int),
+            np.full(spw_nchan, 2, dtype=int),
+            np.full(spw_nchan, 3, dtype=int),
+        ))
         uvobj.spw_array = np.arange(4)
         uvobj.Nspws = 4
         if not future_shapes:
@@ -9023,14 +9163,12 @@ def test_frequency_average_uneven(
         # Make multiple spws
         uvobj._set_flex_spw()
         spw_nchan = int(uvobj.Nfreqs / 4)
-        uvobj.flex_spw_id_array = np.concatenate(
-            (
-                np.full(spw_nchan, 0, dtype=int),
-                np.full(spw_nchan, 1, dtype=int),
-                np.full(spw_nchan, 2, dtype=int),
-                np.full(spw_nchan, 3, dtype=int),
-            )
-        )
+        uvobj.flex_spw_id_array = np.concatenate((
+            np.full(spw_nchan, 0, dtype=int),
+            np.full(spw_nchan, 1, dtype=int),
+            np.full(spw_nchan, 2, dtype=int),
+            np.full(spw_nchan, 3, dtype=int),
+        ))
         uvobj.spw_array = np.arange(4)
         uvobj.Nspws = 4
         if not future_shapes:
@@ -9748,8 +9886,10 @@ def test_multifile_read_errors(read_func, filelist):
     uv = UVData()
     with pytest.raises(
         ValueError,
-        match="Reading multiple files from class specific read functions is no "
-        "longer supported.",
+        match=(
+            "Reading multiple files from class specific read functions is no "
+            "longer supported."
+        ),
     ):
         getattr(uv, read_func)(filelist)
 
@@ -10003,10 +10143,12 @@ def test_parse_ants_x_orientation_kwarg(hera_uvh5):
 def test_getattr_error(casa_uvfits):
     with pytest.raises(
         ValueError,
-        match="The older phase attributes, including phase_type, phase_center_ra, "
-        "phase_center_dec, phase_center_frame, phase_center_epoch, object_name cannot "
-        "be used with data phased with the new method. This was phased with the new "
-        "method because it has fk5 phase frames.",
+        match=(
+            "The older phase attributes, including phase_type, phase_center_ra,"
+            " phase_center_dec, phase_center_frame, phase_center_epoch, object_name"
+            " cannot be used with data phased with the new method. This was phased with"
+            " the new method because it has fk5 phase frames."
+        ),
     ):
         casa_uvfits.phase_type
 
@@ -10016,38 +10158,50 @@ def test_getattr_error(casa_uvfits):
     [
         (
             "phase_type",
-            " The phase_type is now represented as the 'cat_type' in the "
-            "phase_center_catalog (the old 'drift' type corresponds to the "
-            "new 'unprojected' type, the old 'phased' type corresponds to the "
-            "new 'sidereal' type, and there is also now support for an 'ephem' "
-            "type to support moving objects and a new 'driftscan' type which "
-            "can point at any alt/az (not just zenith) and which always has "
-            "w-projection applied).",
+            (
+                " The phase_type is now represented as the 'cat_type' in the "
+                "phase_center_catalog (the old 'drift' type corresponds to the "
+                "new 'unprojected' type, the old 'phased' type corresponds to the "
+                "new 'sidereal' type, and there is also now support for an 'ephem' "
+                "type to support moving objects and a new 'driftscan' type which "
+                "can point at any alt/az (not just zenith) and which always has "
+                "w-projection applied)."
+            ),
         ),
         (
             "phase_center_ra",
-            " The phase_center_ra is now represented as the 'cat_lon' in the "
-            "phase_center_catalog.",
+            (
+                " The phase_center_ra is now represented as the 'cat_lon' in the "
+                "phase_center_catalog."
+            ),
         ),
         (
             "phase_center_dec",
-            " The phase_center_dec is now represented as the 'cat_lat' in the "
-            "phase_center_catalog.",
+            (
+                " The phase_center_dec is now represented as the 'cat_lat' in the "
+                "phase_center_catalog."
+            ),
         ),
         (
             "phase_center_frame",
-            " The phase_center_frame is now represented as the 'cat_frame' in the "
-            "phase_center_catalog.",
+            (
+                " The phase_center_frame is now represented as the 'cat_frame' in the "
+                "phase_center_catalog."
+            ),
         ),
         (
             "phase_center_epoch",
-            " The phase_center_epoch is now represented as the 'cat_epoch' in the "
-            "phase_center_catalog.",
+            (
+                " The phase_center_epoch is now represented as the 'cat_epoch' in the "
+                "phase_center_catalog."
+            ),
         ),
         (
             "object_name",
-            " The object_name is now represented as the 'cat_name' in the "
-            "phase_center_catalog.",
+            (
+                " The object_name is now represented as the 'cat_name' in the "
+                "phase_center_catalog."
+            ),
         ),
     ],
 )
@@ -10624,8 +10778,10 @@ def test_split_phase_center_err_multiname(carma_miriad):
         [
             [0, 1.5],
             TypeError,
-            "catalog_identifier must be a string, an integer or a list of strings or "
-            "integers.",
+            (
+                "catalog_identifier must be a string, an integer or a list of strings"
+                " or integers."
+            ),
         ],
     ),
 )
@@ -11130,7 +11286,8 @@ def test_fix_phase(hera_uvh5, tmp_path, future_shapes, use_ant_pos, phase_frame)
             outfile = os.path.join(tmp_path, "test_bad_phase.uv")
             with uvtest.check_warnings(
                 UserWarning,
-                "writing default values for restfreq, vsource, veldop, jyperk, and systemp",
+                "writing default values for restfreq, vsource, veldop, jyperk, and"
+                " systemp",
             ):
                 uv_in_bad_copy.write_miriad(outfile, clobber=True)
 
@@ -11161,9 +11318,9 @@ def test_fix_phase(hera_uvh5, tmp_path, future_shapes, use_ant_pos, phase_frame)
         uv_in_bad2.gst0 = None
         uv_in_bad2.rdate = None
         uv_in_bad2.timesys = None
-    uv_in_bad2.phase_center_catalog[1][
-        "info_source"
-    ] = uv_in_bad_copy.phase_center_catalog[1]["info_source"]
+    uv_in_bad2.phase_center_catalog[1]["info_source"] = (
+        uv_in_bad_copy.phase_center_catalog[1]["info_source"]
+    )
     uv_in_bad2.extra_keywords = uv_in_bad_copy.extra_keywords
     assert uv_in_bad2 == uv_in_bad_copy
 
@@ -11192,8 +11349,10 @@ def test_fix_phase_error(hera_uvh5):
 
     with pytest.raises(
         ValueError,
-        match="Objects with driftscan phase centers were not phased with the old "
-        "method, so no fixing is required.",
+        match=(
+            "Objects with driftscan phase centers were not phased with the old "
+            "method, so no fixing is required."
+        ),
     ):
         uv_in.fix_phase()
 
@@ -11434,8 +11593,9 @@ def test_eq_allowed_failures(bda_test_file, capsys):
     uv2.x_orientation = "EAST"
     assert uv1.__eq__(uv2, check_extra=True, allowed_failures=["x_orientation"])
     captured = capsys.readouterr()
-    assert captured.out == (
-        "x_orientation parameter value is a string, values are different\n"
+    assert (
+        captured.out
+        == "x_orientation parameter value is a string, values are different\n"
         "parameter _x_orientation does not match, but is not required to for equality. "
         "Left is NORTH, right is EAST.\n"
     )
@@ -11459,8 +11619,9 @@ def test_eq_allowed_failures_filename(bda_test_file, capsys):
     uv2.filename = ["bar.uvh5"]
     assert uv1 == uv2
     captured = capsys.readouterr()
-    assert captured.out == (
-        "filename parameter value is a list of strings, values are different\n"
+    assert (
+        captured.out
+        == "filename parameter value is a list of strings, values are different\n"
         "parameter _filename does not match, but is not required to for equality. "
         "Left is ['foo.uvh5'], right is ['bar.uvh5'].\n"
     )
@@ -11481,8 +11642,9 @@ def test_eq_allowed_failures_filename_string(bda_test_file, capsys):
     uv2.filename = ["bar.uvh5"]
     assert uv1.__eq__(uv2, allowed_failures="filename")
     captured = capsys.readouterr()
-    assert captured.out == (
-        "filename parameter value is a list of strings, values are different\n"
+    assert (
+        captured.out
+        == "filename parameter value is a list of strings, values are different\n"
         "parameter _filename does not match, but is not required to for equality. "
         "Left is ['foo.uvh5'], right is ['bar.uvh5'].\n"
     )
@@ -11836,16 +11998,23 @@ def test_set_nsamples_wrong_shape_error(hera_uvh5):
         ["zen.2458661.23480.HH.uvh5", ""],
         [
             "sma_test.mir",
-            "The lst_array is not self-consistent with the time_array and telescope "
-            "location. Consider recomputing with the `set_lsts_from_time_array` method",
+            (
+                "The lst_array is not self-consistent with the time_array and telescope"
+                " location. Consider recomputing with the `set_lsts_from_time_array`"
+                " method"
+            ),
         ],
         [
             "carma_miriad",
             [
-                "Altitude is not present in Miriad file, using known location values "
-                "for SZA.",
-                "The uvw_array does not match the expected values given the antenna "
-                "positions.",
+                (
+                    "Altitude is not present in Miriad file, using known location"
+                    " values for SZA."
+                ),
+                (
+                    "The uvw_array does not match the expected values given the antenna"
+                    " positions."
+                ),
             ]
             + [
                 f"{extra_key} in extra_keywords is a list, array or dict, which will "
@@ -11855,13 +12024,17 @@ def test_set_nsamples_wrong_shape_error(hera_uvh5):
         ],
         [
             "1133866760.uvfits",
-            "Fixing auto-correlations to be be real-only, after some imaginary values "
-            "were detected in data_array.",
+            (
+                "Fixing auto-correlations to be be real-only, after some imaginary"
+                " values were detected in data_array."
+            ),
         ],
         [
             fhd_files,
-            "Telescope location derived from obs lat/lon/alt values does not match the "
-            "location in the layout file.",
+            (
+                "Telescope location derived from obs lat/lon/alt values does not match"
+                " the location in the layout file."
+            ),
         ],
     ],
 )
@@ -11987,9 +12160,11 @@ def test_convert_remove_flex_pol_error(uv_phase_comp):
     uvd2.flex_spw_polarization_array[1] = uvd2.flex_spw_polarization_array[0]
     with pytest.raises(
         ValueError,
-        match="Some spectral windows have identical frequencies, "
-        "channel widths and polarizations, so spws cannot be "
-        "combined. Set combine_spws=False to avoid this error.",
+        match=(
+            "Some spectral windows have identical frequencies, "
+            "channel widths and polarizations, so spws cannot be "
+            "combined. Set combine_spws=False to avoid this error."
+        ),
     ):
         uvd2.remove_flex_pol()
 
@@ -12182,9 +12357,9 @@ def test_flex_pol_uvh5(future_shapes, multispw, sorting, uv_phase_comp, tmp_path
         for idx, spw in enumerate(uvd2.spw_array):
             new_spw = spw_renumber_dict[spw]
             new_spw_array[idx] = new_spw
-            uvd2.flex_spw_id_array[
-                np.nonzero(uvd2.flex_spw_id_array == spw)[0]
-            ] = new_spw
+            uvd2.flex_spw_id_array[np.nonzero(uvd2.flex_spw_id_array == spw)[0]] = (
+                new_spw
+            )
         uvd2.spw_array = new_spw_array
         uvd2.check()
 
@@ -12483,9 +12658,11 @@ def test_init_like_hera_cal(
         hera_uvh5._set_app_coords_helper()
         warn_type = [DeprecationWarning, DeprecationWarning, UserWarning]
         msg = [
-            "The phase_center_catalog was not set and a complete set of old phase "
-            "attributes (phase_type, phase_center_ra, phase_center_dec, "
-            "phase_center_frame, phase_center_epoch, object_name)",
+            (
+                "The phase_center_catalog was not set and a complete set of old phase "
+                "attributes (phase_type, phase_center_ra, phase_center_dec, "
+                "phase_center_frame, phase_center_epoch, object_name)"
+            ),
             "flex_spw_id_array is not set. It will be required starting in version 3.0",
             "The uvw_array does not match the expected values",
         ]
@@ -12493,8 +12670,10 @@ def test_init_like_hera_cal(
     else:
         warn_type = [DeprecationWarning]
         msg = [
-            "The phase_center_catalog was not set and a complete set of old phase "
-            "attributes (phase_type",
+            (
+                "The phase_center_catalog was not set and a complete set of old phase "
+                "attributes (phase_type"
+            ),
             "flex_spw_id_array is not set. It will be required starting in version 3.0",
         ]
 
@@ -12530,8 +12709,10 @@ def test_init_like_hera_cal(
         # already set will issue the correct warning (and do nothing)
         with uvtest.check_warnings(
             DeprecationWarning,
-            match="phase_center_catalog is already set, so object_name, which is an "
-            "old phase attribute, cannot be set.",
+            match=(
+                "phase_center_catalog is already set, so object_name, which is an "
+                "old phase attribute, cannot be set."
+            ),
         ):
             uvd.object_name = "foo"
 

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -11128,7 +11128,11 @@ def test_fix_phase(hera_uvh5, tmp_path, future_shapes, use_ant_pos, phase_frame)
             uv_in_bad_copy.write_uvfits(outfile)
         elif file_type == "miriad":
             outfile = os.path.join(tmp_path, "test_bad_phase.uv")
-            uv_in_bad_copy.write_miriad(outfile)
+            with uvtest.check_warnings(
+                UserWarning,
+                "writing default values for restfreq, vsource, veldop, jyperk, and systemp",
+            ):
+                uv_in_bad_copy.write_miriad(outfile, clobber=True)
 
     with uvtest.check_warnings(read_warn_type, match=read_warn_msg):
         with warnings.catch_warnings():

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -1679,8 +1679,6 @@ def test_miriad_convention(casa_uvfits, tmp_path):
     testfile1 = str(tmp_path / "uv1.uvfits")
     uv.write_uvfits(testfile1, use_miriad_convention=True)
 
-
-
     # These are based on known values in casa_tutorial_uvfits
     expected_vals = {"ANTENNA1_0": 4, "ANTENNA2_0": 8, "NOSTA_0": 1}
 

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -1694,3 +1694,19 @@ def test_miriad_convention(casa_uvfits, tmp_path):
     assert hdu[0].data["ANTENNA1"][0] == expected_vals["ANTENNA1_0"]
     assert hdu[0].data["ANTENNA2"][0] == expected_vals["ANTENNA2_0"]
     assert hdu[1].data["NOSTA"][0] == expected_vals["NOSTA_0"]
+
+    # Test that antennas get +1 if there is a 0-indexed antennas
+    old_idx = uv.antenna_numbers[0]
+    new_idx = 0
+    uv.antenna_numbers[0] = new_idx
+    uv.ant_1_array[uv.ant_1_array == old_idx] = new_idx
+    uv.ant_2_array[uv.ant_2_array == old_idx] = new_idx
+
+    testfile1 = str(tmp_path / "uv1.uvfits")
+    uv.write_uvfits(testfile1, use_miriad_convention=True)
+
+    hdu = fits.open(testfile1)
+
+    assert hdu[0].data["ANTENNA1"][0] == expected_vals["ANTENNA1_0"] + 1
+    assert hdu[0].data["ANTENNA2"][0] == expected_vals["ANTENNA2_0"] + 1
+    assert hdu[1].data["NOSTA"][0] == 1 #expected_vals["NOSTA_0"]

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -1629,7 +1629,7 @@ def test_miriad_convention(casa_uvfits, tmp_path):
     uv.read(casa_tutorial_uvfits)
 
     # Change an antenna ID to 512
-    old_idx = uv.antenna_numbers[10]     # This is antenna 19
+    old_idx = uv.antenna_numbers[10]  # This is antenna 19
     new_idx = 512
 
     uv.antenna_numbers[10] = new_idx
@@ -1642,15 +1642,12 @@ def test_miriad_convention(casa_uvfits, tmp_path):
     hdu = fits.open(testfile1)
 
     # These are based on known values in casa_tutorial_uvfits
-    expected_vals = {
-        'ANTENNA1_0': 4,
-        'ANTENNA2_0': 8,
-        'NOSTA_0': 2
-    }
+    expected_vals = {"ANTENNA1_0": 4, "ANTENNA2_0": 8, "NOSTA_0": 1}
 
     # Check baselines match MIRIAD convention
-    bl_miriad_expected = uvutils.antnums_to_baseline(uv.ant_1_array, uv.ant_2_array, 
-                                                     512, use_miriad_convention=True)
+    bl_miriad_expected = uvutils.antnums_to_baseline(
+        uv.ant_1_array, uv.ant_2_array, 512, use_miriad_convention=True
+    )
     assert np.allclose(hdu[0].data["BASELINE"], bl_miriad_expected)
 
     # Quick check of other antenna values

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -1333,8 +1333,7 @@ def test_multi_files(casa_uvfits, tmp_path):
 
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis "
         "using pyuvdata.",
@@ -1374,8 +1373,7 @@ def test_multi_files_axis(casa_uvfits, tmp_path):
     uv1.read([testfile1, testfile2], axis="freq", use_future_array_shapes=True)
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis "
         "using pyuvdata.",
@@ -1419,8 +1417,7 @@ def test_multi_files_metadata_only(casa_uvfits, tmp_path):
 
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history
-        + "  Downselected to "
+        uv_full.history + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis "
         "using pyuvdata.",
@@ -1607,10 +1604,12 @@ def test_uvfits_extra_params(sma_mir, tmp_path):
 
     spw_dict = dict(zip(sma_uvfits.spw_array, sma_mir.spw_array))
 
-    assert np.all([
-        idx == spw_dict[jdx]
-        for idx, jdx in zip(sma_mir.flex_spw_id_array, sma_uvfits.flex_spw_id_array)
-    ])
+    assert np.all(
+        [
+            idx == spw_dict[jdx]
+            for idx, jdx in zip(sma_mir.flex_spw_id_array, sma_uvfits.flex_spw_id_array)
+        ]
+    )
     sma_uvfits.spw_array = sma_mir.spw_array
     sma_uvfits.flex_spw_id_array = sma_mir.flex_spw_id_array
 

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -1709,4 +1709,4 @@ def test_miriad_convention(casa_uvfits, tmp_path):
 
     assert hdu[0].data["ANTENNA1"][0] == expected_vals["ANTENNA1_0"] + 1
     assert hdu[0].data["ANTENNA2"][0] == expected_vals["ANTENNA2_0"] + 1
-    assert hdu[1].data["NOSTA"][0] == 1 #expected_vals["NOSTA_0"]
+    assert hdu[1].data["NOSTA"][0] == 1  # expected_vals["NOSTA_0"]

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -1236,7 +1236,14 @@ def test_read_uvfits_write_miriad(casa_uvfits, tmp_path):
     uvfits_uv = casa_uvfits
     miriad_uv = UVData()
     testfile = str(tmp_path / "outtest_miriad")
-    uvfits_uv.write_miriad(testfile, clobber=True)
+    with uvtest.check_warnings(
+        UserWarning,
+        [
+            "The uvw_array does not match the expected values given the antenna positions.",
+            "writing default values for restfreq, vsource, veldop, jyperk, and systemp",
+        ],
+    ):
+        uvfits_uv.write_miriad(testfile, clobber=True)
     miriad_uv.read_miriad(testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
@@ -1260,7 +1267,14 @@ def test_read_uvfits_write_miriad(casa_uvfits, tmp_path):
 
     # check that setting it works after selecting a single time
     uvfits_uv.select(times=uvfits_uv.time_array[0])
-    uvfits_uv.write_miriad(testfile, clobber=True)
+    with uvtest.check_warnings(
+        UserWarning,
+        [
+            "The uvw_array does not match the expected values given the antenna positions.",
+            "writing default values for restfreq, vsource, veldop, jyperk, and systemp",
+        ],
+    ):
+        uvfits_uv.write_miriad(testfile, clobber=True)
     miriad_uv.read_miriad(testfile, use_future_array_shapes=True)
 
     # make sure filenames are what we expect
@@ -1621,6 +1635,10 @@ def test_uvfits_phasing_errors(hera_uvh5, tmp_path):
 
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.filterwarnings(
+    "ignore:The shapes of several attributes will be changing "
+    "in the future to remove the deprecated spectral window axis."
+)
 def test_miriad_convention(casa_uvfits, tmp_path):
     """
     Test writing a MIRIAD-compatible UVFITS file

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -1617,3 +1617,17 @@ def test_uvfits_phasing_errors(hera_uvh5, tmp_path):
         ValueError, match="The data are not all phased to a sidereal source"
     ):
         hera_uvh5.write_uvfits(tmp_path)
+
+
+@pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_miriad_convention(casa_uvfits, tmp_path):
+    """
+    Reading multiple files at once using "axis" keyword.
+    """
+    uv_full = casa_uvfits
+    testfile1 = str(tmp_path / "uv1.uvfits")
+    uv_full.write_uvfits(testfile1, use_miriad_convention=True)
+
+    hdu = fits.open(testfile1)
+    print(hdu[0].data["BASELINE"])

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -1679,7 +1679,7 @@ def test_miriad_convention(casa_uvfits, tmp_path):
     testfile1 = str(tmp_path / "uv1.uvfits")
     uv.write_uvfits(testfile1, use_miriad_convention=True)
 
-    hdu = fits.open(testfile1)
+
 
     # These are based on known values in casa_tutorial_uvfits
     expected_vals = {"ANTENNA1_0": 4, "ANTENNA2_0": 8, "NOSTA_0": 1}
@@ -1688,12 +1688,13 @@ def test_miriad_convention(casa_uvfits, tmp_path):
     bl_miriad_expected = uvutils.antnums_to_baseline(
         uv.ant_1_array, uv.ant_2_array, 512, use_miriad_convention=True
     )
-    assert np.allclose(hdu[0].data["BASELINE"], bl_miriad_expected)
+    with fits.open(testfile1) as hdu:
+        assert np.allclose(hdu[0].data["BASELINE"], bl_miriad_expected)
 
-    # Quick check of other antenna values
-    assert hdu[0].data["ANTENNA1"][0] == expected_vals["ANTENNA1_0"]
-    assert hdu[0].data["ANTENNA2"][0] == expected_vals["ANTENNA2_0"]
-    assert hdu[1].data["NOSTA"][0] == expected_vals["NOSTA_0"]
+        # Quick check of other antenna values
+        assert hdu[0].data["ANTENNA1"][0] == expected_vals["ANTENNA1_0"]
+        assert hdu[0].data["ANTENNA2"][0] == expected_vals["ANTENNA2_0"]
+        assert hdu[1].data["NOSTA"][0] == expected_vals["NOSTA_0"]
 
     # Test that antennas get +1 if there is a 0-indexed antennas
     old_idx = uv.antenna_numbers[0]
@@ -1702,11 +1703,10 @@ def test_miriad_convention(casa_uvfits, tmp_path):
     uv.ant_1_array[uv.ant_1_array == old_idx] = new_idx
     uv.ant_2_array[uv.ant_2_array == old_idx] = new_idx
 
-    testfile1 = str(tmp_path / "uv1.uvfits")
+    testfile1 = str(tmp_path / "uv2.uvfits")
     uv.write_uvfits(testfile1, use_miriad_convention=True)
 
-    hdu = fits.open(testfile1)
-
-    assert hdu[0].data["ANTENNA1"][0] == expected_vals["ANTENNA1_0"] + 1
-    assert hdu[0].data["ANTENNA2"][0] == expected_vals["ANTENNA2_0"] + 1
-    assert hdu[1].data["NOSTA"][0] == 1  # expected_vals["NOSTA_0"]
+    with fits.open(testfile1) as hdu:
+        assert hdu[0].data["ANTENNA1"][0] == expected_vals["ANTENNA1_0"] + 1
+        assert hdu[0].data["ANTENNA2"][0] == expected_vals["ANTENNA2_0"] + 1
+        assert hdu[1].data["NOSTA"][0] == 1  # expected_vals["NOSTA_0"]

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -217,8 +217,10 @@ def test_break_read_uvfits(tmp_path):
 
     with pytest.raises(
         ValueError,
-        match="Telescope frame in file is foo. Only 'itrs' and 'mcmf' are currently "
-        "supported.",
+        match=(
+            "Telescope frame in file is foo. Only 'itrs' and 'mcmf' are currently "
+            "supported."
+        ),
     ):
         uvobj.read(write_file, read_data=False, use_future_array_shapes=True)
 
@@ -619,8 +621,10 @@ def test_uvw_coordinate_suffixes(casa_uvfits, tmp_path, uvw_suffix):
             UserWarning,
             match=[
                 "Telescope EVLA is not in known_telescopes.",
-                "The baseline coordinates (uvws) in this file are specified in the "
-                "---NCP coordinate system",
+                (
+                    "The baseline coordinates (uvws) in this file are specified in the "
+                    "---NCP coordinate system"
+                ),
                 "The uvw_array does not match the expected values",
             ],
         ):
@@ -771,10 +775,14 @@ def test_readwriteread_large_antnums(tmp_path, casa_uvfits):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna "
-            "positions",
-            "Found antenna numbers > 255 in this data set. This is permitted by "
-            "UVFITS ",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions"
+            ),
+            (
+                "Found antenna numbers > 255 in this data set. This is permitted by "
+                "UVFITS "
+            ),
             "antnums_to_baseline: found antenna numbers > 255, using 2048 baseline",
         ],
     ):
@@ -837,12 +845,16 @@ def test_readwriteread_missing_info(tmp_path, casa_uvfits, lat_lon_alt):
     with uvtest.check_warnings(
         UserWarning,
         match=[
-            "The telescope frame is set to '????', which generally indicates "
-            "ignorance. Defaulting the frame to 'itrs', but this may lead to other "
-            "warnings or errors.",
+            (
+                "The telescope frame is set to '????', which generally indicates "
+                "ignorance. Defaulting the frame to 'itrs', but this may lead to other "
+                "warnings or errors."
+            ),
             "Telescope EVLA is not in known_telescopes.",
-            "The uvw_array does not match the expected values given the antenna "
-            "positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions."
+            ),
         ],
     ):
         uv_out.read(write_file2, use_future_array_shapes=True)
@@ -863,7 +875,7 @@ def test_readwriteread_error_timesys(tmp_path, casa_uvfits):
     with pytest.raises(ValueError) as cm:
         uv_in.write_uvfits(write_file)
     assert str(cm.value).startswith(
-        "This file has a time system IAT. " 'Only "UTC" time system files are supported'
+        'This file has a time system IAT. Only "UTC" time system files are supported'
     )
 
     return
@@ -943,8 +955,10 @@ def test_readwriteread_unflagged_data_warnings(tmp_path, casa_uvfits):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna "
-            "positions",
+            (
+                "The uvw_array does not match the expected values given the antenna "
+                "positions"
+            ),
             "Some unflagged data has nsample = 0",
         ],
     ):
@@ -1022,8 +1036,10 @@ def test_extra_keywords_errors(
             ["str", "comment"],
             [
                 "hello",
-                "this is a very long comment that will be broken into several "
-                "lines\nif everything works properly.",
+                (
+                    "this is a very long comment that will be broken into several "
+                    "lines\nif everything works properly."
+                ),
             ],
         ],
     ),
@@ -1239,7 +1255,10 @@ def test_read_uvfits_write_miriad(casa_uvfits, tmp_path):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna"
+                " positions."
+            ),
             "writing default values for restfreq, vsource, veldop, jyperk, and systemp",
         ],
     ):
@@ -1270,7 +1289,10 @@ def test_read_uvfits_write_miriad(casa_uvfits, tmp_path):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "The uvw_array does not match the expected values given the antenna positions.",
+            (
+                "The uvw_array does not match the expected values given the antenna"
+                " positions."
+            ),
             "writing default values for restfreq, vsource, veldop, jyperk, and systemp",
         ],
     ):
@@ -1311,7 +1333,8 @@ def test_multi_files(casa_uvfits, tmp_path):
 
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis "
         "using pyuvdata.",
@@ -1351,7 +1374,8 @@ def test_multi_files_axis(casa_uvfits, tmp_path):
     uv1.read([testfile1, testfile2], axis="freq", use_future_array_shapes=True)
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis "
         "using pyuvdata.",
@@ -1395,7 +1419,8 @@ def test_multi_files_metadata_only(casa_uvfits, tmp_path):
 
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
-        uv_full.history + "  Downselected to "
+        uv_full.history
+        + "  Downselected to "
         "specific frequencies using pyuvdata. "
         "Combined data along frequency axis "
         "using pyuvdata.",
@@ -1582,12 +1607,10 @@ def test_uvfits_extra_params(sma_mir, tmp_path):
 
     spw_dict = dict(zip(sma_uvfits.spw_array, sma_mir.spw_array))
 
-    assert np.all(
-        [
-            idx == spw_dict[jdx]
-            for idx, jdx in zip(sma_mir.flex_spw_id_array, sma_uvfits.flex_spw_id_array)
-        ]
-    )
+    assert np.all([
+        idx == spw_dict[jdx]
+        for idx, jdx in zip(sma_mir.flex_spw_id_array, sma_uvfits.flex_spw_id_array)
+    ])
     sma_uvfits.spw_array = sma_mir.spw_array
     sma_uvfits.flex_spw_id_array = sma_mir.flex_spw_id_array
 

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -1319,10 +1319,13 @@ def test_multi_files(casa_uvfits, tmp_path):
     uv_full = casa_uvfits
     testfile1 = str(tmp_path / "uv1.uvfits")
     testfile2 = str(tmp_path / "uv2.uvfits")
+
     uv1 = uv_full.copy()
     uv2 = uv_full.copy()
+
     uv1.select(freq_chans=np.arange(0, 32))
     uv2.select(freq_chans=np.arange(32, 64))
+
     uv1.write_uvfits(testfile1)
     uv2.write_uvfits(testfile2)
     uv1.read(
@@ -1363,10 +1366,13 @@ def test_multi_files_axis(casa_uvfits, tmp_path):
     uv_full = casa_uvfits
     testfile1 = str(tmp_path / "uv1.uvfits")
     testfile2 = str(tmp_path / "uv2.uvfits")
+
     uv1 = uv_full.copy()
     uv2 = uv_full.copy()
+
     uv1.select(freq_chans=np.arange(0, 32))
     uv2.select(freq_chans=np.arange(32, 64))
+
     uv1.write_uvfits(testfile1)
     uv2.write_uvfits(testfile2)
 
@@ -1622,6 +1628,7 @@ def test_uvfits_extra_params(sma_mir, tmp_path):
     for cat_name in sma_mir.phase_center_catalog.keys():
         this_cat = sma_mir.phase_center_catalog[cat_name]
         other_cat = sma_uvfits.phase_center_catalog[cat_name]
+
         assert np.isclose(this_cat["cat_lat"], other_cat["cat_lat"])
         assert np.isclose(this_cat["cat_lon"], other_cat["cat_lon"])
     sma_uvfits.phase_center_catalog = sma_mir.phase_center_catalog

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -1623,11 +1623,37 @@ def test_uvfits_phasing_errors(hera_uvh5, tmp_path):
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_miriad_convention(casa_uvfits, tmp_path):
     """
-    Reading multiple files at once using "axis" keyword.
+    Test writing a MIRIAD-compatible UVFITS file
     """
-    uv_full = casa_uvfits
+    uv = UVData()
+    uv.read(casa_tutorial_uvfits)
+
+    # Change an antenna ID to 512
+    old_idx = uv.antenna_numbers[10]     # This is antenna 19
+    new_idx = 512
+
+    uv.antenna_numbers[10] = new_idx
+    uv.ant_1_array[uv.ant_1_array == old_idx] = new_idx
+    uv.ant_2_array[uv.ant_2_array == old_idx] = new_idx
+
     testfile1 = str(tmp_path / "uv1.uvfits")
-    uv_full.write_uvfits(testfile1, use_miriad_convention=True)
+    uv.write_uvfits(testfile1, use_miriad_convention=True)
 
     hdu = fits.open(testfile1)
-    print(hdu[0].data["BASELINE"])
+
+    # These are based on known values in casa_tutorial_uvfits
+    expected_vals = {
+        'ANTENNA1_0': 4,
+        'ANTENNA2_0': 8,
+        'NOSTA_0': 2
+    }
+
+    # Check baselines match MIRIAD convention
+    bl_miriad_expected = uvutils.antnums_to_baseline(uv.ant_1_array, uv.ant_2_array, 
+                                                     512, use_miriad_convention=True)
+    assert np.allclose(hdu[0].data["BASELINE"], bl_miriad_expected)
+
+    # Quick check of other antenna values
+    assert hdu[0].data["ANTENNA1"][0] == expected_vals["ANTENNA1_0"]
+    assert hdu[0].data["ANTENNA2"][0] == expected_vals["ANTENNA2_0"]
+    assert hdu[1].data["NOSTA"][0] == expected_vals["NOSTA_0"]

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -200,8 +200,9 @@ class UVData(UVBase):
 
         self._Nspws = uvp.UVParameter(
             "Nspws",
-            description="Number of spectral windows "
-            "(ie non-contiguous spectral chunks). ",
+            description=(
+                "Number of spectral windows (ie non-contiguous spectral chunks). "
+            ),
             expected_type=int,
         )
 
@@ -1721,9 +1722,9 @@ class UVData(UVBase):
                     )
 
         # Set everything to the first cat ID in the list
-        self.phase_center_id_array[
-            np.isin(self.phase_center_id_array, cat_id_list)
-        ] = cat_id_list[0]
+        self.phase_center_id_array[np.isin(self.phase_center_id_array, cat_id_list)] = (
+            cat_id_list[0]
+        )
 
         # Finally, remove the defunct cat IDs
         for cat_id in cat_id_list[1:]:
@@ -1842,99 +1843,79 @@ class UVData(UVBase):
         col_list.append(
             {"hdr": ("ID", "#"), "fmt": "% 4i", "field": " %4s ", "name": "cat_id"}
         )
-        col_list.append(
-            {
-                "hdr": ("Cat Entry", "Name"),
-                "fmt": "%12s",
-                "field": " %12s ",
-                "name": "cat_name",
-            }
-        )
+        col_list.append({
+            "hdr": ("Cat Entry", "Name"),
+            "fmt": "%12s",
+            "field": " %12s ",
+            "name": "cat_name",
+        })
         col_list.append(
             {"hdr": ("Type", ""), "fmt": "%12s", "field": " %12s ", "name": "cat_type"}
         )
 
         if any_lon:
-            col_list.append(
-                {
-                    "hdr": ("Az/Lon/RA", "hours" if hms_format else "deg"),
-                    "fmt": "% 3i:%02i:%05.2f",
-                    "field": (" %12s " if hms_format else " %13s "),
-                    "name": "cat_lon",
-                }
-            )
+            col_list.append({
+                "hdr": ("Az/Lon/RA", "hours" if hms_format else "deg"),
+                "fmt": "% 3i:%02i:%05.2f",
+                "field": " %12s " if hms_format else " %13s ",
+                "name": "cat_lon",
+            })
         if any_lat:
-            col_list.append(
-                {
-                    "hdr": ("El/Lat/Dec", "deg"),
-                    "fmt": "%1s%2i:%02i:%05.2f",
-                    "field": " %12s ",
-                    "name": "cat_lat",
-                }
-            )
+            col_list.append({
+                "hdr": ("El/Lat/Dec", "deg"),
+                "fmt": "%1s%2i:%02i:%05.2f",
+                "field": " %12s ",
+                "name": "cat_lat",
+            })
         if any_frame:
-            col_list.append(
-                {
-                    "hdr": ("Frame", ""),
-                    "fmt": "%5s",
-                    "field": " %5s ",
-                    "name": "cat_frame",
-                }
-            )
+            col_list.append({
+                "hdr": ("Frame", ""),
+                "fmt": "%5s",
+                "field": " %5s ",
+                "name": "cat_frame",
+            })
         if any_epoch:
-            col_list.append(
-                {
-                    "hdr": ("Epoch", ""),
-                    "fmt": "%7s",
-                    "field": " %7s ",
-                    "name": "cat_epoch",
-                }
-            )
+            col_list.append({
+                "hdr": ("Epoch", ""),
+                "fmt": "%7s",
+                "field": " %7s ",
+                "name": "cat_epoch",
+            })
         if any_times:
-            col_list.append(
-                {
-                    "hdr": ("   Ephem Range   ", "Start-MJD    End-MJD"),
-                    "fmt": " %8.2f  % 8.2f",
-                    "field": " %20s ",
-                    "name": "cat_times",
-                }
-            )
+            col_list.append({
+                "hdr": ("   Ephem Range   ", "Start-MJD    End-MJD"),
+                "fmt": " %8.2f  % 8.2f",
+                "field": " %20s ",
+                "name": "cat_times",
+            })
         if any_pm_ra:
-            col_list.append(
-                {
-                    "hdr": ("PM-Ra", "mas/yr"),
-                    "fmt": "%.4g",
-                    "field": " %6s ",
-                    "name": "cat_pm_ra",
-                }
-            )
+            col_list.append({
+                "hdr": ("PM-Ra", "mas/yr"),
+                "fmt": "%.4g",
+                "field": " %6s ",
+                "name": "cat_pm_ra",
+            })
         if any_pm_dec:
-            col_list.append(
-                {
-                    "hdr": ("PM-Dec", "mas/yr"),
-                    "fmt": "%.4g",
-                    "field": " %6s ",
-                    "name": "cat_pm_dec",
-                }
-            )
+            col_list.append({
+                "hdr": ("PM-Dec", "mas/yr"),
+                "fmt": "%.4g",
+                "field": " %6s ",
+                "name": "cat_pm_dec",
+            })
         if any_dist:
-            col_list.append(
-                {
-                    "hdr": ("Dist", "pc"),
-                    "fmt": "%.1e",
-                    "field": " %7s ",
-                    "name": "cat_dist",
-                }
-            )
+            col_list.append({
+                "hdr": ("Dist", "pc"),
+                "fmt": "%.1e",
+                "field": " %7s ",
+                "name": "cat_dist",
+            })
         if any_vrad:
-            col_list.append(
-                {
-                    "hdr": ("V_rad", "km/s"),
-                    "fmt": "%.4g",
-                    "field": " %6s ",
-                    "name": "cat_vrad",
-                }
-            )
+            col_list.append({
+                "hdr": ("V_rad", "km/s"),
+                "fmt": "%.4g",
+                "field": " %6s ",
+                "name": "cat_vrad",
+            })
 
         top_str = ""
         bot_str = ""
@@ -3091,12 +3072,10 @@ class UVData(UVBase):
         # Only these pols have "true" auto-correlations, that we'd expect
         # to be real only. Select on only them
         auto_pol_list = ["xx", "yy", "rr", "ll", "pI", "pQ", "pU", "pV"]
-        pol_screen = np.array(
-            [
-                uvutils.POL_NUM2STR_DICT[pol] in auto_pol_list
-                for pol in self.polarization_array
-            ]
-        )
+        pol_screen = np.array([
+            uvutils.POL_NUM2STR_DICT[pol] in auto_pol_list
+            for pol in self.polarization_array
+        ])
 
         # Make sure we actually have work to do here, otherwise skip all of this
         if (np.any(pol_screen) and np.any(auto_screen)) and not (
@@ -3455,12 +3434,10 @@ class UVData(UVBase):
                 # to be real only. Select on only them
                 auto_pol_list = ["xx", "yy", "rr", "ll", "pI", "pQ", "pU", "pV"]
                 if self.flex_spw_polarization_array is not None:
-                    pol_screen = np.array(
-                        [
-                            uvutils.POL_NUM2STR_DICT[pol] in auto_pol_list
-                            for pol in self.flex_spw_polarization_array
-                        ]
-                    )
+                    pol_screen = np.array([
+                        uvutils.POL_NUM2STR_DICT[pol] in auto_pol_list
+                        for pol in self.flex_spw_polarization_array
+                    ])
                     # There should be a better way...
                     spw_inds = np.zeros_like(self.flex_spw_id_array)
                     for spw_ind, spw in enumerate(self.spw_array):
@@ -3468,12 +3445,10 @@ class UVData(UVBase):
                         spw_inds[these_freq_inds] = spw_ind
                     freq_screen = pol_screen[spw_inds]
                 else:
-                    pol_screen = np.array(
-                        [
-                            uvutils.POL_NUM2STR_DICT[pol] in auto_pol_list
-                            for pol in self.polarization_array
-                        ]
-                    )
+                    pol_screen = np.array([
+                        uvutils.POL_NUM2STR_DICT[pol] in auto_pol_list
+                        for pol in self.polarization_array
+                    ])
 
                 # Check autos if they have imag component -- doing iscomplex first and
                 # then pol select was faster in every case checked in test files.
@@ -3603,7 +3578,9 @@ class UVData(UVBase):
         """
         return uvutils.baseline_to_antnums(baseline, self.Nants_telescope)
 
-    def antnums_to_baseline(self, ant1, ant2, attempt256=False, use_miriad_convention=False):
+    def antnums_to_baseline(
+        self, ant1, ant2, attempt256=False, use_miriad_convention=False
+    ):
         """
         Get the baseline number corresponding to two given antenna numbers.
 
@@ -3619,11 +3596,11 @@ class UVData(UVBase):
         use_miriad_convention : bool
             Option to use the MIRIAD convention where BASELINE id is
                 if ant2 < 256:
-                    bl = 256 * ant1 + ant2 
+                    bl = 256 * ant1 + ant2
                 else:
                     bl = 2048 * ant1 + ant2 + 2**16
             Note MIRIAD uses 1-indexed antenna IDs, but this code accepts 0-based.
-            
+
         Returns
         -------
         int or array of int
@@ -3632,7 +3609,10 @@ class UVData(UVBase):
         # set attempt256 to false if using miriad convention
         attempt256 = False if use_miriad_convention else attempt256
         return uvutils.antnums_to_baseline(
-            ant1, ant2, self.Nants_telescope, attempt256=attempt256, 
+            ant1,
+            ant2,
+            self.Nants_telescope,
+            attempt256=attempt256,
             use_miriad_convention=use_miriad_convention,
         )
 
@@ -3661,16 +3641,14 @@ class UVData(UVBase):
         if ant2 is None:
             if not isinstance(ant1, tuple):
                 raise ValueError(
-                    "antpair2ind must be fed an antpair tuple "
-                    "or expand it as arguments"
+                    "antpair2ind must be fed an antpair tuple or expand it as arguments"
                 )
             ant2 = ant1[1]
             ant1 = ant1[0]
         else:
             if not isinstance(ant1, (int, np.integer)):
                 raise ValueError(
-                    "antpair2ind must be fed an antpair tuple or "
-                    "expand it as arguments"
+                    "antpair2ind must be fed an antpair tuple or expand it as arguments"
                 )
         if not isinstance(ordered, (bool, np.bool_)):
             raise ValueError("ordered must be a boolean")
@@ -3813,8 +3791,9 @@ class UVData(UVBase):
             blt_ind2 = self.antpair2ind(key[1], key[0])
             if len(blt_ind1) + len(blt_ind2) == 0:
                 raise KeyError(
-                    "Antenna pair {pair} not found in "
-                    "data".format(pair=(key[0], key[1]))
+                    "Antenna pair {pair} not found in data".format(
+                        pair=(key[0], key[1])
+                    )
                 )
             if type(key[2]) is str:
                 # pol is str
@@ -4025,7 +4004,9 @@ class UVData(UVBase):
                     out = np.squeeze(out, axis=1)
         elif squeeze != "none":
             raise ValueError(
-                '"' + str(squeeze) + '" is not a valid option for squeeze.'
+                '"'
+                + str(squeeze)
+                + '" is not a valid option for squeeze.'
                 'Only "default", "none", or "full" are allowed.'
             )
 
@@ -4767,13 +4748,13 @@ class UVData(UVBase):
                 orig_data_array = copy.copy(self.data_array)
                 for pol_ind in np.arange(self.Npols):
                     if self.future_array_shapes:
-                        self.data_array[
-                            index_array, :, new_pol_inds[pol_ind]
-                        ] = np.conj(orig_data_array[index_array, :, pol_ind])
+                        self.data_array[index_array, :, new_pol_inds[pol_ind]] = (
+                            np.conj(orig_data_array[index_array, :, pol_ind])
+                        )
                     else:
-                        self.data_array[
-                            index_array, :, :, new_pol_inds[pol_ind]
-                        ] = np.conj(orig_data_array[index_array, :, :, pol_ind])
+                        self.data_array[index_array, :, :, new_pol_inds[pol_ind]] = (
+                            np.conj(orig_data_array[index_array, :, :, pol_ind])
+                        )
 
             ant_1_vals = self.ant_1_array[index_array]
             ant_2_vals = self.ant_2_array[index_array]
@@ -5470,9 +5451,9 @@ class UVData(UVBase):
         self.phase_center_app_ra[select_mask_use] = self.lst_array[
             select_mask_use
         ].copy()
-        self.phase_center_app_dec[
-            select_mask_use
-        ] = self.telescope_location_lat_lon_alt[0]
+        self.phase_center_app_dec[select_mask_use] = (
+            self.telescope_location_lat_lon_alt[0]
+        )
         self.phase_center_frame_pa[select_mask_use] = 0
 
         return
@@ -5521,16 +5502,12 @@ class UVData(UVBase):
         # instance of a UVData object.
         if lookup_name and (cat_name not in name_dict):
             if (cat_type is None) or (cat_type == "ephem"):
-                [
-                    cat_times,
-                    cat_lon,
-                    cat_lat,
-                    cat_dist,
-                    cat_vrad,
-                ] = uvutils.lookup_jplhorizons(
-                    cat_name,
-                    time_array,
-                    telescope_loc=self.telescope_location_lat_lon_alt,
+                [cat_times, cat_lon, cat_lat, cat_dist, cat_vrad] = (
+                    uvutils.lookup_jplhorizons(
+                        cat_name,
+                        time_array,
+                        telescope_loc=self.telescope_location_lat_lon_alt,
+                    )
                 )
                 cat_type = "ephem"
                 cat_pm_ra = cat_pm_dec = None
@@ -5633,16 +5610,12 @@ class UVData(UVBase):
             if check_ephem and (info_source == "jplh"):
                 # Concat the two time ranges to make sure that we cover both the
                 # requested time range _and_ the original time range.
-                [
-                    cat_times,
-                    cat_lon,
-                    cat_lat,
-                    cat_dist,
-                    cat_vrad,
-                ] = uvutils.lookup_jplhorizons(
-                    cat_name,
-                    np.concatenate((np.reshape(time_array, -1), cat_times)),
-                    telescope_loc=self.telescope_location_lat_lon_alt,
+                [cat_times, cat_lon, cat_lat, cat_dist, cat_vrad] = (
+                    uvutils.lookup_jplhorizons(
+                        cat_name,
+                        np.concatenate((np.reshape(time_array, -1), cat_times)),
+                        telescope_loc=self.telescope_location_lat_lon_alt,
+                    )
                 )
             elif check_ephem:
                 # The ephem was user-supplied during the call to the phase method,
@@ -6172,8 +6145,9 @@ class UVData(UVBase):
         compatible, reason = self._old_phase_attributes_compatible()
         if not compatible:
             raise ValueError(
-                "Objects with " + reason + " were not phased with the old "
-                "method, so no fixing is required."
+                "Objects with "
+                + reason
+                + " were not phased with the old method, so no fixing is required."
             )
 
         # Record the old values
@@ -6440,22 +6414,14 @@ class UVData(UVBase):
         # Create blt arrays for convenience
         prec_t = -2 * np.floor(np.log10(this._time_array.tols[-1])).astype(int)
         prec_b = 8
-        this_blts = np.array(
-            [
-                "_".join(
-                    ["{1:.{0}f}".format(prec_t, blt[0]), str(blt[1]).zfill(prec_b)]
-                )
-                for blt in zip(this.time_array, this.baseline_array)
-            ]
-        )
-        other_blts = np.array(
-            [
-                "_".join(
-                    ["{1:.{0}f}".format(prec_t, blt[0]), str(blt[1]).zfill(prec_b)]
-                )
-                for blt in zip(other.time_array, other.baseline_array)
-            ]
-        )
+        this_blts = np.array([
+            "_".join(["{1:.{0}f}".format(prec_t, blt[0]), str(blt[1]).zfill(prec_b)])
+            for blt in zip(this.time_array, this.baseline_array)
+        ])
+        other_blts = np.array([
+            "_".join(["{1:.{0}f}".format(prec_t, blt[0]), str(blt[1]).zfill(prec_b)])
+            for blt in zip(other.time_array, other.baseline_array)
+        ])
         # Check we don't have overlapping data
         both_pol, this_pol_ind, other_pol_ind = np.intersect1d(
             this.polarization_array, other.polarization_array, return_indices=True
@@ -6718,8 +6684,7 @@ class UVData(UVBase):
                 params_match = getattr(this, cp) == getattr(other, cp)
             if not params_match:
                 msg = (
-                    "UVParameter " + cp[1:] + " does not match. "
-                    "Cannot combine objects."
+                    "UVParameter " + cp[1:] + " does not match. Cannot combine objects."
                 )
                 raise ValueError(msg)
 
@@ -6850,12 +6815,10 @@ class UVData(UVBase):
                         [this_flexpol_dict[key] for key in this.spw_array]
                     )
                 # Need to sort out the order of the individual windows first.
-                f_order = np.concatenate(
-                    [
-                        np.where(this.flex_spw_id_array == idx)[0]
-                        for idx in sorted(this.spw_array)
-                    ]
-                )
+                f_order = np.concatenate([
+                    np.where(this.flex_spw_id_array == idx)[0]
+                    for idx in sorted(this.spw_array)
+                ])
 
                 # With spectral windows sorted, check and see if channels within
                 # windows need sorting. If they are ordered in ascending or descending
@@ -6919,13 +6882,11 @@ class UVData(UVBase):
             p_order = np.argsort(np.abs(this.polarization_array))
             if not self.metadata_only:
                 if this.future_array_shapes:
-                    zero_pad = np.zeros(
-                        (
-                            this.data_array.shape[0],
-                            this.data_array.shape[1],
-                            len(pnew_inds),
-                        )
-                    )
+                    zero_pad = np.zeros((
+                        this.data_array.shape[0],
+                        this.data_array.shape[1],
+                        len(pnew_inds),
+                    ))
                     this.data_array = np.concatenate(
                         [this.data_array, zero_pad], axis=2
                     )
@@ -6936,14 +6897,12 @@ class UVData(UVBase):
                         [this.flag_array, 1 - zero_pad], axis=2
                     ).astype(np.bool_)
                 else:
-                    zero_pad = np.zeros(
-                        (
-                            this.data_array.shape[0],
-                            1,
-                            this.data_array.shape[2],
-                            len(pnew_inds),
-                        )
-                    )
+                    zero_pad = np.zeros((
+                        this.data_array.shape[0],
+                        1,
+                        this.data_array.shape[2],
+                        len(pnew_inds),
+                    ))
                     this.data_array = np.concatenate(
                         [this.data_array, zero_pad], axis=3
                     )
@@ -6980,20 +6939,20 @@ class UVData(UVBase):
         if not self.metadata_only:
             if this.future_array_shapes:
                 this.data_array[np.ix_(blt_t2o, freq_t2o, pol_t2o)] = other.data_array
-                this.nsample_array[
-                    np.ix_(blt_t2o, freq_t2o, pol_t2o)
-                ] = other.nsample_array
+                this.nsample_array[np.ix_(blt_t2o, freq_t2o, pol_t2o)] = (
+                    other.nsample_array
+                )
                 this.flag_array[np.ix_(blt_t2o, freq_t2o, pol_t2o)] = other.flag_array
             else:
-                this.data_array[
-                    np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)
-                ] = other.data_array
-                this.nsample_array[
-                    np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)
-                ] = other.nsample_array
-                this.flag_array[
-                    np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)
-                ] = other.flag_array
+                this.data_array[np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)] = (
+                    other.data_array
+                )
+                this.nsample_array[np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)] = (
+                    other.nsample_array
+                )
+                this.flag_array[np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)] = (
+                    other.flag_array
+                )
 
             # Fix ordering
             baxis_num = 0
@@ -7646,8 +7605,9 @@ class UVData(UVBase):
                     param = "_" + param
                 if param not in compatibility_params:
                     msg = (
-                        "Provided parameter " + param[1:] + " is not a recognizable "
-                        "UVParameter."
+                        "Provided parameter "
+                        + param[1:]
+                        + " is not a recognizable UVParameter."
                     )
                     raise ValueError(msg)
                 remove_params.append(param)
@@ -7661,8 +7621,9 @@ class UVData(UVBase):
             params_match = getattr(this, param) == getattr(other, param)
             if not params_match:
                 msg = (
-                    "UVParameter " + param[1:] + " does not match. Cannot "
-                    "combine objects."
+                    "UVParameter "
+                    + param[1:]
+                    + " does not match. Cannot combine objects."
                 )
                 raise ValueError(msg)
 
@@ -7672,7 +7633,9 @@ class UVData(UVBase):
         ):
             if this.extra_keywords[intersection] != other.extra_keywords[intersection]:
                 warnings.warn(
-                    "Keyword " + intersection + " in _extra_keywords is different "
+                    "Keyword "
+                    + intersection
+                    + " in _extra_keywords is different "
                     "in the two objects. Taking the first object's entry."
                 )
 
@@ -8709,26 +8672,23 @@ class UVData(UVBase):
             uv_obj = self.copy()
 
         # Figure out which index positions we want to hold on to.
-        (
-            blt_inds,
-            freq_inds,
-            pol_inds,
-            history_update_string,
-        ) = uv_obj._select_preprocess(
-            antenna_nums,
-            antenna_names,
-            ant_str,
-            bls,
-            frequencies,
-            freq_chans,
-            times,
-            time_range,
-            lsts,
-            lst_range,
-            polarizations,
-            blt_inds,
-            phase_center_ids,
-            catalog_names,
+        (blt_inds, freq_inds, pol_inds, history_update_string) = (
+            uv_obj._select_preprocess(
+                antenna_nums,
+                antenna_names,
+                ant_str,
+                bls,
+                frequencies,
+                freq_chans,
+                times,
+                time_range,
+                lsts,
+                lst_range,
+                polarizations,
+                blt_inds,
+                phase_center_ids,
+                catalog_names,
+            )
         )
 
         # Call the low-level selection method.
@@ -9076,8 +9036,9 @@ class UVData(UVBase):
 
         # add to the history
         history_update_string = (
-            " Upsampled data to {:f} second integration time "
-            "using pyuvdata.".format(max_int_time)
+            " Upsampled data to {:f} second integration time using pyuvdata.".format(
+                max_int_time
+            )
         )
         self.history = self.history + history_update_string
 
@@ -9580,8 +9541,9 @@ class UVData(UVBase):
             )
         else:
             history_update_string = (
-                " Downsampled data by a factor of {} in "
-                "time using pyuvdata.".format(n_times_to_avg)
+                " Downsampled data by a factor of {} in time using pyuvdata.".format(
+                    n_times_to_avg
+                )
             )
         self.history = self.history + history_update_string
 
@@ -9946,9 +9908,9 @@ class UVData(UVBase):
                             reg_mask[ax0_inds, this_chan, :, ax2_inds], axis=1
                         )
                         ff_inds = np.nonzero(fully_flagged)
-                        reg_mask[
-                            ax0_inds[ff_inds], this_chan, :, ax2_inds[ff_inds]
-                        ] = False
+                        reg_mask[ax0_inds[ff_inds], this_chan, :, ax2_inds[ff_inds]] = (
+                            False
+                        )
                 if this_ragged:
                     ax0_inds, ax2_inds = np.nonzero(
                         final_flag_array[:, final_spw_chans[spw][-1], :]
@@ -10280,12 +10242,10 @@ class UVData(UVBase):
                     )
                     conj_inds = conj_group_inds[np.array(conj_orientation)]
                     # check that the integration times are all the same
-                    int_times = np.concatenate(
-                        (
-                            self.integration_time[regular_inds],
-                            self.integration_time[conj_inds],
-                        )
-                    )
+                    int_times = np.concatenate((
+                        self.integration_time[regular_inds],
+                        self.integration_time[conj_inds],
+                    ))
                     if not np.all(
                         np.abs(int_times - new_obj.integration_time[obj_time_ind])
                         < new_obj._integration_time.tols[1]
@@ -10297,18 +10257,14 @@ class UVData(UVBase):
                         )
 
                     if not self.metadata_only:
-                        vis_to_avg = np.concatenate(
-                            (
-                                self.data_array[regular_inds],
-                                np.conj(self.data_array[conj_inds]),
-                            )
-                        )
-                        nsample_to_avg = np.concatenate(
-                            (
-                                self.nsample_array[regular_inds],
-                                self.nsample_array[conj_inds],
-                            )
-                        )
+                        vis_to_avg = np.concatenate((
+                            self.data_array[regular_inds],
+                            np.conj(self.data_array[conj_inds]),
+                        ))
+                        nsample_to_avg = np.concatenate((
+                            self.nsample_array[regular_inds],
+                            self.nsample_array[conj_inds],
+                        ))
                         flags_to_avg = np.concatenate(
                             (self.flag_array[regular_inds], self.flag_array[conj_inds])
                         )
@@ -12001,7 +11957,7 @@ class UVData(UVBase):
 
         if antenna_names is not None and antenna_nums is not None:
             raise ValueError(
-                "Only one of antenna_nums and antenna_names can " "be provided."
+                "Only one of antenna_nums and antenna_names can be provided."
             )
 
         if multi:
@@ -12880,7 +12836,7 @@ class UVData(UVBase):
             Option to use the MIRIAD baseline convention, and write to BASELINE column.
             This supports up to 2048 antennas, where baseline ID is given by
                 if ant2 < 256:
-                    bl = 256 * ant1 + ant2 
+                    bl = 256 * ant1 + ant2
                 else:
                     bl = 2048 * ant1 + ant2 + 2**16
             Note antennas should be 1-indexed (start at 1, not 0). This mode is required
@@ -13279,12 +13235,10 @@ class UVData(UVBase):
         for pol in pol_list:
             try:
                 feed_pols = uvutils.POL_TO_FEED_DICT[uvutils.POL_NUM2STR_DICT[pol]]
-                pol_groups.append(
-                    [
-                        pol_list.index(uvutils.POL_STR2NUM_DICT[item + item])
-                        for item in feed_pols
-                    ]
-                )
+                pol_groups.append([
+                    pol_list.index(uvutils.POL_STR2NUM_DICT[item + item])
+                    for item in feed_pols
+                ])
             except KeyError:
                 # If we run into a key error, it means that one of the dicts above does
                 # not have a match to the given polarization, in which case assume that

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -1722,9 +1722,9 @@ class UVData(UVBase):
                     )
 
         # Set everything to the first cat ID in the list
-        self.phase_center_id_array[np.isin(self.phase_center_id_array, cat_id_list)] = (
-            cat_id_list[0]
-        )
+        self.phase_center_id_array[
+            np.isin(self.phase_center_id_array, cat_id_list)
+        ] = cat_id_list[0]
 
         # Finally, remove the defunct cat IDs
         for cat_id in cat_id_list[1:]:
@@ -1843,79 +1843,99 @@ class UVData(UVBase):
         col_list.append(
             {"hdr": ("ID", "#"), "fmt": "% 4i", "field": " %4s ", "name": "cat_id"}
         )
-        col_list.append({
-            "hdr": ("Cat Entry", "Name"),
-            "fmt": "%12s",
-            "field": " %12s ",
-            "name": "cat_name",
-        })
+        col_list.append(
+            {
+                "hdr": ("Cat Entry", "Name"),
+                "fmt": "%12s",
+                "field": " %12s ",
+                "name": "cat_name",
+            }
+        )
         col_list.append(
             {"hdr": ("Type", ""), "fmt": "%12s", "field": " %12s ", "name": "cat_type"}
         )
 
         if any_lon:
-            col_list.append({
-                "hdr": ("Az/Lon/RA", "hours" if hms_format else "deg"),
-                "fmt": "% 3i:%02i:%05.2f",
-                "field": " %12s " if hms_format else " %13s ",
-                "name": "cat_lon",
-            })
+            col_list.append(
+                {
+                    "hdr": ("Az/Lon/RA", "hours" if hms_format else "deg"),
+                    "fmt": "% 3i:%02i:%05.2f",
+                    "field": " %12s " if hms_format else " %13s ",
+                    "name": "cat_lon",
+                }
+            )
         if any_lat:
-            col_list.append({
-                "hdr": ("El/Lat/Dec", "deg"),
-                "fmt": "%1s%2i:%02i:%05.2f",
-                "field": " %12s ",
-                "name": "cat_lat",
-            })
+            col_list.append(
+                {
+                    "hdr": ("El/Lat/Dec", "deg"),
+                    "fmt": "%1s%2i:%02i:%05.2f",
+                    "field": " %12s ",
+                    "name": "cat_lat",
+                }
+            )
         if any_frame:
-            col_list.append({
-                "hdr": ("Frame", ""),
-                "fmt": "%5s",
-                "field": " %5s ",
-                "name": "cat_frame",
-            })
+            col_list.append(
+                {
+                    "hdr": ("Frame", ""),
+                    "fmt": "%5s",
+                    "field": " %5s ",
+                    "name": "cat_frame",
+                }
+            )
         if any_epoch:
-            col_list.append({
-                "hdr": ("Epoch", ""),
-                "fmt": "%7s",
-                "field": " %7s ",
-                "name": "cat_epoch",
-            })
+            col_list.append(
+                {
+                    "hdr": ("Epoch", ""),
+                    "fmt": "%7s",
+                    "field": " %7s ",
+                    "name": "cat_epoch",
+                }
+            )
         if any_times:
-            col_list.append({
-                "hdr": ("   Ephem Range   ", "Start-MJD    End-MJD"),
-                "fmt": " %8.2f  % 8.2f",
-                "field": " %20s ",
-                "name": "cat_times",
-            })
+            col_list.append(
+                {
+                    "hdr": ("   Ephem Range   ", "Start-MJD    End-MJD"),
+                    "fmt": " %8.2f  % 8.2f",
+                    "field": " %20s ",
+                    "name": "cat_times",
+                }
+            )
         if any_pm_ra:
-            col_list.append({
-                "hdr": ("PM-Ra", "mas/yr"),
-                "fmt": "%.4g",
-                "field": " %6s ",
-                "name": "cat_pm_ra",
-            })
+            col_list.append(
+                {
+                    "hdr": ("PM-Ra", "mas/yr"),
+                    "fmt": "%.4g",
+                    "field": " %6s ",
+                    "name": "cat_pm_ra",
+                }
+            )
         if any_pm_dec:
-            col_list.append({
-                "hdr": ("PM-Dec", "mas/yr"),
-                "fmt": "%.4g",
-                "field": " %6s ",
-                "name": "cat_pm_dec",
-            })
+            col_list.append(
+                {
+                    "hdr": ("PM-Dec", "mas/yr"),
+                    "fmt": "%.4g",
+                    "field": " %6s ",
+                    "name": "cat_pm_dec",
+                }
+            )
         if any_dist:
-            col_list.append({
-                "hdr": ("Dist", "pc"),
-                "fmt": "%.1e",
-                "field": " %7s ",
-                "name": "cat_dist",
-            })
+            col_list.append(
+                {
+                    "hdr": ("Dist", "pc"),
+                    "fmt": "%.1e",
+                    "field": " %7s ",
+                    "name": "cat_dist",
+                }
+            )
         if any_vrad:
-            col_list.append({
-                "hdr": ("V_rad", "km/s"),
-                "fmt": "%.4g",
-                "field": " %6s ",
-                "name": "cat_vrad",
-            })
+            col_list.append(
+                {
+                    "hdr": ("V_rad", "km/s"),
+                    "fmt": "%.4g",
+                    "field": " %6s ",
+                    "name": "cat_vrad",
+                }
+            )
 
         top_str = ""
         bot_str = ""
@@ -3072,10 +3092,12 @@ class UVData(UVBase):
         # Only these pols have "true" auto-correlations, that we'd expect
         # to be real only. Select on only them
         auto_pol_list = ["xx", "yy", "rr", "ll", "pI", "pQ", "pU", "pV"]
-        pol_screen = np.array([
-            uvutils.POL_NUM2STR_DICT[pol] in auto_pol_list
-            for pol in self.polarization_array
-        ])
+        pol_screen = np.array(
+            [
+                uvutils.POL_NUM2STR_DICT[pol] in auto_pol_list
+                for pol in self.polarization_array
+            ]
+        )
 
         # Make sure we actually have work to do here, otherwise skip all of this
         if (np.any(pol_screen) and np.any(auto_screen)) and not (
@@ -3434,10 +3456,12 @@ class UVData(UVBase):
                 # to be real only. Select on only them
                 auto_pol_list = ["xx", "yy", "rr", "ll", "pI", "pQ", "pU", "pV"]
                 if self.flex_spw_polarization_array is not None:
-                    pol_screen = np.array([
-                        uvutils.POL_NUM2STR_DICT[pol] in auto_pol_list
-                        for pol in self.flex_spw_polarization_array
-                    ])
+                    pol_screen = np.array(
+                        [
+                            uvutils.POL_NUM2STR_DICT[pol] in auto_pol_list
+                            for pol in self.flex_spw_polarization_array
+                        ]
+                    )
                     # There should be a better way...
                     spw_inds = np.zeros_like(self.flex_spw_id_array)
                     for spw_ind, spw in enumerate(self.spw_array):
@@ -3445,10 +3469,12 @@ class UVData(UVBase):
                         spw_inds[these_freq_inds] = spw_ind
                     freq_screen = pol_screen[spw_inds]
                 else:
-                    pol_screen = np.array([
-                        uvutils.POL_NUM2STR_DICT[pol] in auto_pol_list
-                        for pol in self.polarization_array
-                    ])
+                    pol_screen = np.array(
+                        [
+                            uvutils.POL_NUM2STR_DICT[pol] in auto_pol_list
+                            for pol in self.polarization_array
+                        ]
+                    )
 
                 # Check autos if they have imag component -- doing iscomplex first and
                 # then pol select was faster in every case checked in test files.
@@ -4002,9 +4028,7 @@ class UVData(UVBase):
                     out = np.squeeze(out, axis=1)
         elif squeeze != "none":
             raise ValueError(
-                '"'
-                + str(squeeze)
-                + '" is not a valid option for squeeze.'
+                '"' + str(squeeze) + '" is not a valid option for squeeze.'
                 'Only "default", "none", or "full" are allowed.'
             )
 
@@ -4746,13 +4770,13 @@ class UVData(UVBase):
                 orig_data_array = copy.copy(self.data_array)
                 for pol_ind in np.arange(self.Npols):
                     if self.future_array_shapes:
-                        self.data_array[index_array, :, new_pol_inds[pol_ind]] = (
-                            np.conj(orig_data_array[index_array, :, pol_ind])
-                        )
+                        self.data_array[
+                            index_array, :, new_pol_inds[pol_ind]
+                        ] = np.conj(orig_data_array[index_array, :, pol_ind])
                     else:
-                        self.data_array[index_array, :, :, new_pol_inds[pol_ind]] = (
-                            np.conj(orig_data_array[index_array, :, :, pol_ind])
-                        )
+                        self.data_array[
+                            index_array, :, :, new_pol_inds[pol_ind]
+                        ] = np.conj(orig_data_array[index_array, :, :, pol_ind])
 
             ant_1_vals = self.ant_1_array[index_array]
             ant_2_vals = self.ant_2_array[index_array]
@@ -5449,9 +5473,9 @@ class UVData(UVBase):
         self.phase_center_app_ra[select_mask_use] = self.lst_array[
             select_mask_use
         ].copy()
-        self.phase_center_app_dec[select_mask_use] = (
-            self.telescope_location_lat_lon_alt[0]
-        )
+        self.phase_center_app_dec[
+            select_mask_use
+        ] = self.telescope_location_lat_lon_alt[0]
         self.phase_center_frame_pa[select_mask_use] = 0
 
         return
@@ -5500,12 +5524,16 @@ class UVData(UVBase):
         # instance of a UVData object.
         if lookup_name and (cat_name not in name_dict):
             if (cat_type is None) or (cat_type == "ephem"):
-                [cat_times, cat_lon, cat_lat, cat_dist, cat_vrad] = (
-                    uvutils.lookup_jplhorizons(
-                        cat_name,
-                        time_array,
-                        telescope_loc=self.telescope_location_lat_lon_alt,
-                    )
+                [
+                    cat_times,
+                    cat_lon,
+                    cat_lat,
+                    cat_dist,
+                    cat_vrad,
+                ] = uvutils.lookup_jplhorizons(
+                    cat_name,
+                    time_array,
+                    telescope_loc=self.telescope_location_lat_lon_alt,
                 )
                 cat_type = "ephem"
                 cat_pm_ra = cat_pm_dec = None
@@ -5608,12 +5636,16 @@ class UVData(UVBase):
             if check_ephem and (info_source == "jplh"):
                 # Concat the two time ranges to make sure that we cover both the
                 # requested time range _and_ the original time range.
-                [cat_times, cat_lon, cat_lat, cat_dist, cat_vrad] = (
-                    uvutils.lookup_jplhorizons(
-                        cat_name,
-                        np.concatenate((np.reshape(time_array, -1), cat_times)),
-                        telescope_loc=self.telescope_location_lat_lon_alt,
-                    )
+                [
+                    cat_times,
+                    cat_lon,
+                    cat_lat,
+                    cat_dist,
+                    cat_vrad,
+                ] = uvutils.lookup_jplhorizons(
+                    cat_name,
+                    np.concatenate((np.reshape(time_array, -1), cat_times)),
+                    telescope_loc=self.telescope_location_lat_lon_alt,
                 )
             elif check_ephem:
                 # The ephem was user-supplied during the call to the phase method,
@@ -6412,14 +6444,22 @@ class UVData(UVBase):
         # Create blt arrays for convenience
         prec_t = -2 * np.floor(np.log10(this._time_array.tols[-1])).astype(int)
         prec_b = 8
-        this_blts = np.array([
-            "_".join(["{1:.{0}f}".format(prec_t, blt[0]), str(blt[1]).zfill(prec_b)])
-            for blt in zip(this.time_array, this.baseline_array)
-        ])
-        other_blts = np.array([
-            "_".join(["{1:.{0}f}".format(prec_t, blt[0]), str(blt[1]).zfill(prec_b)])
-            for blt in zip(other.time_array, other.baseline_array)
-        ])
+        this_blts = np.array(
+            [
+                "_".join(
+                    ["{1:.{0}f}".format(prec_t, blt[0]), str(blt[1]).zfill(prec_b)]
+                )
+                for blt in zip(this.time_array, this.baseline_array)
+            ]
+        )
+        other_blts = np.array(
+            [
+                "_".join(
+                    ["{1:.{0}f}".format(prec_t, blt[0]), str(blt[1]).zfill(prec_b)]
+                )
+                for blt in zip(other.time_array, other.baseline_array)
+            ]
+        )
         # Check we don't have overlapping data
         both_pol, this_pol_ind, other_pol_ind = np.intersect1d(
             this.polarization_array, other.polarization_array, return_indices=True
@@ -6813,10 +6853,12 @@ class UVData(UVBase):
                         [this_flexpol_dict[key] for key in this.spw_array]
                     )
                 # Need to sort out the order of the individual windows first.
-                f_order = np.concatenate([
-                    np.where(this.flex_spw_id_array == idx)[0]
-                    for idx in sorted(this.spw_array)
-                ])
+                f_order = np.concatenate(
+                    [
+                        np.where(this.flex_spw_id_array == idx)[0]
+                        for idx in sorted(this.spw_array)
+                    ]
+                )
 
                 # With spectral windows sorted, check and see if channels within
                 # windows need sorting. If they are ordered in ascending or descending
@@ -6880,11 +6922,13 @@ class UVData(UVBase):
             p_order = np.argsort(np.abs(this.polarization_array))
             if not self.metadata_only:
                 if this.future_array_shapes:
-                    zero_pad = np.zeros((
-                        this.data_array.shape[0],
-                        this.data_array.shape[1],
-                        len(pnew_inds),
-                    ))
+                    zero_pad = np.zeros(
+                        (
+                            this.data_array.shape[0],
+                            this.data_array.shape[1],
+                            len(pnew_inds),
+                        )
+                    )
                     this.data_array = np.concatenate(
                         [this.data_array, zero_pad], axis=2
                     )
@@ -6895,12 +6939,14 @@ class UVData(UVBase):
                         [this.flag_array, 1 - zero_pad], axis=2
                     ).astype(np.bool_)
                 else:
-                    zero_pad = np.zeros((
-                        this.data_array.shape[0],
-                        1,
-                        this.data_array.shape[2],
-                        len(pnew_inds),
-                    ))
+                    zero_pad = np.zeros(
+                        (
+                            this.data_array.shape[0],
+                            1,
+                            this.data_array.shape[2],
+                            len(pnew_inds),
+                        )
+                    )
                     this.data_array = np.concatenate(
                         [this.data_array, zero_pad], axis=3
                     )
@@ -6937,20 +6983,20 @@ class UVData(UVBase):
         if not self.metadata_only:
             if this.future_array_shapes:
                 this.data_array[np.ix_(blt_t2o, freq_t2o, pol_t2o)] = other.data_array
-                this.nsample_array[np.ix_(blt_t2o, freq_t2o, pol_t2o)] = (
-                    other.nsample_array
-                )
+                this.nsample_array[
+                    np.ix_(blt_t2o, freq_t2o, pol_t2o)
+                ] = other.nsample_array
                 this.flag_array[np.ix_(blt_t2o, freq_t2o, pol_t2o)] = other.flag_array
             else:
-                this.data_array[np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)] = (
-                    other.data_array
-                )
-                this.nsample_array[np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)] = (
-                    other.nsample_array
-                )
-                this.flag_array[np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)] = (
-                    other.flag_array
-                )
+                this.data_array[
+                    np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)
+                ] = other.data_array
+                this.nsample_array[
+                    np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)
+                ] = other.nsample_array
+                this.flag_array[
+                    np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)
+                ] = other.flag_array
 
             # Fix ordering
             baxis_num = 0
@@ -7631,9 +7677,7 @@ class UVData(UVBase):
         ):
             if this.extra_keywords[intersection] != other.extra_keywords[intersection]:
                 warnings.warn(
-                    "Keyword "
-                    + intersection
-                    + " in _extra_keywords is different "
+                    "Keyword " + intersection + " in _extra_keywords is different "
                     "in the two objects. Taking the first object's entry."
                 )
 
@@ -8670,23 +8714,26 @@ class UVData(UVBase):
             uv_obj = self.copy()
 
         # Figure out which index positions we want to hold on to.
-        (blt_inds, freq_inds, pol_inds, history_update_string) = (
-            uv_obj._select_preprocess(
-                antenna_nums,
-                antenna_names,
-                ant_str,
-                bls,
-                frequencies,
-                freq_chans,
-                times,
-                time_range,
-                lsts,
-                lst_range,
-                polarizations,
-                blt_inds,
-                phase_center_ids,
-                catalog_names,
-            )
+        (
+            blt_inds,
+            freq_inds,
+            pol_inds,
+            history_update_string,
+        ) = uv_obj._select_preprocess(
+            antenna_nums,
+            antenna_names,
+            ant_str,
+            bls,
+            frequencies,
+            freq_chans,
+            times,
+            time_range,
+            lsts,
+            lst_range,
+            polarizations,
+            blt_inds,
+            phase_center_ids,
+            catalog_names,
         )
 
         # Call the low-level selection method.
@@ -9906,9 +9953,9 @@ class UVData(UVBase):
                             reg_mask[ax0_inds, this_chan, :, ax2_inds], axis=1
                         )
                         ff_inds = np.nonzero(fully_flagged)
-                        reg_mask[ax0_inds[ff_inds], this_chan, :, ax2_inds[ff_inds]] = (
-                            False
-                        )
+                        reg_mask[
+                            ax0_inds[ff_inds], this_chan, :, ax2_inds[ff_inds]
+                        ] = False
                 if this_ragged:
                     ax0_inds, ax2_inds = np.nonzero(
                         final_flag_array[:, final_spw_chans[spw][-1], :]
@@ -10240,10 +10287,12 @@ class UVData(UVBase):
                     )
                     conj_inds = conj_group_inds[np.array(conj_orientation)]
                     # check that the integration times are all the same
-                    int_times = np.concatenate((
-                        self.integration_time[regular_inds],
-                        self.integration_time[conj_inds],
-                    ))
+                    int_times = np.concatenate(
+                        (
+                            self.integration_time[regular_inds],
+                            self.integration_time[conj_inds],
+                        )
+                    )
                     if not np.all(
                         np.abs(int_times - new_obj.integration_time[obj_time_ind])
                         < new_obj._integration_time.tols[1]
@@ -10255,14 +10304,18 @@ class UVData(UVBase):
                         )
 
                     if not self.metadata_only:
-                        vis_to_avg = np.concatenate((
-                            self.data_array[regular_inds],
-                            np.conj(self.data_array[conj_inds]),
-                        ))
-                        nsample_to_avg = np.concatenate((
-                            self.nsample_array[regular_inds],
-                            self.nsample_array[conj_inds],
-                        ))
+                        vis_to_avg = np.concatenate(
+                            (
+                                self.data_array[regular_inds],
+                                np.conj(self.data_array[conj_inds]),
+                            )
+                        )
+                        nsample_to_avg = np.concatenate(
+                            (
+                                self.nsample_array[regular_inds],
+                                self.nsample_array[conj_inds],
+                            )
+                        )
                         flags_to_avg = np.concatenate(
                             (self.flag_array[regular_inds], self.flag_array[conj_inds])
                         )
@@ -12832,7 +12885,7 @@ class UVData(UVBase):
             that they are real-only in data_array. Default is False.
         use_miriad_convention : bool
             Option to use the MIRIAD baseline convention, and write to BASELINE column.
-            This mode is required for UVFITS files with >256 antennas to be 
+            This mode is required for UVFITS files with >256 antennas to be
             readable by MIRIAD, and supports up to 2048 antennas.
             The MIRIAD baseline ID is given by
             `bl = 256 * ant1 + ant2` if `ant2 < 256`, otherwise
@@ -13232,10 +13285,12 @@ class UVData(UVBase):
         for pol in pol_list:
             try:
                 feed_pols = uvutils.POL_TO_FEED_DICT[uvutils.POL_NUM2STR_DICT[pol]]
-                pol_groups.append([
-                    pol_list.index(uvutils.POL_STR2NUM_DICT[item + item])
-                    for item in feed_pols
-                ])
+                pol_groups.append(
+                    [
+                        pol_list.index(uvutils.POL_STR2NUM_DICT[item + item])
+                        for item in feed_pols
+                    ]
+                )
             except KeyError:
                 # If we run into a key error, it means that one of the dicts above does
                 # not have a match to the given polarization, in which case assume that

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -3603,7 +3603,7 @@ class UVData(UVBase):
         """
         return uvutils.baseline_to_antnums(baseline, self.Nants_telescope)
 
-    def antnums_to_baseline(self, ant1, ant2, attempt256=False):
+    def antnums_to_baseline(self, ant1, ant2, attempt256=False, use_miriad_convention=False):
         """
         Get the baseline number corresponding to two given antenna numbers.
 
@@ -3616,7 +3616,14 @@ class UVData(UVBase):
         attempt256 : bool
             Option to try to use the older 256 standard used in many uvfits files
             (will use 2048 standard if there are more than 256 antennas).
-
+        use_miriad_convention : bool
+            Option to use the MIRIAD convention where BASELINE id is
+                if ant2 < 256:
+                    bl = 256 * ant1 + ant2 
+                else:
+                    bl = 2048 * ant1 + ant2 + 2**16
+            Note antennas should be 1-indexed (start at 1, not 0)
+            
         Returns
         -------
         int or array of int
@@ -12826,6 +12833,7 @@ class UVData(UVBase):
         strict_uvw_antpos_check=False,
         check_autos=True,
         fix_autos=False,
+        use_miriad_convention=False,
     ):
         """
         Write the data to a uvfits file.
@@ -12865,6 +12873,15 @@ class UVData(UVBase):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is False.
+        use_miriad_convention : bool
+            Option to use the MIRIAD baseline convention, and write to BASELINE column.
+            This supports up to 2048 antennas, where baseline ID is given by
+                if ant2 < 256:
+                    bl = 256 * ant1 + ant2 
+                else:
+                    bl = 2048 * ant1 + ant2 + 2**16
+            Note antennas should be 1-indexed (start at 1, not 0). This mode is required
+            for UVFITS files to be readable by MIRIAD.
 
         Raises
         ------

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -3622,15 +3622,18 @@ class UVData(UVBase):
                     bl = 256 * ant1 + ant2 
                 else:
                     bl = 2048 * ant1 + ant2 + 2**16
-            Note antennas should be 1-indexed (start at 1, not 0)
+            Note MIRIAD uses 1-indexed antenna IDs, but this code accepts 0-based.
             
         Returns
         -------
         int or array of int
             baseline number corresponding to the two antenna numbers.
         """
+        # set attempt256 to false if using miriad convention
+        attempt256 = False if use_miriad_convention else attempt256
         return uvutils.antnums_to_baseline(
-            ant1, ant2, self.Nants_telescope, attempt256=attempt256
+            ant1, ant2, self.Nants_telescope, attempt256=attempt256, 
+            use_miriad_convention=use_miriad_convention,
         )
 
     def antpair2ind(self, ant1, ant2=None, ordered=True):
@@ -12921,6 +12924,7 @@ class UVData(UVBase):
             strict_uvw_antpos_check=strict_uvw_antpos_check,
             check_autos=check_autos,
             fix_autos=fix_autos,
+            use_miriad_convention=use_miriad_convention,
         )
         del uvfits_obj
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -3595,10 +3595,8 @@ class UVData(UVBase):
             (will use 2048 standard if there are more than 256 antennas).
         use_miriad_convention : bool
             Option to use the MIRIAD convention where BASELINE id is
-                if ant2 < 256:
-                    bl = 256 * ant1 + ant2
-                else:
-                    bl = 2048 * ant1 + ant2 + 2**16
+            `bl = 256 * ant1 + ant2` if `ant2 < 256`, otherwise
+            `bl = 2048 * ant1 + ant2 + 2**16`.
             Note MIRIAD uses 1-indexed antenna IDs, but this code accepts 0-based.
 
         Returns
@@ -12834,13 +12832,12 @@ class UVData(UVBase):
             that they are real-only in data_array. Default is False.
         use_miriad_convention : bool
             Option to use the MIRIAD baseline convention, and write to BASELINE column.
-            This supports up to 2048 antennas, where baseline ID is given by
-                if ant2 < 256:
-                    bl = 256 * ant1 + ant2
-                else:
-                    bl = 2048 * ant1 + ant2 + 2**16
-            Note antennas should be 1-indexed (start at 1, not 0). This mode is required
-            for UVFITS files to be readable by MIRIAD.
+            This mode is required for UVFITS files with >256 antennas to be 
+            readable by MIRIAD, and supports up to 2048 antennas.
+            The MIRIAD baseline ID is given by
+            `bl = 256 * ant1 + ant2` if `ant2 < 256`, otherwise
+            `bl = 2048 * ant1 + ant2 + 2**16`.
+            Note MIRIAD uses 1-indexed antenna IDs, but this code accepts 0-based.
 
         Raises
         ------

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -59,11 +59,9 @@ class UVFITS(UVData):
             # angles in uvfits files are stored in degrees, so convert to radians
             self.lst_array = np.deg2rad(vis_hdu.data.par("lst"))
             if run_check_acceptability:
-                (
-                    latitude,
-                    longitude,
-                    altitude,
-                ) = self.telescope_location_lat_lon_alt_degrees
+                (latitude, longitude, altitude) = (
+                    self.telescope_location_lat_lon_alt_degrees
+                )
             uvutils.check_lsts_against_times(
                 jd_array=self.time_array,
                 lst_array=self.lst_array,
@@ -159,13 +157,11 @@ class UVFITS(UVData):
         # setting the dtype below enforces double precision
         self.uvw_array = (-1) * (
             np.array(
-                np.stack(
-                    (
-                        vis_hdu.data.par(uvw_names[0]),
-                        vis_hdu.data.par(uvw_names[1]),
-                        vis_hdu.data.par(uvw_names[2]),
-                    )
-                ),
+                np.stack((
+                    vis_hdu.data.par(uvw_names[0]),
+                    vis_hdu.data.par(uvw_names[1]),
+                    vis_hdu.data.par(uvw_names[2]),
+                )),
                 dtype=self._uvw_array.expected_type,
             )
             * const.c.to("m/s").value
@@ -441,13 +437,11 @@ class UVFITS(UVData):
                     np.tile(abs(fq_hdu.data["CH WIDTH"]), (uvfits_nchan, 1))
                 ).flatten()
                 self.freq_array = np.reshape(
-                    np.transpose(
-                        (
-                            ref_freq
-                            + fq_hdu.data["IF FREQ"]
-                            + np.outer(np.arange(uvfits_nchan), fq_hdu.data["CH WIDTH"])
-                        )
-                    ),
+                    np.transpose((
+                        ref_freq
+                        + fq_hdu.data["IF FREQ"]
+                        + np.outer(np.arange(uvfits_nchan), fq_hdu.data["CH WIDTH"])
+                    )),
                     (1, -1),
                 )
             else:

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -791,7 +791,7 @@ class UVFITS(UVData):
         strict_uvw_antpos_check=False,
         check_autos=True,
         fix_autos=False,
-        use_miriad_convention=False
+        use_miriad_convention=False,
     ):
         """
         Write the data to a uvfits file.
@@ -832,7 +832,7 @@ class UVFITS(UVData):
             Option to use the MIRIAD baseline convention, and write to BASELINE column.
             This supports up to 2048 antennas, where baseline ID is given by
                 if ant2 < 256:
-                    bl = 256 * ant1 + ant2 
+                    bl = 256 * ant1 + ant2
                 else:
                     bl = 2048 * ant1 + ant2 + 2**16
             This mode is required for UVFITS files to be readable by MIRIAD.
@@ -1020,8 +1020,10 @@ class UVFITS(UVData):
         # Generate baseline IDs
         attempt256 = False if use_miriad_convention else True
         baselines_use = self.antnums_to_baseline(
-            self.ant_1_array, self.ant_2_array, attempt256=attempt256, 
-            use_miriad_convention=use_miriad_convention
+            self.ant_1_array,
+            self.ant_2_array,
+            attempt256=attempt256,
+            use_miriad_convention=use_miriad_convention,
         )
         # Set up dictionaries for populating hdu
         # Antenna arrays are populated with actual antenna numbers,
@@ -1097,7 +1099,7 @@ class UVFITS(UVData):
             pscal_dict["DATE2   "] = 1.0
             pzero_dict["DATE2   "] = 0.0
             parnames_use.append("DATE2   ")
-        
+
         if use_miriad_convention:
             # MIRIAD requires BASELINE column.
             parnames_use.append("BASELINE")
@@ -1283,10 +1285,7 @@ class UVFITS(UVData):
         )
         col2 = fits.Column(name="STABXYZ", format="3D", array=rot_ecef_positions)
         # col3 = fits.Column(name="ORBPARAM", format="0D", array=Norb)
-        if use_miriad_convention:
-            col4 = fits.Column(name="NOSTA", format="1J", array=self.antenna_numbers+1)
-        else:
-            col4 = fits.Column(name="NOSTA", format="1J", array=self.antenna_numbers)            
+        col4 = fits.Column(name="NOSTA", format="1J", array=self.antenna_numbers)
         col5 = fits.Column(name="MNTSTA", format="1J", array=mntsta)
         col6 = fits.Column(name="STAXOF", format="1E", array=staxof)
         col7 = fits.Column(name="POLTYA", format="1A", array=poltya)

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -1009,7 +1009,14 @@ class UVFITS(UVData):
         else:
             time_array1 = self.time_array - jd_midnight
         int_time_array = self.integration_time
-        
+
+        # If using MIRIAD convention, we need 1-indexed data
+        if use_miriad_convention:
+            if np.min(self.antenna_numbers) == 0:
+                self.antenna_numbers += 1
+                self.ant_1_array += 1
+                self.ant_2_array += 1
+
         # Generate baseline IDs
         attempt256 = False if use_miriad_convention else True
         baselines_use = self.antnums_to_baseline(
@@ -1033,11 +1040,6 @@ class UVFITS(UVData):
             "SUBARRAY": np.ones_like(self.ant_1_array),
             "INTTIM  ": int_time_array,
         }
-
-        if use_miriad_convention:
-            # Convert to 1-based indexes
-            group_parameter_dict["ANTENNA1"] += 1
-            group_parameter_dict["ANTENNA2"] += 1
 
         id_offset = int(0 in self.phase_center_catalog)
         group_parameter_dict["SOURCE  "] = self.phase_center_id_array + id_offset

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -59,9 +59,11 @@ class UVFITS(UVData):
             # angles in uvfits files are stored in degrees, so convert to radians
             self.lst_array = np.deg2rad(vis_hdu.data.par("lst"))
             if run_check_acceptability:
-                (latitude, longitude, altitude) = (
-                    self.telescope_location_lat_lon_alt_degrees
-                )
+                (
+                    latitude,
+                    longitude,
+                    altitude,
+                ) = self.telescope_location_lat_lon_alt_degrees
             uvutils.check_lsts_against_times(
                 jd_array=self.time_array,
                 lst_array=self.lst_array,
@@ -157,11 +159,13 @@ class UVFITS(UVData):
         # setting the dtype below enforces double precision
         self.uvw_array = (-1) * (
             np.array(
-                np.stack((
-                    vis_hdu.data.par(uvw_names[0]),
-                    vis_hdu.data.par(uvw_names[1]),
-                    vis_hdu.data.par(uvw_names[2]),
-                )),
+                np.stack(
+                    (
+                        vis_hdu.data.par(uvw_names[0]),
+                        vis_hdu.data.par(uvw_names[1]),
+                        vis_hdu.data.par(uvw_names[2]),
+                    )
+                ),
                 dtype=self._uvw_array.expected_type,
             )
             * const.c.to("m/s").value
@@ -437,11 +441,13 @@ class UVFITS(UVData):
                     np.tile(abs(fq_hdu.data["CH WIDTH"]), (uvfits_nchan, 1))
                 ).flatten()
                 self.freq_array = np.reshape(
-                    np.transpose((
-                        ref_freq
-                        + fq_hdu.data["IF FREQ"]
-                        + np.outer(np.arange(uvfits_nchan), fq_hdu.data["CH WIDTH"])
-                    )),
+                    np.transpose(
+                        (
+                            ref_freq
+                            + fq_hdu.data["IF FREQ"]
+                            + np.outer(np.arange(uvfits_nchan), fq_hdu.data["CH WIDTH"])
+                        )
+                    ),
                     (1, -1),
                 )
             else:
@@ -824,7 +830,7 @@ class UVFITS(UVData):
             that they are real-only in data_array. Default is False.
         use_miriad_convention : bool
             Option to use the MIRIAD baseline convention, and write to BASELINE column.
-            This mode is required for UVFITS files with >256 antennas to be 
+            This mode is required for UVFITS files with >256 antennas to be
             readable by MIRIAD, and supports up to 2048 antennas.
             The MIRIAD baseline ID is given by
             `bl = 256 * ant1 + ant2` if `ant2 < 256`, otherwise

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -791,6 +791,7 @@ class UVFITS(UVData):
         strict_uvw_antpos_check=False,
         check_autos=True,
         fix_autos=False,
+        use_miriad_convention=False
     ):
         """
         Write the data to a uvfits file.
@@ -827,6 +828,15 @@ class UVFITS(UVData):
         fix_autos : bool
             If auto-correlations with imaginary values are found, fix those values so
             that they are real-only in data_array. Default is False.
+        use_miriad_convention : bool
+            Option to use the MIRIAD baseline convention, and write to BASELINE column.
+            This supports up to 2048 antennas, where baseline ID is given by
+                if ant2 < 256:
+                    bl = 256 * ant1 + ant2 
+                else:
+                    bl = 2048 * ant1 + ant2 + 2**16
+            Note antennas should be 1-indexed (start at 1, not 0). This mode is required
+            for UVFITS files to be readable by MIRIAD.
 
         Raises
         ------
@@ -1001,7 +1011,8 @@ class UVFITS(UVData):
         int_time_array = self.integration_time
 
         baselines_use = self.antnums_to_baseline(
-            self.ant_1_array, self.ant_2_array, attempt256=True
+            self.ant_1_array, self.ant_2_array, attempt256=True, 
+            use_miriad_convention=use_miriad_convention
         )
         # Set up dictionaries for populating hdu
         # Antenna arrays are populated with actual antenna numbers,
@@ -1077,7 +1088,11 @@ class UVFITS(UVData):
             pscal_dict["DATE2   "] = 1.0
             pzero_dict["DATE2   "] = 0.0
             parnames_use.append("DATE2   ")
-        if np.max(self.ant_1_array) < 255 and np.max(self.ant_2_array) < 255:
+        
+        if use_miriad_convention:
+            # MIRIAD requires BASELINE column.
+            parnames_use.append("BASELINE")
+        elif np.max(self.ant_1_array) < 255 and np.max(self.ant_2_array) < 255:
             # if the number of antennas is less than 256 then include both the
             # baseline array and the antenna arrays in the group parameters.
             # Otherwise just use the antenna arrays

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -824,12 +824,11 @@ class UVFITS(UVData):
             that they are real-only in data_array. Default is False.
         use_miriad_convention : bool
             Option to use the MIRIAD baseline convention, and write to BASELINE column.
-            This supports up to 2048 antennas, where baseline ID is given by
-                if ant2 < 256:
-                    bl = 256 * ant1 + ant2
-                else:
-                    bl = 2048 * ant1 + ant2 + 2**16
-            This mode is required for UVFITS files to be readable by MIRIAD.
+            This mode is required for UVFITS files with >256 antennas to be 
+            readable by MIRIAD, and supports up to 2048 antennas.
+            The MIRIAD baseline ID is given by
+            `bl = 256 * ant1 + ant2` if `ant2 < 256`, otherwise
+            `bl = 2048 * ant1 + ant2 + 2**16`.
             Note MIRIAD uses 1-indexed antenna IDs, but this code accepts 0-based.
 
         Raises

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ all_optional_reqs = (
     + novas_reqs
 )
 test_reqs = all_optional_reqs + [
-    "pytest>=6.2",
+    "pytest>=6.2, <8.0",
     "pytest-xdist",
     "pytest-cases>=3.6.9",
     "pytest-cov",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
**NOTE: This is just a rebased/cherry-picked version of #1388, which is approved but unable to merge due to conflicts (boiling down to a single line in the tests file)**

This PR has three main components:
* Updates to `miriad.py` for writing files that are compatible with miriad processing tasks.
* Updates to `ms.py` to fix a bug when writing from data with legacy array shape.
* Updates to `uvfits.py` to support miriad BASELINE convention for 256+ antennas.

## Description

This PR adds support for Miriad and MS file writing for the SKA-low AAVS pathfinder telescopes. Data from AAVS is output in a simple HDF5 format, which we are converting into standard formats using `pyuvdata` in the [aavs_uv](https://github.com/ska-sci-ops/aavs_uv) package. Some further context to the issues is given in:

* https://github.com/ska-sci-ops/aavs_uv/issues/36
* https://github.com/ska-sci-ops/aavs_uv/issues/53
* https://github.com/ska-sci-ops/aavs_uv/issues/44

### Combining PRs 1375 and 1380

This PR supersedes previous PRs https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1375 (MS bug) and  https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1380 (Miriad support). I've combined these are the changes to `miriad.py` introduced a warning in `test_ms.py` that needed to be caught by pytest. This PR should also (hopefully!) catch all the new warnings created, which I was struggling to do in the previous PRs. 

Also, I accidentally broke a PR by changing the branch name :scream:.

### Miriad BASELINE convention support

This PR also updated `uvfits.py`. In addition to updates to `miriad.py` and `ms.py`, I added an option in `uvfits.py` so users can create MIRIAD-compatible UVFITS files with more than 256 antennas. This required adding a specific `BASELINE` convention. 

Miriad has a convention for storing baseline IDs, which is slightly different to those already implemented in the pyuvdata for UVFITS `BASELINE`. From the user guide:

```
Baseline is stored as 256 * ant1 + ant2, or 2048 * ant1 + ant2 + 65536
The uv coordinates are calculated as
uvw = xyz(ant2) - xyz(ant1).
Note that this is different from the AIPS/FITS convention
(where uvw = xyz(ant1) - xyz(ant2)).
When writing this variable, software must ensure that
ant1 < ant2.
```

This convention has crept into UVFITS, e.g. in the [MWA C tools](
https://github.com/steve-ord/MWACUtils/blob/5e0bc5ef3c3c6a2ca939879209a9f4fde2c34eb1/mwac_utils/uvfits.c#L1013): 

```C
void EncodeBaseline(int b1, int b2, float *result) {
  if (b2 > 255) {
    *result = b1*2048 + b2 + 65536;
  } else {
    *result = b1*256 + b2;
  }
}
```

As SKA-low's commissioning has had a huge amount of work from members of the MWA team, we (Sci Ops) would like to be able to produce miriad-compatible UVFITS files.

My solution was to add a `use_miriad_convention=True` flag to `write_uvfits`. The UVFITS writer code already has some logic to select `BASELINE` convention, (see `antnums_to_baseline` in [utils.pyx](https://github.com/ska-sci-ops/pyuvdata/blob/1a6a4e3cff6baf41498f0f109f0e7d09a0c019c4/pyuvdata/utils.pyx#L181)), so I added a [`_antnum_to_bl_2048_miriad`](https://github.com/ska-sci-ops/pyuvdata/blob/011b729d1626b8678377b04010c5ebe45dc314b8/pyuvdata/utils.pyx#L167C18-L167C43) in the Cython baseline convention logic.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass. (I hope!)
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

