### PR TITLE
Fix correct_cable_len default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Bug in which `correct_cable_len` defaulted to `None` instead of `True`
+for `read_mwa_corr_fits`.
+
 ## [2.4.3] - 2024-3-25
 
 ### Added

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -1240,7 +1240,7 @@ def test_bscale(tmp_path):
 @pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only")
 def test_default_corrections(tmp_path):
     """Test that default corrections are applied"""
-    # mwa_corr_fits defaults to applying corrections for cable reflections, 
+    # mwa_corr_fits defaults to applying corrections for cable reflections,
     # digital gains, and the polyphase filter bank bandpass
     uv1 = UVData()
     uv2 = UVData()

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -1245,7 +1245,7 @@ def test_default_corrections(tmp_path):
     uv1 = UVData()
     uv2 = UVData()
     uv1.read(filelist[0:2], use_future_array_shapes=True)
-    uv1.read(filelist[11:13], use_future_array_shapes=True)
+    uv2.read(filelist[11:13], use_future_array_shapes=True)
 
     assert "Divided out digital gains" in uv1.history
     assert "Divided out digital gains" in uv2.history

--- a/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
+++ b/pyuvdata/uvdata/tests/test_mwa_corr_fits.py
@@ -1234,3 +1234,22 @@ def test_bscale(tmp_path):
     # check mwax data
     uv4.read(filelist[11:13], use_future_array_shapes=True)
     assert "SCALEFAC" not in uv4.extra_keywords.keys()
+
+
+@pytest.mark.filterwarnings("ignore:some coarse channel files were not submitted")
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only")
+def test_default_corrections(tmp_path):
+    """Test that default corrections are applied"""
+    # mwa_corr_fits defaults to applying corrections for cable reflections, 
+    # digital gains, and the polyphase filter bank bandpass
+    uv1 = UVData()
+    uv2 = UVData()
+    uv1.read(filelist[0:2], use_future_array_shapes=True)
+    uv1.read(filelist[11:13], use_future_array_shapes=True)
+
+    assert "Divided out digital gains" in uv1.history
+    assert "Divided out digital gains" in uv2.history
+    assert "Divided out pfb coarse channel bandpass" in uv1.history
+    assert "Divided out pfb coarse channel bandpass" in uv2.history
+    assert "Applied cable length correction" in uv1.history
+    assert "Applied cable length correction" in uv2.history

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -11553,7 +11553,7 @@ class UVData(UVBase):
         use_aoflagger_flags=None,
         remove_dig_gains=True,
         remove_coarse_band=True,
-        correct_cable_len=None,
+        correct_cable_len=True,
         correct_van_vleck=False,
         cheby_approx=True,
         flag_small_auto_ants=True,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The expected behavior is for `mwa_corr_fits` to have the default setting `correct_cable_len=True` but instead the default is `correct_cable_len=None". This pull request fixes the default setting.
## Description
<!--- Describe your changes in detail -->
A test is also added to test that all three corrections--cable length, digital gains, and polyphase filter bank bandpass--are applied by default by `read_mwa_corr_fits`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
In transitioning the default behavior of `correct_cable_len=False` to a new default of `correct_cable_len=True`, there was an intermediate stage in which `correct_cable_len` was set as `None` with handling later in the code. Inadvertently, during the transition process the default incorrectly became `correct_cable_len=None`.

closes #1418 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
