### PR TITLE
fix: use x_orientation when setting polarizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Bug in which passing 'ee' or 'nn' pols to UVData.new() would error, even if
+`x_orientation` was passed.
+
 ## [2.4.2] - 2024-2-22
 
 ### Added

--- a/pyuvdata/uvdata/initializers.py
+++ b/pyuvdata/uvdata/initializers.py
@@ -528,9 +528,14 @@ def new_uvdata(
 
     flex_spw_id_array, spw_array = get_spw_params(flex_spw_id_array, freq_array)
 
+    if x_orientation is not None:
+        x_orientation = XORIENTMAP[x_orientation.lower()]
+
     polarization_array = np.array(polarization_array)
     if polarization_array.dtype.kind != "i":
-        polarization_array = utils.polstr2num(polarization_array)
+        polarization_array = utils.polstr2num(
+            polarization_array, x_orientation=x_orientation
+        )
 
     if not instrument:
         instrument = telescope_name
@@ -542,9 +547,6 @@ def new_uvdata(
         f"Object created by new_uvdata() at {Time.now().iso} using "
         f"pyuvdata version {__version__}."
     )
-
-    if x_orientation is not None:
-        x_orientation = XORIENTMAP[x_orientation.lower()]
 
     # Now set all the metadata
     obj.freq_array = freq_array

--- a/pyuvdata/uvdata/tests/test_initializers.py
+++ b/pyuvdata/uvdata/tests/test_initializers.py
@@ -13,6 +13,7 @@ import pytest
 from astropy.coordinates import EarthLocation
 
 from pyuvdata import UVData
+from pyuvdata.utils import polnum2str
 from pyuvdata.uvdata.initializers import (
     configure_blt_rectangularity,
     get_antenna_params,
@@ -542,3 +543,13 @@ def test_passing_xorient(simplest_working_params, xorient):
         assert uvd.x_orientation == "east"
     else:
         assert uvd.x_orientation == "north"
+
+
+def test_passing_directional_pols(simplest_working_params):
+    kw = {**simplest_working_params, **{"polarization_array": ["ee"]}}
+
+    with pytest.raises(KeyError, match="'ee'"):
+        UVData.new(**kw)
+
+    uvd = UVData.new(x_orientation="east", **kw)
+    assert polnum2str(uvd.polarization_array[0], x_orientation="east") == "ee"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This simply fixes a bug where if you try setting `polarization_array = ['ee', 'nn']` in `UVData.new()`, even when you have `x_orientation` defined, it errors, because it wasn't using the x_orientation info.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
