### PR TITLE
Fixing bugs with extra catalog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 - Updated minimum optional dependency versions: astropy-healpix>=1.0.2
 
 ### Fixed
+- Fixed a bug writing UVData objects to UVFITS formats with extra phase center catalog
+entries resulted in an error on read.
+- Fixed a bug where calling `UVData._set_app_coords_helper` with extra phase center
+catalog entries resulted in an error.
 - Bug in which `correct_cable_len` defaulted to `None` instead of `True`
 for `read_mwa_corr_fits`.
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2482,7 +2482,7 @@ class UVData(UVBase):
         else:
             app_ra = np.zeros(self.Nblts, dtype=float)
             app_dec = np.zeros(self.Nblts, dtype=float)
-            for cat_id in self.phase_center_catalog.keys():
+            for cat_id in np.unique(self.phase_center_id_array):
                 temp_dict = self.phase_center_catalog[cat_id]
                 select_mask = self.phase_center_id_array == cat_id
                 cat_type = temp_dict["cat_type"]

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -690,15 +690,6 @@ class UVFITS(UVData):
 
             if read_source:
                 su_hdu = hdu_list[hdunames["AIPS SU"]]
-                # We should have as many entries in the AIPS SU header as we have
-                # unique entries in the SOURCES random paramter (checked in the call
-                # to get_parameter_data above)
-                if len(su_hdu.data) != len(np.unique(self.phase_center_id_array)):
-                    raise RuntimeError(
-                        "The UVFITS file has a malformed AIPS SU table - number of "
-                        "sources do not match the number of unique source IDs in the "
-                        "primary data header."
-                    )  # pragma: no cover
 
                 # Set up these arrays so we can assign values to them
                 self.phase_center_app_ra = np.zeros(self.Nblts)
@@ -737,6 +728,16 @@ class UVFITS(UVData):
                         cat_epoch=sou_epoch,
                         info_source="uvfits file",
                     )
+
+                # All entries in phase_center_id_array should in in the catalog, so
+                # check that now before we continue reading through the file.
+                if not all(
+                    np.isin(self.phase_center_id_array, list(self.phase_center_catalog))
+                ):
+                    raise RuntimeError(
+                        "The UVFITS file has a malformed AIPS SU table - entries in "
+                        "primary data header have no corresponding match."
+                    )  # pragma: no cover
 
             # Calculate the apparent coordinate values
             self._set_app_coords_helper()

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -1489,13 +1489,17 @@ class UVFITS(UVData):
                 else 2000.0
             )
 
-            app_ra[idx] = np.median(
-                self.phase_center_app_ra[self.phase_center_id_array == cat_id]
-            )
+            if any(self.phase_center_id_array == cat_id):
+                # Fill in these values if we calculated them for the phase centers,
+                # otherwise let them just be zero, since there's no clear reference
+                # time to tie them to (and this metadata isn't used by pyuvdata anyway).
+                app_ra[idx] = np.median(
+                    self.phase_center_app_ra[self.phase_center_id_array == cat_id]
+                )
 
-            app_dec[idx] = np.median(
-                self.phase_center_app_dec[self.phase_center_id_array == cat_id]
-            )
+                app_dec[idx] = np.median(
+                    self.phase_center_app_dec[self.phase_center_id_array == cat_id]
+                )
 
         ra_arr *= 180.0 / np.pi
         dec_arr *= 180.0 / np.pi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a couple of bugs when extra entries are found in `UVData.phase_center_catalog`.

## Description
<!--- Describe your changes in detail -->
The `UVData.read_uvfits` and `UVData._set_app_coords_helper` methods have been updated to fix a pair of bugs arising when extra entries are present in the `UVData.phase_center_catalog` parameter (that is, entries that no entry along the Nblt axis is phased up to).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The above changes arise from two separate but similar issues. First, when reading in a UVFITS file, we had previously enforced that the number of entries in the SOURCE table must equal the number of unique entries in the "SOURCE" column on the main metadata table. No such constraint is placed on `UVData` objects, and so this error has been changed to only catch when the SOURCE column has no corresponding entry in the phase center catalog.

A second bug in `UVData._set_app_coords_helper` was the result of failing to check for zero-length lists when calling various utility functions, and so the code has been modified to only run the helper function on the unique entries found within `UVData.phase_center_id_array`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
