### PR TITLE
Fix a couple of things for UVCal objects with time_range defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- A `UVCal.get_lst_array` method similar to the `get_time_array` method that either
+returns the LST of the mean of the start and stop time for each time range or the
+lst_array (if there's a lst_array and no lst_range).
 - A `UVCal.get_time_array` method that either returns the mean of the start and stop
 time for each time range or the time_array (if there's a time_array and no time_range).
 
 ### Changed
+- When FHD calibration solutions are read in, the `time_range` is now set to be
+one quarter of an integration time before and after the earliest and latest times
+respectively. This is a change from extending it by half an integration time to
+prevent apparent overlaps in neighboring calibration solutions due to jd precision loss.
 - Improved performance for `antpair2ind` and `_key2inds` by using the
 `blts_are_rectangular` parameter, and also by caching the results. To improve
 performance of the cache, the resulting indices are returned as slices whenever possible.

--- a/pyuvdata/uvcal/fhd_cal.py
+++ b/pyuvdata/uvcal/fhd_cal.py
@@ -95,14 +95,17 @@ class FHDCal(UVCal):
         time_use = bl_info["time_use"][0]
 
         time_array_use = time_array[np.where(time_use > 0)]
-        # extend the range by half the integration time in each direction
+        # extend the range by 1/4 the integration time in each direction
         # to make sure that the original data times are covered by the range.
+        # Note that this leaves gaps between adjacent files in principal, but
+        # using 1/2 the integration time occasionally led to time_ranges overlapping
+        # slightly because of precision issues.
         intime_jd = self.integration_time / (24.0 * 3600.0)
         self.time_range = np.reshape(
             np.asarray(
                 [
-                    np.min(time_array_use) - intime_jd / 2.0,
-                    np.max(time_array_use) + intime_jd / 2.0,
+                    np.min(time_array_use) - intime_jd / 4.0,
+                    np.max(time_array_use) + intime_jd / 4.0,
                 ]
             ),
             (1, 2),

--- a/pyuvdata/uvcal/tests/test_uvcal.py
+++ b/pyuvdata/uvcal/tests/test_uvcal.py
@@ -602,6 +602,18 @@ def test_get_time_array(gain_data):
     assert np.allclose(time_array, orig_time_array)
 
 
+def test_lst_array(gain_data):
+    calobj = gain_data
+    orig_lst_array = copy.copy(calobj.lst_array)
+
+    lst_array = calobj.get_lst_array()
+    assert np.allclose(lst_array, orig_lst_array)
+
+    calobj = time_array_to_time_range(calobj)
+    lst_array = calobj.get_lst_array()
+    assert np.allclose(lst_array, orig_lst_array)
+
+
 def test_unknown_telescopes(gain_data, tmp_path):
     calobj = gain_data
 

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -322,6 +322,7 @@ class UVCal(UVBase):
             description=desc,
             form=("Ntimes", 2),
             expected_type=float,
+            tols=1e-3 / (60.0 * 60.0 * 24.0),
             required=False,
         )
 

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -1778,6 +1778,38 @@ class UVCal(UVBase):
         else:
             return self.time_array
 
+    def get_lst_array(self, *, astrometry_library=None):
+        """
+        Get an lst array of calibration solution lsts.
+
+        LSTs are for the center of the integration, shape (Ntimes), units in radians.
+        If an lst_range is defined on the object, the lsts are the LST of the mean
+        of the start and stop times for each range. Otherwise return the lst_array
+        (which can be None).
+
+        Parameters
+        ----------
+        astrometry_library : str
+            Library used for calculating LSTs. Allowed options are 'erfa' (which uses
+            the pyERFA), 'novas' (which uses the python-novas library), and 'astropy'
+            (which uses the astropy utilities). Default is erfa unless the
+            telescope_location frame is MCMF (on the moon), in which case the default
+            is astropy.
+
+        """
+        if self.lst_range is not None:
+            latitude, longitude, altitude = self.telescope_location_lat_lon_alt_degrees
+            return uvutils.get_lst_for_time(
+                jd_array=self.get_time_array(),
+                latitude=latitude,
+                longitude=longitude,
+                altitude=altitude,
+                astrometry_library=astrometry_library,
+                frame=self._telescope_location.frame,
+            )
+        else:
+            return self.lst_array
+
     def reorder_antennas(
         self,
         order="number",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a `get_lst_array` helper method similar to the existing `get_time_array` method which returns the central LST for each lst_range.

It also reduces the time_range slightly for FHD calibration solutions. They used to be extended by half an integration time beyond the earlier and latest times used in the solution, but this could cause apparent (but spurious) overlaps for neighboring solutions because of a loss of precision on the times (in JD) in FHD. This PR reduces the extension to ¼ of the integration time in each direction.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
