### PR TITLE
Dcp utils miriad baseline fix

### DIFF
--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4382,9 +4382,10 @@ def test_determine_blt_order_size_1():
 
 
 def test_antnums_to_baseline_miriad_convention():
-    ant1 = np.array([0, 1, 2, 3, 0, 0]) + 1  # Ant1 array should be 1-based
-    ant2 = np.array([0, 1, 2, 3, 255, 256]) + 1  # Ant2 array should be 1-based
-    bl_gold = np.array([257, 514, 771, 1028, 67840, 67841], dtype="uint64")
+    ant1 = np.array([1, 2, 3, 1, 1, 1, 255, 256])  # Ant1 array should be 1-based
+    ant2 = np.array([0, 1, 2, 254, 255, 256, 0, 1])  # Ant2 array should be 1-based
+    bl_gold = np.array([256, 513, 770, 510, 511, 67840, 65280, 65537], dtype="uint64")
+
     n_ant = 256
     bl = uvutils.antnums_to_baseline(ant1, ant2, n_ant, use_miriad_convention=True)
     assert np.allclose(bl, bl_gold)

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -207,7 +207,7 @@ cdef inline void _antnum_to_bl_2048_miriad(
   cdef Py_ssize_t i
 
   for i in range(nbls):
-    if ant2[i] >= 255:
+    if ant2[i] > 255:      # MIRIAD uses 1-index antenna IDs 
       baselines[i] = 2048 * (ant1[i]) + (ant2[i]) + 2 ** 16
     else:
       baselines[i] = 256 * (ant1[i]) + (ant2[i])


### PR DESCRIPTION
Minor bugfix for MIRIAD baseline calculations.

## Description
MIRIAD indexes antennas starting at 1, not 0, so comparator should be >255 instead of >=255. Changed a comparator from `>= 255` to `>255`.

## Motivation and Context
Minor bugfix for code to calculate  baseline ID in MIRIAD convention. The code was correct for 0-indexed antennas (ANT0, ANT1, ...), but MIRIAD uses 1-indexed antennas (ANT1, ANT2 ...).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:

- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
