### PR TITLE
Minor fixes for handling of older SMA data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ positions are near surface of whatever celestial body their positions are refere
 (either the Earth or Moon, currently).
 
 ### Changed
+- Made the determination of whether or not to create a flex-pol dataset when reading
+in a MIR more robust (particularly with pre-V3 data formats).
+- Reading in of MIR data sets into `UVData` objects will now use pyuvdata-calculated
+values for `lst_array` via (`UVData.set_lsts_from_time_array`) instead of those read in
+from the file due to known precision issues in the later (~25 ms), so long as the two
+agree within this known precision limit.
 - `UVFlag.to_baseline` and `UVFlag.to_antenna` are now more robust to differences
 in antenna metadata sorting.
 - Made `MirParser` more robust against metadata indexing errors.
@@ -68,6 +74,8 @@ fully tested and didn't work properly.
 - Having `freq_array` and `channel_width` defined on wide-band UVCal objects.
 
 ### Fixed
+- A bug where `time_array` was not being correctly calculated for older (pre-V3) MIR
+data formats.
 - A small bug in UVFlag that could occur when reading in an older UVFlag HDF5
 file with missing antenna metadata.
 - A small bug (mostly affecting continuous integration) that threw an error when the

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4143,6 +4143,7 @@ def test_uvw_track_generator_errs():
 @pytest.mark.parametrize("use_uvw", [False, True])
 @pytest.mark.parametrize("use_earthloc", [False, True])
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
+@pytest.mark.filterwarnings("ignore:> 25 ms errors detected reading in LST values")
 def test_uvw_track_generator(flip_u, use_uvw, use_earthloc):
     sma_mir = UVData.from_file(os.path.join(DATA_PATH, "sma_test.mir"))
     sma_mir.set_lsts_from_time_array()

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -359,10 +359,6 @@ class Mir(UVData):
                 pol_split_tuning = not (
                     loa_chunks.issubset(lob_chunks) or lob_chunks.issubset(loa_chunks)
                 )
-                print(loa_chunks)
-                print(lob_chunks)
-                print(pol_split_tuning)
-                print("hi!")
 
         # Map MIR pol code to pyuvdata/AIPS polarization number
         pol_code_dict = {}

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -4183,7 +4183,7 @@ class MirParser(object):
         # bl_data updates: ant1rx, ant2rx, u, v, w
         # First, update the antenna receiver if these values are unfilled (true in some
         # earlier tracks, no version demarcation notes it).
-        if np.all(self.bl_data["ant1rx"] == 0) and np.all(self.bl_data["ant2rx"] == 0):
+        if np.all(self.bl_data["ant1rx"] == 0) or np.all(self.bl_data["ant2rx"] == 0):
             ipol = self.bl_data["ipol"]
             irec = self.bl_data["irec"]
 

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -4148,15 +4148,18 @@ class MirParser(object):
         for key, value in mjd_day_dict.items():
             if isinstance(value, str):
                 mjd_day_dict[key] = Time(
-                    datetime.strptime(value, "%b %d, %Y"), scale="tt"
-                ).tt.mjd
+                    datetime.strptime(value, "%b %d, %Y"), scale="utc"
+                ).mjd
 
         mjd_arr = (self.in_data["dhrs"] / 24.0) + np.array(
             [mjd_day_dict[idx] for idx in self.in_data["iref_time"]]
         )
 
         # Tally the JD dates, since that's used for various helper functions
-        jd_arr = Time(mjd_arr, format="mjd", scale="utc").utc.jd
+        jd_arr = Time(mjd_arr, format="mjd", scale="utc").jd
+
+        # Also, convert MJD back into the expected TT timescale
+        mjd_arr = Time(mjd_arr, format="mjd", scale="utc").tt.mjd
 
         # Calculate the LST at the time of obs
         lst_arr = (12.0 / np.pi) * uvutils.get_lst_for_time(

--- a/pyuvdata/uvdata/tests/conftest.py
+++ b/pyuvdata/uvdata/tests/conftest.py
@@ -106,8 +106,10 @@ def sma_mir_main():
     testfile = os.path.join(DATA_PATH, "sma_test.mir")
     with uvtest.check_warnings(
         UserWarning,
-        match="The lst_array is not self-consistent with the time_array and telescope "
-        "location. Consider recomputing with the `set_lsts_from_time_array` method.",
+        match=[
+            "> 25 ms errors detected reading in LST values from MIR data. ",
+            "The lst_array is not self-consistent with the time_array and telescope ",
+        ],
     ):
         uv_object.read(testfile, use_future_array_shapes=True)
     uv_object.set_lsts_from_time_array()

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -789,3 +789,14 @@ def test_generate_sma_antpos_dict(use_file, sma_mir):
     ant_dict = generate_sma_antpos_dict(filepath)
     for ant_num, xyz_pos in zip(sma_mir.antenna_numbers, sma_mir.antenna_positions):
         assert np.allclose(ant_dict[ant_num], xyz_pos)
+
+
+def test_spw_consistency_warning():
+    mir_data = MirParser(sma_mir_test_file)
+    mir_data.sp_data._data["fres"][1] *= 2
+    mir_data.bl_data._data["ant1rx"][:] = 0
+    mir_data.bl_data._data["ant2rx"][:] = 0
+
+    mir_uv = Mir()
+    with uvtest.check_warnings(UserWarning, match="Discrepancy in fres"):
+        mir_uv._init_from_mir_parser(mir_data)

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -791,8 +791,7 @@ def test_generate_sma_antpos_dict(use_file, sma_mir):
         assert np.allclose(ant_dict[ant_num], xyz_pos)
 
 
-def test_spw_consistency_warning():
-    mir_data = MirParser(sma_mir_test_file)
+def test_spw_consistency_warning(mir_data):
     mir_data.sp_data._data["fres"][1] *= 2
     mir_data.bl_data._data["ant1rx"][:] = 0
     mir_data.bl_data._data["ant2rx"][:] = 0

--- a/pyuvdata/uvdata/tests/test_mir.py
+++ b/pyuvdata/uvdata/tests/test_mir.py
@@ -29,8 +29,10 @@ def sma_mir_filt_main():
     uv_object = UVData()
     with uvtest.check_warnings(
         UserWarning,
-        match="The lst_array is not self-consistent with the time_array and telescope "
-        "location. Consider recomputing with the `set_lsts_from_time_array` method.",
+        match=[
+            "> 25 ms errors detected reading in LST values from MIR data. ",
+            "The lst_array is not self-consistent with the time_array and telescope ",
+        ],
     ):
         uv_object.read(
             sma_mir_test_file,
@@ -265,10 +267,9 @@ def test_mir_partial_read(sma_mir):
         match=[
             "Warning: a select on read keyword is set that is not supported by "
             "read_mir. This select will be done after reading the file.",
-            "The lst_array is not self-consistent with the time_array and telescope "
-            "location. Consider recomputing with the `set_lsts_from_time_array` method",
-            "The lst_array is not self-consistent with the time_array and telescope "
-            "location. Consider recomputing with the `set_lsts_from_time_array` method",
+            "> 25 ms errors detected reading in LST values from MIR data. ",
+            "The lst_array is not self-consistent with the time_array and telescope ",
+            "The lst_array is not self-consistent with the time_array and telescope ",
         ],
     ):
         uv3 = UVData.from_file(
@@ -303,8 +304,10 @@ def test_multi_nchan_spw_read(tmp_path):
     uv_in = UVData()
     with uvtest.check_warnings(
         UserWarning,
-        match="The lst_array is not self-consistent with the time_array and telescope "
-        "location. Consider recomputing with the `set_lsts_from_time_array` method.",
+        match=[
+            "> 25 ms errors detected reading in LST values from MIR data. ",
+            "The lst_array is not self-consistent with the time_array and telescope ",
+        ],
     ):
         uv_in.read_mir(sma_mir_test_file, corrchunk=[0, 1, 2, 3, 4])
     uv_in.set_lsts_from_time_array()
@@ -315,6 +318,7 @@ def test_multi_nchan_spw_read(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent with the.")
+@pytest.mark.filterwarnings("ignore:> 25 ms errors detected reading in LST values")
 def test_read_mir_write_ms_flex_pol(mir_data, tmp_path):
     """
     Mir to MS loopback test with flex-pol.
@@ -393,7 +397,13 @@ def test_inconsistent_sp_records(mir_data, sma_mir):
 
     mir_uv = UVData()
     mir_obj = Mir()
-    with uvtest.check_warnings(UserWarning, "Per-spectral window metadata differ."):
+    with uvtest.check_warnings(
+        UserWarning,
+        match=[
+            "Per-spectral window metadata differ.",
+            "> 25 ms errors detected reading in LST values",
+        ],
+    ):
         mir_obj._init_from_mir_parser(mir_data)
     mir_uv._convert_from_filetype(mir_obj)
     mir_uv.use_future_array_shapes()
@@ -411,7 +421,13 @@ def test_inconsistent_bl_records(mir_data, sma_mir):
     mir_data.load_data()
     mir_uv = UVData()
     mir_obj = Mir()
-    with uvtest.check_warnings(UserWarning, "Per-baseline metadata differ."):
+    with uvtest.check_warnings(
+        UserWarning,
+        match=[
+            "> 25 ms errors detected reading in LST values",
+            "Per-baseline metadata differ.",
+        ],
+    ):
         mir_obj._init_from_mir_parser(mir_data)
     mir_uv._convert_from_filetype(mir_obj)
     mir_uv.use_future_array_shapes()
@@ -420,6 +436,7 @@ def test_inconsistent_bl_records(mir_data, sma_mir):
     assert mir_uv == sma_mir
 
 
+@pytest.mark.filterwarnings("ignore:> 25 ms errors detected reading in LST values")
 def test_multi_ipol(mir_data, sma_mir):
     """
     Test that the MIR object does the right thing when different polarization types
@@ -621,6 +638,7 @@ def test_flex_pol_spw_all_flag(sma_mir_filt):
     assert np.all(sma_mir_filt.flex_spw_polarization_array == -5)
 
 
+@pytest.mark.filterwarnings("ignore:> 25 ms errors detected reading in LST values")
 def test_bad_sphid(mir_data):
     """
     Test what bad values for sphid in sp_data result in an error.
@@ -636,6 +654,7 @@ def test_bad_sphid(mir_data):
     assert str(err.value).startswith("'Mismatch between keys in vis_data and sphid")
 
 
+@pytest.mark.filterwarnings("ignore:> 25 ms errors detected reading in LST values")
 def test_bad_pol_code(mir_data):
     """
     Test that an extra (unused) pol code doesn't produce an error. Note that we want
@@ -652,6 +671,7 @@ def test_bad_pol_code(mir_data):
 
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
+@pytest.mark.filterwarnings("ignore:> 25 ms errors detected reading in LST values")
 def test_rechunk_on_read():
     """Test that rechunking on read works as expected."""
     uv_data = UVData.from_file(
@@ -664,6 +684,7 @@ def test_rechunk_on_read():
 
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
+@pytest.mark.filterwarnings("ignore:> 25 ms errors detected reading in LST values")
 @pytest.mark.parametrize(
     "select_kwargs",
     [
@@ -688,6 +709,7 @@ def test_select_on_read(select_kwargs, sma_mir):
     assert sma_mir == uv_data
 
 
+@pytest.mark.filterwarnings("ignore:> 25 ms errors detected reading in LST values")
 def test_non_icrs_coord_read(mir_data):
     # When fed a non-J2000 coordinate, we want to convert that so that it can easily
     mir_uv = UVData()
@@ -714,6 +736,7 @@ def test_non_icrs_coord_read(mir_data):
     )
 
 
+@pytest.mark.filterwarnings("ignore:> 25 ms errors detected reading in LST values")
 def test_dedoppler_data(mir_data, sma_mir):
     mir_uv = UVData()
     mir_obj = Mir()
@@ -763,14 +786,16 @@ def test_source_pos_change_warning(mir_data, tmp_path):
     ):
         mir_copy.__iadd__(mir_data, force=True, merge=False)
 
-    print(mir_copy.auto_data)
-
     # Muck the ra coord
     mir_copy.in_data["rar"] = [0, 1]
     mir_obj = Mir()
 
     with uvtest.check_warnings(
-        UserWarning, "Position for 3c84 changes by more than an arcminute."
+        UserWarning,
+        [
+            "> 25 ms errors detected reading in LST values",
+            "Position for 3c84 changes by more than an arcminute.",
+        ],
     ):
         mir_obj._init_from_mir_parser(mir_copy)
 
@@ -797,5 +822,8 @@ def test_spw_consistency_warning(mir_data):
     mir_data.bl_data._data["ant2rx"][:] = 0
 
     mir_uv = Mir()
-    with uvtest.check_warnings(UserWarning, match="Discrepancy in fres"):
+    with uvtest.check_warnings(
+        UserWarning,
+        match=["Discrepancy in fres", "> 25 ms errors detected reading in LST values"],
+    ):
         mir_uv._init_from_mir_parser(mir_data)

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -30,18 +30,6 @@ from ..mir_parser import (
 )
 
 
-@pytest.fixture(scope="session")
-def mir_data_main():
-    mir_data = MirParser()
-
-    yield mir_data._load_test_data(load_cross=True, load_auto=True, has_auto=True)
-
-
-@pytest.fixture(scope="function")
-def mir_data(mir_data_main):
-    yield mir_data_main.copy()
-
-
 @pytest.fixture(scope="module")
 def compass_soln_file(tmp_path_factory):
     tmp_path = tmp_path_factory.mktemp("mir_parser", numbered=True)

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -11987,11 +11987,22 @@ def test_set_nsamples_wrong_shape_error(hera_uvh5):
         ["zen.2458661.23480.HH.uvh5", ""],
         [
             "sma_test.mir",
-            (
-                "The lst_array is not self-consistent with the time_array and telescope"
-                " location. Consider recomputing with the `set_lsts_from_time_array`"
-                " method"
-            ),
+            [
+                (
+                    "The lst_array is not self-consistent with the time_array and "
+                    "telescope location. Consider recomputing with the "
+                    "`set_lsts_from_time_array` method"
+                ),
+                (
+                    "> 25 ms errors detected reading in LST values from MIR data. "
+                    "This typically signifies a minor metadata recording error (which "
+                    "can be mitigated by calling the `set_lsts_from_time_array` method "
+                    "with `update_vis=False`), though additional errors about "
+                    "uvw-position accuracy may signal more significant issues with "
+                    "metadata accuracy that could have substantial impact on "
+                    "downstream analysis."
+                ),
+            ],
         ],
         [
             "carma_miriad",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a few issues that became apparent after #1371 was merged.

## Description
<!--- Describe your changes in detail -->
There are a couple of changes that have been made here:
- Some fixtures in `test_mir_parser` that were redundant have been removed.
- Reading in of MIR data has been reordered so that data-like attributes are read in last (which is helpful in testing/debugging)
- A bug has been fixed in `MirParser._make_v3_compliant` where MJDs were not calculated correctly (forgot to convert UTC back to TT, which is the MIR standard).
- Changed the way that `Mir` determines whether or not a data set should be flex-pol. 
- When reading in MIR datasets, the corresponding value for `UVData.lst_array` is now filled by `set_lsts_from_time_array` under most circumstances. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The change in flex-pol handling primarily affects reading in of older, pre-V3 MIR-formatted SMA data. Specifically, "gunnLO" was not consistently filled/used in pre-V3 data, whereas "fsky" has historically always been present, hence switching from the former to the latter.

The change in LST-handling arises from nuisance warnings about errors in the LSTs, which after #1356 have reduced somewhat in frequency for MIR data sets, but still regularly arise. I believe this is due to how these values are presently calculated, as a polled average rather than directly calculated at the integration mid-point, producing errors of up to 25 ms. Given that this is a long-standing feature, the reader now defaults to using pyuvdata-calculated LST values so long as they agree w/ the recorded values to within this precision limit. This has the advantage of providing "truer-to-observed" values while reducing the erroneous warnings. When the recorded values are _not_ within the precision limit, they are plugged into `lst_array` so that a warning is appropriately raised (and the issue can be handled by the user accordingly).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).