### PR TITLE
Dcp uvfits rdate fix

### DIFF
--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -60,9 +60,11 @@ class UVFITS(UVData):
             # angles in uvfits files are stored in degrees, so convert to radians
             self.lst_array = np.deg2rad(vis_hdu.data.par("lst"))
             if run_check_acceptability:
-                (latitude, longitude, altitude) = (
-                    self.telescope_location_lat_lon_alt_degrees
-                )
+                (
+                    latitude,
+                    longitude,
+                    altitude,
+                ) = self.telescope_location_lat_lon_alt_degrees
             uvutils.check_lsts_against_times(
                 jd_array=self.time_array,
                 lst_array=self.lst_array,
@@ -1161,11 +1163,12 @@ class UVFITS(UVData):
 
         # Create an  astropy.time.Time object from first timestamp.
         # This is used to generate DATE-OBS and RDATE keywords
-        eloc = EarthLocation(self.telescope_location[0],
-                             self.telescope_location[1],
-                             self.telescope_location[2],
-                             unit='m'
-                             )
+        eloc = EarthLocation(
+            self.telescope_location[0],
+            self.telescope_location[1],
+            self.telescope_location[2],
+            unit="m",
+        )
         obs_date0 = Time(self.time_array[0], format="jd", scale="utc", location=eloc)
 
         # Per AIPS memo 117, DATE-OBS is the YYYY-MM-DD string

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -11,6 +11,7 @@ import numpy as np
 from astropy import constants as const
 from astropy.io import fits
 from astropy.time import Time
+from astropy.coordinates import EarthLocation
 from docstring_parser import DocstringStyle
 
 from .. import utils as uvutils
@@ -1160,7 +1161,12 @@ class UVFITS(UVData):
 
         # Create an  astropy.time.Time object from first timestamp.
         # This is used to generate DATE-OBS and RDATE keywords
-        obs_date0 = Time(self.time_array[0], format="jd", scale="utc", location=self.location)
+        eloc = EarthLocation(self.telescope_location[0],
+                             self.telescope_location[1],
+                             self.telescope_location[2],
+                             unit='m'
+                             )
+        obs_date0 = Time(self.time_array[0], format="jd", scale="utc", location=eloc)
 
         # Per AIPS memo 117, DATE-OBS is the YYYY-MM-DD string
         hdu.header["DATE-OBS"] = obs_date0.strftime("%Y-%m-%d")


### PR DESCRIPTION
Fixes to RDATE and DATE-OBS header parameters in UVFITS writer

## Description
As per #1433, RDATE calculation is odd. I've also updated DATE-OBS to be YYYY-MM-DD, instead of ISOT, as this is what AIPS memo 117 uses.

## Motivation and Context
This fixes incorrect RDATE and DATE-OBS header parameters. These parameters are used by MIRIAD when importing UVFITS files, and MIRIAD was getting confused. I'm not sure if CASA uses these when importing uvfits (if it did, I think this would have been caught sooner?)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass. 
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

### Bugfix notes

One unit test now fails, `test_uvfits_extra_params`, due to DUT1 being slightly different (-0.2136028 vs expected -0.2137079). Not sure if test is incorrect, or astropy's DUT1 calculation is unexpected.