### PR TITLE
Adding support for initializing `MirParser` from `Path` objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added support for initializing `MirParser` and `MirMetaData` objects from `Path`
+objects.
 - Added a brief tutorial on how to convert SMA MIR data into MS format (with some notes
 on SMA specific keywords than can be used).
 - Added the `Mir.generate_sma_antpos_dict` method for reading in SMA-formatted antenna

--- a/pyuvdata/uvdata/mir_meta_data.py
+++ b/pyuvdata/uvdata/mir_meta_data.py
@@ -2223,8 +2223,8 @@ class MirMetaData(object):
         FileNotFoundError
             If running the check and no file is found (and `invert_check=False`).
         """
-        if not isinstance(filepath, str):
-            raise ValueError("filepath must be of type str.")
+        if not isinstance(filepath, (str, Path)):
+            raise ValueError("filepath must be of type str or Path.")
 
         if os.path.isdir(filepath):
             filepath = os.path.join(os.path.abspath(filepath), self._filetype)

--- a/pyuvdata/uvdata/mir_meta_data.py
+++ b/pyuvdata/uvdata/mir_meta_data.py
@@ -10,6 +10,7 @@ This module provides a python interface for individual Mir metadata files, e.g.
 import copy
 import os
 import warnings
+from pathlib import Path
 
 import numpy as np
 
@@ -570,7 +571,7 @@ class MirMetaData(object):
 
         if obj is None:
             return
-        if isinstance(obj, str):
+        if isinstance(obj, (str, Path)):
             self.read(filepath=obj)
             return
 

--- a/pyuvdata/uvdata/mir_meta_data.py
+++ b/pyuvdata/uvdata/mir_meta_data.py
@@ -537,13 +537,14 @@ class MirMetaData(object):
 
         Parameters
         ----------
-        obj : str or ndarray or int
-            Optional argument used to specify how to initialize the object. If a str is
-            supplied, then it is treated as the path to the Mir data folder containing
-            the metadata. If an int is supplied, a "blank" (zero-filled) array of
-            metadata is generated, with length of `obj`. If an ndarray is supplied, then
-            the supplied array is used as the underlying data set for the object (where
-            dtype of the array must match that appropriate for the object).
+        obj : str or Path or ndarray or int
+            Optional argument used to specify how to initialize the object. If a str or
+            Path is supplied, then it is treated as the path to the Mir data folder
+            containing the metadata. If an int is supplied, a "blank" (zero-filled)
+            array of metadata is generated, with length of `obj`. If an ndarray is
+            supplied, then the supplied array is used as the underlying data set for the
+            object (where dtype of the array must match that appropriate for the
+            object).
         filetype : str
             Name of the type MirMetaData object, which is then used as the file name
             that is read from/written to within the folder specified by the path.
@@ -2197,7 +2198,7 @@ class MirMetaData(object):
 
         Parameters
         ----------
-        filepath : str
+        filepath : str or Path
             Either the file to write to, or if providing the name of an existing folder,
             the name of the folder to write in (with the file name set by the _filetype
             attribute, which is automatically set for various subclasses of
@@ -2246,7 +2247,7 @@ class MirMetaData(object):
 
         Parameters
         ----------
-        filepath : str
+        filepath : str or Path
             Path of the folder containing the metadata in question.
         """
         self._data = np.fromfile(
@@ -2881,7 +2882,7 @@ class MirAntposData(MirMetaData):
 
         Parameters
         ----------
-        filepath : str
+        filepath : str or Path
             Path of the folder containing the metadata in question.
         """
         with open(self._gen_filepath(filepath), "r") as antennas_file:
@@ -3415,7 +3416,7 @@ class MirAcData(MirMetaData):
 
         Parameters
         ----------
-        filepath : str
+        filepath : str or Path
             Path of the folder containing the metadata in question.
         """
         try:

--- a/pyuvdata/uvdata/mir_parser.py
+++ b/pyuvdata/uvdata/mir_parser.py
@@ -92,7 +92,7 @@ class MirParser(object):
 
         Parameters
         ----------
-        filepath : str
+        filepath : str or Path
             Filepath is the path to the folder containing the Mir data set.
         compass_soln : str
             Optional argument, specifying the path of COMPASS-derived flagging and

--- a/pyuvdata/uvdata/tests/test_mir_parser.py
+++ b/pyuvdata/uvdata/tests/test_mir_parser.py
@@ -2318,3 +2318,16 @@ def test_mir_remember_me_vis_data(mir_data):
         np.all(sp_raw["data"] == check_arr) if (np.mod(idx, 5) == 0) else True
         for idx, sp_raw in enumerate(mir_data.raw_data.values())
     )
+
+
+def test_mir_parser_read_path_vs_str():
+    from pathlib import Path
+
+    sma_data_path = str(os.path.join(DATA_PATH, "sma_test.mir"))
+    sma_str_init = MirParser(
+        sma_data_path, load_cross=True, load_auto=True, has_auto=True
+    )
+    sma_path_init = MirParser(
+        Path(sma_data_path), load_cross=True, load_auto=True, has_auto=True
+    )
+    assert sma_str_init == sma_path_init


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added support for using `Path` objects to initialize `MirParser` objects in addiion to strings. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This was a previously (but not explicitly) supported feature with `MirParser` class that was integrated into some internal scripts prior to merging of #1371. Because adding support for this was trivial, I've added it back here.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

