### PR TITLE
Cython3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- updated minimum cython dependency to 3.0.
 - Updated minimum optional dependency versions: astropy-healpix>=1.0.2
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ you will need the following packages:
 * pytest >= 6.2
 * pytest-cases >= 3.8.3
 * pytest-cov
-* cython >=0.23
+* cython >=3.0
 * coverage
 * pre-commit
 * matplotlib

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -14,6 +14,6 @@ dependencies:
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
-  - cython>=3
+  - cython>=3.0
   - setuptools_scm<7.0|>=7.0.3
   - pip

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -14,6 +14,6 @@ dependencies:
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
-  - cython
+  - cython>=3
   - setuptools_scm<7.0|>=7.0.3
   - pip

--- a/ci/pyuvdata_min_versions_tests.yml
+++ b/ci/pyuvdata_min_versions_tests.yml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-cases==3.8.3
   - pytest-cov
   - pytest-xdist
-  - cython
+  - cython==3.0.0
   - setuptools==61
   - setuptools_scm==7.0.3
   - pip

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -19,7 +19,7 @@ dependencies:
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
-  - cython
+  - cython>=3
   - setuptools_scm<7.0|>=7.0.3
   - pip
   - pip:

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -19,7 +19,7 @@ dependencies:
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
-  - cython>=3
+  - cython>=3.0
   - setuptools_scm<7.0|>=7.0.3
   - pip
   - pip:

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
-  - cython
+  - cython>=3
   - setuptools_scm<7.0|>=7.0.3
   - pip
   - pip:

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
-  - cython>=3
+  - cython>=3.0
   - setuptools_scm<7.0|>=7.0.3
   - pip
   - pip:

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,7 +6,7 @@ dependencies:
   - astropy-healpix>=1.0.2
   - astroquery>=0.4.4
   - coverage
-  - cython>=0.23
+  - cython>=3.0
   - docstring_parser>=0.15
   - h5py>=3.4
   - hdf5plugin>=3.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61",
             "wheel",
             "setuptools_scm!=7.0.0,!=7.0.1,!=7.0.2",
             "oldest-supported-numpy",
-            "cython>=0.23"]
+            "cython>=3.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -16,6 +16,7 @@ cimport cython
 cimport numpy
 from libc.math cimport atan2, cos, sin, sqrt
 
+
 cdef class Ellipsoid:
   cdef readonly numpy.float64_t gps_a, gps_b, e_squared, e_prime_squared, b_div_a2
 

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -16,11 +16,6 @@ cimport cython
 cimport numpy
 from libc.math cimport atan2, cos, sin, sqrt
 
-# This initializes the numpy 1.7 c-api.
-# cython 3.0 will do this by default.
-# We may be able to just remove this then.
-numpy.import_array()
-
 cdef class Ellipsoid:
   cdef readonly numpy.float64_t gps_a, gps_b, e_squared, e_prime_squared, b_div_a2
 

--- a/pyuvdata/uvbeam/uvbeam.pyx
+++ b/pyuvdata/uvbeam/uvbeam.pyx
@@ -15,11 +15,6 @@ cimport numpy
 from libc.math cimport fabs
 from numpy.math cimport PI
 
-# This initializes the numpy 1.7 c-api.
-# cython 3.0 will do this by default.
-# We may be able to just remove this then.
-numpy.import_array()
-
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/pyuvdata/uvdata/corr_fits.pyx
+++ b/pyuvdata/uvdata/corr_fits.pyx
@@ -16,11 +16,6 @@ from cython.parallel import parallel, prange
 
 from libc.math cimport exp, pi, sqrt
 
-# This initializes the numpy 1.7 c-api.
-# cython 3.0 will do this by default.
-# We may be able to just remove this then.
-numpy.import_array()
-
 ctypedef fused int_like:
   numpy.int_t
   int

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -503,6 +503,8 @@ class MWACorrFITS(UVData):
             An array of indices for antenna 2
 
         """
+        # This approach was necessary in older cythons but it is is still
+        # ambiguous the best way to pass strings even in cython>=3.
         # as of version 0.29.X cython does not handle numpy arrays of strings
         # particularly efficiently. Casting to bytes, then into this demonic
         # form is a workaround found here: https://stackoverflow.com/a/28777163

--- a/pyuvdata/uvdata/src/miriad_wrap.pyx
+++ b/pyuvdata/uvdata/src/miriad_wrap.pyx
@@ -15,10 +15,6 @@ from libc.string cimport strncmp
 DEF PREAMBLE_SIZE = 5
 DEF MAXVAR = 32768
 
-# This initializes the numpy 1.7 c-api.
-# cython 3.0 will do this by default.
-# We may be able to just remove this then.
-numpy.import_array()
 
 cdef extern from "miriad.h":
   cdef int H_BYTE  "H_BYTE"

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ test_reqs = all_optional_reqs + [
     "pytest-xdist",
     "pytest-cases>=3.8.3",
     "pytest-cov",
-    "cython",
+    "cython>=3.0",
     "coverage",
     "pre-commit",
 ]


### PR DESCRIPTION
bumps the cython version to 3.0. It's been stable since October 2023.

Not sure if it is possible to change some string thins in corr fits so i'd hold off on full PR for time being.