### PR TITLE
mwa_corr_fits speedup: don't read the array twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Speed up for reading MWA correlator FITS files into `UVData`.
 - Now compatible with pytest>=8.0 but require pytest-cases>=3.8.3.
 
 ### Fixed

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -704,9 +704,7 @@ class MWACorrFITS(UVData):
                 time_ind = np.where(time_array == time)[0][0]
                 # dump data into matrix
                 # and take data from real to complex numbers
-                coarse_chan_data[time_ind, :, :] = (
-                    hdu.data[:, 0::2] + 1j * hdu.data[:, 1::2]
-                )
+                coarse_chan_data.view(np.float32)[time_ind, :, :] = hdu.data
                 # fill nsample and flag arrays
                 # think about using the mwax weights array in the future
                 self.nsample_array[


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A small change that should significantly speed up mwa_corr_fits reading suggested by @kartographer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [x] Other: performance improvement


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

