### PR TITLE
unpin pytest and require pytest-cases>=3.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Now compatible with pytest>=8.0 but require pytest-cases>=3.8.3.
+
 ### Fixed
 - Bug in which passing 'ee' or 'nn' pols to UVData.new() would error, even if
 `x_orientation` was passed.

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ If you want to do development on pyuvdata, in addition to the other dependencies
 you will need the following packages:
 
 * pytest >= 6.2
-* pytest-cases >= 3.6.9
+* pytest-cases >= 3.8.3
 * pytest-cov
 * cython >=0.23
 * coverage

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -9,8 +9,8 @@ dependencies:
   - numpy>=1.20.*
   - pyerfa>=2.0
   - coverage
-  - pytest>=6.2.0,<8.0
-  - pytest-cases>=3.6.9
+  - pytest>=6.2.0
+  - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
   - cython

--- a/ci/pyuvdata_min_versions_tests.yml
+++ b/ci/pyuvdata_min_versions_tests.yml
@@ -15,7 +15,7 @@ dependencies:
   - scipy==1.5.*
   - coverage
   - pytest==6.2.0
-  - pytest-cases==3.6.9
+  - pytest-cases==3.8.3
   - pytest-cov
   - pytest-xdist
   - cython

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -15,8 +15,8 @@ dependencies:
   - pyyaml>=5.3
   - scipy>=1.5
   - coverage
-  - pytest>=6.2.0,<8.0
-  - pytest-cases>=3.6.9
+  - pytest>=6.2.0
+  - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
   - cython

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -14,8 +14,8 @@ dependencies:
   - pyyaml>=5.3
   - scipy>=1.5
   - coverage
-  - pytest>=6.2.0,<8.0
-  - pytest-cases>=3.6.9
+  - pytest>=6.2.0
+  - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
   - cython

--- a/ci/test_requirements.txt
+++ b/ci/test_requirements.txt
@@ -1,5 +1,5 @@
 coverage
 packaging
-pytest>=6.2, <8.0
+pytest>=6.2
 pytest-cov
-pytest-cases>=3.6.9
+pytest-cases>=3.8.3

--- a/environment.yaml
+++ b/environment.yaml
@@ -16,8 +16,8 @@ dependencies:
   - pre-commit
   - pyerfa>=2.0
   - pypandoc
-  - pytest>=6.2.0,<8.0
-  - pytest-cases>=3.6.9
+  - pytest>=6.2.0
+  - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
   - python-casacore>=3.3.1

--- a/setup.py
+++ b/setup.py
@@ -119,9 +119,9 @@ all_optional_reqs = (
     + novas_reqs
 )
 test_reqs = all_optional_reqs + [
-    "pytest>=6.2, <8.0",
+    "pytest>=6.2",
     "pytest-xdist",
-    "pytest-cases>=3.6.9",
+    "pytest-cases>=3.8.3",
     "pytest-cov",
     "cython",
     "coverage",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A new version of pytest-cases finally came out that is compatible with pytest >= 8, so this PR removes the pytest pin and updates the pytest-cases requirement.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #1384

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
