### PR TITLE
Handle differently sorted ant metadata in UVFlag to_baseline and to_antenna

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ positions are near surface of whatever celestial body their positions are refere
 (either the Earth or Moon, currently).
 
 ### Changed
+- `UVFlag.to_baseline` and `UVFlag.to_antenna` are now more robust to differences
+in antenna metadata sorting.
 - Made `MirParser` more robust against metadata indexing errors.
 - Made `MirParser` handling of autocorrelation data more robust.
 - Improved hooks for handling and loading of COMPASS solutions into `MirParser` objects.

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -2370,7 +2370,8 @@ def test_to_waterfall_waterfall():
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize("uvd_future_shapes", [True, False])
 @pytest.mark.parametrize("uvf_future_shapes", [True, False])
-def test_to_baseline_flags(uvdata_obj, uvd_future_shapes, uvf_future_shapes):
+@pytest.mark.parametrize("resort", [True, False])
+def test_to_baseline_flags(uvdata_obj, uvd_future_shapes, uvf_future_shapes, resort):
     uv = uvdata_obj
     if not uvd_future_shapes:
         uv.use_current_array_shapes()
@@ -2391,6 +2392,18 @@ def test_to_baseline_flags(uvdata_obj, uvd_future_shapes, uvf_future_shapes):
         uv.flex_spw_id_array = np.zeros(uv.Nfreqs, dtype=int)
         uv.flex_spw_id_array[uv.Nfreqs // 2 :] = 1
         uv.check()
+
+    if resort:
+        rng = np.random.default_rng()
+        new_order = rng.permutation(uvf.Nants_telescope)
+        if uvf_future_shapes:
+            uvf.antenna_numbers = uvf.antenna_numbers[new_order]
+            uvf.antenna_names = uvf.antenna_names[new_order]
+            uvf.antenna_positions = uvf.antenna_positions[new_order, :]
+        else:
+            uv.antenna_numbers = uvf.antenna_numbers[new_order]
+            uv.antenna_names = uvf.antenna_names[new_order]
+            uv.antenna_positions = uvf.antenna_positions[new_order, :]
 
     uvf.to_baseline(uv)
     assert uvf.type == "baseline"
@@ -2736,7 +2749,8 @@ def test_to_baseline_metric_force_pol(uvdata_obj):
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 @pytest.mark.parametrize("uvf_future_shapes", [True, False])
 @pytest.mark.parametrize("uvc_future_shapes", [True, False])
-def test_to_antenna_flags(uvcal_obj, uvf_future_shapes, uvc_future_shapes):
+@pytest.mark.parametrize("resort", [True, False])
+def test_to_antenna_flags(uvcal_obj, uvf_future_shapes, uvc_future_shapes, resort):
     uvc = uvcal_obj
     if not uvc_future_shapes:
         uvc.use_current_array_shapes()
@@ -2764,6 +2778,18 @@ def test_to_antenna_flags(uvcal_obj, uvf_future_shapes, uvc_future_shapes):
         uvc.flex_spw_id_array = np.zeros(uvc.Nfreqs, dtype=int)
         uvc.flex_spw_id_array[uvc.Nfreqs // 2 :] = 1
         uvc.check()
+
+    if resort:
+        rng = np.random.default_rng()
+        new_order = rng.permutation(uvf.Nants_telescope)
+        if uvf_future_shapes:
+            uvf.antenna_numbers = uvf.antenna_numbers[new_order]
+            uvf.antenna_names = uvf.antenna_names[new_order]
+            uvf.antenna_positions = uvf.antenna_positions[new_order, :]
+        else:
+            uvc.antenna_numbers = uvf.antenna_numbers[new_order]
+            uvc.antenna_names = uvf.antenna_names[new_order]
+            uvc.antenna_positions = uvf.antenna_positions[new_order, :]
 
     uvf.to_antenna(uvc)
     assert uvf.type == "antenna"

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -1658,6 +1658,8 @@ class UVFlag(UVBase):
 
         Broadcasts the flag array to all baselines.
         This function does NOT apply flags to uv (see utils.apply_uvflag for that).
+        Note that the antenna metadata arrays (`antenna_names`, `antenna_numbers`
+        and `antenna_positions`) may be reordered to match the ordering on `uv`.
 
         Parameters
         ----------
@@ -1949,6 +1951,8 @@ class UVFlag(UVBase):
 
         Broadcasts the flag array to all antennas.
         This function does NOT apply flags to uv (see utils.apply_uvflag for that).
+        Note that the antenna metadata arrays (`antenna_names`, `antenna_numbers`
+        and `antenna_positions`) may be reordered to match the ordering on `uv`.
 
         Parameters
         ----------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix an error in UVFlag.to_baseline and UVFlag.to_antenna when the antenna metadata (antenna_names, antenna_numbers, antenna_positions) have the same set of antennas but they are differently sorted on the objects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #1396

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
