### PR TITLE
Version 3 -- Endgame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ time for each time range or the time_array (if there's a time_array and no time_
 - Added new keyword handling for v.6 of the MIR data format within `MirParser`.
 
 ### Changed
+- Future array shapes are now the only supported standard for `UVData`, `UVCal`,
+`UVFlag`, `UVBeam` classes.
+- `UVCal` objects where the cal type is delay must now have `wide_band=True`.
+- The `flex_spw_id_array` is now required for `UVCal` objects were `wide_band=False`.
+- `UVCal` objects with `wide_band=True` may only have the `freq_range` parameter set and
+the `freq_array`and `channel_width` parameters. If `wide_band=False`, then the
+`freq_array`and `channel_width` parameters must be set, while the `freq_range` parameter
+must be left unset.
+- For `UVCal` objects, only one of the time-based parameters (`time_array` and
+`time_range`) may be set on a given object.
+
 - Telescope-related metadata (including antenna metadata) on `UVData`, `UVCal`
 and `UVFlag` have been refactored into a `Telescope` object (attached to these
 objects as the `telescope` attribute) and most of the code related to these
@@ -65,6 +76,10 @@ times for those solutions.
 - Updated minimum optional dependency versions: astropy-healpix>=1.0.2
 
 ### Deprecated
+- The `future_array_shapes` attribute on `UVBase` objects has been deprecated, as
+pyuvdata now exclusively uses future array shapes.
+- The `use_future_array_shapes` keyword in several different class methods, as well as
+the `use_future_array_shapes` method on `UVBase` objects.
 - Accessing the telescope-related metadata through their old attribute names on
 `UVData`, `UVCal` and `UVFlag` rather than via their attributes on the attached
 `Telescope` object (e.g. `UVData.telescope_name` -> `UVData.telescope.name` and
@@ -80,6 +95,8 @@ and the `Telescope.from_known_telescopes` classmethod.
 and the `Telescope.from_known_telescopes` classmethod.
 
 ### Fixed
+- Fixed a minor bug in `utils._check_freq_spacing` that raised issues which raised an
+error when evaluating a "flex-spw" dataset where Nspws was 1.
 - Fixed a bug in `UVBase` where `allowed_failures` was being ignored if a parameter had
 `required=True` set.
 - Fixed a bug where selection and addition/concat methods did not operate correctly on
@@ -90,6 +107,16 @@ entries resulted in an error on read.
 catalog entries resulted in an error.
 - Bug in which `correct_cable_len` defaulted to `None` instead of `True`
 for `read_mwa_corr_fits`.
+
+### Removed
+- Support for current array shapes has been removed on `UVData`, `UVCal`, `UVFlag`, and
+`UVBeam` objects, as well as the `use_current_array_shapes` method for these classes.
+- The `flex_spw` attribute has been removed on `UVData` and `UVCal` objects.
+- Support for using the old phasing attributes (`phase_center_ra`, `phase_center_dec`,
+`phase_center_frame`, `phase_center_epoch`, `phase_type`, and `object_name`) in `UVData`.
+- Support for handling of the `input_flag_array` parameter for `UVCal` objects.
+- Support for providing capitalized variants of `UVBeam.feed_array`.
+- Support for 'unknown' cal type in `UVCal` objects.
 
 ## [2.4.3] - 2024-3-25
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,6 @@ napoleon_use_rtype = False
 # use this to create custom sections
 # currently used for the UVData.read method
 napoleon_custom_sections = [
-    ("Phasing", "params_style"),
     ("Selecting", "params_style"),
     ("Checking", "params_style"),
     ("Miriad", "params_style"),

--- a/docs/references/calfits_memo.tex
+++ b/docs/references/calfits_memo.tex
@@ -60,7 +60,7 @@ These axes, in order, represent
 	\item Gain-type: this axis stores the concatenation of the UVCal arrays [real(gain\_array), imaginary(gain\_array), flag\_array, input\_flag\_array, quality\_array], in that order.
 	If there is no input\_flag\_array or no quality\_array for this calibration, they are \emph{not} appended to the axis.
 	Correspondingly, in a ``gain''-type calibration, this axis may be of length 3 to 5, depending on the inclusion of the input\_flag\_array and quality\_array.
-	In older files, the quality\_array is always present while the input\_flag\_array was optional. In newer files, the input\_flag\_array has been deprecated (as of \texttt{pyuvdata} version 3.0)
+    In older files, the quality\_array is always present while the input\_flag\_array was optional. In newer files, the input\_flag\_array is not present (support for it in UVCal was deprecated as of \texttt{pyuvdata} version 3.0)
     while the quality\_array can be present or absent and a boolean header item \textbf{HASQLTY} will be present to indicate its presence
 	(to make it clear which array is present if the axis is length 4). So if the axis is length 4 and there is no \textbf{HASQLTY} header keyword,
 	the fourth array is the quality\_array and there is no input\_flag\_array. If the axis is length 4 and the \textbf{HASQLTY} header keyword is present, then

--- a/docs/references/calfits_memo.tex
+++ b/docs/references/calfits_memo.tex
@@ -60,8 +60,8 @@ These axes, in order, represent
 	\item Gain-type: this axis stores the concatenation of the UVCal arrays [real(gain\_array), imaginary(gain\_array), flag\_array, input\_flag\_array, quality\_array], in that order.
 	If there is no input\_flag\_array or no quality\_array for this calibration, they are \emph{not} appended to the axis.
 	Correspondingly, in a ``gain''-type calibration, this axis may be of length 3 to 5, depending on the inclusion of the input\_flag\_array and quality\_array.
-	In older files, the quality\_array is always present while the input\_flag\_array was optional. In newer files, the input\_flag\_array is generally
-	not present while the quality\_array can be present or absent and a boolean header item \textbf{HASQLTY} will be present to indicate its presence
+	In older files, the quality\_array is always present while the input\_flag\_array was optional. In newer files, the input\_flag\_array has been deprecated (as of \texttt{pyuvdata} version 3.0)
+    while the quality\_array can be present or absent and a boolean header item \textbf{HASQLTY} will be present to indicate its presence
 	(to make it clear which array is present if the axis is length 4). So if the axis is length 4 and there is no \textbf{HASQLTY} header keyword,
 	the fourth array is the quality\_array and there is no input\_flag\_array. If the axis is length 4 and the \textbf{HASQLTY} header keyword is present, then
 	if \textbf{HASQLTY} is True, the fourth array is the quality\_array, otherwise it is the input\_flag\_array.

--- a/docs/uvbeam_tutorial.rst
+++ b/docs/uvbeam_tutorial.rst
@@ -61,40 +61,6 @@ parameters for common beam pixel and E-field coordinate systems include:
     - ``basis_vector_array[1, 0, :] = 0``
     - ``basis_vector_array[1, 1, :] = 1``
 
-UVBeam: parameter shape changes
--------------------------------
-As detailed in :ref:`uvdata_future_shapes`, UVData objects now support flexible spectral
-windows and will have several parameter shapes change in version 3.0. UVData objects
-also have a method to convert to the planned future array shapes now to support an
-orderly conversion of code and packages that use UVData objects to the future shapes.
-
-UVBeam objects will also see parameter shape changes in version 3.0, but will not add
-support for flexible spectral windows as there does not currently seem to be a need for
-spectral window support currently in UVBeam.
-
-In version 3.0, several parameters will change shape. The length 1 axis that was
-originally intended for the spectral windows axis will be removed from the
-``data_array`` , ``freq_array``, ``bandpass_array``, ``receiver_temperature_array``,
-``loss_array``, ``mismatch_array``, ``s_parameters`` and ``coupling_matrix``.
-In addition, the ``spw_array`` and ``Nspws`` parameters will become optional.
-
-In order to support an orderly conversion of code and packages that use the UVBeam
-object to these new parameter shapes, we have created the
-:meth:`pyuvdata.UVBeam.use_future_array_shapes` method which will change the parameters
-listed above to have their future shapes. We have also added ``use_future_array_shapes``
-parameters to the :meth:`pyuvdata.UVBeam.read` and :meth:`pyuvdata.UVBeam.from_file` methods
-(as well as the underlying :meth:`pyuvdata.UVBeam.read_beamfits`,
-:meth:`pyuvdata.UVBeam.read_cst_beam`, :meth:`pyuvdata.UVBeam.read_mwa_beam` methods),
-which can be set to ``True`` to yield an object with the future shapes. Users writing
-new code that uses UVBeam objects are encouraged to call the ``use_future_array_shapes``
-method immediately after creating a UVBeam object or use the corresponding parameter
-when reading in data from a file to ensure that the code will be compatible with the
-forthcoming changes. Developers and maintainers of existing code that uses UVBeam
-objects are encouraged to similarly update their code to use the new shapes at their
-earliest convenience to ensure future compatibility. The method and parameters will be
-deprecated but not removed in version 3.0 (it will just become a no-op) so that code
-that calls it will continue to function.
-
 UVBeam: Reading/writing
 -----------------------
 Reading and writing beam files using UVBeam.
@@ -137,7 +103,6 @@ a) Reading a CST power beam file
   ...   feed_name='PAPER_dipole', feed_version='0.1',
   ...   model_name='E-field pattern - Rigging height 4.9m',
   ...   model_version='1.0',
-  ...   use_future_array_shapes=True,
   ... )
   >>> print(beam.beam_type)
   power
@@ -149,7 +114,7 @@ a) Reading a CST power beam file
   >>> # You can also use a yaml settings file.
   >>> # Note that using a yaml file requires that pyyaml is installed.
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam = UVBeam.from_file(settings_file, beam_type='power', use_future_array_shapes=True)
+  >>> beam = UVBeam.from_file(settings_file, beam_type='power')
   >>> print(beam.beam_type)
   power
   >>> print(beam.pixel_coordinate_system)
@@ -183,12 +148,12 @@ b) Reading a CST E-field beam file
 
   >>> # the same interface as for power beams, just specify beam_type = 'efield'
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam = UVBeam.from_file(settings_file, beam_type='efield', use_future_array_shapes=True)
+  >>> beam = UVBeam.from_file(settings_file, beam_type='efield')
   >>> print(beam.beam_type)
   efield
 
   >>> # UVBeam also has a `from_file` class method we can call directly.
-  >>> beam3 = UVBeam.from_file(settings_file, beam_type="efield", use_future_array_shapes=True)
+  >>> beam3 = UVBeam.from_file(settings_file, beam_type="efield")
   >>> beam == beam3
   True
 
@@ -214,15 +179,13 @@ c) Reading in the MWA full embedded element beam
   >>> from pyuvdata.data import DATA_PATH
 
   >>> mwa_beam_file = os.path.join(DATA_PATH, 'mwa_full_EE_test.h5')
-  >>> beam = UVBeam.from_file(mwa_beam_file, use_future_array_shapes=True)
+  >>> beam = UVBeam.from_file(mwa_beam_file)
   >>> print(beam.beam_type)
   efield
 
   >>> delays = np.zeros((2, 16), dtype='int')
   >>> delays[:, 0] = 32
-  >>> beam = UVBeam.from_file(
-  ...    mwa_beam_file, pixels_per_deg=1, delays=delays, use_future_array_shapes=True
-  ... )
+  >>> beam = UVBeam.from_file(mwa_beam_file, pixels_per_deg=1, delays=delays)
 
 
 d) Writing a regularly gridded beam FITS file
@@ -245,7 +208,6 @@ files and az/za grid.
   ...    beam_type='power',
   ...    freq_range=(1e8, 1.5e8),
   ...    za_range=(0, 90.0),
-  ...    use_future_array_shapes=True,
   ... )
   >>> write_file = os.path.join('.', 'tutorial.fits')
   >>> beam.write_beamfits(write_file, clobber=True)
@@ -261,7 +223,7 @@ See :ref:`uvbeam_to_healpix` for more details on the :meth:`pyuvdata.UVBeam.to_h
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam = UVBeam.from_file(settings_file, beam_type='power', use_future_array_shapes=True)
+  >>> beam = UVBeam.from_file(settings_file, beam_type='power')
 
   >>> # note that the `to_healpix` method requires astropy_healpix to be installed
   >>> # this beam file is very large. Let's cut down the size to ease the computation
@@ -321,7 +283,7 @@ a) Selecting a range of Zenith Angles
   >>> from pyuvdata.data import DATA_PATH
   >>> import matplotlib.pyplot as plt
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam = UVBeam.from_file(settings_file, beam_type='power', use_future_array_shapes=True)
+  >>> beam = UVBeam.from_file(settings_file, beam_type='power')
   >>> # Make a new object with a reduced zenith angle range with the select method
   >>> new_beam = beam.select(axis2_inds=np.arange(0, 20), inplace=False)
 
@@ -361,7 +323,7 @@ or "ee).
   >>> from pyuvdata.data import DATA_PATH
   >>> import pyuvdata.utils as uvutils
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> uvb = UVBeam.from_file(settings_file, beam_type='efield', use_future_array_shapes=True)
+  >>> uvb = UVBeam.from_file(settings_file, beam_type='efield')
 
   >>> # The feeds names can be found in the feed_array
   >>> print(uvb.feed_array)
@@ -444,7 +406,7 @@ extra interpolation errors.
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam = UVBeam.from_file(settings_file, beam_type='power', use_future_array_shapes=True)
+  >>> beam = UVBeam.from_file(settings_file, beam_type='power')
 
   >>> # this beam file is very large. Let's cut down the size to ease the computation
   >>> za_max = np.deg2rad(10.0)
@@ -471,7 +433,7 @@ a) Convert a regularly gridded efield beam to a power beam (leaving original int
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam = UVBeam.from_file(settings_file, beam_type='efield', use_future_array_shapes=True)
+  >>> beam = UVBeam.from_file(settings_file, beam_type='efield')
   >>> new_beam = beam.efield_to_power(inplace=False)
 
   >>> # plot zenith angle cut through the beams
@@ -495,7 +457,7 @@ b) Generating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beams
   >>> from pyuvdata.data import DATA_PATH
   >>> from pyuvdata import utils as uvutils
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam = UVBeam.from_file(settings_file, beam_type='efield', use_future_array_shapes=True)
+  >>> beam = UVBeam.from_file(settings_file, beam_type='efield')
 
   >>> # this beam file is very large. Let's cut down the size to ease the computation
   >>> za_max = np.deg2rad(10.0)
@@ -530,9 +492,7 @@ a) Calculating pseudo Stokes ('pI', 'pQ', 'pU', 'pV') beam area and beam squared
   >>> from pyuvdata import UVBeam
   >>> from pyuvdata.data import DATA_PATH
   >>> settings_file = os.path.join(DATA_PATH, 'NicCSTbeams/NicCSTbeams.yaml')
-  >>> beam = UVBeam.from_file(
-  ...    settings_file, beam_type='efield', use_future_array_shapes=True
-  ... )
+  >>> beam = UVBeam.from_file(settings_file, beam_type='efield')
 
   >>> # note that the `to_healpix` method requires astropy_healpix to be installed
   >>> # this beam file is very large. Let's cut down the size to ease the computation

--- a/docs/uvcal_tutorial.rst
+++ b/docs/uvcal_tutorial.rst
@@ -48,57 +48,6 @@ Those methods take the antenna numbers (i.e. numbers listed in ``telescope.anten
 as inputs.
 
 
-UVCal: parameter shape changes
--------------------------------
-As detailed in :ref:`uvdata_future_shapes`, UVData objects now support flexible spectral
-windows and will have several of their parameter shapes change in version 3.0. They also
-have a method to convert to the planned future array shapes now to support an orderly
-conversion of code and packages that use UVData objects to the future shapes.
-
-UVCal objects now also support flexible spectral windows and will see parameter shape
-changes in version 3.0.
-
-Spectral windows are implemented on standard "gain" type UVCal objects in a similar way
-to the UVData implementation, where windows are defined as sets of frequency channels
-with some extra parameters to track which channels are in each spectral window. This
-allows for spectral windows to have arbitrary numbers of frequency channels and makes
-the ``channel_width`` parameter be an array of length ``Nfreqs`` rather than a scalar,
-but only when the UVCal object contains flexible spectral windows. Supporting multiple
-spectral windows in this way removes the need for the spectral window axis on several
-UVCal parameters, but the axis was left as a length 1 axis for backwards compatibility.
-
-Spectral windows are treated a little differently for wide-band style UVCal objects,
-which do not have an explicit frequency axis. For those objects, which include all
-"delay" type UVCal objects as well as wide-band gain objects, the ``freq_array``
-and ``channel_width`` parameters are not required but the ``freq_range`` parameter is
-required. UVCal objects that are wide-band and use the future array shapes
-can support multiple spectral windows, see details below.
-
-In version 3.0, several parameters will change shape. For standard "gain" type
-UVCal objects, the length 1 axis that was originally intended for the spectral windows
-axis will be removed from the ``gain_array`` , ``flag_array``, ``quality_array``,
-``input_flag_array``, ``total_quality_array`` and ``freq_array`` parameters and the
-``channel_width`` parameter will always be an array of length ``Nfreqs``. For
-wide-band and "delay" type UVCal objects, the spectral window axis will be retained but
-the axis corresponding to the frequency axis will be removed from the ``gain_array`` ,
-``delay_array``, ``flag_array``, ``quality_array``, ``input_flag_array`` and the
-``total_quality_array`` and the ``freq_range`` parameter will gain a spectral window
-axis. In addition, the ``integration_time`` parameter will always be an array of
-length ``Ntimes``.
-
-In order to support an orderly conversion of code and packages that use the ``UVCal``
-object to these new parameter shapes, we have created the
-:meth:`pyuvdata.UVCal.use_future_array_shapes` method which will change the parameters
-listed above to have their future shapes. Users writing new code that uses ``UVCal``
-objects are encouraged to call that method immediately after creating a UVCal object
-or reading in data from a file to ensure that the code will be compatible with the
-forthcoming changes. Developers and maintainers of existing code that uses ``UVCal``
-objects are encouraged to similarly add that method call and convert their code to use
-the new shapes at their earliest convenience to ensure future compatibility. The method
-will be deprecated but not removed in version 3.0 (it will just become a no-op) so
-that code that calls it will continue to function.
-
-
 UVCal: Reading/writing
 ----------------------
 Calibration files using UVCal.
@@ -115,9 +64,9 @@ a) Reading a CalFITS gain calibration file.
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
   >>> # Here we use the ``from_file`` class method, can also use the ``read`` method.
   >>> # Can optionally specify the ``file_type`` to either method
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
   >>> cal = UVCal()
-  >>> cal.read(filename, file_type="calfits", use_future_array_shapes=True)
+  >>> cal.read(filename, file_type="calfits")
 
   >>> # Cal type:
   >>> print(cal.cal_type)
@@ -172,7 +121,6 @@ b) FHD cal to CalFITS
   ...    obs_file=obs_testfile,
   ...    settings_file=settings_testfile,
   ...    layout_file=layout_testfile,
-  ...    use_future_array_shapes=True,
   ... )
   >>> fhd_cal = UVCal()
   >>> fhd_cal.read(
@@ -181,7 +129,6 @@ b) FHD cal to CalFITS
   ...    settings_file=settings_testfile,
   ...    layout_file=layout_testfile,
   ...    file_type="fhd",
-  ...    use_future_array_shapes=True,
   ... )
   >>> fhd_cal.write_calfits(os.path.join('.', 'tutorial_cal.fits'), clobber=True)
 
@@ -196,7 +143,7 @@ b) CalFITS to CalH5
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
   >>> # Here we use the ``from_file`` class method, can also use the ``read`` method.
   >>> # Can optionally specify the ``file_type`` to either method
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
 
   >>> cal.write_calh5(os.path.join('.', 'tutorial_cal.calh5'), clobber=True)
 
@@ -211,7 +158,7 @@ c) MSCal to CalH5
   >>> filename = os.path.join(DATA_PATH, 'sma.ms.amp.gcal')
   >>> # Here we use the ``from_file`` class method, can also use the ``read`` method.
   >>> # Can optionally specify the ``file_type`` to either method
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
 
   >>> cal.write_calh5(os.path.join('.', 'tutorial_cal.ms'), clobber=True)
 
@@ -231,7 +178,7 @@ data-like arrays as well, filled with zeros.
   >>> from pyuvdata import UVData, UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> uvd_file = os.path.join(DATA_PATH, "zen.2458098.45361.HH.uvh5_downselected")
-  >>> uvd = UVData.from_file(uvd_file, file_type="uvh5", use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(uvd_file, file_type="uvh5")
   >>> uvc = UVCal.initialize_from_uvdata(uvd, gain_convention="multiply", cal_style="redundant")
   >>> print(uvc.ant_array)
   [ 0  1 11 12 13 23 24 25]
@@ -295,7 +242,7 @@ a) Data for a single antenna and instrumental polarization
   >>> from pyuvdata import UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'zen.2457555.42443.HH.uvcA.omni.calfits')
-  >>> uvc = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> uvc = UVCal.from_file(filename)
   >>> gain = uvc.get_gains(9, 'Jxx')  # gain for ant=9, pol='Jxx'
 
   >>> # One can equivalently make any of these calls with the input wrapped in a tuple.
@@ -325,11 +272,9 @@ a) Calibration of UVData by UVCal
   >>> uvd = UVData.from_file(
   ...    os.path.join(DATA_PATH, "zen.2458098.45361.HH.uvh5_downselected"),
   ...    file_type="uvh5",
-  ...    use_future_array_shapes=True
   ... )
   >>> uvc = UVCal.from_file(
   ...    os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected"),
-  ...    use_future_array_shapes=True
   ... )
   >>> # this is an old calfits file which has the wrong antenna names, so we need to fix them first.
   >>> # fix the antenna names in the uvcal object to match the uvdata object
@@ -358,7 +303,7 @@ a) Select antennas to keep on UVCal object using the antenna number.
   >>> from pyuvdata.data import DATA_PATH
   >>> import numpy as np
   >>> filename = os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
 
   >>> # print all the antennas numbers with data in the original file
   >>> print(cal.ant_array)
@@ -378,7 +323,7 @@ b) Select antennas to keep using the antenna names, also select frequencies to k
   >>> from pyuvdata import UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
 
   >>> # print all the antenna names with data in the original file
   >>> print([cal.telescope.antenna_names[np.where(cal.telescope.antenna_numbers==a)[0][0]] for a in cal.ant_array])
@@ -407,7 +352,7 @@ d) Select times
   >>> from pyuvdata import UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
   >>> cal2 = cal.copy()
 
   >>> # print all the times in the original file
@@ -442,7 +387,7 @@ represting the physical orientation of the dipole can also be used (e.g. "Jnn" o
   >>> from pyuvdata.data import DATA_PATH
   >>> import pyuvdata.utils as uvutils
   >>> filename = os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
 
   >>> # Jones component numbers can be found in the jones_array
   >>> print(cal.jones_array)
@@ -500,7 +445,7 @@ a) Add frequencies.
   >>> from pyuvdata import UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal1 = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal1 = UVCal.from_file(filename)
   >>> cal2 = cal1.copy()
 
   >>> # Downselect frequencies to recombine
@@ -519,7 +464,7 @@ b) Add times.
   >>> from pyuvdata import UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal1 = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal1 = UVCal.from_file(filename)
   >>> cal2 = cal1.copy()
 
   >>> # Downselect times to recombine
@@ -542,14 +487,14 @@ directly without creating a third uvcal object.
   >>> from pyuvdata import UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal1 = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal1 = UVCal.from_file(filename)
   >>> cal2 = cal1.copy()
   >>> times = np.unique(cal1.time_array)
   >>> cal1.select(times=times[0:len(times) // 2])
   >>> cal2.select(times=times[len(times) // 2:])
   >>> cal1.__add__(cal2, inplace=True)
 
-  >>> cal1.read(filename, use_future_array_shapes=True)
+  >>> cal1.read(filename)
   >>> cal2 = cal1.copy()
   >>> cal1.select(times=times[0:len(times) // 2])
   >>> cal2.select(times=times[len(times) // 2:])
@@ -568,7 +513,7 @@ with the previous file(s).
   >>> from pyuvdata import UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
   >>> cal1 = cal.select(freq_chans=np.arange(0, 2), inplace=False)
   >>> cal2 = cal.select(freq_chans=np.arange(2, 4), inplace=False)
   >>> cal3 = cal.select(freq_chans=np.arange(4, 7), inplace=False)
@@ -577,7 +522,7 @@ with the previous file(s).
   >>> cal3.write_calfits(os.path.join('.', 'tutorial3.fits'))
   >>> filenames = [os.path.join('.', f) for f
   ...              in ['tutorial1.fits', 'tutorial2.fits', 'tutorial3.fits']]
-  >>> cal.read(filenames, use_future_array_shapes=True)
+  >>> cal.read(filenames)
 
   >>> # For FHD cal datasets pass lists for each file type
   >>> obs_testfiles = [
@@ -601,7 +546,6 @@ with the previous file(s).
   ...    obs_file=obs_testfiles,
   ...    settings_file=settings_testfiles,
   ...    layout_file=layout_testfiles,
-  ...    use_future_array_shapes=True,
   ... )
 
 e) Fast concatenation
@@ -630,7 +574,7 @@ this must be done manually by the user if a reordering is desired
   >>> from pyuvdata import UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
   >>> cal1 = cal.select(freq_chans=np.arange(0, 2), inplace=False)
   >>> cal2 = cal.select(freq_chans=np.arange(2, 4), inplace=False)
   >>> cal3 = cal.select(freq_chans=np.arange(4, 7), inplace=False)
@@ -639,7 +583,7 @@ this must be done manually by the user if a reordering is desired
   >>> cal3.write_calfits(os.path.join('.', 'tutorial3.fits'), clobber=True)
   >>> filenames = [os.path.join('.', f) for f
   ...              in ['tutorial1.fits', 'tutorial2.fits', 'tutorial3.fits']]
-  >>> cal.read(filenames, axis="freq", use_future_array_shapes=True)
+  >>> cal.read(filenames, axis="freq")
 
 
 .. _uvcal_sorting_data:
@@ -662,7 +606,7 @@ specified by passing an index array.
   >>> from pyuvdata import UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
   >>> # Default is to order by antenna number
   >>> cal.reorder_antennas()
   >>> print(np.min(np.diff(cal.ant_array)) >= 0)
@@ -689,10 +633,8 @@ channels.
   >>> from pyuvdata import UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
   >>> # First create a multi-spectral window UVCal object:
-  >>> cal._set_flex_spw()
-  >>> cal.channel_width = np.zeros(cal.Nfreqs, dtype=np.float64) + cal.channel_width
   >>> cal.Nspws = 2
   >>> cal.flex_spw_id_array = np.concatenate((np.ones(cal.Nfreqs // 2, dtype=int), np.full(cal.Nfreqs // 2, 2, dtype=int)))
   >>> cal.spw_array = np.array([1, 2])
@@ -745,7 +687,7 @@ array for the time axis.
   >>> from pyuvdata import UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.gain.calfits')
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
 
   >>> # Default is to order by ascending time
   >>> cal.reorder_times()
@@ -770,7 +712,7 @@ by the Jones component number or name, or by an explicit index ordering set by t
   >>> from pyuvdata import UVCal
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
   >>> # Default is to order by Jones component name
   >>> cal.reorder_jones()
   >>> print(cal.jones_array)
@@ -791,7 +733,7 @@ object's ``gain_array`` to an array consistent with its pre-existing ``delay_arr
 
   >>> # This file has a cal_type of 'delay'.
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.delay.calfits')
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
   >>> print(cal.cal_type)
   delay
 
@@ -806,20 +748,20 @@ object's ``gain_array`` to an array consistent with its pre-existing ``delay_arr
 
   >>> # If we want the calibration to use a positive value in its exponent, rather
   >>> # than the default negative value:
-  >>> cal = UVCal.from_file(filename, use_future_array_shapes=True)
+  >>> cal = UVCal.from_file(filename)
   >>> cal.convert_to_gain(delay_convention='plus', freq_array=freq_array, channel_width=channel_width)
 
   >>> # Convert to gain *without* running the default check that internal arrays are
   >>> # of compatible shapes:
-  >>> cal.read(filename, use_future_array_shapes=True)
+  >>> cal.read(filename)
   >>> cal.convert_to_gain(freq_array=freq_array, channel_width=channel_width, run_check=False)
 
   >>> # Convert to gain *without* running the default check that optional parameters
   >>> # are properly shaped and typed:
-  >>> cal.read(filename, use_future_array_shapes=True)
+  >>> cal.read(filename)
   >>> cal.convert_to_gain(freq_array=freq_array, channel_width=channel_width, check_extra=False)
 
   >>> # Convert to gain *without* running the default checks on the reasonableness
   >>> # of the resulting calibration's parameters.
-  >>> cal.read(filename, use_future_array_shapes=True)
+  >>> cal.read(filename)
   >>> cal.convert_to_gain(freq_array=freq_array, channel_width=channel_width, run_check_acceptability=False)

--- a/docs/uvdata_tutorial.rst
+++ b/docs/uvdata_tutorial.rst
@@ -54,42 +54,6 @@ are the easiest way to get data for particular sets of baselines. Those methods 
 the antenna numbers (i.e. numbers listed in ``telescope.antenna_numbers``) as inputs.
 
 
-.. _uvdata_future_shapes:
-
-UVData: parameter shape changes
--------------------------------
-Initially, UVData objects were designed to support spectral windows as a separate axis,
-although support for more than one spectral window was never implemented
-(so the spectral window axis was always constrained to be length 1). This structure
-would have required that all spectral windows had the same number of channels. In
-version 2.1.2 we introduced flexible spectral windows, which implemented spectral
-windows as sets of frequency channels with some extra parameters to track which
-channels were in each spectral window. This structure allows for spectral windows to
-have arbitrary numbers of frequency channels. This structure made the ``channel_width``
-parameter be an array of length ``Nfreqs`` rather than a scalar, but only when the
-UVData object contained flexible spectral windows. Supporting multiple spectral windows
-in this way removes the need for the spectral window axis on several UVData parameters,
-but the axis was left as a length 1 axis for backwards compatibility.
-
-In version 3.0, we will remove the length 1 axis that was originally intended
-for the spectral windows axis from the ``data_array``, ``flag_array``, ``nsample_array``
-and ``freq_array`` parameters and the ``channel_width`` parameter will always be an
-array of length ``Nfreqs``.
-
-In order to support an orderly conversion of code and packages that use the ``UVData``
-object to these new parameter shapes, we have created the
-:meth:`pyuvdata.UVData.use_future_array_shapes` method and option on the read method,
-which will change the parameters listed above to have their future shapes. Users writing
-new code that uses ``UVData`` objects are encouraged to use the option in the read
-methods or call that method immediately after creating a UVData object to ensure that
-the code will be compatible with the forthcoming changes. Developers and maintainers of
-existing code that uses ``UVData`` objects are encouraged to similarly add that option
-or method call and convert their code to use the new shapes at their earliest
-convenience to ensure future compatibility. The method and option will be deprecated
-but not removed in version 3.0 (it will just become a no-op) so that code that calls it
-will continue to function.
-
-
 UVData: File conversion
 -----------------------
 Converting between tested data formats.
@@ -107,10 +71,8 @@ a) miriad -> uvfits
   >>> # This miriad file is known to be a drift scan.
   >>> # Use the `read` or `from_file` method, optionally specify the file type.
   >>> miriad_file = os.path.join(DATA_PATH, 'new.uvA')
-  >>> uvd = UVData.from_file(miriad_file, use_future_array_shapes=True)
-  >>> uvd = UVData.from_file(
-  ...    miriad_file, file_type='miriad', use_future_array_shapes=True,
-  ... )
+  >>> uvd = UVData.from_file(miriad_file)
+  >>> uvd = UVData.from_file(miriad_file, file_type='miriad')
 
   >>> # Write out the uvfits file
   >>> write_file = os.path.join('.', 'tutorial.uvfits')
@@ -128,10 +90,10 @@ b) uvfits -> miriad
   >>> uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
 
   >>> # Use the `read` or `from_file` method, optionally specify the file type.
-  >>> uvd.read(uvfits_file, use_future_array_shapes=True)
-  >>> uvd.read(uvfits_file, file_type='uvfits', use_future_array_shapes=True)
+  >>> uvd.read(uvfits_file)
+  >>> uvd.read(uvfits_file, file_type='uvfits')
   >>> # Here we use the ``from_file`` class method without needing to initialize a new object.
-  >>> uvd = UVData.from_file(uvfits_file, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(uvfits_file)
 
   >>> # Write out the miriad file
   >>> write_file = os.path.join('.', 'tutorial.uv')
@@ -165,7 +127,6 @@ When reading FHD format, we need to point to several files for each observation.
   ...    layout_file=layout_file,
   ...    params_file=params_file,
   ...    settings_file=settings_file,
-  ...    use_future_array_shapes=True
   ... )
   >>> write_file = os.path.join('.', 'tutorial.uvfits')
   >>> uvd.write_uvfits(write_file)
@@ -196,7 +157,6 @@ d) FHD -> miriad
   ...    layout_file=layout_file,
   ...    params_file=params_file,
   ...    settings_file=settings_file,
-  ...    use_future_array_shapes=True
   ... )
   >>> write_file = os.path.join('.','tutorial.uv')
   >>> if os.path.exists(write_file):
@@ -215,8 +175,8 @@ e) CASA -> uvfits
   >>> # Use the `read` method, optionally specify the file type. Can also use the
   >>> # file type specific `read_ms` method, but only if reading a single file.
   >>> # note that reading CASA measurement sets requires casacore to be installed
-  >>> uvd = UVData.from_file(ms_file, use_future_array_shapes=True)
-  >>> uvd = UVData.from_file(ms_file, file_type='ms', use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(ms_file)
+  >>> uvd = UVData.from_file(ms_file, file_type='ms')
 
   >>> # Write out uvfits file
   >>> write_file = os.path.join('.', 'tutorial.uvfits')
@@ -234,7 +194,7 @@ f) CASA -> miriad
   >>> ms_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.ms')
 
   >>> # note that reading CASA measurement sets requires casacore to be installed
-  >>> uvd = UVData.from_file(ms_file, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(ms_file)
 
   >>> # Write out Miriad file
   >>> write_file = os.path.join('.', 'tutorial.uv')
@@ -252,7 +212,7 @@ g) miriad -> uvh5
 
   >>> # This miriad file is known to be a drift scan.
   >>> miriad_file = os.path.join(DATA_PATH, 'new.uvA')
-  >>> uvd = UVData.from_file(miriad_file, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(miriad_file)
 
   >>> # Write out the uvh5 file
   >>> uvd.write_uvh5(os.path.join('.', 'tutorial.uvh5'))
@@ -266,7 +226,7 @@ h) uvfits -> uvh5
   >>> from pyuvdata.data import DATA_PATH
   >>> import os
   >>> uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(uvfits_file, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(uvfits_file)
 
   >>> # Write out the uvh5 file
   >>> write_file = os.path.join('.', 'tutorial.uvh5')
@@ -276,8 +236,8 @@ h) uvfits -> uvh5
 
   >>> # Read the uvh5 file back in.
   >>> # Use the `read` or `from_file` method, optionally specify the file type.
-  >>> uvd = UVData.from_file(write_file, use_future_array_shapes=True)
-  >>> uvd = UVData.from_file(write_file, file_type='uvh5', use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(write_file)
+  >>> uvd = UVData.from_file(write_file, file_type='uvh5')
 
 i) MWA correlator -> uvfits
 ***************************
@@ -307,8 +267,8 @@ approximation, and there is an option to instead use a slower integral implement
   >>> # Use the `read` or `from_file` method, optionally specify the file type.
   >>> # Apply cable corrections and phase data before writing to uvfits
   >>> # Skip routine time/frequency flagging - see flag_init and associated keywords in documentation
-  >>> uvd.read(filelist, correct_cable_len=True, phase_to_pointing_center=True, flag_init=False, use_future_array_shapes=True)
-  >>> uvd = UVData.from_file(filelist, file_type='mwa_corr_fits', correct_cable_len=True, phase_to_pointing_center=True, flag_init=False, use_future_array_shapes=True)
+  >>> uvd.read(filelist, correct_cable_len=True, phase_to_pointing_center=True, flag_init=False)
+  >>> uvd = UVData.from_file(filelist, file_type='mwa_corr_fits', correct_cable_len=True, phase_to_pointing_center=True, flag_init=False)
 
   >>> # Write out uvfits file
   >>> write_file = os.path.join('.', 'tutorial.uvfits')
@@ -571,7 +531,7 @@ a) Data for single antenna pair / polarization combination.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
   >>> data = uvd.get_data(1, 2, 'rr')  # data for ant1=1, ant2=2, pol='rr'
   >>> times = uvd.get_times(1, 2)  # times corresponding to 0th axis in data
   >>> print(data.shape)
@@ -592,7 +552,7 @@ b) Flags and nsamples for above data.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> flags = uvd.get_flags(1, 2, 'rr')
   >>> nsamples = uvd.get_nsamples(1, 2, 'rr')
@@ -610,7 +570,7 @@ c) Data for single antenna pair, all polarizations.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> data = uvd.get_data(1, 2)
   >>> print(data.shape)
@@ -630,7 +590,7 @@ d) Data for single polarization, all baselines.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> data = uvd.get_data('rr')
   >>> print(data.shape)
@@ -648,7 +608,7 @@ and :meth:`pyuvdata.UVData.set_nsamples` methods.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> data = uvd.get_data(1, 2, "rr", force_copy=True, squeeze="none")
   >>> data *= 2
@@ -663,7 +623,7 @@ f) Iterate over all antenna pair / polarizations.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> for key, data in uvd.antpairpol_iter():
   ...  flags = uvd.get_flags(key)
@@ -680,7 +640,7 @@ g) Convenience functions to ask what antennas, baselines, and pols are in the da
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> # Get all unique antennas in data
   >>> print(uvd.get_ants())
@@ -724,7 +684,7 @@ Phasing/unphasing data
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> uvh5_file = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-  >>> uvd = UVData.from_file(uvh5_file, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(uvh5_file)
 
   >>> # We can get information on the sources in the data set by using the
   >>> # `print_phase_center_info` command. This object is initially unprojected (unphased)
@@ -831,7 +791,7 @@ the data have had baseline-dependent averaging applied.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> datafile = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-  >>> uvd = UVData.from_file(datafile, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(datafile)
   >>> uvd2 = uvd.copy()
   >>> print("Range of integration times: ", np.amin(uvd.integration_time),
   ...       "-", np.amax(uvd.integration_time))
@@ -866,7 +826,7 @@ b) Upsampling in time
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> datafile = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-  >>> uvd = UVData.from_file(datafile, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(datafile)
   >>> print("Range of integration times: ", np.amin(uvd.integration_time),
   ...       "-", np.amax(uvd.integration_time))
   Range of integration times:  1.879048192 - 1.879048192
@@ -889,7 +849,7 @@ c) Resampling a BDA dataset in time
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> testfile = os.path.join(DATA_PATH, "simulated_bda_file.uvh5")
-  >>> uvd = UVData.from_file(testfile, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(testfile)
   >>> print(
   ...    "Range of integration times: ", np.amin(uvd.integration_time), "-", np.amax(uvd.integration_time)
   ... )
@@ -919,7 +879,7 @@ averaging will be done over spectral window boundaries.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> datafile = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-  >>> uvd = UVData.from_file(datafile, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(datafile)
   >>> print("Channel width: ", uvd.channel_width)
   Channel width:  [122070.3125 122070.3125 122070.3125 122070.3125]
 
@@ -944,7 +904,7 @@ Note: there is now support for reading in only part of a uvfits, uvh5 or miriad 
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> print(uvd.data_array.shape)
   (1360, 64, 4)
@@ -1005,7 +965,7 @@ utility method.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> data_file = os.path.join(DATA_PATH, 'new.uvA')
-  >>> uvd = UVData.from_file(data_file, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(data_file)
   >>> antpos = uvd.telescope.get_enu_antpos()
 
   >>> # using utils
@@ -1042,7 +1002,7 @@ a) Select 3 antennas to keep using the antenna number.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> # print all the antennas numbers with data in the original file
   >>> print(np.unique(uvd.ant_1_array.tolist() + uvd.ant_2_array.tolist()))
@@ -1062,7 +1022,7 @@ b) Select 3 antennas to keep using the antenna names, also select 5 frequencies 
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> # print all the antenna names with data in the original file
   >>> unique_ants = np.unique(uvd.ant_1_array.tolist() + uvd.ant_2_array.tolist())
@@ -1091,7 +1051,7 @@ c) Select a few antenna pairs to keep
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> # print how many antenna pairs with data in the original file
   >>> print(len(set(zip(uvd.ant_1_array, uvd.ant_2_array))))
@@ -1112,7 +1072,7 @@ d) Select antenna pairs using baseline numbers
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> # baseline numbers can be found in the baseline_array
   >>> print(len(uvd.baseline_array))
@@ -1142,7 +1102,7 @@ the physical orientation of the dipole can also be used (e.g. "nn" or "ee).
   >>> from pyuvdata.data import DATA_PATH
   >>> import pyuvdata.utils as uvutils
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> # polarization numbers can be found in the polarization_array
   >>> print(uvd.polarization_array)
@@ -1172,7 +1132,7 @@ the physical orientation of the dipole can also be used (e.g. "nn" or "ee).
 
   >>> # read in a file with linear polarizations and an x_orientation
   >>> filename = os.path.join(DATA_PATH, 'zen.2458661.23480.HH.uvh5')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> # print polarization numbers and strings
   >>> print(uvd.polarization_array)
@@ -1213,7 +1173,7 @@ ________________________________
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> # Print the number of antenna pairs in the original file
   >>> print(len(uvd.get_antpairs()))
@@ -1240,7 +1200,7 @@ ___________________________
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> # Print the number of antenna pairs in the original file
   >>> print(len(uvd.get_antpairs()))
@@ -1274,7 +1234,7 @@ all antenna pairs kept in the object will retain data for each specified polariz
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> # Print the number of antennas and polarizations with data in the original file
   >>> print((len(uvd.get_antpairs()), uvd.get_pols()))
@@ -1310,7 +1270,7 @@ If a minus sign is present in front of an antenna number, it will not be kept in
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> # Print the number of antenna pairs in the original file
   >>> print(len(uvd.get_antpairs()))
@@ -1338,7 +1298,7 @@ second, the range is assumed to wrap around LST = 0 = 2*pi.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
 
   >>> # Times can be found in the time_array, which is length Nblts.
   >>> # Use unique to find the unique times
@@ -1387,7 +1347,7 @@ h) Select data and return new object (leaving original intact).
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
   >>> uvd2 = uvd.select(antenna_nums=[1, 12, 21], inplace=False)
 
   >>> # print all the antennas numbers with data in the original file
@@ -1412,7 +1372,7 @@ a) Combine frequencies.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd1 = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd1 = UVData.from_file(filename)
   >>> uvd2 = uvd1.copy()
 
   >>> # Downselect frequencies to recombine
@@ -1431,7 +1391,7 @@ b) Combine times.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd1 = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd1 = UVData.from_file(filename)
   >>> uvd2 = uvd1.copy()
 
   >>> # Downselect times to recombine
@@ -1455,13 +1415,13 @@ directly without creating a third uvdata object.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd1 = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd1 = UVData.from_file(filename)
   >>> uvd2 = uvd1.copy()
   >>> uvd1.select(times=times[0:len(times) // 2])
   >>> uvd2.select(times=times[len(times) // 2:])
   >>> uvd1.__add__(uvd2, inplace=True)
 
-  >>> uvd1 = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd1 = UVData.from_file(filename)
   >>> uvd2 = uvd1.copy()
   >>> uvd1.select(times=times[0:len(times) // 2])
   >>> uvd2.select(times=times[len(times) // 2:])
@@ -1480,7 +1440,7 @@ and combined with the previous file(s).
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
   >>> uvd1 = uvd.select(freq_chans=np.arange(0, 20), inplace=False)
   >>> uvd2 = uvd.select(freq_chans=np.arange(20, 40), inplace=False)
   >>> uvd3 = uvd.select(freq_chans=np.arange(40, 64), inplace=False)
@@ -1489,7 +1449,7 @@ and combined with the previous file(s).
   >>> uvd3.write_uvfits(os.path.join('.', 'tutorial3.uvfits'))
   >>> filenames = [os.path.join('.', f) for f
   ...             in ['tutorial1.uvfits', 'tutorial2.uvfits', 'tutorial3.uvfits']]
-  >>> uvd = UVData.from_file(filenames, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filenames)
 
 e) Fast concatenation
 *********************
@@ -1523,7 +1483,7 @@ stored in the uvh5 format.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename)
   >>> uvd1 = uvd.select(freq_chans=np.arange(0, 20), inplace=False)
   >>> uvd2 = uvd.select(freq_chans=np.arange(20, 40), inplace=False)
   >>> uvd3 = uvd.select(freq_chans=np.arange(40, 64), inplace=False)
@@ -1532,7 +1492,7 @@ stored in the uvh5 format.
   >>> uvd3.write_uvfits(os.path.join('.', 'tutorial3.uvfits'))
   >>> filenames = [os.path.join('.', f) for f
   ...             in ['tutorial1.uvfits', 'tutorial2.uvfits', 'tutorial3.uvfits']]
-  >>> uvd = UVData.from_file(filenames, axis='freq', use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filenames, axis='freq')
 
 
 UVData: Summing and differencing visibilities
@@ -1547,7 +1507,7 @@ and :meth:`pyuvdata.UVData.diff_vis` methods.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd1 = UVData.from_file(filename, use_future_array_shapes=True)
+  >>> uvd1 = UVData.from_file(filename)
   >>> uvd2 = uvd1.copy()
 
   >>> # sum visibilities
@@ -1591,7 +1551,7 @@ Measurement set (ms) files do not support reading only the metadata
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
 
   >>> # read the metadata but not the data
-  >>> uvd = UVData.from_file(filename, read_data=False, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename, read_data=False)
 
   >>> print(uvd.metadata_only)
   True
@@ -1624,30 +1584,30 @@ done after the read, which does not save memory.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(filename, freq_chans=np.arange(32), use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename, freq_chans=np.arange(32))
   >>> print(uvd.data_array.shape)
   (1360, 32, 4)
 
   >>> # Reading in the metadata can help with specifying what data to read in
-  >>> uvd = UVData.from_file(filename, read_data=False, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename, read_data=False)
   >>> unique_times = np.unique(uvd.time_array)
   >>> print(unique_times.shape)
   (15,)
 
   >>> times_to_keep = unique_times[[0, 2, 4]]
-  >>> uvd = UVData.from_file(filename, times=times_to_keep, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename, times=times_to_keep)
   >>> print(uvd.data_array.shape)
   (179, 64, 4)
 
   >>> # Select a few baselines from a miriad file
   >>> filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcA')
-  >>> uvd = UVData.from_file(filename, bls=[(9, 10), (9, 20)], use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename, bls=[(9, 10), (9, 20)])
   >>> print(uvd.get_antpairs())
   [(9, 10), (9, 20)]
 
   >>> # Select certain frequencies from a uvh5 file
   >>> filename = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-  >>> uvd = UVData.from_file(filename, freq_chans=np.arange(2), use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename, freq_chans=np.arange(2))
   >>> print(uvd.data_array.shape)
   (200, 2, 2)
 
@@ -1675,7 +1635,7 @@ are written to the appropriate parts of the file on disk.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> filename = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-  >>> uvd = UVData.from_file(filename, read_data=False, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(filename, read_data=False)
   >>> partfile = os.path.join('.', 'tutorial_partial_io.uvh5')
   >>> uvd.initialize_uvh5_file(partfile, clobber=True)
 
@@ -1685,7 +1645,7 @@ are written to the appropriate parts of the file on disk.
   >>> freq_inds1 = np.arange(Hfreqs)
   >>> freq_inds2 = np.arange(Hfreqs, Nfreqs)
   >>> uvd2 = UVData()
-  >>> uvd2 = UVData.from_file(filename, freq_chans=freq_inds1, use_future_array_shapes=True)
+  >>> uvd2 = UVData.from_file(filename, freq_chans=freq_inds1)
   >>> data_array = 0.5 * uvd2.data_array
   >>> flag_array = uvd2.flag_array
   >>> nsample_array = uvd2.nsample_array
@@ -1697,7 +1657,7 @@ are written to the appropriate parts of the file on disk.
   ...   freq_chans=freq_inds1
   ... )
 
-  >>> uvd2 = UVData.from_file(filename, freq_chans=freq_inds2, use_future_array_shapes=True)
+  >>> uvd2 = UVData.from_file(filename, freq_chans=freq_inds2)
   >>> data_array = 2.0 * uvd2.data_array
   >>> flag_array = uvd2.flag_array
   >>> nsample_array = uvd2.nsample_array
@@ -1731,7 +1691,7 @@ various conventions (``'ant1<ant2'``, ``'ant2<ant1'``, ``'u<0'``, ``'u>0'``, ``'
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(uvfits_file, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(uvfits_file)
   >>> uvd.conjugate_bls('ant1<ant2')
   >>> print(np.min(uvd.ant_2_array - uvd.ant_1_array) >= 0)
   True
@@ -1756,7 +1716,7 @@ an option to sort the auto visibilities before the cross visibilities (``autos_f
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(uvfits_file, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(uvfits_file)
 
   >>> # The default is to sort first by time, then by baseline
   >>> uvd.reorder_blts()
@@ -1795,7 +1755,7 @@ channels.
   >>> from pyuvdata import UVData
   >>> from pyuvdata.data import DATA_PATH
   >>> testfile = os.path.join(DATA_PATH, "sma_test.mir")
-  >>> uvd = UVData.from_file(testfile, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(testfile)
 
   >>> # Sort by spectral window number and by frequency within the spectral window
   >>> # Now the spectral windows are in ascending order and the frequencies in each window
@@ -1841,7 +1801,7 @@ ordering set by the user.
   >>> from pyuvdata.data import DATA_PATH
   >>> import pyuvdata.utils as uvutils
   >>> uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-  >>> uvd = UVData.from_file(uvfits_file, use_future_array_shapes=True)
+  >>> uvd = UVData.from_file(uvfits_file)
   >>> print(uvutils.polnum2str(uvd.polarization_array))
   ['rr', 'll', 'rl', 'lr']
 
@@ -1953,7 +1913,6 @@ object.
 
   >>> uvd = UVData.from_file(
   ...    os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5"),
-  ...    use_future_array_shapes=True,
   ... )
   >>> # make a copy to enable comparisons after converting to and from flex_pol
   >>> uvd_orig = uvd.copy()
@@ -2034,7 +1993,6 @@ the baseline array.
   >>> # This file contains a HERA19 layout.
   >>> uvd = UVData.from_file(
   ...   os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'),
-  ...   use_future_array_shapes=True
   ... )
   >>> uvd.unproject_phase(use_ant_pos=True)
   >>> tol = 0.05  # Tolerance in meters
@@ -2085,7 +2043,6 @@ in the full data array based on redundancy.
   >>> from pyuvdata.data import DATA_PATH
   >>> uv0 = UVData.from_file(
   ...   os.path.join(DATA_PATH, 'fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits'),
-  ...   use_future_array_shapes=True
   ... )
   >>> tol = 0.02   # In meters
 
@@ -2135,9 +2092,7 @@ contains antenna 1 will also be flagged).
   >>> from pyuvdata.data import DATA_PATH
   >>> import numpy as np
 
-  >>> uvd = UVData.from_file(
-  ...    os.path.join(DATA_PATH, 'zen.2458661.23480.HH.uvh5'), use_future_array_shapes=True
-  ... )
+  >>> uvd = UVData.from_file(os.path.join(DATA_PATH, 'zen.2458661.23480.HH.uvh5'))
   >>> # Build a binary mask where the cross-correlations are stored.
   >>> cross_mask = uvd.ant_1_array != uvd.ant_2_array
   >>> # Check to see that all the crosses have amplitudes greater than 1

--- a/pyuvdata/conftest.py
+++ b/pyuvdata/conftest.py
@@ -46,7 +46,6 @@ def uvcalibrate_init_data_main():
     uvdata.read(
         os.path.join(DATA_PATH, "zen.2458098.45361.HH.uvh5_downselected"),
         file_type="uvh5",
-        use_future_array_shapes=True,
     )
     uvcal = UVCal()
     with uvtest.check_warnings(
@@ -56,8 +55,7 @@ def uvcalibrate_init_data_main():
         "antenna_diameters are set using values from known telescopes for HERA.",
     ):
         uvcal.read_calfits(
-            os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected"),
-            use_future_array_shapes=True,
+            os.path.join(DATA_PATH, "zen.2458098.45361.HH.omni.calfits_downselected")
         )
 
     yield uvdata, uvcal

--- a/pyuvdata/ms_utils.py
+++ b/pyuvdata/ms_utils.py
@@ -1258,7 +1258,6 @@ def write_ms_spectral_window(
     channel_width=None,
     spw_array=None,
     id_array=None,
-    use_future_array_shapes=True,
 ):
     """
     Write out the spectral information into a CASA table.
@@ -1275,20 +1274,15 @@ def write_ms_spectral_window(
         context).
     freq_array : ndarray
         Required if uvobj not provided, frequency centers for each channel. Expected
-        shape is (1, Nfreqs,) if use_future_array_shapes=False, otherwise (Nfreqs,)
-        if use_future_array_shapes=True.
+        shape is (Nfreqs,), type float.
     channel_width : ndarray or float
         Required if uvobj not provided, frequency centers for each channel. Expected
-        to be a float if use_future_array_shapes=False, otherwise an ndarray of shape
-        (Nfreqs,) if use_future_array_shapes=True.
+        to be of shape (Nfreqs,), type float.
     spw_array : ndarray
         Required if uvobj not provided, ID numbers for spectral windows.
     id_array : ndarray
         Map of how each entry in `freq_array` matches to the spectral windows in
         `spw_array`. Required if uvobj not provided.
-    use_future_array_shapes : bool
-        If False, assume current array shapes for parameters. Default is True, which
-        assumes future array shapes for provided parameters.
 
     Raises
     ------
@@ -1309,11 +1303,6 @@ def write_ms_spectral_window(
             id_array = uvobj.flex_spw_id_array
 
         spw_array = uvobj.spw_array
-        use_future_array_shapes = uvobj.future_array_shapes
-
-    if not use_future_array_shapes:
-        freq_array = freq_array[0]
-        channel_width = np.full_like(freq_array, channel_width)
 
     # Construct a couple of columns we're going to use that are not part of
     # the MS v2.0 baseline format (though are useful for pyuvdata objects).

--- a/pyuvdata/tests/test_telescopes.py
+++ b/pyuvdata/tests/test_telescopes.py
@@ -309,9 +309,7 @@ def test_get_telescope_no_loc():
 def test_hera_loc():
     hera_file = os.path.join(DATA_PATH, "zen.2458098.45361.HH.uvh5_downselected")
     hera_data = UVData()
-    hera_data.read(
-        hera_file, read_data=False, file_type="uvh5", use_future_array_shapes=True
-    )
+    hera_data.read(hera_file, read_data=False, file_type="uvh5")
 
     telescope_obj = Telescope.from_known_telescopes("HERA")
 

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4134,6 +4134,14 @@ def test_uvcalibrate_time_mismatch(uvcalibrate_data, time_range):
         with pytest.raises(ValueError, match=expected_err):
             uvutils.uvcalibrate(uvd, uvc, inplace=False)
 
+        uvc.phase_center_id_array = np.arange(uvc.Ntimes)
+        uvc.phase_center_catalog = {0: None}
+        uvc.select(phase_center_ids=0)
+        with uvtest.check_warnings(
+            UserWarning, match="Time_range on UVCal does not cover all UVData times"
+        ):
+            _ = uvutils.uvcalibrate(uvd, uvc, inplace=False, time_check=False)
+
 
 def test_uvcalibrate_time_wrong_size(uvcalibrate_data):
     uvd, uvc = uvcalibrate_data

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -192,10 +192,7 @@ def calc_uvw_args():
 @pytest.fixture(scope="session")
 def utils_uvdata_main():
     uvd = UVData()
-    uvd.read(
-        os.path.join(DATA_PATH, "zen.2457698.40355.xx.HH.uvcAA.uvh5"),
-        use_future_array_shapes=True,
-    )
+    uvd.read(os.path.join(DATA_PATH, "zen.2457698.40355.xx.HH.uvcAA.uvh5"))
 
     yield uvd
 
@@ -3023,8 +3020,7 @@ def test_redundancy_finder(grid_alg):
     """
     uvd = UVData()
     uvd.read_uvfits(
-        os.path.join(DATA_PATH, "fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits"),
-        use_future_array_shapes=True,
+        os.path.join(DATA_PATH, "fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits")
     )
 
     uvd.select(times=uvd.time_array[0])
@@ -3192,8 +3188,7 @@ def test_high_tolerance_redundancy_error():
     """
     uvd = UVData()
     uvd.read_uvfits(
-        os.path.join(DATA_PATH, "fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits"),
-        use_future_array_shapes=True,
+        os.path.join(DATA_PATH, "fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits")
     )
 
     uvd.select(times=uvd.time_array[0])
@@ -3253,10 +3248,7 @@ def test_redundancy_conjugates(grid_alg):
 def test_redundancy_finder_fully_redundant_array(grid_alg):
     """Test the redundancy finder for a fully redundant array."""
     uvd = UVData()
-    uvd.read_uvfits(
-        os.path.join(DATA_PATH, "test_redundant_array.uvfits"),
-        use_future_array_shapes=True,
-    )
+    uvd.read_uvfits(os.path.join(DATA_PATH, "test_redundant_array.uvfits"))
     uvd.select(times=uvd.time_array[0])
 
     tol = 1  # meters
@@ -3771,10 +3763,7 @@ def test_uvcalibrate_apply_gains_oldfiles(utils_uvdata):
     # give it an x_orientation
     uvd.telescope.x_orientation = "east"
     uvc = UVCal()
-    uvc.read_calfits(
-        os.path.join(DATA_PATH, "zen.2457698.40355.xx.gain.calfits"),
-        use_future_array_shapes=True,
-    )
+    uvc.read_calfits(os.path.join(DATA_PATH, "zen.2457698.40355.xx.gain.calfits"))
     # downselect to match each other in shape (but not in actual values!)
     uvd.select(frequencies=uvd.freq_array[:10])
     uvc.select(times=uvc.time_array[:3])
@@ -3821,37 +3810,20 @@ def test_uvcalibrate_apply_gains_oldfiles(utils_uvdata):
             )
 
 
-@pytest.mark.filterwarnings("ignore:The shapes of several attributes will be changing")
-@pytest.mark.filterwarnings("ignore:When converting a delay-style cal to future array")
 @pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
-@pytest.mark.parametrize("uvd_future_shapes", [True, False])
-@pytest.mark.parametrize("uvc_future_shapes", [True, False])
-def test_uvcalibrate_delay_oldfiles(uvd_future_shapes, uvc_future_shapes, utils_uvdata):
+def test_uvcalibrate_delay_oldfiles(utils_uvdata):
     uvd = utils_uvdata
 
     uvc = UVCal()
-    uvc.read_calfits(
-        os.path.join(DATA_PATH, "zen.2457698.40355.xx.delay.calfits"),
-        use_future_array_shapes=uvc_future_shapes,
-    )
+    uvc.read_calfits(os.path.join(DATA_PATH, "zen.2457698.40355.xx.delay.calfits"))
     # downselect to match
-    if not uvc_future_shapes:
-        uvc.select(times=uvc.time_array[3], frequencies=np.squeeze(uvd.freq_array))
-    else:
-        uvc.select(times=uvc.time_array[3])
+    uvc.select(times=uvc.time_array[3])
     uvc.gain_convention = "multiply"
 
-    if uvc_future_shapes:
-        freq_array_use = np.squeeze(uvd.freq_array)
-        if uvd_future_shapes:
-            chan_with_use = uvd.channel_width
-        else:
-            chan_with_use = np.full(uvd.Nfreqs, uvd.channel_width)
-    else:
-        freq_array_use = uvc.freq_array[0, :]
-        chan_with_use = uvc.channel_width
+    freq_array_use = np.squeeze(uvd.freq_array)
+    chan_with_use = uvd.channel_width
 
     ant_expected = [
         "The uvw_array does not match the expected values",
@@ -3876,27 +3848,12 @@ def test_uvcalibrate_delay_oldfiles(uvd_future_shapes, uvc_future_shapes, utils_
     assert uvdcal == uvdcal2
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
-@pytest.mark.parametrize("uvc_future_shapes", [True, False])
-@pytest.mark.parametrize("uvd_future_shapes", [True, False])
 @pytest.mark.parametrize("flip_gain_conj", [False, True])
 @pytest.mark.parametrize("gain_convention", ["divide", "multiply"])
 @pytest.mark.parametrize("time_range", [None, "Ntimes", 3])
-def test_uvcalibrate(
-    uvcalibrate_data,
-    uvc_future_shapes,
-    uvd_future_shapes,
-    flip_gain_conj,
-    gain_convention,
-    time_range,
-):
+def test_uvcalibrate(uvcalibrate_data, flip_gain_conj, gain_convention, time_range):
     uvd, uvc = uvcalibrate_data
-
-    if not uvd_future_shapes:
-        uvd.use_current_array_shapes()
-    if not uvc_future_shapes:
-        uvc.use_current_array_shapes()
 
     if time_range is not None:
         tstarts = uvc.time_array - uvc.integration_time / (86400 * 2)
@@ -3993,17 +3950,8 @@ def test_uvcalibrate_dterm_handling(uvcalibrate_data):
 
 @pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:Changing number of antennas, but preserving")
-@pytest.mark.parametrize("uvc_future_shapes", [True, False])
-@pytest.mark.parametrize("uvd_future_shapes", [True, False])
-def test_uvcalibrate_flag_propagation(
-    uvcalibrate_data, uvc_future_shapes, uvd_future_shapes
-):
+def test_uvcalibrate_flag_propagation(uvcalibrate_data):
     uvd, uvc = uvcalibrate_data
-
-    if not uvd_future_shapes:
-        uvd.use_current_array_shapes()
-    if not uvc_future_shapes:
-        uvc.use_current_array_shapes()
 
     # test flag propagation
     uvc.flag_array[0] = True
@@ -4120,14 +4068,8 @@ def test_uvcalibrate_extra_cal_antennas(uvcalibrate_data):
     )
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvcalibrate_antenna_names_mismatch(uvcalibrate_init_data, future_shapes):
+def test_uvcalibrate_antenna_names_mismatch(uvcalibrate_init_data):
     uvd, uvc = uvcalibrate_init_data
-
-    if not future_shapes:
-        uvd.use_current_array_shapes()
-        uvc.use_current_array_shapes()
 
     with pytest.raises(
         ValueError,
@@ -4385,17 +4327,13 @@ def test_uvcalibrate_wideband_gain(uvcalibrate_data):
 
 @pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.filterwarnings("ignore:When converting a delay-style cal to future array")
 @pytest.mark.filterwarnings("ignore:Nfreqs will be required to be 1 for wide_band cals")
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
 def test_uvcalibrate_delay_multispw(utils_uvdata):
     uvd = utils_uvdata
 
     uvc = UVCal()
-    uvc.read_calfits(
-        os.path.join(DATA_PATH, "zen.2457698.40355.xx.delay.calfits"),
-        use_future_array_shapes=True,
-    )
+    uvc.read_calfits(os.path.join(DATA_PATH, "zen.2457698.40355.xx.delay.calfits"))
     # downselect to match
     uvc.select(times=uvc.time_array[3])
     uvc.gain_convention = "multiply"

--- a/pyuvdata/tests/test_uvbase.py
+++ b/pyuvdata/tests/test_uvbase.py
@@ -650,3 +650,27 @@ def test_setattr_old_telescope():
             np.testing.assert_allclose(
                 new_telescope._location.xyz(), test_obj.telescope._location.xyz()
             )
+
+
+def test_future_array_shapes():
+    """Check warnings and errors on deprecated future array shape calls."""
+    uvobj = UVBase()
+
+    with uvtest.check_warnings(None):
+        # Verify that providing no args raises no warnings
+        uvobj._set_future_array_shapes()
+
+    with uvtest.check_warnings(
+        DeprecationWarning, match="Future array shapes are now always used"
+    ):
+        uvobj._set_future_array_shapes(use_future_array_shapes=True)
+
+    with pytest.raises(
+        ValueError, match='The future is now! So-called "current" array shapes no'
+    ):
+        uvobj._set_future_array_shapes(use_future_array_shapes=False)
+
+    with uvtest.check_warnings(
+        DeprecationWarning, match="Future array shapes are now always used"
+    ):
+        uvobj.use_future_array_shapes()

--- a/pyuvdata/tests/test_uvbase.py
+++ b/pyuvdata/tests/test_uvbase.py
@@ -674,3 +674,9 @@ def test_future_array_shapes():
         DeprecationWarning, match="Future array shapes are now always used"
     ):
         uvobj.use_future_array_shapes()
+
+    with uvtest.check_warnings(
+        DeprecationWarning,
+        match="The UVData.future_array_shapes attribute is now deprecated",
+    ):
+        assert uvobj.future_array_shapes

--- a/pyuvdata/tests/test_uvbase.py
+++ b/pyuvdata/tests/test_uvbase.py
@@ -676,7 +676,6 @@ def test_future_array_shapes():
         uvobj.use_future_array_shapes()
 
     with uvtest.check_warnings(
-        DeprecationWarning,
-        match="The UVData.future_array_shapes attribute is now deprecated",
+        DeprecationWarning, match="The future_array_shapes attribute is now deprecated"
     ):
         assert uvobj.future_array_shapes

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -3359,7 +3359,7 @@ def transform_app_to_icrs(
     app_dec,
     telescope_loc,
     telescope_frame="itrs",
-    ellipsoid=None,
+    ellipsoid="SPHERE",
     astrometry_library=None,
 ):
     """
@@ -3416,8 +3416,6 @@ def transform_app_to_icrs(
             raise ValueError(
                 "Need to install `lunarsky` package to work with MCMF frame."
             )
-        if ellipsoid is None:
-            ellipsoid = "SPHERE"
 
     # Make sure that the library requested is actually permitted
     if astrometry_library is None:
@@ -3589,7 +3587,7 @@ def calc_frame_pos_angle(
     ref_frame,
     ref_epoch=None,
     telescope_frame="itrs",
-    ellipsoid=None,
+    ellipsoid="SPHERE",
     offset_pos=(np.pi / 360.0),
 ):
     """
@@ -3645,9 +3643,6 @@ def calc_frame_pos_angle(
         return np.zeros_like(time_array)
 
     assert offset_pos > 0, "offset_pos must be greater than 0."
-
-    if telescope_frame == "mcmf" and ellipsoid is None:
-        ellipsoid = "SPHERE"
 
     # This creates an array of unique entries of ra + dec + time, since the processing
     # time for each element can be non-negligible, and entries along the Nblt axis can

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -464,7 +464,6 @@ def _check_freq_spacing(
     channel_width,
     channel_width_tols,
     flex_spw,
-    future_array_shapes,
     spw_array,
     flex_spw_id_array,
     raise_errors=True,
@@ -477,16 +476,13 @@ def _check_freq_spacing(
     Parameters
     ----------
     freq_array : array of float
-        Array of frequencies, shape (1, Nfreqs) or (Nfreqs,) if future_array_shapes=True
+        Array of frequencies, shape (Nfreqs,).
     freq_tols : tuple of float
         freq_array tolerances (from uvobj._freq_array.tols).
     channel_width : float or array of float
-        Channel widths, either a scalar or an array of shape (Nfreqs,) if flex_spw=True
-        and/or future_array_shapes=True.
+        Channel widths, either a scalar or an array of shape (Nfreqs,).
     channel_width_tols : tuple of float
         channel_width tolerances (from uvobj._channel_width.tols).
-    future_array_shapes : bool
-        Indicates that parameters have future shapes.
     flex_spw :  bool
         Indicates there are flexible spectral windows.
     spw_array : array of integers or None
@@ -508,12 +504,8 @@ def _check_freq_spacing(
     spacing_error = False
     chanwidth_error = False
     Nfreqs = freq_array.size
-    if future_array_shapes:
-        freq_spacing = np.diff(freq_array)
-        freq_array_use = freq_array
-    else:
-        freq_spacing = np.diff(freq_array[0])
-        freq_array_use = freq_array[0]
+    freq_spacing = np.diff(freq_array)
+    freq_array_use = freq_array
 
     if Nfreqs == 1:
         # Skip all of this if there is only 1 channel
@@ -564,25 +556,15 @@ def _check_freq_spacing(
         freq_dir = np.sign(np.mean(freq_spacing))
         if not _test_array_constant(freq_spacing, tols=freq_tols):
             spacing_error = True
-        if future_array_shapes:
-            if not _test_array_constant(channel_width, tols=freq_tols):
-                spacing_error = True
-            else:
-                if not np.isclose(
-                    np.mean(freq_spacing),
-                    np.mean(channel_width) * freq_dir,
-                    rtol=channel_width_tols[0],
-                    atol=channel_width_tols[1],
-                ):
-                    chanwidth_error = True
-        else:
-            if not np.isclose(
-                np.mean(freq_spacing),
-                channel_width * freq_dir,
-                rtol=channel_width_tols[0],
-                atol=channel_width_tols[1],
-            ):
-                chanwidth_error = True
+        if not _test_array_constant(channel_width, tols=freq_tols):
+            spacing_error = True
+        elif not np.isclose(
+            np.mean(freq_spacing),
+            np.mean(channel_width) * freq_dir,
+            rtol=channel_width_tols[0],
+            atol=channel_width_tols[1],
+        ):
+            chanwidth_error = True
     if raise_errors and spacing_error:
         raise ValueError(
             "The frequencies are not evenly spaced (probably because of a select "
@@ -608,7 +590,6 @@ def _sort_freq_helper(
     spw_array,
     flex_spw,
     flex_spw_id_array,
-    future_array_shapes,
     spw_order,
     channel_order,
     select_spw,
@@ -631,9 +612,6 @@ def _sort_freq_helper(
         directly from the object parameter.
     flex_spw_id_array : array_like of int
         Array of SPW IDs for each channel, taken directly from the object parameter.
-    future_array_shapes : bool
-        Flag indicating whether the object uses the future array shapes, taken
-        directly from the object parameter.
     spw_order : str or array_like of int
         A string describing the desired order of spectral windows along the
         frequecy axis. Allowed strings include `number` (sort on spectral window
@@ -704,7 +682,7 @@ def _sort_freq_helper(
     else:
         index_array = np.arange(Nfreqs)
         # Multipy by 1.0 here to make a cheap copy of the array to manipulate
-        temp_freqs = 1.0 * (freq_array if future_array_shapes else freq_array[0, :])
+        temp_freqs = 1.0 * freq_array
         # Same trick for ints -- add 0 to make a cheap copy
         temp_spws = 0 + (
             flex_spw_id_array if flex_spw else (np.zeros(Nfreqs) + spw_array)
@@ -5859,14 +5837,8 @@ def uvcalibrate(
 
     downselect_cal_freq = False
     if uvcal.freq_array is not None:
-        if uvdata.future_array_shapes:
-            uvdata_freq_arr_use = uvdata.freq_array
-        else:
-            uvdata_freq_arr_use = uvdata.freq_array[0, :]
-        if uvcal.future_array_shapes:
-            uvcal_freq_arr_use = uvcal.freq_array
-        else:
-            uvcal_freq_arr_use = uvcal.freq_array[0, :]
+        uvdata_freq_arr_use = uvdata.freq_array
+        uvcal_freq_arr_use = uvcal.freq_array
         try:
             freq_arr_match = np.allclose(
                 np.sort(uvcal_freq_arr_use),
@@ -5945,16 +5917,8 @@ def uvcalibrate(
             # make a copy to convert to gain
             uvcal_use = uvcal_use.copy()
             new_uvcal = True
-        if uvdata.future_array_shapes:
-            freq_array_use = uvdata.freq_array
-        else:
-            freq_array_use = uvdata.freq_array[0, :]
-        if uvcal.future_array_shapes == uvdata.future_array_shapes:
-            channel_width = uvdata.channel_width
-        elif uvcal.future_array_shapes:
-            channel_width = np.zeros(uvdata.Nfreqs, dtype=float) + uvdata.channel_width
-        else:
-            channel_width = uvdata.channel_width[0]
+        freq_array_use = uvdata.freq_array
+        channel_width = uvdata.channel_width
         uvcal_use.convert_to_gain(
             delay_convention=delay_convention,
             freq_array=freq_array_use,
@@ -6008,10 +5972,7 @@ def uvcalibrate(
                 uvcal_use._key_exists(antnum=uvcal_ant1_num, jpol=feed1)
                 and uvcal_use._key_exists(antnum=uvcal_ant2_num, jpol=feed2)
             ):
-                if uvdata.future_array_shapes:
-                    uvdata.flag_array[blt_inds, :, pol_ind] = True
-                else:
-                    uvdata.flag_array[blt_inds, 0, :, pol_ind] = True
+                uvdata.flag_array[blt_inds, :, pol_ind] = True
                 continue
 
             uvcal_key1 = (uvcal_ant1_num, feed1)
@@ -6036,25 +5997,16 @@ def uvcalibrate(
             if prop_flags:
                 mask = np.isclose(gain, 0.0) | flag
                 gain[mask] = 1.0
-                if uvdata.future_array_shapes:
-                    uvdata.flag_array[blt_inds, :, pol_ind] += mask
-                else:
-                    uvdata.flag_array[blt_inds, 0, :, pol_ind] += mask
+                uvdata.flag_array[blt_inds, :, pol_ind] += mask
 
             # apply to data
             mult_gains = uvcal_use.gain_convention == "multiply"
             if undo:
                 mult_gains = not mult_gains
-            if uvdata.future_array_shapes:
-                if mult_gains:
-                    uvdata.data_array[blt_inds, :, pol_ind] *= gain
-                else:
-                    uvdata.data_array[blt_inds, :, pol_ind] /= gain
+            if mult_gains:
+                uvdata.data_array[blt_inds, :, pol_ind] *= gain
             else:
-                if mult_gains:
-                    uvdata.data_array[blt_inds, 0, :, pol_ind] *= gain
-                else:
-                    uvdata.data_array[blt_inds, 0, :, pol_ind] /= gain
+                uvdata.data_array[blt_inds, :, pol_ind] /= gain
 
     # update attributes
     uvdata.history += "\nCalibrated with pyuvdata.utils.uvcalibrate."
@@ -6174,12 +6126,7 @@ def apply_uvflag(
             continue
         uvf_ap_inds = uvf.antpair2ind(*ap)
         # addition of boolean is OR
-        if uvd.future_array_shapes == uvf.future_array_shapes:
-            uvd.flag_array[uvd_ap_inds] += uvf.flag_array[uvf_ap_inds]
-        elif uvd.future_array_shapes:
-            uvd.flag_array[uvd_ap_inds] += uvf.flag_array[uvf_ap_inds, 0, :, :]
-        else:
-            uvd.flag_array[uvd_ap_inds, 0, :, :] += uvf.flag_array[uvf_ap_inds]
+        uvd.flag_array[uvd_ap_inds] += uvf.flag_array[uvf_ap_inds]
 
     uvd.history += "\nFlagged with pyuvdata.utils.apply_uvflags."
 

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -59,16 +59,6 @@ class Body(enum.Enum):
     # lunar sky not installed, don't add any moon bodies
     pass
 
-# expose up to python
-# in order to not have circular dependencies
-# define transformation parameters here
-# parameters for transforming between xyz & lat/lon/alt
-# keep for consistent API though these really shouldn't be used anymore
-gps_a = Body.Earth.value.gps_a
-gps_b =  Body.Earth.value.gps_b
-e_squared =  Body.Earth.value.e_squared
-e_prime_squared =  Body.Earth.value.e_prime_squared
-
 ctypedef fused int_or_float:
     numpy.uint64_t
     numpy.int64_t

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -171,6 +171,15 @@ class UVBase(object):
                     elif __name == "telescope_location_lat_lon_alt_degrees":
                         ret_val = self.telescope._location.lat_lon_alt_degrees()
                 return ret_val
+        elif __name == "future_array_shapes":
+            warnings.warn(
+                f"The UVData.{__name} attribute is now deprecated, as all UVBase "
+                "objects use future array shapes. This will become an error in "
+                "version 3.2.",
+                DeprecationWarning,
+            )
+            # Always true as of v3.0
+            return True
 
         return super().__getattribute__(__name)
 

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -832,3 +832,37 @@ class UVBase(object):
 
         """
         return copy.deepcopy(self)
+
+    def _set_future_array_shapes(self, use_future_array_shapes=None):
+        """
+        Set future_array_shapes to True and adjust required parameters.
+
+        This method should not be called directly by users; instead it is called
+        by file-reading methods and `use_future_array_shapes` to indicate the
+        `future_array_shapes` is True and define expected parameter shapes.
+        This function has been deprecated, and will result in an error in version 3.2.
+        """
+        if use_future_array_shapes is None:
+            # This basically wraps no-ops when no argument is passed.
+            return
+
+        if not use_future_array_shapes:
+            raise ValueError(
+                'The future is now! So-called "current" array shapes no longer '
+                'supported, must use "future" array shapes (spw-axis dropped).'
+            )
+        warnings.warn(
+            (
+                "Future array shapes are now always used, setting/calling "
+                "use_future_array_shapes will result in an error in version 3.2."
+            ),
+            DeprecationWarning,
+        )
+
+    def use_future_array_shapes(self):
+        """
+        Change the array shapes of this object to match the planned future shapes.
+
+        This function has been deprecated, and will result in an error in version 3.2.
+        """
+        self._set_future_array_shapes(True)

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -173,7 +173,7 @@ class UVBase(object):
                 return ret_val
         elif __name == "future_array_shapes":
             warnings.warn(
-                f"The UVData.{__name} attribute is now deprecated, as all UVBase "
+                f"The {__name} attribute is now deprecated, as all UVBase "
                 "objects use future array shapes. This will become an error in "
                 "version 3.2.",
                 DeprecationWarning,

--- a/pyuvdata/uvbeam/initializers.py
+++ b/pyuvdata/uvbeam/initializers.py
@@ -174,8 +174,6 @@ def new_uvbeam(
         uvb.Npols = uvb.polarization_array.size
         uvb._set_power()
 
-    uvb._set_future_array_shapes()
-
     if (nside is not None) and (axis1_array is not None or axis2_array is not None):
         raise ValueError(
             "Provide *either* nside (and optionally healpix_pixel_array and "

--- a/pyuvdata/uvbeam/tests/conftest.py
+++ b/pyuvdata/uvbeam/tests/conftest.py
@@ -49,7 +49,6 @@ def make_cst_beam(beam_type):
             "\nOnly 2 files included to keep test data volume low."
         ),
         extra_keywords=extra_keywords,
-        use_future_array_shapes=True,
     )
 
     # add optional parameters for testing purposes

--- a/pyuvdata/uvbeam/tests/test_beamfits.py
+++ b/pyuvdata/uvbeam/tests/test_beamfits.py
@@ -15,7 +15,6 @@ import pyuvdata.tests as uvtest
 import pyuvdata.utils as uvutils
 from pyuvdata import UVBeam
 from pyuvdata.data import DATA_PATH
-from pyuvdata.uvbeam.uvbeam import _future_array_shapes_warning
 
 filenames = ["HERA_NicCST_150MHz.txt", "HERA_NicCST_123MHz.txt"]
 cst_folder = "NicCSTbeams"
@@ -45,7 +44,7 @@ def cst_power_1freq_cut_healpix(cst_efield_1freq_cut_healpix_main):
 def hera_beam_casa():
     beam_in = UVBeam()
     casa_file = os.path.join(DATA_PATH, "HERABEAM.FITS")
-    beam_in.read_beamfits(casa_file, run_check=False, use_future_array_shapes=True)
+    beam_in.read_beamfits(casa_file, run_check=False)
 
     # fill in missing parameters
     beam_in.data_normalization = "peak"
@@ -88,15 +87,9 @@ def twofreq_healpix(cst_efield_2freq_cut_healpix, tmp_path_factory):
     yield testfile
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0")
 @pytest.mark.filterwarnings("ignore:Fixing auto polarization power beams")
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_read_cst_write_read_fits_efield(cst_efield_1freq, future_shapes, tmp_path):
+def test_read_cst_write_read_fits_efield(cst_efield_1freq, tmp_path):
     beam_in = cst_efield_1freq.copy()
-
-    if not future_shapes:
-        beam_in.use_current_array_shapes()
 
     assert beam_in.filename == ["HERA_NicCST_150MHz.txt"]
 
@@ -105,7 +98,7 @@ def test_read_cst_write_read_fits_efield(cst_efield_1freq, future_shapes, tmp_pa
     write_file = str(tmp_path / "outtest_beam.fits")
 
     beam_in.write_beamfits(write_file, clobber=True)
-    beam_out.read_beamfits(write_file, use_future_array_shapes=future_shapes)
+    beam_out.read_beamfits(write_file)
 
     assert beam_in == beam_out
 
@@ -121,7 +114,7 @@ def test_read_cst_write_read_fits_power(cst_power_1freq, tmp_path):
     write_file = str(tmp_path / "outtest_beam.fits")
 
     beam_in.write_beamfits(write_file, clobber=True)
-    beam_out.read_beamfits(write_file, use_future_array_shapes=True)
+    beam_out.read_beamfits(write_file)
     assert beam_in == beam_out
 
     return
@@ -151,7 +144,7 @@ def test_read_cst_write_read_fits_intensity(cst_power_1freq, tmp_path):
         hdulist.writeto(write_file2, overwrite=True)
         hdulist.close()
 
-    beam_out.read_beamfits(write_file2, use_future_array_shapes=True)
+    beam_out.read_beamfits(write_file2)
     assert beam_in == beam_out
 
     return
@@ -181,7 +174,7 @@ def test_read_cst_write_read_fits_no_coordsys(cst_power_1freq, tmp_path):
         hdulist.writeto(write_file2, overwrite=True)
         hdulist.close()
 
-    beam_out.read_beamfits(write_file2, use_future_array_shapes=True)
+    beam_out.read_beamfits(write_file2)
     assert beam_in == beam_out
 
     return
@@ -213,7 +206,7 @@ def test_read_cst_write_read_fits_change_freq_units(cst_power_1freq, tmp_path):
         hdulist.writeto(write_file2, overwrite=True)
         hdulist.close()
 
-    beam_out.read_beamfits(write_file2, use_future_array_shapes=True)
+    beam_out.read_beamfits(write_file2)
     assert beam_in == beam_out
 
     return
@@ -226,21 +219,16 @@ def test_writeread_healpix(cst_efield_1freq_cut_healpix, tmp_path):
     write_file = str(tmp_path / "outtest_beam_hpx.fits")
 
     beam_in.write_beamfits(write_file, clobber=True)
-    beam_out.read_beamfits(write_file, use_future_array_shapes=True)
+    beam_out.read_beamfits(write_file)
 
     assert beam_in == beam_out
 
     return
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0")
-@pytest.mark.parametrize("future_shapes", [True, False])
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-def test_writeread_healpix_power(cst_power_1freq_cut_healpix, tmp_path, future_shapes):
+def test_writeread_healpix_power(cst_power_1freq_cut_healpix, tmp_path):
     # redo for power beam
     beam_in = cst_power_1freq_cut_healpix
-    if not future_shapes:
-        beam_in.use_current_array_shapes()
 
     beam_out = UVBeam()
 
@@ -250,7 +238,7 @@ def test_writeread_healpix_power(cst_power_1freq_cut_healpix, tmp_path, future_s
     assert np.iscomplexobj(np.real_if_close(beam_in.data_array, tol=10))
 
     beam_in.write_beamfits(write_file, clobber=True)
-    beam_out.read_beamfits(write_file, use_future_array_shapes=future_shapes)
+    beam_out.read_beamfits(write_file)
 
     assert beam_in == beam_out
 
@@ -260,10 +248,6 @@ def test_writeread_healpix_power(cst_power_1freq_cut_healpix, tmp_path, future_s
 def test_writeread_healpix_no_corrdsys(cst_power_1freq_cut_healpix, tmp_path):
     beam_in = cst_power_1freq_cut_healpix
     beam_out = UVBeam()
-
-    # for some unknown reason, sometimes beam_in does not have future shapes.
-    # ensure it does (it's a no op if it already has future shapes)
-    beam_in.use_future_array_shapes()
 
     write_file = str(tmp_path / "outtest_beam.fits")
     write_file2 = str(tmp_path / "outtest_beam2.fits")
@@ -284,7 +268,7 @@ def test_writeread_healpix_no_corrdsys(cst_power_1freq_cut_healpix, tmp_path):
         hdulist.writeto(write_file2, overwrite=True)
         hdulist.close()
 
-    beam_out.read_beamfits(write_file2, use_future_array_shapes=True)
+    beam_out.read_beamfits(write_file2)
     assert beam_in == beam_out
 
     return
@@ -413,7 +397,7 @@ def test_header_val_errors(cst_efield_1freq, tmp_path, header_dict, err, error_m
         hdulist.close()
 
     with pytest.raises(err, match=error_msg):
-        beam_out.read_beamfits(write_file2, use_future_array_shapes=True)
+        beam_out.read_beamfits(write_file2)
 
     return
 
@@ -483,7 +467,7 @@ def test_basisvec_hdu_errors(cst_efield_1freq, tmp_path, header_dict, error_msg)
         hdulist.close()
 
     with pytest.raises(ValueError, match=error_msg):
-        beam_out.read_beamfits(write_file2, use_future_array_shapes=True)
+        beam_out.read_beamfits(write_file2)
 
     return
 
@@ -535,7 +519,7 @@ def test_healpix_errors(cst_efield_1freq_cut_healpix, tmp_path, header_dict, err
         hdulist.close()
 
     with pytest.raises(ValueError, match=error_msg):
-        beam_out.read_beamfits(write_file2, use_future_array_shapes=True)
+        beam_out.read_beamfits(write_file2)
 
     return
 
@@ -594,7 +578,7 @@ def test_healpix_basisvec_hdu_errors(
         hdulist.close()
 
     with pytest.raises(ValueError, match=error_msg):
-        beam_out.read_beamfits(write_file2, use_future_array_shapes=True)
+        beam_out.read_beamfits(write_file2)
 
     return
 
@@ -623,7 +607,7 @@ def test_casa_beam(tmp_path, hera_beam_casa):
     assert expected_extra_keywords.sort() == list(beam_in.extra_keywords.keys()).sort()
 
     beam_in.write_beamfits(write_file, clobber=True)
-    beam_out.read_beamfits(write_file, use_future_array_shapes=True)
+    beam_out.read_beamfits(write_file)
 
     assert beam_in == beam_out
 
@@ -694,7 +678,7 @@ def test_extra_keywords_boolean(tmp_path, hera_beam_casa):
     beam_in.extra_keywords["bool"] = True
     beam_in.extra_keywords["bool2"] = False
     beam_in.write_beamfits(testfile, clobber=True)
-    beam_out.read_beamfits(testfile, run_check=False, use_future_array_shapes=True)
+    beam_out.read_beamfits(testfile, run_check=False)
 
     assert beam_in == beam_out
 
@@ -710,7 +694,7 @@ def test_extra_keywords_int(tmp_path, hera_beam_casa):
     beam_in.extra_keywords["int1"] = np.int64(5)
     beam_in.extra_keywords["int2"] = 7
     beam_in.write_beamfits(testfile, clobber=True)
-    beam_out.read_beamfits(testfile, run_check=False, use_future_array_shapes=True)
+    beam_out.read_beamfits(testfile, run_check=False)
 
     assert beam_in == beam_out
 
@@ -726,7 +710,7 @@ def test_extra_keywords_float(tmp_path, hera_beam_casa):
     beam_in.extra_keywords["float1"] = np.int64(5.3)
     beam_in.extra_keywords["float2"] = 6.9
     beam_in.write_beamfits(testfile, clobber=True)
-    beam_out.read_beamfits(testfile, run_check=False, use_future_array_shapes=True)
+    beam_out.read_beamfits(testfile, run_check=False)
 
     assert beam_in == beam_out
 
@@ -742,7 +726,7 @@ def test_extra_keywords_complex(tmp_path, hera_beam_casa):
     beam_in.extra_keywords["complex1"] = np.complex64(5.3 + 1.2j)
     beam_in.extra_keywords["complex2"] = 6.9 + 4.6j
     beam_in.write_beamfits(testfile, clobber=True)
-    beam_out.read_beamfits(testfile, run_check=False, use_future_array_shapes=True)
+    beam_out.read_beamfits(testfile, run_check=False)
 
     assert beam_in == beam_out
 
@@ -762,7 +746,7 @@ def test_multi_files(cst_efield_2freq, tmp_path):
     beam2 = beam_full.select(freq_chans=1, inplace=False)
     beam1.write_beamfits(testfile1, clobber=True)
     beam2.write_beamfits(testfile2, clobber=True)
-    beam1.read_beamfits([testfile1, testfile2], use_future_array_shapes=True)
+    beam1.read_beamfits([testfile1, testfile2])
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
         beam_full.history + "  Downselected "
@@ -781,7 +765,7 @@ def test_partial_read_freq(request, beamfile):
     beamfile = request.getfixturevalue(beamfile)
 
     beam2 = UVBeam()
-    beam2.read(beamfile, freq_range=(145e6, 155e6), use_future_array_shapes=True)
+    beam2.read(beamfile, freq_range=(145e6, 155e6))
 
     assert beam2.freq_array.shape == (1,)
     assert beam2.freq_array[0] == 150e6
@@ -801,9 +785,7 @@ def test_partial_read_azza(twofreq, twosinglefreq, nfiles, select_param):
     else:
         file_use = twosinglefreq
 
-    beam2 = UVBeam.from_file(
-        file_use, az_range=az_range, za_range=za_range, use_future_array_shapes=True
-    )
+    beam2 = UVBeam.from_file(file_use, az_range=az_range, za_range=za_range)
 
     if select_param == "az":
         assert beam2.axis1_array.shape == (181,)
@@ -818,4 +800,4 @@ def test_azza_range_onhealpix(twofreq_healpix):
     with pytest.raises(
         ValueError, match="az_range and za_range are not supported for healpix beams"
     ):
-        beam2.read(twofreq_healpix, az_range=(0, 90), use_future_array_shapes=True)
+        beam2.read(twofreq_healpix, az_range=(0, 90))

--- a/pyuvdata/uvbeam/tests/test_cst_beam.py
+++ b/pyuvdata/uvbeam/tests/test_cst_beam.py
@@ -12,7 +12,6 @@ import pyuvdata.tests as uvtest
 from pyuvdata import UVBeam
 from pyuvdata.data import DATA_PATH
 from pyuvdata.uvbeam.cst_beam import CSTBeam
-from pyuvdata.uvbeam.uvbeam import _future_array_shapes_warning
 
 filenames = ["HERA_NicCST_150MHz.txt", "HERA_NicCST_123MHz.txt"]
 cst_folder = "NicCSTbeams"
@@ -105,10 +104,7 @@ def test_frequencyparse_decimal_non_mhz():
     assert parsed_freqs == [120.87e3, 120.87e9, 120.87]
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0")
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_read_yaml(cst_efield_2freq_mod, future_shapes):
+def test_read_yaml(cst_efield_2freq_mod):
     beam1 = UVBeam()
     beam2 = UVBeam()
 
@@ -120,13 +116,9 @@ def test_read_yaml(cst_efield_2freq_mod, future_shapes):
     }
 
     beam1 = cst_efield_2freq_mod
-    if not future_shapes:
-        beam1.use_current_array_shapes()
     assert beam1.filename == ["HERA_NicCST_123MHz.txt", "HERA_NicCST_150MHz.txt"]
 
-    beam2.read_cst_beam(
-        cst_yaml_file, beam_type="efield", use_future_array_shapes=future_shapes
-    )
+    beam2.read_cst_beam(cst_yaml_file, beam_type="efield")
     assert beam2.filename == sorted(
         [
             os.path.basename(cst_yaml_file),
@@ -169,9 +161,7 @@ def test_read_yaml_onefile(cst_efield_1freq_mod, tmp_path):
 
     beam1 = cst_efield_1freq_mod
 
-    beam2.read_cst_beam(
-        test_yaml_file, beam_type="efield", use_future_array_shapes=True
-    )
+    beam2.read_cst_beam(test_yaml_file, beam_type="efield")
     assert beam1 == beam2
 
     assert beam2.reference_impedance == 100
@@ -200,12 +190,7 @@ def test_read_yaml_override(cst_efield_2freq_mod):
             "the value in the settings yaml file."
         ),
     ):
-        beam2.read_cst_beam(
-            cst_yaml_file,
-            beam_type="efield",
-            telescope_name="test",
-            use_future_array_shapes=True,
-        )
+        beam2.read_cst_beam(cst_yaml_file, beam_type="efield", telescope_name="test")
 
     assert beam1 == beam2
 
@@ -220,24 +205,14 @@ def test_read_yaml_freq_select(cst_efield_1freq_mod):
 
     beam1 = cst_efield_1freq_mod
 
-    beam2.read_cst_beam(
-        cst_yaml_file,
-        beam_type="efield",
-        frequency_select=[150e6],
-        use_future_array_shapes=True,
-    )
+    beam2.read_cst_beam(cst_yaml_file, beam_type="efield", frequency_select=[150e6])
 
     assert beam1 == beam2
 
     # test error with using frequency_select where no such frequency
     freq = 180e6
     with pytest.raises(ValueError, match=f"frequency {freq} not in frequency list"):
-        beam2.read_cst_beam(
-            cst_yaml_file,
-            beam_type="power",
-            frequency_select=[freq],
-            use_future_array_shapes=True,
-        )
+        beam2.read_cst_beam(cst_yaml_file, beam_type="power", frequency_select=[freq])
 
 
 def test_read_yaml_feed_pol_list(cst_efield_2freq_mod, cst_efield_1freq_mod):
@@ -264,9 +239,7 @@ def test_read_yaml_feed_pol_list(cst_efield_2freq_mod, cst_efield_1freq_mod):
 
     beam1 = cst_efield_2freq_mod
 
-    beam2.read_cst_beam(
-        test_yaml_file, beam_type="efield", use_future_array_shapes=True
-    )
+    beam2.read_cst_beam(test_yaml_file, beam_type="efield")
     assert beam1 == beam2
 
     assert beam2.reference_impedance == 100
@@ -275,12 +248,7 @@ def test_read_yaml_feed_pol_list(cst_efield_2freq_mod, cst_efield_1freq_mod):
     # also test with frequency_select
     beam1 = cst_efield_1freq_mod
 
-    beam2.read_cst_beam(
-        test_yaml_file,
-        beam_type="efield",
-        frequency_select=[150e6],
-        use_future_array_shapes=True,
-    )
+    beam2.read_cst_beam(test_yaml_file, beam_type="efield", frequency_select=[150e6])
     assert beam1 == beam2
 
     os.remove(test_yaml_file)
@@ -334,21 +302,13 @@ def test_read_yaml_multi_pol(tmp_path):
             history="Derived from https://github.com/Nicolas-Fagnoni/Simulations."
             "\nOnly 2 files included to keep test data volume low.",
             extra_keywords=extra_keywords,
-            use_future_array_shapes=True,
         )
 
-    beam2.read_cst_beam(
-        test_yaml_file, beam_type="efield", use_future_array_shapes=True
-    )
+    beam2.read_cst_beam(test_yaml_file, beam_type="efield")
     assert beam1 == beam2
 
     # also test with frequency_select
-    beam2.read_cst_beam(
-        test_yaml_file,
-        beam_type="efield",
-        frequency_select=[150e6],
-        use_future_array_shapes=True,
-    )
+    beam2.read_cst_beam(test_yaml_file, beam_type="efield", frequency_select=[150e6])
     assert beam2.feed_array.tolist() == ["x", "y"]
     assert beam1 == beam2
 
@@ -375,9 +335,7 @@ def test_read_yaml_errors(tmp_path):
             "not present."
         ),
     ):
-        beam1.read_cst_beam(
-            test_yaml_file, beam_type="power", use_future_array_shapes=True
-        )
+        beam1.read_cst_beam(test_yaml_file, beam_type="power")
 
     with open(cst_yaml_file, "r") as file:
         settings_dict = yaml.safe_load(file)
@@ -388,9 +346,7 @@ def test_read_yaml_errors(tmp_path):
 
     beam1 = UVBeam()
     with pytest.raises(ValueError, match=("filenames in yaml file must be a list.")):
-        beam1.read_cst_beam(
-            test_yaml_file, beam_type="power", use_future_array_shapes=True
-        )
+        beam1.read_cst_beam(test_yaml_file, beam_type="power")
 
     with open(cst_yaml_file, "r") as file:
         settings_dict = yaml.safe_load(file)
@@ -401,9 +357,7 @@ def test_read_yaml_errors(tmp_path):
 
     beam1 = UVBeam()
     with pytest.raises(ValueError, match=("frequencies in yaml file must be a list.")):
-        beam1.read_cst_beam(
-            test_yaml_file, beam_type="power", use_future_array_shapes=True
-        )
+        beam1.read_cst_beam(test_yaml_file, beam_type="power")
 
     os.remove(test_yaml_file)
 
@@ -434,7 +388,6 @@ def test_read_power(cst_power_2freq):
         feed_version="0.1",
         model_name="E-field pattern - Rigging height 4.9m",
         model_version="1.0",
-        use_future_array_shapes=True,
     )
 
     assert np.allclose(beam1.freq_array, beam2.freq_array)
@@ -467,7 +420,6 @@ def test_read_power_single_freq(cst_power_1freq):
             model_name="E-field pattern - Rigging height 4.9m",
             model_version="1.0",
             rotate_pol=False,
-            use_future_array_shapes=True,
         )
 
     assert beam2.freq_array == [150e6]
@@ -493,7 +445,6 @@ def test_read_power_multi_pol():
         feed_version="0.1",
         model_name="E-field pattern - Rigging height 4.9m",
         model_version="1.0",
-        use_future_array_shapes=True,
     )
     assert beam1.data_array.shape == (1, 2, 1, 181, 360)
     assert np.allclose(beam1.data_array[:, 0, :, :, :], beam1.data_array[:, 1, :, :, :])
@@ -509,7 +460,6 @@ def test_read_power_multi_pol():
         feed_version="0.1",
         model_name="E-field pattern - Rigging height 4.9m",
         model_version="1.0",
-        use_future_array_shapes=True,
     )
     assert np.allclose(beam2.polarization_array, np.array([-7, -8]))
     assert beam2.data_array.shape == (1, 2, 1, 181, 360)
@@ -590,7 +540,7 @@ def test_read_errors(files, kwargs, err_msg):
     )
 
     with pytest.raises(ValueError, match=err_msg):
-        beam1.read_cst_beam(files, **kwargs, use_future_array_shapes=True)
+        beam1.read_cst_beam(files, **kwargs)
 
 
 def test_read_efield(cst_efield_2freq):
@@ -613,7 +563,6 @@ def test_read_efield(cst_efield_2freq):
         feed_version="0.1",
         model_name="E-field pattern - Rigging height 4.9m",
         model_version="1.0",
-        use_future_array_shapes=True,
     )
     assert beam2.feed_array[0] == "y"
     assert beam2.feed_array[1] == "x"
@@ -633,7 +582,6 @@ def test_read_efield(cst_efield_2freq):
             model_name="E-field pattern - Rigging height 4.9m",
             model_version="1.0",
             rotate_pol=False,
-            use_future_array_shapes=True,
         )
 
     assert beam2.pixel_coordinate_system == "az_za"
@@ -654,7 +602,6 @@ def test_read_efield(cst_efield_2freq):
         feed_version="0.1",
         model_name="E-field pattern - Rigging height 4.9m",
         model_version="1.0",
-        use_future_array_shapes=True,
     )
     assert beam1.data_array.shape == (2, 2, 1, 181, 360)
     assert np.allclose(beam1.data_array[:, 0, :, :, :], beam1.data_array[:, 1, :, :, :])
@@ -817,7 +764,6 @@ def test_no_deg_units(tmp_path):
             feed_version="0.1",
             model_name="E-field pattern - Rigging height 4.9m",
             model_version="1.0",
-            use_future_array_shapes=True,
         )
 
     with uvtest.check_warnings(
@@ -831,7 +777,6 @@ def test_no_deg_units(tmp_path):
             feed_version="0.1",
             model_name="E-field pattern - Rigging height 4.9m",
             model_version="1.0",
-            use_future_array_shapes=True,
         )
 
     assert beam1 == beam2
@@ -854,7 +799,6 @@ def test_no_deg_units(tmp_path):
             feed_version="0.1",
             model_name="E-field pattern - Rigging height 4.9m",
             model_version="1.0",
-            use_future_array_shapes=True,
         )
 
 
@@ -963,12 +907,7 @@ def test_hera_yaml():
     beam1 = UVBeam()
     beam2 = UVBeam()
 
-    beam1.read_cst_beam(
-        cst_yaml_vivaldi,
-        beam_type="efield",
-        frequency_select=[150e6],
-        use_future_array_shapes=True,
-    )
+    beam1.read_cst_beam(cst_yaml_vivaldi, beam_type="efield", frequency_select=[150e6])
 
     assert beam1.reference_impedance == 100
     extra_keywords = {
@@ -979,12 +918,7 @@ def test_hera_yaml():
     }
     assert beam1.extra_keywords == extra_keywords
 
-    beam2.read_cst_beam(
-        cst_yaml_vivaldi,
-        beam_type="power",
-        frequency_select=[150e6],
-        use_future_array_shapes=True,
-    )
+    beam2.read_cst_beam(cst_yaml_vivaldi, beam_type="power", frequency_select=[150e6])
 
     beam1.efield_to_power(calc_cross_pols=False)
 

--- a/pyuvdata/uvbeam/tests/test_uvbeam.py
+++ b/pyuvdata/uvbeam/tests/test_uvbeam.py
@@ -53,7 +53,6 @@ def uvbeam_data():
         "model_version",
         "history",
         "antenna_type",
-        "future_array_shapes",
     ]
     required_parameters = ["_" + prop for prop in required_properties]
 

--- a/pyuvdata/uvbeam/tests/test_uvbeam.py
+++ b/pyuvdata/uvbeam/tests/test_uvbeam.py
@@ -53,6 +53,7 @@ def uvbeam_data():
         "model_version",
         "history",
         "antenna_type",
+        "future_array_shapes",
     ]
     required_parameters = ["_" + prop for prop in required_properties]
 

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -578,50 +578,6 @@ class UVBeam(UVBase):
         """
         return initializers.new_uvbeam(**kwargs)
 
-    def _freq_params(self):
-        """List of strings giving the parameters shaped like the freq_array."""
-        form = self._freq_array.form
-        param_list = []
-        for uvpar in self:
-            this_par = getattr(self, uvpar)
-            if this_par.form == form:
-                param_list.append(this_par.name)
-        return param_list
-
-    def _set_future_array_shapes(self, use_future_array_shapes=None):
-        """
-        Set future_array_shapes to True and adjust required parameters.
-
-        This method should not be called directly by users; instead it is called
-        by file-reading methods and `use_future_array_shapes` to indicate the
-        `future_array_shapes` is True and define expected parameter shapes.
-        This function has been deprecated, and will result in an error in version 3.2.
-        """
-        if use_future_array_shapes is None:
-            # This basically wraps no-ops when no argument is passed.
-            return
-
-        if not use_future_array_shapes:
-            raise ValueError(
-                'The future is now! So-called "current" array shapes no longer '
-                'supported, must use "future" array shapes (spw-axis dropped).'
-            )
-        warnings.warn(
-            (
-                "Future array shapes are now always used, setting/calling "
-                "use_future_array_shapes will result in an error in version 3.2."
-            ),
-            DeprecationWarning,
-        )
-
-    def use_future_array_shapes(self):
-        """
-        Change the array shapes of this object to match the planned future shapes.
-
-        This function has been deprecated, and will result in an error in version 3.2.
-        """
-        self._set_future_array_shapes(True)
-
     def _set_cs_params(self):
         """Set parameters depending on pixel_coordinate_system."""
         if self.pixel_coordinate_system == "healpix":
@@ -864,20 +820,6 @@ class UVBeam(UVBase):
         if self.basis_vector_array is not None:
             if np.max(np.linalg.norm(self.basis_vector_array, axis=1)) > (1 + 1e-15):
                 raise ValueError("basis vectors must have lengths of 1 or less.")
-
-        # issue warning for deprecated values in feed_array
-        if self.beam_type == "efield":
-            warn_feed = []
-            for feed in self.feed_array:
-                if feed in ["N", "E", "R", "L"]:
-                    warn_feed.append(feed)
-            if len(warn_feed) > 0:
-                warnings.warn(
-                    f"Feed array has values {warn_feed} that are deprecated. "
-                    "Values in feed_array should be lower case. This will become "
-                    "an error in version 2.6",
-                    DeprecationWarning,
-                )
 
         # issue warning if extra_keywords keys are longer than 8 characters
         for key in list(self.extra_keywords.keys()):

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -340,6 +340,18 @@ class UVBeam(UVBase):
             tols=1e-3,
         )
 
+        desc = (
+            "Flag indicating that this object is using the future array shapes. "
+            "Defunct, will be removed in version 3.2."
+        )
+        self._future_array_shapes = uvp.UVParameter(
+            "future_array_shapes",
+            description=desc,
+            expected_type=bool,
+            value=True,
+            acceptable_vals=[True],
+        )
+
         # --------- metadata -------------
         self._telescope_name = uvp.UVParameter(
             "telescope_name",

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -1812,7 +1812,7 @@ class UVBeam(UVBase):
             objects with the "healpix" pixel_coordinate_system.
         freq_interp_kind : str
             Interpolation method to use frequency. See scipy.interpolate.interp1d
-            for details. Deefaults to "cubic" (Note that this is a change. It used to
+            for details. Defaults to "cubic" (Note that this is a change. It used to
             default to "linear" when it was assigned to the object. However, multiple
             groups have found that a linear interpolation leads to nasty artifacts in
             visibility simulations for EoR applications.)

--- a/pyuvdata/uvbeam/uvbeam.py
+++ b/pyuvdata/uvbeam/uvbeam.py
@@ -340,18 +340,6 @@ class UVBeam(UVBase):
             tols=1e-3,
         )
 
-        desc = (
-            "Flag indicating that this object is using the future array shapes. "
-            "Defunct, will be removed in version 3.2."
-        )
-        self._future_array_shapes = uvp.UVParameter(
-            "future_array_shapes",
-            description=desc,
-            expected_type=bool,
-            value=True,
-            acceptable_vals=[True],
-        )
-
         # --------- metadata -------------
         self._telescope_name = uvp.UVParameter(
             "telescope_name",

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -493,7 +493,6 @@ class CALFITS(UVCal):
         filename,
         *,
         read_data=True,
-        combine_input_flags=True,
         background_lsts=True,
         run_check=True,
         check_extra=True,
@@ -719,12 +718,8 @@ class CALFITS(UVCal):
                         data[:, 0, :, :, :, 0] + 1j * data[:, 0, :, :, :, 1]
                     )
                     self.flag_array = data[:, 0, :, :, :, 2].astype("bool")
-                    n_arrays = hdr.pop("NAXIS1")
-                    input_flag_idx = 3 if (n_arrays in [4, 5]) else None
                     if has_quality:
                         self.quality_array = data[:, 0, :, :, :, -1]
-                        if n_arrays == 4:
-                            input_flag_idx = None
                 if self.cal_type == "delay":
                     self.delay_array = data[:, 0, :, :, :, 0]
                     if has_quality:
@@ -732,15 +727,9 @@ class CALFITS(UVCal):
 
                     flag_data = sechdu.data
                     self.flag_array = flag_data[:, 0, :, :, :, 0].astype("bool")
-                    input_flag_idx = 1 if (sechdu.header["NAXIS1"] == 2) else None
 
                     # Combine the flags down to one windows worth
                     self.flag_array = np.all(self.flag_array, axis=1, keepdims=True)
-
-                if combine_input_flags and input_flag_idx is not None:
-                    self.flag_array |= data[:, 0, :, :, :, input_flag_idx].astype(
-                        "bool"
-                    )
 
                 # get total quality array if present
                 if "TOTQLTY" in hdunames:

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -223,8 +223,6 @@ class CALFITS(UVCal):
             freq_range_use = self.freq_range
         if self.cal_type == "delay":
             prihdr["FRQRANGE"] = ",".join(map(str, freq_range_use))
-        elif self.freq_range is not None:
-            prihdr["FRQRANGE"] = ",".join(map(str, freq_range_use))
 
         if self.time_range is not None:
             prihdr["TMERANGE"] = ",".join(map(str, self.time_range[0, :]))
@@ -244,11 +242,6 @@ class CALFITS(UVCal):
             prihdr["HASQLTY"] = True
         else:
             prihdr["HASQLTY"] = False
-
-        if self.cal_type == "unknown":
-            raise ValueError(
-                "unknown calibration type. Do not know how to store parameters"
-            )
 
         # Define primary header values
         # Arrays have (column-major) dimensions of

--- a/pyuvdata/uvcal/calfits.py
+++ b/pyuvdata/uvcal/calfits.py
@@ -679,7 +679,6 @@ class CALFITS(UVCal):
                 )
             if self.cal_type == "delay":
                 self._set_delay()
-                # True by fiat as of v3.0
                 self.Nfreqs = 1
 
                 sechdu = fname[hdunames["FLAGS"]]

--- a/pyuvdata/uvcal/calh5.py
+++ b/pyuvdata/uvcal/calh5.py
@@ -71,7 +71,6 @@ class FastCalH5Meta(hdf5_utils.HDF5Meta):
             "observer",
             "ref_antenna_name",
             "sky_catalog",
-            "sky_field",
             "instrument",
             "version",
         }
@@ -269,7 +268,6 @@ class CalH5(UVCal):
             "ref_antenna_array",
             "scan_number_array",
             "sky_catalog",
-            "sky_field",
         ]:
             try:
                 setattr(self, attr, getattr(meta, attr))
@@ -779,8 +777,6 @@ class CalH5(UVCal):
             header["ref_antenna_name"] = np.string_(self.ref_antenna_name)
         if self.sky_catalog is not None:
             header["sky_catalog"] = np.string_(self.sky_catalog)
-        if self.sky_field is not None:
-            header["sky_field"] = np.string_(self.sky_field)
         if self.phase_center_id_array is not None:
             header["phase_center_id_array"] = self.phase_center_id_array
         if self.Nphase is not None:

--- a/pyuvdata/uvcal/calh5.py
+++ b/pyuvdata/uvcal/calh5.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 from functools import cached_property
 from pathlib import Path
 
@@ -183,6 +182,12 @@ class CalH5(UVCal):
             "antenna_numbers",
             "antenna_positions",
         ]
+
+        # Antenna diameters is an optional parameter _inside_ of the telescope attr,
+        # so let's just check if it's there now and add it to the required keys if it is
+        if "antenna_diameters" in meta.header:
+            required_telescope_keys.append("antenna_diameters")
+
         self.telescope = Telescope.from_hdf5(
             meta,
             required_keys=required_telescope_keys,
@@ -228,7 +233,6 @@ class CalH5(UVCal):
         ]
 
         optional_parameters = [
-            "antenna_diameters",
             "channel_width",
             "flex_spw_id_array",
             "flex_jones_array",

--- a/pyuvdata/uvcal/initializers.py
+++ b/pyuvdata/uvcal/initializers.py
@@ -368,9 +368,6 @@ def new_uvcal(
     uvc.flex_spw_id_array = flex_spw_id_array
     uvc.spw_array = spw_array
 
-    if not wide_band:
-        uvc._set_flex_spw()
-
     for k, v in kwargs.items():
         if hasattr(uvc, k):
             setattr(uvc, k, v)

--- a/pyuvdata/uvcal/initializers.py
+++ b/pyuvdata/uvcal/initializers.py
@@ -149,8 +149,8 @@ def new_uvcal(
         and 'total_quality_array'. If any entry is provided, the output will contain
         all necessary data-like arrays. Any key *not* provided in this case will be
         set to default "empty" values (e.g. all ones for gains, all False for flags) if
-        they are required or `None` if they are not required (i.e. input_flag_array,
-        quality_array, total_quality_array).
+        they are required or `None` if they are not required (i.e. quality_array,
+        total_quality_array).
     history : str, optional
         History string to be added to the object. Default is a simple string
         containing the date and time and pyuvdata version.
@@ -389,7 +389,6 @@ def new_uvcal(
 
         # Flag array
         uvc.flag_array = data.get("flag_array", np.zeros(shape, dtype=bool))
-        uvc.input_flag_array = data.get("input_flag_array", None)
 
         if cal_type == "delay":
             uvc.delay_array = data.get("delay_array", np.zeros(shape, dtype=float))

--- a/pyuvdata/uvcal/initializers.py
+++ b/pyuvdata/uvcal/initializers.py
@@ -357,7 +357,6 @@ def new_uvcal(
     elif cal_style == "sky":
         uvc._set_sky()
 
-    uvc._set_future_array_shapes()
     uvc._set_wide_band(wide_band)
 
     uvc.Nants_data = len(ant_array)
@@ -451,10 +450,6 @@ def new_uvcal_from_uvdata(
 
     if not isinstance(uvdata, UVData):
         raise ValueError("uvdata must be a UVData object.")
-
-    uses_future_shapes = uvdata.future_array_shapes
-    if not uses_future_shapes:
-        uvdata.use_future_array_shapes()
 
     if cal_type == "delay":
         wide_band = True
@@ -663,11 +658,5 @@ def new_uvcal_from_uvdata(
         history=history,
         **kwargs,
     )
-
-    # Now convert the UVData object and UVCal object to proper array shapes
-    if not uses_future_shapes:
-        uvdata.use_current_array_shapes()
-        if not wide_band:
-            new.use_current_array_shapes()
 
     return new

--- a/pyuvdata/uvcal/initializers.py
+++ b/pyuvdata/uvcal/initializers.py
@@ -149,8 +149,7 @@ def new_uvcal(
         and 'total_quality_array'. If any entry is provided, the output will contain
         all necessary data-like arrays. Any key *not* provided in this case will be
         set to default "empty" values (e.g. all ones for gains, all False for flags) if
-        they are required or `None` if they are not required (i.e. quality_array,
-        total_quality_array).
+        they are required or `None` if they are not required (i.e. total_quality_array).
     history : str, optional
         History string to be added to the object. Default is a simple string
         containing the date and time and pyuvdata version.

--- a/pyuvdata/uvcal/ms_cal.py
+++ b/pyuvdata/uvcal/ms_cal.py
@@ -72,9 +72,6 @@ class MSCal(UVCal):
         # Use the utility function to verify this actually is an MS file
         ms_utils._ms_utils_call_checks(filepath)
 
-        # Set some initial things from the get go -- no legacy support!
-        self._set_future_array_shapes()
-
         self.filename = [os.path.basename(filepath)]
         self._filename.form = (1,)
 
@@ -423,15 +420,6 @@ class MSCal(UVCal):
             # CASA always wants to see Njones == 2. Easy enough to pad when Njones == 1,
             # but we risk losing information when Njones > 2.
             raise ValueError("CASA MS calibration tables cannot support Njones > 2.")
-
-        # Given that this is coming in _just_ before the "current" array shapes retire,
-        # I'm not going to bother to work toward supporting it unless there's a
-        # particular pressing need.
-        if not self.future_array_shapes:
-            raise ValueError(
-                "In order to call this method, you must be using future array shapes. "
-                "Call the `use_future_array_shapes` method before proceeding."
-            )
 
         if self.gain_convention != "divide":
             raise ValueError(

--- a/pyuvdata/uvcal/ms_cal.py
+++ b/pyuvdata/uvcal/ms_cal.py
@@ -92,15 +92,15 @@ class MSCal(UVCal):
 
         if main_info_dict["subType"] == "G Jones":
             # This is a so-called "wideband" gains calibration table, i.e. not bandpass
-            self._set_wide_band()
-            self._set_gain
+            self._set_wide_band(True)
+            self._set_gain()
         elif main_info_dict["subType"] == "B Jones":
             # This is a bandpass solution
-            self._set_flex_spw()
+            self._set_wide_band(False)
             self._set_gain()
         elif main_info_dict["subType"] == "K Jones":
             # This is a delay solution? Need to understand the units...
-            self._set_wide_band()
+            self._set_wide_band(True)
             self._set_delay()
         else:
             # I don't know what this is, so don't proceed any further.

--- a/pyuvdata/uvcal/tests/__init__.py
+++ b/pyuvdata/uvcal/tests/__init__.py
@@ -18,7 +18,7 @@ def time_array_to_time_range(calobj_in, keep_time_array=False):
     return calobj
 
 
-def extend_jones_axis(calobj, input_flag=True, total_quality=True):
+def extend_jones_axis(calobj, total_quality=True):
     while calobj.Njones < 4:
         new_jones = np.min(calobj.jones_array) - 1
         calobj.jones_array = np.append(calobj.jones_array, new_jones)

--- a/pyuvdata/uvcal/tests/__init__.py
+++ b/pyuvdata/uvcal/tests/__init__.py
@@ -28,7 +28,6 @@ def extend_jones_axis(calobj, input_flag=True, total_quality=True):
                 "gain_array",
                 "delay_array",
                 "flag_array",
-                "input_flag_array",
                 "quality_array",
                 "total_quality_array",
             ]
@@ -41,8 +40,6 @@ def extend_jones_axis(calobj, input_flag=True, total_quality=True):
                     setattr(calobj, attr, attr_value)
 
     if not calobj.metadata_only:
-        if calobj.input_flag_array is None and input_flag:
-            calobj.input_flag_array = calobj.flag_array
         if calobj.total_quality_array is None and total_quality:
             calobj.total_quality_array = np.ones(
                 calobj._total_quality_array.expected_shape(calobj)

--- a/pyuvdata/uvcal/tests/conftest.py
+++ b/pyuvdata/uvcal/tests/conftest.py
@@ -132,7 +132,6 @@ def fhd_cal_fit(fhd_cal_fit_main):
 @pytest.fixture
 def multi_spw_gain(gain_data):
     gain_obj = gain_data.copy()
-    gain_obj._set_flex_spw()
     gain_obj.channel_width = (
         np.zeros(gain_obj.Nfreqs, dtype=np.float64) + gain_obj.channel_width
     )
@@ -160,6 +159,7 @@ def multi_spw_gain(gain_data):
 @pytest.fixture
 def wideband_gain(gain_data):
     gain_obj = gain_data.copy()
+    gain_obj.flex_spw_id_array = None
     gain_obj._set_wide_band()
 
     gain_obj.spw_array = np.array([1, 2, 3])

--- a/pyuvdata/uvcal/tests/conftest.py
+++ b/pyuvdata/uvcal/tests/conftest.py
@@ -26,7 +26,7 @@ def gain_data_main():
             "antenna_diameters are set using values from known telescopes for HERA."
         ],
     ):
-        gain_object = UVCal.from_file(gainfile, use_future_array_shapes=True)
+        gain_object = UVCal.from_file(gainfile)
     gain_object.freq_range = None
 
     yield gain_object
@@ -41,29 +41,15 @@ def gain_data(gain_data_main):
 
     yield gain_object
 
-    del gain_object
-
 
 @pytest.fixture(scope="session")
 def delay_data_main():
     """Read in delay calfits file, add input flag array."""
     delayfile = os.path.join(DATA_PATH, "zen.2457698.40355.xx.delay.calfits")
-    with uvtest.check_warnings(
-        UserWarning,
-        match=[
-            "telescope_location, antenna_positions, antenna_diameters are not "
-            "set or are being overwritten. telescope_location, antenna_positions, "
-            "antenna_diameters are set using values from known telescopes for HERA.",
-            "When converting a delay-style cal to future array shapes the flag_array "
-            "must drop the frequency axis",
-        ],
-    ):
-        delay_object = UVCal.from_file(delayfile, use_future_array_shapes=True)
+    delay_object = UVCal.from_file(delayfile)
 
     # yield the data for testing, then del after tests finish
     yield delay_object
-
-    del delay_object
 
 
 @pytest.fixture(scope="function")
@@ -100,7 +86,6 @@ def fhd_cal_raw_main():
         layout_file=test_fhd_cal.layout_testfile,
         settings_file=test_fhd_cal.settings_testfile,
         raw=True,
-        use_future_array_shapes=True,
     )
 
     yield fhd_cal
@@ -127,7 +112,6 @@ def fhd_cal_fit_main():
         layout_file=test_fhd_cal.layout_testfile,
         settings_file=test_fhd_cal.settings_testfile,
         raw=False,
-        use_future_array_shapes=True,
     )
 
     yield fhd_cal

--- a/pyuvdata/uvcal/tests/conftest.py
+++ b/pyuvdata/uvcal/tests/conftest.py
@@ -44,7 +44,7 @@ def gain_data(gain_data_main):
 
 @pytest.fixture(scope="session")
 def delay_data_main():
-    """Read in delay calfits file, add input flag array."""
+    """Read in delay calfits file."""
     delayfile = os.path.join(DATA_PATH, "zen.2457698.40355.xx.delay.calfits")
     delay_object = UVCal.from_file(delayfile)
 
@@ -56,23 +56,6 @@ def delay_data_main():
 def delay_data(delay_data_main):
     """Make function level delay uvcal object."""
     delay_object = delay_data_main.copy()
-
-    yield delay_object
-
-
-@pytest.fixture(scope="session")
-def delay_data_inputflag_main(delay_data_main):
-    """Add an input flag array to delay object."""
-    delay_object = delay_data_main.copy()
-
-    # yield the data for testing, then del after tests finish
-    yield delay_object
-
-
-@pytest.fixture(scope="function")
-def delay_data_inputflag(delay_data_inputflag_main):
-    """Make function level delay uvcal object."""
-    delay_object = delay_data_inputflag_main.copy()
 
     yield delay_object
 
@@ -185,8 +168,8 @@ def wideband_gain(gain_data):
 
 
 @pytest.fixture
-def multi_spw_delay(delay_data_inputflag):
-    delay_obj = delay_data_inputflag.copy()
+def multi_spw_delay(delay_data):
+    delay_obj = delay_data.copy()
     delay_obj.Nspws = 3
     delay_obj.spw_array = np.array([1, 2, 3])
 

--- a/pyuvdata/uvcal/tests/conftest.py
+++ b/pyuvdata/uvcal/tests/conftest.py
@@ -54,8 +54,8 @@ def delay_data_main():
             "telescope_location, antenna_positions, antenna_diameters are not "
             "set or are being overwritten. telescope_location, antenna_positions, "
             "antenna_diameters are set using values from known telescopes for HERA.",
-            "When converting a delay-style cal to future array shapes the flag_array"
-            " (and input_flag_array if it exists) must drop the frequency axis",
+            "When converting a delay-style cal to future array shapes the flag_array "
+            "must drop the frequency axis",
         ],
     ):
         delay_object = UVCal.from_file(delayfile, use_future_array_shapes=True)
@@ -73,23 +73,14 @@ def delay_data(delay_data_main):
 
     yield delay_object
 
-    del delay_object
-
 
 @pytest.fixture(scope="session")
 def delay_data_inputflag_main(delay_data_main):
     """Add an input flag array to delay object."""
     delay_object = delay_data_main.copy()
 
-    # add an input flag array for testing
-    delay_object.input_flag_array = np.zeros(
-        delay_object._input_flag_array.expected_shape(delay_object), dtype=bool
-    )
-
     # yield the data for testing, then del after tests finish
     yield delay_object
-
-    del delay_object
 
 
 @pytest.fixture(scope="function")
@@ -98,8 +89,6 @@ def delay_data_inputflag(delay_data_inputflag_main):
     delay_object = delay_data_inputflag_main.copy()
 
     yield delay_object
-
-    del delay_object
 
 
 @pytest.fixture(scope="session")
@@ -194,9 +183,6 @@ def wideband_gain(gain_data):
     gain_obj.gain_array = gain_obj.gain_array[:, 0:3, :, :]
     gain_obj.flag_array = gain_obj.flag_array[:, 0:3, :, :]
     gain_obj.quality_array = gain_obj.quality_array[:, 0:3, :, :]
-    gain_obj.input_flag_array = np.zeros(
-        gain_obj._input_flag_array.expected_shape(gain_obj)
-    ).astype(np.bool_)
 
     gain_obj.freq_range = np.zeros((gain_obj.Nspws, 2), dtype=gain_obj.freq_array.dtype)
     gain_obj.freq_range[0, :] = gain_obj.freq_array[[0, 2]]
@@ -208,15 +194,10 @@ def wideband_gain(gain_data):
     gain_obj.flex_spw_id_array = None
     gain_obj.Nfreqs = 1
 
-    with uvtest.check_warnings(
-        DeprecationWarning,
-        match="The input_flag_array is deprecated and will be removed in version 2.5",
-    ):
+    with uvtest.check_warnings(None):
         gain_obj.check(check_freq_spacing=True)
 
     yield gain_obj
-
-    del gain_obj
 
 
 @pytest.fixture
@@ -228,9 +209,6 @@ def multi_spw_delay(delay_data_inputflag):
     # copy the delay array to the second SPW
     delay_obj.delay_array = np.repeat(delay_obj.delay_array, delay_obj.Nspws, axis=1)
     delay_obj.flag_array = np.repeat(delay_obj.flag_array, delay_obj.Nspws, axis=1)
-    delay_obj.input_flag_array = np.repeat(
-        delay_obj.input_flag_array, delay_obj.Nspws, axis=1
-    )
     delay_obj.quality_array = np.repeat(
         delay_obj.quality_array, delay_obj.Nspws, axis=1
     )
@@ -242,12 +220,7 @@ def multi_spw_delay(delay_data_inputflag):
     delay_obj.freq_range[2, 0] = delay_obj.freq_range[1, 1]
     delay_obj.freq_range[2, 1] = delay_obj.freq_range[1, 1] + 10e6
 
-    with uvtest.check_warnings(
-        DeprecationWarning,
-        match="The input_flag_array is deprecated and will be removed in version 2.5",
-    ):
+    with uvtest.check_warnings(None):
         delay_obj.check()
 
     yield delay_obj
-
-    del delay_obj

--- a/pyuvdata/uvcal/tests/test_calfits.py
+++ b/pyuvdata/uvcal/tests/test_calfits.py
@@ -21,21 +21,12 @@ from pyuvdata.uvcal.uvcal import _future_array_shapes_warning
 
 
 @pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.filterwarnings("ignore:The input_flag_array is deprecated")
 @pytest.mark.parametrize("future_shapes", [True, False])
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 @pytest.mark.parametrize("quality", [True, False])
-@pytest.mark.parametrize("input_flag_array", [True, False])
 @pytest.mark.parametrize("time_range", [True, False])
 def test_readwriteread(
-    future_shapes,
-    caltype,
-    quality,
-    input_flag_array,
-    time_range,
-    gain_data,
-    delay_data,
-    tmp_path,
+    future_shapes, caltype, quality, time_range, gain_data, delay_data, tmp_path
 ):
     """
     Omnical/Firstcal fits loopback test.
@@ -58,8 +49,6 @@ def test_readwriteread(
 
     if not quality:
         cal_in.quality_array = None
-    if input_flag_array:
-        cal_in.input_flag_array = cal_in.flag_array
     # add total_quality_array so that can be tested as well
     cal_in.total_quality_array = np.ones(
         cal_in._total_quality_array.expected_shape(cal_in)
@@ -81,12 +70,6 @@ def test_readwriteread(
     else:
         warn_type = []
         warn_msg = []
-
-    if input_flag_array:
-        warn_type.append(DeprecationWarning)
-        warn_msg.append(
-            "The input_flag_array is deprecated and will be removed in version 2.5"
-        )
 
     if len(warn_type) == 0:
         warn_type = None
@@ -269,27 +252,6 @@ def test_readwriteread_no_time_range(tmp_path):
     cal_in.write_calfits(write_file, clobber=True)
     cal_out = UVCal.from_file(write_file, use_future_array_shapes=True)
     assert cal_in == cal_out
-
-    return
-
-
-def test_error_unknown_cal_type(delay_data, tmp_path):
-    """
-    Test an error is raised when writing an unknown cal type.
-    """
-    cal_in = delay_data
-    write_file = str(tmp_path / "outtest_firstcal.fits")
-
-    with uvtest.check_warnings(
-        DeprecationWarning,
-        match="Setting the cal_type to 'unknown' is deprecated. This will become an "
-        "error in version 2.5",
-    ):
-        cal_in._set_unknown_cal_type()
-    with pytest.raises(ValueError, match="unknown calibration type"):
-        cal_in.write_calfits(write_file, run_check=False, clobber=True)
-
-    return
 
 
 @pytest.mark.parametrize(
@@ -525,30 +487,6 @@ def test_extra_keywords_warnings(gain_data, tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:When converting a delay-style cal to future array")
-@pytest.mark.filterwarnings("ignore:The input_flag_array is deprecated")
-@pytest.mark.parametrize("caltype", ["gain", "delay"])
-def test_input_flag_array(caltype, gain_data, delay_data, tmp_path):
-    """
-    Test when data file has input flag array.
-
-    Currently we do not have a testfile, so we will artifically create one
-    and check for internal consistency.
-    """
-    if caltype == "gain":
-        cal_in = gain_data
-    else:
-        cal_in = delay_data
-
-    write_file = str(tmp_path / "outtest_input_flags.fits")
-    cal_in.input_flag_array = np.zeros(
-        cal_in._input_flag_array.expected_shape(cal_in), dtype=bool
-    )
-    cal_in.write_calfits(write_file, clobber=True)
-    cal_out = UVCal.from_file(write_file, use_future_array_shapes=True)
-    assert cal_in == cal_out
-
-
-@pytest.mark.filterwarnings("ignore:When converting a delay-style cal to future array")
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 def test_jones(caltype, gain_data, delay_data, tmp_path):
     """
@@ -747,7 +685,7 @@ def test_calfits_partial_read(gain_data, delay_data, tmp_path, caltype, param_di
     if caltype == "delay":
         msg.append(
             "When converting a delay-style cal to future array shapes the flag_array "
-            "(and input_flag_array if it exists) must drop the frequency axis so that "
+            "must drop the frequency axis so that "
             "it will be the same shape as the delay_array"
         )
 

--- a/pyuvdata/uvcal/tests/test_calfits.py
+++ b/pyuvdata/uvcal/tests/test_calfits.py
@@ -636,7 +636,7 @@ def test_calfits_partial_read(gain_data, delay_data, tmp_path, caltype, param_di
         if par == "times":
             param_dict[par] = orig_time_array[val]
 
-    extend_jones_axis(calobj, input_flag=False, total_quality=False)
+    extend_jones_axis(calobj, total_quality=False)
 
     write_file = str(tmp_path / "outtest.calfits")
     calobj.write_calfits(write_file, clobber=True)

--- a/pyuvdata/uvcal/tests/test_calfits.py
+++ b/pyuvdata/uvcal/tests/test_calfits.py
@@ -115,7 +115,7 @@ def test_moon_loopback(tmp_path, gain_data, selenoid):
 
         hdulist.writeto(write_file2, overwrite=True)
 
-    cal_out = UVCal.from_file(write_file2, use_future_array_shapes=True)
+    cal_out = UVCal.from_file(write_file2)
     assert cal_out == cal_in
 
 

--- a/pyuvdata/uvcal/tests/test_calh5.py
+++ b/pyuvdata/uvcal/tests/test_calh5.py
@@ -64,7 +64,6 @@ def test_calh5_write_read_loop_multi_spw_gain(multi_spw_gain, tmp_path):
 
 def test_calh5_write_read_loop_wideband_gain(wideband_gain, tmp_path):
     calobj = wideband_gain
-    calobj.input_flag_array = None
 
     write_file = str(tmp_path / "outtest.calh5")
     calobj.write_calh5(write_file, clobber=True)
@@ -94,7 +93,6 @@ def test_calh5_write_read_loop_delay(delay_data, tmp_path, time_range, future_sh
 
 def test_calh5_write_read_loop_multi_spw_delay(multi_spw_delay, tmp_path):
     calobj = multi_spw_delay
-    calobj.input_flag_array = None
 
     write_file = str(tmp_path / "outtest.calh5")
     calobj.write_calh5(write_file, clobber=True)
@@ -359,7 +357,6 @@ def test_calh5_partial_read(
         calobj = gain_data
     else:
         calobj = multi_spw_delay
-        calobj.input_flag_array = None
 
     orig_time_array = calobj.time_array
     orig_lst_array = calobj.lst_array

--- a/pyuvdata/uvcal/tests/test_calh5.py
+++ b/pyuvdata/uvcal/tests/test_calh5.py
@@ -359,7 +359,7 @@ def test_calh5_partial_read(
         if par.startswith("antenna"):
             total_quality = False
 
-    extend_jones_axis(calobj, input_flag=False, total_quality=total_quality)
+    extend_jones_axis(calobj, total_quality=total_quality)
 
     write_file = str(tmp_path / "outtest.calh5")
     calobj.write_calh5(write_file, clobber=True)

--- a/pyuvdata/uvcal/tests/test_calh5.py
+++ b/pyuvdata/uvcal/tests/test_calh5.py
@@ -10,25 +10,18 @@ import numpy as np
 import pytest
 from astropy.units import Quantity
 
-import pyuvdata.tests as uvtest
 import pyuvdata.utils as uvutils
 from pyuvdata import UVCal
 from pyuvdata.data import DATA_PATH
 from pyuvdata.tests.test_utils import selenoids
 from pyuvdata.uvcal import FastCalH5Meta
 from pyuvdata.uvcal.tests import extend_jones_axis, time_array_to_time_range
-from pyuvdata.uvcal.uvcal import _future_array_shapes_warning
 from pyuvdata.uvdata import FastUVH5Meta
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0")
-@pytest.mark.parametrize("future_shapes", [True, False])
 @pytest.mark.parametrize("time_range", [True, False])
-def test_calh5_write_read_loop_gain(gain_data, tmp_path, time_range, future_shapes):
+def test_calh5_write_read_loop_gain(gain_data, tmp_path, time_range):
     calobj = gain_data
-    if not future_shapes:
-        calobj.use_current_array_shapes()
     if time_range:
         calobj = time_array_to_time_range(calobj)
 
@@ -41,13 +34,13 @@ def test_calh5_write_read_loop_gain(gain_data, tmp_path, time_range, future_shap
 
     write_file = str(tmp_path / "outtest.calh5")
     calobj.write_calh5(write_file, clobber=True)
-    calobj2 = UVCal.from_file(write_file, use_future_array_shapes=future_shapes)
+    calobj2 = UVCal.from_file(write_file)
 
     assert calobj == calobj2
 
     cal_meta = FastCalH5Meta(write_file)
     calobj3 = UVCal()
-    calobj3.read_calh5(cal_meta, use_future_array_shapes=future_shapes)
+    calobj3.read_calh5(cal_meta)
 
     assert calobj == calobj3
 
@@ -57,7 +50,7 @@ def test_calh5_write_read_loop_multi_spw_gain(multi_spw_gain, tmp_path):
 
     write_file = str(tmp_path / "outtest.calh5")
     calobj.write_calh5(write_file, clobber=True)
-    calobj2 = UVCal.from_file(write_file, use_future_array_shapes=True)
+    calobj2 = UVCal.from_file(write_file)
 
     assert calobj == calobj2
 
@@ -67,26 +60,20 @@ def test_calh5_write_read_loop_wideband_gain(wideband_gain, tmp_path):
 
     write_file = str(tmp_path / "outtest.calh5")
     calobj.write_calh5(write_file, clobber=True)
-    calobj2 = UVCal.from_file(write_file, use_future_array_shapes=True)
+    calobj2 = UVCal.from_file(write_file)
 
     assert calobj == calobj2
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0")
-@pytest.mark.filterwarnings("ignore:When converting a delay-style cal to future array")
-@pytest.mark.parametrize("future_shapes", [True, False])
 @pytest.mark.parametrize("time_range", [True, False])
-def test_calh5_write_read_loop_delay(delay_data, tmp_path, time_range, future_shapes):
+def test_calh5_write_read_loop_delay(delay_data, tmp_path, time_range):
     calobj = delay_data
-    if not future_shapes:
-        calobj.use_current_array_shapes()
     if time_range:
         calobj = time_array_to_time_range(calobj)
 
     write_file = str(tmp_path / "outtest.calh5")
     calobj.write_calh5(write_file, clobber=True)
-    calobj2 = UVCal.from_file(write_file, use_future_array_shapes=future_shapes)
+    calobj2 = UVCal.from_file(write_file)
 
     assert calobj == calobj2
 
@@ -96,7 +83,7 @@ def test_calh5_write_read_loop_multi_spw_delay(multi_spw_delay, tmp_path):
 
     write_file = str(tmp_path / "outtest.calh5")
     calobj.write_calh5(write_file, clobber=True)
-    calobj2 = UVCal.from_file(write_file, use_future_array_shapes=True)
+    calobj2 = UVCal.from_file(write_file)
 
     assert calobj == calobj2
 
@@ -107,7 +94,7 @@ def test_calh5_loop_bitshuffle(gain_data, tmp_path):
     calobj = gain_data
     write_file = str(tmp_path / "outtest.calh5")
     calobj.write_calh5(write_file, clobber=True, data_compression="bitshuffle")
-    calobj2 = UVCal.from_file(write_file, use_future_array_shapes=True)
+    calobj2 = UVCal.from_file(write_file)
 
     assert calobj == calobj2
 
@@ -142,7 +129,7 @@ def test_calh5_loop_moon(tmp_path, gain_data, selenoid):
     write_file = str(tmp_path / "outtest.calh5")
     cal_in.write_calh5(write_file, clobber=True)
 
-    cal_out = UVCal.from_file(write_file, use_future_array_shapes=True)
+    cal_out = UVCal.from_file(write_file)
 
     assert cal_out.telescope._location.frame == "mcmf"
     assert cal_out.telescope._location.ellipsoid == selenoid
@@ -210,7 +197,7 @@ def test_calh5_no_lsts(gain_data, tmp_path, time_range):
         else:
             del h5f["/Header/lst_array"]
 
-    calobj2 = UVCal.from_file(write_file, use_future_array_shapes=True)
+    calobj2 = UVCal.from_file(write_file)
 
     assert calobj == calobj2
 
@@ -224,7 +211,7 @@ def test_none_extra_keywords(gain_data, tmp_path):
     cal_obj.extra_keywords["foo"] = None
 
     cal_obj.write_calh5(testfile)
-    test_calh5.read(testfile, use_future_array_shapes=True)
+    test_calh5.read(testfile)
 
     assert test_calh5 == cal_obj
 
@@ -235,13 +222,11 @@ def test_none_extra_keywords(gain_data, tmp_path):
     return
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 def test_read_write_calh5_errors(gain_data, tmp_path):
     """
     Test raising errors in write_calh5 function.
     """
     cal_obj = gain_data
-    cal_obj.use_current_array_shapes()
 
     cal_out = UVCal()
     testfile = str(tmp_path / "outtest.calh5")
@@ -254,8 +239,7 @@ def test_read_write_calh5_errors(gain_data, tmp_path):
 
     # use clobber=True to write out anyway
     cal_obj.write_calh5(testfile, clobber=True)
-    with uvtest.check_warnings(DeprecationWarning, match=_future_array_shapes_warning):
-        cal_out.read(testfile)
+    cal_out.read(testfile)
 
     # make sure filenames are what we expect
     assert cal_obj.filename == ["zen.2457698.40355.xx.gain.calfits"]
@@ -384,7 +368,7 @@ def test_calh5_partial_read(
 
     calobj2.select(**param_dict)
 
-    calobj3 = UVCal.from_file(write_file, use_future_array_shapes=True, **param_dict)
+    calobj3 = UVCal.from_file(write_file, **param_dict)
 
     assert calobj2 == calobj3
 

--- a/pyuvdata/uvcal/tests/test_initializers.py
+++ b/pyuvdata/uvcal/tests/test_initializers.py
@@ -250,11 +250,7 @@ def test_new_uvcal_set_empty(uvc_simplest):
 def test_new_uvcal_set_delay(uvc_simplest):
     uvc = {k: v for k, v in uvc_simplest.items() if k not in ("freq_array", "cal_type")}
     new = new_uvcal(
-        delay_array=np.linspace(1, 10, 10),
-        freq_range=[150e6, 180e6],
-        wide_band=False,
-        empty=True,
-        **uvc
+        delay_array=np.linspace(1, 10, 10), freq_range=[150e6, 180e6], empty=True, **uvc
     )
     assert new.cal_type == "delay"
     assert new.delay_array.shape[1] == new.Nspws

--- a/pyuvdata/uvcal/tests/test_ms_cal.py
+++ b/pyuvdata/uvcal/tests/test_ms_cal.py
@@ -146,7 +146,6 @@ def test_ms_cal_wrong_ms_type():
 
 def test_ms_cal_time_ranges(gain_data, tmp_path):
     filepath = os.path.join(tmp_path, "mscal_time_range.ms")
-    gain_data._set_flex_spw()
     gain_data.flex_spw_id_array = np.full(gain_data.Nfreqs, gain_data.spw_array[0])
     gain_data.set_lsts_from_time_array()
 

--- a/pyuvdata/uvcal/tests/test_ms_cal.py
+++ b/pyuvdata/uvcal/tests/test_ms_cal.py
@@ -98,7 +98,7 @@ def test_ms_cal_wideband_loopback(sma_pcal, tmp_path, write_func, filename):
     testfile = os.path.join(tmp_path, filename)
     getattr(sma_pcal, write_func)(testfile, clobber=True)
 
-    uvcal.read(testfile, use_future_array_shapes=True)
+    uvcal.read(testfile)
     # Check that the histories line up
     assert sma_pcal.history in uvcal.history
     assert sma_pcal.__eq__(uvcal, allowed_failures=allowed_failures)
@@ -113,7 +113,7 @@ def test_ms_cal_delay_loopback(sma_dcal, tmp_path, write_func, filename):
     testfile = os.path.join(tmp_path, filename)
     getattr(sma_dcal, write_func)(testfile, clobber=True)
 
-    uvcal.read(testfile, use_future_array_shapes=True)
+    uvcal.read(testfile)
     # Check that the histories line up
     assert sma_dcal.history in uvcal.history
     assert sma_dcal.__eq__(uvcal, allowed_failures=allowed_failures)
@@ -128,7 +128,7 @@ def test_ms_cal_bandpass_loopback(sma_bcal, tmp_path, write_func, filename):
     testfile = os.path.join(tmp_path, filename)
     getattr(sma_bcal, write_func)(testfile, clobber=True)
 
-    uvcal.read(testfile, use_future_array_shapes=True)
+    uvcal.read(testfile)
     # Check that the histories line up
     assert sma_bcal.history in uvcal.history
     assert sma_bcal.__eq__(uvcal, allowed_failures=allowed_failures)
@@ -190,10 +190,6 @@ def test_ms_cal_write_err(tmp_path):
 
     uvc.jones_array = [1, 2]
 
-    with pytest.raises(ValueError, match="you must be using future array shapes"):
-        uvc.write_ms_cal(filepath, clobber=True)
-
-    uvc.future_array_shapes = True
     with pytest.raises(ValueError, match="only supports UVCal objects with gain"):
         uvc.write_ms_cal(filepath, clobber=True)
 

--- a/pyuvdata/uvcal/tests/test_uvcal.py
+++ b/pyuvdata/uvcal/tests/test_uvcal.py
@@ -245,7 +245,7 @@ def test_equality(gain_data):
     assert gain_data == gain_data
 
 
-def test_check(gain_data, delay_data_inputflag):
+def test_check(gain_data, delay_data):
     """Test that parameter checks run properly"""
     assert gain_data.check()
 
@@ -253,19 +253,19 @@ def test_check(gain_data, delay_data_inputflag):
     with pytest.raises(ValueError, match="The freq_range attribute should not be set"):
         gain_data.check()
 
-    assert delay_data_inputflag.check()
+    assert delay_data.check()
 
-    delay_data_inputflag.flex_spw_id_array = np.array([0])
+    delay_data.flex_spw_id_array = np.array([0])
     with pytest.raises(ValueError, match="The flex_spw_id_array attribute should not"):
-        delay_data_inputflag.check()
+        delay_data.check()
 
-    delay_data_inputflag.channel_width = np.array([1.0])
+    delay_data.channel_width = np.array([1.0])
     with pytest.raises(ValueError, match="The channel_width attribute should not be"):
-        delay_data_inputflag.check()
+        delay_data.check()
 
-    delay_data_inputflag.freq_array = np.array([1.0])
+    delay_data.freq_array = np.array([1.0])
     with pytest.raises(ValueError, match="The freq_array attribute should not be set"):
-        delay_data_inputflag.check()
+        delay_data.check()
 
 
 def test_check_flag_array(gain_data):
@@ -325,14 +325,14 @@ def test_check_lst(gain_data, time_range):
 
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
-def test_array_shape_errors(caltype, gain_data, delay_data_inputflag, wideband_gain):
+def test_array_shape_errors(caltype, gain_data, delay_data, wideband_gain):
     if caltype == "gain":
         calobj = gain_data
         calobj2 = calobj.copy()
         calobj_wideband = wideband_gain
         calobj_wideband.select(spws=1)
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     calobj.integration_time[-1] = calobj.integration_time[0] * 2.0
     if caltype == "delay":
@@ -580,8 +580,8 @@ def test_flexible_spw(gain_data):
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
 @pytest.mark.parametrize("convention", ["minus", "plus"])
 @pytest.mark.parametrize("same_freqs", [True, False])
-def test_convert_to_gain(convention, same_freqs, delay_data_inputflag):
-    delay_obj = delay_data_inputflag
+def test_convert_to_gain(convention, same_freqs, delay_data):
+    delay_obj = delay_data
 
     freq_array = np.arange(30) * 1e6 + 1e8
     channel_width = np.full(30, 1e6)
@@ -651,8 +651,8 @@ def test_convert_to_gain(convention, same_freqs, delay_data_inputflag):
         assert new_gain_obj == new_gain_obj2
 
 
-def test_convert_to_gain_errors(gain_data, delay_data_inputflag, multi_spw_delay):
-    delay_obj = delay_data_inputflag
+def test_convert_to_gain_errors(gain_data, delay_data, multi_spw_delay):
+    delay_obj = delay_data
     gain_obj = gain_data
 
     delay_obj.Nfreqs = 1
@@ -706,13 +706,13 @@ def test_convert_to_gain_errors(gain_data, delay_data_inputflag, multi_spw_delay
 
 
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
-def test_select_antennas(caltype, gain_data, delay_data_inputflag, tmp_path):
+def test_select_antennas(caltype, gain_data, delay_data, tmp_path):
     if caltype == "gain":
         calobj = gain_data
         # test list handling
         calobj.ant_array = calobj.ant_array.tolist()
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     calobj2 = calobj.copy()
 
@@ -789,11 +789,11 @@ def test_select_antennas(caltype, gain_data, delay_data_inputflag, tmp_path):
 
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 @pytest.mark.parametrize("time_range", [True, False])
-def test_select_times(caltype, time_range, gain_data, delay_data_inputflag, tmp_path):
+def test_select_times(caltype, time_range, gain_data, delay_data, tmp_path):
     if caltype == "gain":
         calobj = gain_data
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     orig_time_array = calobj.time_array
     times_to_keep = orig_time_array[2:5]
@@ -1028,11 +1028,11 @@ def test_select_frequencies_multispw(multi_spw_gain, tmp_path):
     assert calobj3 == calobj2
 
 
-def test_select_freq_chans_delay_err(delay_data_inputflag):
+def test_select_freq_chans_delay_err(delay_data):
     with pytest.raises(
         ValueError, match="Cannot select on frequencies because this is a wide_band"
     ):
-        delay_data_inputflag.select(freq_chans=[0])
+        delay_data.select(freq_chans=[0])
 
 
 def test_select_freq_chans(gain_data):
@@ -1120,13 +1120,11 @@ def test_select_spws_wideband(caltype, multi_spw_delay, wideband_gain, tmp_path)
 @pytest.mark.parametrize(
     "jones_to_keep", ([-5, -6], ["xx", "yy"], ["nn", "ee"], [[-5, -6]])
 )
-def test_select_polarizations(
-    caltype, jones_to_keep, gain_data, delay_data_inputflag, tmp_path
-):
+def test_select_polarizations(caltype, jones_to_keep, gain_data, delay_data, tmp_path):
     if caltype == "gain":
         calobj = gain_data
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     calobj2 = calobj.copy()
 
@@ -1213,13 +1211,13 @@ def test_select_phase_centers(uvcal_phase_center):
 
 
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
-def test_select(caltype, gain_data, delay_data_inputflag):
+def test_select(caltype, gain_data, delay_data):
     # now test selecting along all axes at once
     if caltype == "gain":
         calobj = gain_data
         freqs_to_keep = calobj.freq_array[np.arange(2, 5)]
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
         freqs_to_keep = None
 
     calobj2 = calobj.copy()
@@ -1331,12 +1329,12 @@ def test_select_wideband(caltype, multi_spw_delay, wideband_gain):
 
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 @pytest.mark.parametrize("method", ["__iadd__", "fast_concat"])
-def test_add_antennas(caltype, gain_data, method, delay_data_inputflag):
+def test_add_antennas(caltype, gain_data, method, delay_data):
     """Test adding antennas between two UVCal objects"""
     if caltype == "gain":
         calobj = gain_data
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     calobj2 = calobj.copy()
 
@@ -1411,11 +1409,11 @@ def test_add_antennas(caltype, gain_data, method, delay_data_inputflag):
 
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 @pytest.mark.parametrize("metadata_only", [True, False])
-def test_reorder_ants(caltype, metadata_only, gain_data, delay_data_inputflag):
+def test_reorder_ants(caltype, metadata_only, gain_data, delay_data):
     if caltype == "gain":
         calobj = gain_data
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     calobj2 = calobj.copy(metadata_only=metadata_only)
     if metadata_only:
@@ -1475,7 +1473,7 @@ def test_reorder_ants_errors(gain_data):
 
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 @pytest.mark.parametrize("metadata_only", [True, False])
-def test_reorder_freqs(caltype, metadata_only, gain_data, delay_data_inputflag):
+def test_reorder_freqs(caltype, metadata_only, gain_data, delay_data):
     if caltype == "gain":
         calobj = gain_data
         # add total_quality_array
@@ -1484,7 +1482,7 @@ def test_reorder_freqs(caltype, metadata_only, gain_data, delay_data_inputflag):
             (1, calobj.Ntimes, calobj.Njones),
         )
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     calobj2 = calobj.copy(metadata_only=metadata_only)
     if metadata_only:
@@ -1602,9 +1600,7 @@ def test_reorder_freqs_errors(gain_data, multi_spw_delay):
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 @pytest.mark.parametrize("metadata_only", [True, False])
 @pytest.mark.parametrize("time_range", [True, False])
-def test_reorder_times(
-    caltype, metadata_only, time_range, gain_data, delay_data_inputflag
-):
+def test_reorder_times(caltype, metadata_only, time_range, gain_data, delay_data):
     if caltype == "gain":
         calobj = gain_data
         # add total_quality_array
@@ -1614,7 +1610,7 @@ def test_reorder_times(
         )
         calobj.check()
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     if time_range:
         calobj = time_array_to_time_range(calobj)
@@ -1673,11 +1669,11 @@ def test_reorder_times_errors(gain_data):
 
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 @pytest.mark.parametrize("metadata_only", [True, False])
-def test_reorder_jones(caltype, metadata_only, gain_data, delay_data_inputflag):
+def test_reorder_jones(caltype, metadata_only, gain_data, delay_data):
     if caltype == "gain":
         calobj = gain_data
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     # all the input objects have a Njones=1, extend to get to 4
     calobj2 = calobj.copy(metadata_only=metadata_only)
@@ -2220,12 +2216,12 @@ def test_add_spw_wideband(axis, caltype, method, multi_spw_delay, wideband_gain)
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 @pytest.mark.parametrize("time_range", [True, False])
 @pytest.mark.parametrize("method", ["__iadd__", "fast_concat"])
-def test_add_times(caltype, time_range, method, gain_data, delay_data_inputflag):
+def test_add_times(caltype, time_range, method, gain_data, delay_data):
     """Test adding times between two UVCal objects"""
     if caltype == "gain":
         calobj = gain_data
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     n_times2 = calobj.Ntimes // 2
     times1 = calobj.time_array[:n_times2]
@@ -2406,12 +2402,12 @@ def test_add_times_multispw(method, multi_spw_gain, quality):
 
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 @pytest.mark.parametrize("method", ["__iadd__", "fast_concat"])
-def test_add_jones(caltype, method, gain_data, delay_data_inputflag):
+def test_add_jones(caltype, method, gain_data, delay_data):
     """Test adding Jones axes between two UVCal objects"""
     if caltype == "gain":
         calobj = gain_data
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     calobj2 = calobj.copy()
 
@@ -2541,12 +2537,12 @@ def test_add_jones_multispw(method, quality, multi_spw_gain):
 
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 @pytest.mark.parametrize("method", ["__add__", "fast_concat"])
-def test_add(caltype, method, gain_data, delay_data_inputflag):
+def test_add(caltype, method, gain_data, delay_data):
     """Test miscellaneous aspects of add method"""
     if caltype == "gain":
         calobj = gain_data
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     calobj2 = calobj.copy()
 
@@ -3022,14 +3018,12 @@ def test_multi_files_errors(method):
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
 @pytest.mark.parametrize("method", ["__add__", "fast_concat"])
 @pytest.mark.parametrize("file_type", ["calfits", "calh5"])
-def test_multi_files(
-    caltype, method, gain_data, delay_data_inputflag, tmp_path, file_type
-):
+def test_multi_files(caltype, method, gain_data, delay_data, tmp_path, file_type):
     """Test read function when multiple files are included"""
     if caltype == "gain":
         calobj = gain_data
     else:
-        calobj = delay_data_inputflag
+        calobj = delay_data
 
     calobj2 = calobj.copy()
 
@@ -3162,12 +3156,12 @@ def test_write_read_optional_attrs(gain_data, tmp_path, file_type):
 
 
 @pytest.mark.parametrize("caltype", ["gain", "delay", None])
-def test_copy(gain_data, delay_data_inputflag, caltype):
+def test_copy(gain_data, delay_data, caltype):
     """Test the copy method"""
     if caltype == "gain":
         uv_object = gain_data
     elif caltype == "delay":
-        uv_object = delay_data_inputflag
+        uv_object = delay_data
     else:
         uv_object = gain_data
         uv_object.cal_type = caltype

--- a/pyuvdata/uvcal/tests/test_uvcal.py
+++ b/pyuvdata/uvcal/tests/test_uvcal.py
@@ -245,9 +245,27 @@ def test_equality(gain_data):
     assert gain_data == gain_data
 
 
-def test_check(gain_data):
+def test_check(gain_data, delay_data_inputflag):
     """Test that parameter checks run properly"""
     assert gain_data.check()
+
+    gain_data.freq_range = np.array([[1.0, 2.0]])
+    with pytest.raises(ValueError, match="The freq_range attribute should not be set"):
+        gain_data.check()
+
+    assert delay_data_inputflag.check()
+
+    delay_data_inputflag.flex_spw_id_array = np.array([0])
+    with pytest.raises(ValueError, match="The flex_spw_id_array attribute should not"):
+        delay_data_inputflag.check()
+
+    delay_data_inputflag.channel_width = np.array([1.0])
+    with pytest.raises(ValueError, match="The channel_width attribute should not be"):
+        delay_data_inputflag.check()
+
+    delay_data_inputflag.freq_array = np.array([1.0])
+    with pytest.raises(ValueError, match="The freq_array attribute should not be set"):
+        delay_data_inputflag.check()
 
 
 def test_check_flag_array(gain_data):

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -2257,9 +2257,6 @@ class UVCal(UVBase):
                 spw_index = np.asarray(
                     [np.nonzero(orig_spw_array == spw)[0][0] for spw in self.spw_array]
                 )
-                if self.freq_range is not None:
-                    # this can go away in v3 becuse freq_range will always be None
-                    self.freq_range = self.freq_range[spw_index, :]
                 if self.flex_jones_array is not None:
                     self.flex_jones_array = self.flex_jones_array[spw_index]
 

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -338,7 +338,7 @@ class UVCal(UVBase):
             expected_type=str,
             value="gain",
             description=desc,
-            acceptable_vals=["delay", "gain", "unknown"],
+            acceptable_vals=["delay", "gain"],
         )
 
         desc = (
@@ -426,14 +426,6 @@ class UVCal(UVBase):
             acceptable_vals=["sky", "redundant"],
         )
 
-        desc = (
-            "Deprecated, will be removed in version 2.5. Only used if cal_style is "
-            "'sky'. Short string describing field center or dominant source."
-        )
-        self._sky_field = uvp.UVParameter(
-            "sky_field", form="str", required=False, expected_type=str, description=desc
-        )
-
         desc = 'Required if cal_style = "sky". Name of calibration catalog.'
         self._sky_catalog = uvp.UVParameter(
             "sky_catalog",
@@ -507,20 +499,6 @@ class UVCal(UVBase):
             expected_type=str,
             description=desc,
             required=False,
-        )
-
-        desc = (
-            "Deprecated, support will be removed in version 2.5. Array of input flags, "
-            "True is flagged. shape: (Nants_data, 1, Nfreqs, Ntimes, Njones) or "
-            "(Nants_data, Nfreqs, Ntimes, Njones) if future_array_shapes=True, "
-            "type = bool."
-        )
-        self._input_flag_array = uvp.UVParameter(
-            "input_flag_array",
-            description=desc,
-            required=False,
-            form=("Nants_data", 1, "Nfreqs", "Ntimes", "Njones"),
-            expected_type=bool,
         )
 
         desc = "Origin (on github for e.g) of calibration software. Url and branch."
@@ -743,7 +721,6 @@ class UVCal(UVBase):
                 "gain_array",
                 "delay_array",
                 "flag_array",
-                "input_flag_array",
                 "quality_array",
             ]
             data_form = ("Nants_data", "Nspws", "Ntimes", "Njones")
@@ -763,12 +740,7 @@ class UVCal(UVBase):
 
             if self.future_array_shapes:
                 # can only get here if not a delay solution
-                data_shape_params = [
-                    "gain_array",
-                    "flag_array",
-                    "input_flag_array",
-                    "quality_array",
-                ]
+                data_shape_params = ["gain_array", "flag_array", "quality_array"]
 
                 data_form = ("Nants_data", "Nfreqs", "Ntimes", "Njones")
                 tot_qual_form = ("Nfreqs", "Ntimes", "Njones")
@@ -804,24 +776,6 @@ class UVCal(UVBase):
         if self.future_array_shapes:
             self._set_wide_band()
 
-    def _set_unknown_cal_type(self):
-        """Set cal_type to 'unknown' and adjust required parameters.
-
-        Deprecated.
-        """
-        warnings.warn(
-            "Setting the cal_type to 'unknown' is deprecated. This will become an "
-            "error in version 2.5",
-            DeprecationWarning,
-        )
-        self.cal_type = "unknown"
-        self._gain_array.required = False
-        self._delay_array.required = False
-        self._freq_range.required = False
-        self._freq_array.required = True
-        self._quality_array.form = self._gain_array.form
-        self._total_quality_array.form = self._gain_array.form[1:]
-
     def _set_sky(self):
         """Set cal_style to 'sky' and adjust required parameters."""
         self.cal_style = "sky"
@@ -843,7 +797,6 @@ class UVCal(UVBase):
             "flag_array",
             "quality_array",
             "total_quality_array",
-            "input_flag_array",
         ]
 
     @property
@@ -899,12 +852,7 @@ class UVCal(UVBase):
         self._integration_time.form = ("Ntimes",)
         self._freq_range.form = ("Nspws", 2)
 
-        data_shape_params = [
-            "gain_array",
-            "flag_array",
-            "input_flag_array",
-            "quality_array",
-        ]
+        data_shape_params = ["gain_array", "flag_array", "quality_array"]
         if self.cal_type == "delay":
             self._set_wide_band()
             data_shape_params.append("delay_array")
@@ -955,7 +903,7 @@ class UVCal(UVBase):
             if self.cal_type == "delay":
                 warnings.warn(
                     "When converting a delay-style cal to future array shapes the "
-                    "flag_array (and input_flag_array if it exists) must drop the "
+                    "flag_array must drop the "
                     "frequency axis so that it will be the same shape as the "
                     "delay_array. This will be done using the "
                     "`pyuvdata.utils.and_collapse` function which will only flag an "
@@ -968,10 +916,6 @@ class UVCal(UVBase):
                 self.flag_array = uvutils.and_collapse(self.flag_array, axis=1)[
                     :, np.newaxis, :, :
                 ]
-                if self.input_flag_array is not None:
-                    self.input_flag_array = uvutils.and_collapse(
-                        self.input_flag_array, axis=1
-                    )[:, np.newaxis, :, :]
 
         if self.cal_type == "delay":
             self.freq_array = None
@@ -1052,7 +996,7 @@ class UVCal(UVBase):
         self.future_array_shapes = False
         self.wide_band = False
 
-        gain_shape_params = ["gain_array", "flag_array", "input_flag_array"]
+        gain_shape_params = ["gain_array", "flag_array"]
         delay_shape_params = ["delay_array"]
         if self.cal_type == "delay":
             delay_shape_params.append("quality_array")
@@ -1113,10 +1057,6 @@ class UVCal(UVBase):
             if self.cal_type == "delay":
                 # make the flag array have a frequency axis again
                 self.flag_array = np.repeat(self.flag_array, self.Nfreqs, axis=2)
-                if self.input_flag_array is not None:
-                    self.input_flag_array = np.repeat(
-                        self.input_flag_array, self.Nfreqs, axis=2
-                    )
 
         self._freq_array.form = (1, "Nfreqs")
         if self.freq_array is not None:
@@ -2005,22 +1945,6 @@ class UVCal(UVBase):
                     category=DeprecationWarning,
                 )
 
-        # deprecate 'unknown' cal_type
-        if self.cal_type == "unknown":
-            warnings.warn(
-                "The 'unknown' cal_type is deprecated and will be removed in version "
-                "2.5",
-                DeprecationWarning,
-            )
-
-        # deprecate sky_field
-        if self.sky_field is not None:
-            warnings.warn(
-                "The sky_field parameter is deprecated and will be removed in version "
-                "2.5",
-                DeprecationWarning,
-            )
-
         # call metadata_only to make sure that parameter requirements are set properly
         self.metadata_only
 
@@ -2126,12 +2050,6 @@ class UVCal(UVBase):
                     "This will become an error in version 3.0.",
                     DeprecationWarning,
                 )
-
-        if self.input_flag_array is not None:
-            warnings.warn(
-                "The input_flag_array is deprecated and will be removed in version 2.5",
-                DeprecationWarning,
-            )
 
         if check_freq_spacing:
             self._check_freq_spacing()
@@ -2946,9 +2864,6 @@ class UVCal(UVBase):
         """
         if self.cal_type == "gain":
             raise ValueError("The data is already a gain cal_type.")
-        elif self.cal_type != "delay":
-            # TODO remove this when the unknown cal_type is removed.
-            raise ValueError("cal_type is unknown, cannot convert to gain")
 
         if self.Nspws > 1:
             raise ValueError(
@@ -3081,7 +2996,7 @@ class UVCal(UVBase):
                 warnings.warn(
                     "Existing flag array has a frequency axis of length > 1 but "
                     "frequencies do not match freq_array. The existing flag array "
-                    "(and input_flag_array if it exists) will be collapsed using "
+                    "will be collapsed using "
                     "the `pyuvdata.utils.and_collapse` function which will only "
                     "flag an antpol-time if all of the frequecies are flagged for "
                     "that antpol-time. Then it will be broadcast to all the new "
@@ -3095,22 +3010,9 @@ class UVCal(UVBase):
                     axis=freq_axis,
                 )
                 self.flag_array = np.repeat(new_flag_array, Nfreqs_use, axis=freq_axis)
-                if self.input_flag_array is not None:
-                    new_input_flag_array = np.expand_dims(
-                        uvutils.and_collapse(self.input_flag_array, axis=freq_axis),
-                        axis=freq_axis,
-                    )
-                    self.input_flag_array = np.repeat(
-                        new_input_flag_array, Nfreqs_use, axis=freq_axis
-                    )
         else:
             new_flag_array = np.repeat(self.flag_array, Nfreqs_use, axis=freq_axis)
             self.flag_array = new_flag_array
-            if self.input_flag_array is not None:
-                new_input_flag_array = np.repeat(
-                    self.input_flag_array, Nfreqs_use, axis=freq_axis
-                )
-                self.input_flag_array = new_input_flag_array
 
         if self.total_quality_array is not None:
             if self.future_array_shapes:
@@ -3271,7 +3173,6 @@ class UVCal(UVBase):
         warning_params = [
             "_observer",
             "_git_hash_cal",
-            "_sky_field",
             "_sky_catalog",
             "_Nsources",
             "_baseline_range",
@@ -3567,15 +3468,6 @@ class UVCal(UVBase):
 
         if (
             not self.metadata_only
-            and this.input_flag_array is None
-            and other.input_flag_array is not None
-        ):
-            this.input_flag_array = np.full(
-                this._input_flag_array.expected_shape(this), True, dtype=bool
-            )
-
-        if (
-            not self.metadata_only
             and this.quality_array is None
             and other.quality_array is not None
         ):
@@ -3640,24 +3532,6 @@ class UVCal(UVBase):
                     )
                     this.total_quality_array = None
                     can_combine_tqa = False
-
-                if this.input_flag_array is not None:
-                    if self.future_array_shapes:
-                        zero_pad = np.zeros(
-                            (
-                                len(anew_inds),
-                                this.input_flag_array.shape[1],
-                                this.Ntimes,
-                                this.Njones,
-                            )
-                        )
-                    else:
-                        zero_pad = np.zeros(
-                            (len(anew_inds), 1, this.Nfreqs, this.Ntimes, this.Njones)
-                        )
-                    this.input_flag_array = np.concatenate(
-                        [this.input_flag_array, 1 - zero_pad], axis=0
-                    ).astype(np.bool_)
 
         f_order = None
         if len(fnew_inds) > 0:
@@ -3861,33 +3735,6 @@ class UVCal(UVBase):
                             [this.total_quality_array, zero_pad], axis=1
                         )
 
-                if this.input_flag_array is not None:
-                    if self.future_array_shapes:
-                        zero_pad = np.zeros(
-                            (
-                                this.flag_array.shape[0],
-                                len(fnew_inds),
-                                this.Ntimes,
-                                this.Njones,
-                            )
-                        )
-                        this.input_flag_array = np.concatenate(
-                            [this.input_flag_array, 1 - zero_pad], axis=1
-                        ).astype(np.bool_)
-                    else:
-                        zero_pad = np.zeros(
-                            (
-                                this.flag_array.shape[0],
-                                1,
-                                len(fnew_inds),
-                                this.Ntimes,
-                                this.Njones,
-                            )
-                        )
-                        this.input_flag_array = np.concatenate(
-                            [this.input_flag_array, 1 - zero_pad], axis=2
-                        ).astype(np.bool_)
-
         t_order = None
         if len(tnew_inds) > 0:
             if this.time_array is not None:
@@ -3976,19 +3823,6 @@ class UVCal(UVBase):
                             [this.total_quality_array, zero_pad], axis=1
                         )
 
-                    if this.input_flag_array is not None:
-                        zero_pad = np.zeros(
-                            (
-                                this.input_flag_array.shape[0],
-                                this.input_flag_array.shape[1],
-                                len(tnew_inds),
-                                this.Njones,
-                            )
-                        )
-                        this.input_flag_array = np.concatenate(
-                            [this.input_flag_array, 1 - zero_pad], axis=2
-                        ).astype(np.bool_)
-
                 else:
                     zero_pad_data = np.zeros(
                         (
@@ -4041,20 +3875,6 @@ class UVCal(UVBase):
                         this.total_quality_array = np.concatenate(
                             [this.total_quality_array, zero_pad], axis=2
                         )
-
-                    if this.input_flag_array is not None:
-                        zero_pad = np.zeros(
-                            (
-                                this.input_flag_array.shape[0],
-                                1,
-                                this.input_flag_array.shape[2],
-                                len(tnew_inds),
-                                this.Njones,
-                            )
-                        )
-                        this.input_flag_array = np.concatenate(
-                            [this.input_flag_array, 1 - zero_pad], axis=3
-                        ).astype(np.bool_)
 
         j_order = None
         if len(jnew_inds) > 0:
@@ -4115,18 +3935,6 @@ class UVCal(UVBase):
                             [this.total_quality_array, zero_pad], axis=2
                         )
 
-                    if this.input_flag_array is not None:
-                        zero_pad = np.zeros(
-                            (
-                                this.input_flag_array.shape[0],
-                                this.input_flag_array.shape[1],
-                                this.input_flag_array.shape[2],
-                                len(jnew_inds),
-                            )
-                        )
-                        this.input_flag_array = np.concatenate(
-                            [this.input_flag_array, 1 - zero_pad], axis=3
-                        ).astype(np.bool_)
                 else:
                     zero_pad_data = np.zeros(
                         (
@@ -4190,20 +3998,6 @@ class UVCal(UVBase):
                             [this.total_quality_array, zero_pad], axis=3
                         )
 
-                    if this.input_flag_array is not None:
-                        zero_pad = np.zeros(
-                            (
-                                this.input_flag_array.shape[0],
-                                1,
-                                this.input_flag_array.shape[2],
-                                this.input_flag_array.shape[3],
-                                len(jnew_inds),
-                            )
-                        )
-                        this.input_flag_array = np.concatenate(
-                            [this.input_flag_array, 1 - zero_pad], axis=4
-                        ).astype(np.bool_)
-
         # Now populate the data
         if not self.metadata_only:
             jones_t2o = np.nonzero(np.in1d(this.jones_array, other.jones_array))[0]
@@ -4254,11 +4048,6 @@ class UVCal(UVBase):
                         this.total_quality_array[
                             np.ix_(freqs_t2o, times_t2o, jones_t2o)
                         ] = other.total_quality_array
-                if this.input_flag_array is not None:
-                    if other.input_flag_array is not None:
-                        this.input_flag_array[
-                            np.ix_(ants_t2o, freqs_t2o, times_t2o, jones_t2o)
-                        ] = other.input_flag_array
             else:
                 if this.cal_type == "delay":
                     this.delay_array[
@@ -4289,11 +4078,6 @@ class UVCal(UVBase):
                             this.total_quality_array[
                                 np.ix_([0], freqs_t2o, times_t2o, jones_t2o)
                             ] = other.total_quality_array
-                if this.input_flag_array is not None:
-                    if other.input_flag_array is not None:
-                        this.input_flag_array[
-                            np.ix_(ants_t2o, [0], freqs_t2o, times_t2o, jones_t2o)
-                        ] = other.input_flag_array
 
             # Fix ordering
             ant_axis_num = 0
@@ -4631,7 +4415,6 @@ class UVCal(UVBase):
         warning_params = [
             "_observer",
             "_git_hash_cal",
-            "_sky_field",
             "_sky_catalog",
             "_Nsources",
             "_baseline_range",
@@ -4747,11 +4530,6 @@ class UVCal(UVBase):
             obj.total_quality_array is not None for obj in other
         ]
         this_tqa_exp_shape = this._total_quality_array.expected_shape(this)
-
-        input_flag_exists = [this.input_flag_array is not None] + [
-            obj.input_flag_array is not None for obj in other
-        ]
-        this_ifa_exp_shape = this._input_flag_array.expected_shape(this)
 
         quality_exists = [this.quality_array is not None] + [
             obj.quality_array is not None for obj in other
@@ -4944,32 +4722,6 @@ class UVCal(UVBase):
                     [this.delay_array] + [obj.delay_array for obj in other],
                     axis=axis_num,
                 )
-
-            if np.any(input_flag_exists):
-                if np.all(input_flag_exists):
-                    this.input_flag_array = np.concatenate(
-                        [this.input_flag_array]
-                        + [obj.input_flag_array for obj in other],
-                        axis=axis_num,
-                    )
-                else:
-                    ifa_list = []
-                    if this.input_flag_array is None:
-                        ifa_list.append(np.full(this_ifa_exp_shape, True, dtype=bool))
-                    else:
-                        ifa_list.append(this.input_flag_array)
-                    for obj in other:
-                        if obj.input_flag_array is None:
-                            ifa_list.append(
-                                np.full(
-                                    (obj._input_flag_array.expected_shape(obj)),
-                                    True,
-                                    dtype=bool,
-                                )
-                            )
-                        else:
-                            ifa_list.append(obj.input_flag_array)
-                    this.input_flag_array = np.concatenate(ifa_list, axis=axis_num)
 
             if np.any(quality_exists):
                 if np.all(quality_exists):
@@ -5739,9 +5491,6 @@ class UVCal(UVBase):
         cal_style,
         future_array_shapes=True,
         metadata_only=True,
-        times=None,
-        frequencies=None,
-        jones=None,
         **kwargs,
     ):
         """
@@ -5759,35 +5508,7 @@ class UVCal(UVBase):
             Option to only initialize the metadata. If False, this method also
             initializes the data-like arrays to zeros/ones as appropriate
             (or False for the flag_array) with the appropriate sizes.
-        times : array_like of float, optional
-            Deprecated alias for ``time_array``. Will be removed in v2.5.
-        frequencies : array_like of float, optional
-            Deprecated alias for ``freq_array``. Will be removed in v2.5.
-        jones : array_like of int, optional
-            Deprecated alias for ``jones_array``. Will be removed in v2.5.
         """  # noqa: D207,RST203
-        if times is not None:
-            warnings.warn(
-                "The times keyword is deprecated in favor of time_array and will be "
-                "removed in v2.5.",
-                DeprecationWarning,
-            )
-            kwargs["time_array"] = np.array(times)
-        if frequencies is not None:
-            warnings.warn(
-                "The frequencies keyword is deprecated in favor of freq_array and will "
-                "be removed in v2.5.",
-                DeprecationWarning,
-            )
-            kwargs["freq_array"] = np.array(frequencies)
-        if jones is not None:
-            warnings.warn(
-                "The jones keyword is deprecated in favor of jones_array and will be "
-                "removed in v2.5.",
-                DeprecationWarning,
-            )
-            kwargs["jones_array"] = jones
-
         new = initializers.new_uvcal_from_uvdata(
             uvdata=uvdata,
             gain_convention=gain_convention,
@@ -5840,28 +5561,14 @@ class UVCal(UVBase):
         from . import calfits
 
         if isinstance(filename, (list, tuple)):
-            warnings.warn(
-                "Reading multiple files from file specific read methods is deprecated. "
-                "Use the generic `UVCal.read` method instead. This will become an "
-                "error in version 2.5",
-                DeprecationWarning,
+            raise ValueError(
+                "Use the generic `UVCal.read` method to read multiple files."
             )
 
-            # cannot just call `read` here and let it handle the recursion because we
-            # can get a max recursion depth error. So leave the old handling for
-            # recursion until v2.5
-            self.read_calfits(filename[0], **kwargs)
-            if len(filename) > 1:
-                for f in filename[1:]:
-                    uvcal2 = UVCal()
-                    uvcal2.read_calfits(f, **kwargs)
-                    self += uvcal2
-                del uvcal2
-        else:
-            calfits_obj = calfits.CALFITS()
-            calfits_obj.read_calfits(filename, **kwargs)
-            self._convert_from_filetype(calfits_obj)
-            del calfits_obj
+        calfits_obj = calfits.CALFITS()
+        calfits_obj.read_calfits(filename, **kwargs)
+        self._convert_from_filetype(calfits_obj)
+        del calfits_obj
 
     def read_calh5(self, filename, **kwargs):
         """
@@ -6029,107 +5736,21 @@ class UVCal(UVBase):
         """
         from . import fhd_cal
 
-        if (
-            isinstance(cal_file, (list, tuple))
-            or isinstance(obs_file, (list, tuple))
-            or isinstance(layout_file, (list, tuple))
-            or isinstance(settings_file, (list, tuple))
-        ):
-            warnings.warn(
-                "Reading multiple files from file specific read methods is deprecated. "
-                "Use the generic `UVCal.read` method instead. This will become an "
-                "error in version 2.5",
-                DeprecationWarning,
-            )
-            # cannot just call `read` here and let it handle the recursion because we
-            # can get a max recursion depth error. So leave the old handling for
-            # recursion until v2.5
-
         if isinstance(cal_file, (list, tuple)):
-            if isinstance(obs_file, (list, tuple)):
-                if len(obs_file) != len(cal_file):
-                    raise ValueError(
-                        "Number of obs_files must match number of cal_files"
-                    )
-            else:
-                raise ValueError("Number of obs_files must match number of cal_files")
-
-            if layout_file is not None:
-                if isinstance(layout_file, (list, tuple)):
-                    if len(layout_file) != len(cal_file):
-                        raise ValueError(
-                            "Number of layout_files must match number of cal_files"
-                        )
-                else:
-                    raise ValueError(
-                        "Number of layout_files must match number of cal_files"
-                    )
-                layout_file_use = layout_file[0]
-            else:
-                layout_file_use = None
-
-            if settings_file is not None:
-                if isinstance(settings_file, (list, tuple)):
-                    if len(settings_file) != len(cal_file):
-                        raise ValueError(
-                            "Number of settings_files must match number of cal_files"
-                        )
-                else:
-                    raise ValueError(
-                        "Number of settings_files must match number of cal_files"
-                    )
-                settings_file_use = settings_file[0]
-            else:
-                settings_file_use = None
-
-            self.read_fhd_cal(
-                cal_file=cal_file[0],
-                obs_file=obs_file[0],
-                layout_file=layout_file_use,
-                settings_file=settings_file_use,
-                **kwargs,
+            raise ValueError(
+                "Use the generic `UVCal.read` method to read multiple files."
             )
-            if len(cal_file) > 1:
-                for ind, f in enumerate(cal_file[1:]):
-                    uvcal2 = UVCal()
-                    if settings_file is not None:
-                        settings_file_use = settings_file[ind + 1]
-                    if layout_file is not None:
-                        layout_file_use = layout_file[ind + 1]
-                    uvcal2.read_fhd_cal(
-                        cal_file=f,
-                        obs_file=obs_file[ind + 1],
-                        layout_file=layout_file_use,
-                        settings_file=settings_file_use,
-                        **kwargs,
-                    )
 
-                    self += uvcal2
-                del uvcal2
-        else:
-            if isinstance(obs_file, (list, tuple)):
-                raise ValueError("Number of obs_files must match number of cal_files")
-            if layout_file is not None:
-                if isinstance(layout_file, (list, tuple)) and len(layout_file) > 1:
-                    raise ValueError(
-                        "Number of layout_files must match number of cal_files"
-                    )
-            if settings_file is not None:
-                if isinstance(settings_file, (list, tuple)) and len(settings_file) > 1:
-                    raise ValueError(
-                        "Number of settings_files must match number of cal_files"
-                    )
-
-            fhd_cal_obj = fhd_cal.FHDCal()
-            fhd_cal_obj.read_fhd_cal(
-                cal_file=cal_file,
-                obs_file=obs_file,
-                layout_file=layout_file,
-                settings_file=settings_file,
-                **kwargs,
-            )
-            self._convert_from_filetype(fhd_cal_obj)
-            del fhd_cal_obj
+        fhd_cal_obj = fhd_cal.FHDCal()
+        fhd_cal_obj.read_fhd_cal(
+            cal_file=cal_file,
+            obs_file=obs_file,
+            layout_file=layout_file,
+            settings_file=settings_file,
+            **kwargs,
+        )
+        self._convert_from_filetype(fhd_cal_obj)
+        del fhd_cal_obj
 
     def read_ms_cal(self, filename, **kwargs):
         """
@@ -6165,6 +5786,11 @@ class UVCal(UVBase):
                 default is astropy.
         """
         from . import ms_cal
+
+        if isinstance(filename, (list, tuple)):
+            raise ValueError(
+                "Use the generic `UVCal.read` method to read multiple files."
+            )
 
         ms_cal_obj = ms_cal.MSCal()
         ms_cal_obj.read_ms_cal(filename, **kwargs)

--- a/pyuvdata/uvcal/uvcal.py
+++ b/pyuvdata/uvcal/uvcal.py
@@ -356,34 +356,18 @@ class UVCal(UVBase):
         # --- flexible spectral window information ---
 
         desc = (
-            "Option to construct a 'flexible spectral window', which stores"
-            "all spectral channels across the frequency axis of data_array. "
-            "Allows for spectral windows of variable sizes, and channels of "
-            "varying widths."
-        )
-        self._flex_spw = uvp.UVParameter(
-            "flex_spw", description=desc, expected_type=bool, value=False
-        )
-
-        desc = (
-            "Required if flex_spw = True and will always be required for non-wide-band "
-            "objects starting in version 3.0. Maps individual channels along the "
+            "Required for non-wide-band objects. Maps individual channels along the "
             "frequency axis to individual spectral windows, as listed in the "
             "spw_array. Shape (Nfreqs), type = int."
         )
         self._flex_spw_id_array = uvp.UVParameter(
-            "flex_spw_id_array",
-            description=desc,
-            form=("Nfreqs",),
-            expected_type=int,
-            required=False,
+            "flex_spw_id_array", description=desc, form=("Nfreqs",), expected_type=int
         )
 
         desc = (
-            "Optional, only used if flex_spw = True or wide_band = True. Allows for "
-            "labeling individual spectral windows with different polarizations. If "
-            "set, Njones must be set to 1 (i.e., only one Jones vector per spectral "
-            "window allowed). Shape (Nspws), type = int."
+            "Optional parameter that allows for labeling individual spectral windows "
+            "with different polarizations. If set, Njones must be set to 1 (i.e., only "
+            "one Jones vector per spectral window allowed). Shape (Nspws), type = int."
         )
         self._flex_jones_array = uvp.UVParameter(
             "flex_jones_array",
@@ -644,23 +628,6 @@ class UVCal(UVBase):
         """
         return initializers.new_uvcal(**kwargs)
 
-    def _set_flex_spw(self):
-        """
-        Set flex_spw to True, and adjust required parameters.
-
-        This method should not be called directly by users; instead it is called
-        by the file-reading methods to indicate that an object has multiple spectral
-        windows concatenated together across the frequency axis.
-        """
-        assert not (
-            self.wide_band
-        ), "Cannot set objects wide_band objects to have flexible spectral windows."
-        # Mark once-optional arrays as now required
-        self.flex_spw = True
-        self._flex_spw_id_array.required = True
-        # Now make sure that chan_width is set to be an array
-        self._channel_width.form = ("Nfreqs",)
-
     def _set_wide_band(self, wide_band=True):
         """
         Set the wide_band parameter and adjust required parameters.
@@ -671,10 +638,9 @@ class UVCal(UVBase):
 
         """
         if wide_band:
-            # TODO think about what to test for in flex_spw_id_array
-            assert (
-                not self.flex_spw
-            ), "Cannot set objects with flexible spectral windows to wide_band."
+            assert self.flex_spw_id_array is None or np.array_equal(
+                self.flex_spw_id_array, self.spw_array
+            ), "flex_spw_id_array must be unset or equal to spw_array to set wide_band"
         else:
             assert self.cal_type != "delay", "delay objects cannot have wide_band=False"
         self.wide_band = wide_band
@@ -682,8 +648,9 @@ class UVCal(UVBase):
         if wide_band:
             self._freq_array.required = False
             self._channel_width.required = False
-            # in version 3.0, also set _flex_spw_id_array to not be required
+            self._flex_spw_id_array.required = False
             self._freq_range.required = True
+            self.flex_spw_id_array = None
 
             data_shape_params = [
                 "gain_array",
@@ -703,7 +670,7 @@ class UVCal(UVBase):
         else:
             self._freq_array.required = True
             self._channel_width.required = True
-            # in version 3.0, also set _flex_spw_id_array to be required
+            self._flex_spw_id_array.required = True
             self._freq_range.required = False
             self._flex_spw_id_array.required = True
 
@@ -724,9 +691,9 @@ class UVCal(UVBase):
         self.cal_type = "gain"
         self._gain_array.required = True
         self._delay_array.required = False
-        self._freq_range.required = False
-        self._freq_array.required = True
-        self._channel_width.required = True
+        self._freq_range.required = self.wide_band
+        self._freq_array.required = not self.wide_band
+        self._channel_width.required = not self.wide_band
         self._quality_array.form = self._gain_array.form
         self._total_quality_array.form = self._gain_array.form[1:]
 
@@ -874,19 +841,19 @@ class UVCal(UVBase):
         if combine_spws:
             # check to see if there are spectral windows that have matching freq_array
             # and channel_width (up to sorting). If so, they need to be combined.
-            if self.flex_spw:
+            if self.wide_band:
+                freq_array_check = self.freq_range
+                chan_width_check = np.zeros_like(freq_array_check)
+                index_check = self.spw_array
+                ftol = self._freq_range.tols
+                ctol = [0, 0]
+            else:
                 freq_array_check = self.freq_array
                 chan_width_check = self.channel_width
 
                 index_check = self.flex_spw_id_array
                 ftol = self._freq_array.tols
                 ctol = self._channel_width.tols
-            else:
-                freq_array_check = self.freq_range
-                chan_width_check = np.zeros_like(freq_array_check)
-                index_check = self.spw_array
-                ftol = self._freq_range.tols
-                ctol = [0, 0]
 
             # Build the main spw map, along with some dicts to save intermediate results
             # from frequencies and Jones vectors
@@ -931,7 +898,7 @@ class UVCal(UVBase):
 
         if not combine_spws:
             # If not combining spws, then map everything back to itself
-            index_check = self.flex_spw_id_array if self.flex_spw else self.spw_array
+            index_check = self.spw_array if self.wide_band else self.flex_spw_id_array
             spw_map = dict(zip(self.spw_array, self.spw_array))
 
         # Reverse mapping map for various metadata values
@@ -976,7 +943,7 @@ class UVCal(UVBase):
 
         # Finally, update data attrs if they exist
         if not self.metadata_only:
-            freq_index = self.flex_spw_id_array if self.flex_spw else self.spw_array
+            freq_index = self.spw_array if self.wide_band else self.flex_spw_id_array
             for name, param in zip(self._data_params, self.data_like_parameters):
                 if param is None:
                     continue
@@ -1011,12 +978,6 @@ class UVCal(UVBase):
         is found to have unflagged data in a given spectral window, then an error is
         returned.
         """
-        if not (self.flex_spw or self.wide_band):
-            raise ValueError(
-                "Must use future array shapes to make a flex-Jones UVCal object, "
-                "with either wide_band=True or flex_spw=True."
-            )
-
         if self.metadata_only:
             raise ValueError(
                 "Cannot make a metadata_only UVCal object flex-Jones because flagging "
@@ -1032,7 +993,7 @@ class UVCal(UVBase):
             return
 
         jones_idx_arr = np.full(self.Nspws, -1)
-        spw_id_arr = self.flex_spw_id_array if self.flex_spw else self.spw_array
+        spw_id_arr = self.spw_array if self.wide_band else self.flex_spw_id_array
         for idx, spw in enumerate(self.spw_array):
             spw_screen = spw_id_arr == spw
 
@@ -1093,12 +1054,6 @@ class UVCal(UVBase):
         if self.flex_jones_array is not None:
             raise ValueError("This is already a flex-pol object")
 
-        if not (self.flex_spw or self.wide_band):
-            raise ValueError(
-                "Must use future array shapes to make a flex-Jones UVCal object, "
-                "with either wide_band=True or flex_spw=True."
-            )
-
         if self.Njones == 1:
             # This is basically a no-op, fix the relevant attributes and exit
             self.flex_jones_array = np.full(self.Nspws, self.jones_array[0])
@@ -1112,7 +1067,7 @@ class UVCal(UVBase):
         spw_array = np.concatenate((self.spw_array, new_spw_ids[:new_nspws]))
         flex_spw_id_arr = None
 
-        if self.flex_spw and self.flex_spw_id_array is not None:
+        if not self.wide_band:
             spw_reshape = spw_array.reshape((self.Njones, -1))
             flex_spw_id_arr = np.repeat(
                 self.flex_spw_id_array[np.newaxis], self.Njones, axis=0
@@ -1237,14 +1192,14 @@ class UVCal(UVBase):
 
     def _check_flex_spw_contiguous(self):
         """
-        Check if the spectral windows are contiguous for flex_spw datasets.
+        Check if the spectral windows are contiguous.
 
         This checks the flex_spw_id_array to make sure that all channels for each
         spectral window are together in one block, versus being interspersed (e.g.,
         channel #1 and #3 is in spw #1, channels #2 and #4 are in spw #2).
 
         """
-        if self.flex_spw:
+        if not self.wide_band:
             uvutils._check_flex_spw_contiguous(
                 spw_array=self.spw_array, flex_spw_id_array=self.flex_spw_id_array
             )
@@ -1268,14 +1223,13 @@ class UVCal(UVBase):
             Flag that channel spacing does not match channel width.
 
         """
-        if self.freq_array is None and self.Nfreqs == 1:
+        if (self.freq_array is None) or (self.Nfreqs == 1):
             return False, False
         return uvutils._check_freq_spacing(
             freq_array=self.freq_array,
             freq_tols=self._freq_array.tols,
             channel_width=self.channel_width,
             channel_width_tols=self._channel_width.tols,
-            flex_spw=self.flex_spw,
             spw_array=self.spw_array,
             flex_spw_id_array=self.flex_spw_id_array,
             raise_errors=raise_errors,
@@ -1707,11 +1661,7 @@ class UVCal(UVBase):
         # if wide_band is True, Nfreqs must be 1.
         if self.wide_band:
             if self.Nfreqs != 1:
-                warnings.warn(
-                    "Nfreqs will be required to be 1 for wide_band cals (including "
-                    "all delay cals) starting in version 3.0",
-                    category=DeprecationWarning,
-                )
+                raise ValueError("Nfreqs is required to be 1 for wide_band cals.")
 
         # call metadata_only to make sure that parameter requirements are set properly
         self.metadata_only
@@ -1733,10 +1683,9 @@ class UVCal(UVBase):
                 getattr(self, pair[0]) is not None
                 and getattr(self, pair[1]) is not None
             ):
-                warnings.warn(
+                raise ValueError(
                     f"The {pair[0]} and {pair[1]} attributes are both set, but only "
-                    "one should be set. This will become an error in version 3.0.",
-                    DeprecationWarning,
+                    "one should be set."
                 )
             elif getattr(self, pair[0]) is None and getattr(self, pair[1]) is None:
                 raise ValueError(f"Either {pair[0]} or {pair[1]} must be set.")
@@ -1778,45 +1727,29 @@ class UVCal(UVBase):
                     "files".format(key=key)
                 )
 
-        if not self.wide_band and self.cal_type == "gain":
-            if self.flex_spw_id_array is None:
-                warnings.warn(
-                    "flex_spw_id_array is not set. It will be required starting in "
-                    "version 3.0 for non-wide-band objects",
-                    DeprecationWarning,
+        if not self.wide_band:
+            if not np.all(np.isin(self.flex_spw_id_array, self.spw_array)):
+                raise ValueError(
+                    "All values in the flex_spw_id_array must exist in the spw_array."
                 )
-            else:
-                # Check that all values in flex_spw_id_array are entries in the
-                # spw_array
-                if not np.all(np.isin(self.flex_spw_id_array, self.spw_array)):
-                    raise ValueError(
-                        "All values in the flex_spw_id_array must exist in the "
-                        "spw_array."
-                    )
-        # warn if freq_range or freq_array set when it shouldn't be
-        if (
-            self.cal_type == "gain"
-            and not self.wide_band
-            and self.freq_range is not None
-        ):
-            warnings.warn(
-                "The freq_range attribute should not be set if cal_type='gain' "
-                "and wide_band=False. This will become an error in version 3.0.",
-                DeprecationWarning,
-            )
+            # warn if freq_range or freq_array set when it shouldn't be
+            if self.freq_range is not None:
+                raise ValueError(
+                    "The freq_range attribute should not be set if wide_band=False."
+                )
         if self.wide_band:
             if self.freq_array is not None:
-                warnings.warn(
-                    "The freq_array attribute should not be set if wide_band=True. "
-                    "This will become an error in version 3.0.",
-                    DeprecationWarning,
+                raise ValueError(
+                    "The freq_array attribute should not be set if wide_band=True."
                 )
-
             if self.channel_width is not None:
-                warnings.warn(
-                    "The channel_width attribute should not be set if wide_band=True. "
-                    "This will become an error in version 3.0.",
-                    DeprecationWarning,
+                raise ValueError(
+                    "The channel_width attribute should not be set if wide_band=True."
+                )
+            if self.flex_spw_id_array is not None:
+                raise ValueError(
+                    "The flex_spw_id_array attribute should not be set if "
+                    "wide_band=True."
                 )
 
         if check_freq_spacing:
@@ -2320,7 +2253,6 @@ class UVCal(UVBase):
                 freq_array=self.freq_array,
                 Nspws=self.Nspws,
                 spw_array=self.spw_array,
-                flex_spw=self.flex_spw,
                 flex_spw_id_array=self.flex_spw_id_array,
                 spw_order=spw_order,
                 channel_order=channel_order,
@@ -2421,11 +2353,8 @@ class UVCal(UVBase):
                 )
 
             if self.time_array is not None and self.time_range is not None:
-                warnings.warn(
-                    "The time_array and time_range attributes are both set. "
-                    "Defaulting to using time_range to determine sorting. This will "
-                    "become an error in version 3.0.",
-                    DeprecationWarning,
+                raise ValueError(
+                    "The time_array and time_range attributes are both set."
                 )
 
             if self.time_range is not None:
@@ -2732,13 +2661,6 @@ class UVCal(UVBase):
             check_extra=check_extra, run_check_acceptability=run_check_acceptability
         )
 
-        # Check to make sure that both objects are consistent w/ use of flex_spw
-        if this.flex_spw != other.flex_spw:
-            raise ValueError(
-                "To combine these data, flex_spw must be set to the same "
-                "value (True or False) for both objects."
-            )
-
         if (this.flex_jones_array is None) != (other.flex_jones_array is None):
             raise ValueError(
                 "To combine these data, both objects must be either set to regular "
@@ -2820,12 +2742,7 @@ class UVCal(UVBase):
         )
 
         if self.time_array is not None and self.time_range is not None:
-            warnings.warn(
-                "The time_array and time_range attributes are both set. "
-                "Defaulting to using time_range to determine time matching between "
-                "objects. This will become an error in version 3.0.",
-                DeprecationWarning,
-            )
+            raise ValueError("The time_array and time_range attributes are both set. ")
         if this.time_range is not None:
             if uvutils._check_range_overlap(
                 np.concatenate((this.time_range, other.time_range), axis=0)
@@ -2839,45 +2756,32 @@ class UVCal(UVBase):
                 this.time_array, other.time_array, return_indices=True
             )
 
-        if this.cal_type != "delay" and not this.wide_band:
-            # With flexible spectral window, the handling here becomes a bit funky,
-            # because we are allowed to have channels with the same frequency *if* they
-            # belong to different spectral windows (one real-life example: might want
-            # to preserve guard bands in the correlator, which can have overlaping RF
-            # frequency channels)
-            if this.flex_spw:
-                this_freq_ind = np.array([], dtype=np.int64)
-                other_freq_ind = np.array([], dtype=np.int64)
-                both_freq = np.array([], dtype=float)
-                both_spw = np.intersect1d(this.spw_array, other.spw_array)
-                for idx in both_spw:
-                    this_mask = np.where(this.flex_spw_id_array == idx)[0]
-                    other_mask = np.where(other.flex_spw_id_array == idx)[0]
-                    both_spw_freq, this_spw_ind, other_spw_ind = np.intersect1d(
-                        this.freq_array[this_mask],
-                        other.freq_array[other_mask],
-                        return_indices=True,
-                    )
-                    this_freq_ind = np.append(this_freq_ind, this_mask[this_spw_ind])
-                    other_freq_ind = np.append(
-                        other_freq_ind, other_mask[other_spw_ind]
-                    )
-                    both_freq = np.append(both_freq, both_spw_freq)
-            else:
-                both_freq, this_freq_ind, other_freq_ind = np.intersect1d(
-                    this.freq_array, other.freq_array, return_indices=True
-                )
-
-        elif this.wide_band:
+        if this.wide_band:
             # this is really about spws, but that replaces the freq axis for wide_band
             both_freq, this_freq_ind, other_freq_ind = np.intersect1d(
                 this.spw_array, other.spw_array, return_indices=True
             )
         else:
-            # delay type cal
-            # Make a non-empty array so we raise an error if other data is duplicated
-            both_freq = [0]
-            this_freq_ind = []
+            # With non-wideband objects, the handling here becomes a bit funky,
+            # because we are allowed to have channels with the same frequency *if* they
+            # belong to different spectral windows (one real-life example: might want
+            # to preserve guard bands in the correlator, which can have overlaping RF
+            # frequency channels)
+            this_freq_ind = np.array([], dtype=np.int64)
+            other_freq_ind = np.array([], dtype=np.int64)
+            both_freq = np.array([], dtype=float)
+            both_spw = np.intersect1d(this.spw_array, other.spw_array)
+            for idx in both_spw:
+                this_mask = np.where(this.flex_spw_id_array == idx)[0]
+                other_mask = np.where(other.flex_spw_id_array == idx)[0]
+                both_spw_freq, this_spw_ind, other_spw_ind = np.intersect1d(
+                    this.freq_array[this_mask],
+                    other.freq_array[other_mask],
+                    return_indices=True,
+                )
+                this_freq_ind = np.append(this_freq_ind, this_mask[this_spw_ind])
+                other_freq_ind = np.append(other_freq_ind, other_mask[other_spw_ind])
+                both_freq = np.append(both_freq, both_spw_freq)
 
         both_ants, this_ants_ind, other_ants_ind = np.intersect1d(
             this.ant_array, other.ant_array, return_indices=True
@@ -3004,29 +2908,7 @@ class UVCal(UVBase):
         else:
             tnew_inds = []
 
-        if this.cal_type == "gain" and not this.wide_band:
-            # find the freq indices in "other" but not in "this"
-            if self.flex_spw:
-                other_mask = np.ones_like(other.flex_spw_id_array, dtype=bool)
-                for idx in np.intersect1d(this.spw_array, other.spw_array):
-                    other_mask[other.flex_spw_id_array == idx] = np.isin(
-                        other.freq_array[other.flex_spw_id_array == idx],
-                        this.freq_array[this.flex_spw_id_array == idx],
-                        invert=True,
-                    )
-                temp = np.where(other_mask)[0]
-            else:
-                temp = np.nonzero(~np.in1d(other.freq_array, this.freq_array))[0]
-            if len(temp) > 0:
-                fnew_inds = temp
-                if n_axes > 0:
-                    history_update_string += ", frequency"
-                else:
-                    history_update_string += "frequency"
-                n_axes += 1
-            else:
-                fnew_inds = []
-        elif this.wide_band:
+        if this.wide_band:
             temp = np.nonzero(~np.in1d(other.spw_array, this.spw_array))[0]
             if len(temp) > 0:
                 fnew_inds = temp
@@ -3038,9 +2920,24 @@ class UVCal(UVBase):
             else:
                 fnew_inds = []
         else:
-            # adding along frequency axis is not supported for old delay-type
-            # delay type, set fnew_inds to an empty list
-            fnew_inds = []
+            # find the freq indices in "other" but not in "this"
+            other_mask = np.ones_like(other.flex_spw_id_array, dtype=bool)
+            for idx in np.intersect1d(this.spw_array, other.spw_array):
+                other_mask[other.flex_spw_id_array == idx] = np.isin(
+                    other.freq_array[other.flex_spw_id_array == idx],
+                    this.freq_array[this.flex_spw_id_array == idx],
+                    invert=True,
+                )
+            temp = np.where(other_mask)[0]
+            if len(temp) > 0:
+                fnew_inds = temp
+                if n_axes > 0:
+                    history_update_string += ", frequency"
+                else:
+                    history_update_string += "frequency"
+                n_axes += 1
+            else:
+                fnew_inds = []
 
         temp = np.nonzero(~np.in1d(other.jones_array, this.jones_array))[0]
         if len(temp) > 0:
@@ -3127,51 +3024,42 @@ class UVCal(UVBase):
                         [this.flex_jones_array, other.flex_jones_array[fnew_inds]],
                         axis=0,
                     )
+                f_order = np.argsort(this.spw_array)
             else:
-                this.freq_array = np.concatenate(
-                    [this.freq_array, other.freq_array[fnew_inds]]
-                )
-
-            if this.flex_spw and not this.wide_band:
                 this.flex_spw_id_array = np.concatenate(
                     [this.flex_spw_id_array, other.flex_spw_id_array[fnew_inds]]
                 )
-                concat_spw_array = np.concatenate([this.spw_array, other.spw_array])
+                this.freq_array = np.concatenate(
+                    [this.freq_array, other.freq_array[fnew_inds]]
+                )
+                this.channel_width = np.concatenate(
+                    [this.channel_width, other.channel_width[fnew_inds]]
+                )
+
                 # We want to preserve per-spw information based on first appearance
                 # in the concatenated array.
                 unique_index = np.sort(
                     np.unique(this.flex_spw_id_array, return_index=True)[1]
                 )
-                this.spw_array = this.flex_spw_id_array[unique_index]
-                spw_index = np.asarray(
-                    [
-                        np.nonzero(concat_spw_array == spw)[0][0]
-                        for spw in this.spw_array
-                    ]
-                )
+                this.spw_array = np.sort(this.flex_spw_id_array[unique_index])
                 if this.flex_jones_array is not None:
+                    concat_spw_array = np.concatenate([this.spw_array, other.spw_array])
+                    spw_index = np.asarray(
+                        [
+                            np.nonzero(concat_spw_array == spw)[0][0]
+                            for spw in this.spw_array
+                        ]
+                    )
                     this.flex_jones_array = np.concatenate(
                         [this.flex_jones_array, other.flex_jones_array]
                     )
                     this.flex_jones_array = this.flex_jones_array[spw_index]
-                if this.freq_range is not None and other.freq_range is not None:
-                    # this can be removed in v3.0
-                    this.freq_range = np.concatenate(
-                        [this.freq_range, other.freq_range], axis=0
-                    )
-                elif this.freq_range is not None or other.freq_range is not None:
-                    warnings.warn(
-                        "One object has the freq_range set and one does not. Combined "
-                        "object will not have it set."
-                    )
-                    this.freq_range = None
-
                 # If we have a multi-spw data set, need to sort out the order of
                 # the individual windows first.
                 f_order = np.concatenate(
                     [
                         np.where(this.flex_spw_id_array == idx)[0]
-                        for idx in sorted(this.spw_array)
+                        for idx in this.spw_array
                     ]
                 )
 
@@ -3186,42 +3074,6 @@ class UVCal(UVBase):
                     ):
                         subsort_order = f_order[select_mask]
                         f_order[select_mask] = subsort_order[np.argsort(check_freqs)]
-
-                spw_sort_index = np.asarray(
-                    [
-                        np.nonzero(this.spw_array == spw)[0][0]
-                        for spw in sorted(this.spw_array)
-                    ]
-                )
-                this.spw_array = np.array(sorted(this.spw_array))
-                if this.freq_range is not None:
-                    # this can be removed in v3.0
-                    this.freq_range = this.freq_range[spw_sort_index, :]
-            else:
-                if this_has_spw_id or other_has_spw_id:
-                    this.flex_spw_id_array = np.full(
-                        this.freq_array.size, this.spw_array[0], dtype=int
-                    )
-                if this.wide_band:
-                    f_order = np.argsort(this.spw_array)
-                else:
-                    f_order = np.argsort(this.freq_array)
-
-                    if this.freq_range is not None and other.freq_range is not None:
-                        temp = np.concatenate((this.freq_range, other.freq_range))
-                        this.freq_range = [np.min(temp), np.max(temp)]
-                        this.freq_range = np.array(this.freq_range)[np.newaxis, :]
-                    elif this.freq_range is not None or other.freq_range is not None:
-                        warnings.warn(
-                            "One object has the freq_range set and one does not. "
-                            "Combined object will not have it set."
-                        )
-                        this.freq_range = None
-
-            if not this.wide_band:
-                this.channel_width = np.concatenate(
-                    [this.channel_width, other.channel_width[fnew_inds]]
-                )
 
             if not self.metadata_only:
                 data_array_shape = getattr(this, this._required_data_params[0]).shape
@@ -3486,8 +3338,7 @@ class UVCal(UVBase):
             else:
                 this.freq_array = this.freq_array[f_order]
                 this.channel_width = this.channel_width[f_order]
-                if this.flex_spw_id_array is not None:
-                    this.flex_spw_id_array = this.flex_spw_id_array[f_order]
+                this.flex_spw_id_array = this.flex_spw_id_array[f_order]
         if len(tnew_inds) > 0:
             if this.time_array is not None:
                 this.time_array = this.time_array[t_order]
@@ -3696,13 +3547,8 @@ class UVCal(UVBase):
                 check_extra=check_extra, run_check_acceptability=run_check_acceptability
             )
 
-        # Check that all objects are consistent w/ use of flex_spw
+        # Check that all objects are consistent w/ use of flex-Jones
         for obj in other:
-            if this.flex_spw != obj.flex_spw:
-                raise ValueError(
-                    "To combine these data, flex_spw must be set to the same "
-                    "value (True or False) for all objects."
-                )
             if (this.flex_jones_array is None) != (obj.flex_jones_array is None):
                 raise ValueError(
                     "To combine these data, all objects must be either set to regular "
@@ -3728,16 +3574,6 @@ class UVCal(UVBase):
                     "To combine these data, wide_band must be set to the same "
                     "value (True or False) for all objects."
                 )
-
-        this_has_spw_id = this.flex_spw_id_array is not None
-        other_has_spw_id = np.array(
-            [obj.flex_spw_id_array is not None for obj in other]
-        )
-        if not np.all(other_has_spw_id == this_has_spw_id):
-            warnings.warn(
-                "Some objects have the flex_spw_id_array set and some do not. Combined "
-                "object will have it set."
-            )
 
         allowed_axes = ["antenna", "time", "jones"]
         if this.wide_band is True:
@@ -3878,10 +3714,6 @@ class UVCal(UVBase):
         ]
         this_qa_exp_shape = this._quality_array.expected_shape(this)
 
-        freq_range_exists = [this.freq_range is not None] + [
-            obj.freq_range is not None for obj in other
-        ]
-
         if axis == "antenna":
             this.Nants_data = sum([this.Nants_data] + [obj.Nants_data for obj in other])
             this.ant_array = np.concatenate(
@@ -3896,61 +3728,30 @@ class UVCal(UVBase):
             this.channel_width = np.concatenate(
                 [this.channel_width] + [obj.channel_width for obj in other]
             )
-            if this.flex_spw:
-                this.flex_spw_id_array = np.concatenate(
-                    [this.flex_spw_id_array] + [obj.flex_spw_id_array for obj in other]
-                )
+            this.flex_spw_id_array = np.concatenate(
+                [this.flex_spw_id_array] + [obj.flex_spw_id_array for obj in other]
+            )
+            # We want to preserve per-spw information based on first appearance
+            # in the concatenated array.
+            unique_index = np.sort(
+                np.unique(this.flex_spw_id_array, return_index=True)[1]
+            )
+            this.spw_array = this.flex_spw_id_array[unique_index]
+            this.Nspws = this.spw_array.size
+            if this.flex_jones_array is not None:
                 concat_spw_array = np.concatenate(
                     [this.spw_array] + [obj.spw_array for obj in other]
                 )
-                # We want to preserve per-spw information based on first appearance
-                # in the concatenated array.
-                unique_index = np.sort(
-                    np.unique(this.flex_spw_id_array, return_index=True)[1]
-                )
-                this.spw_array = this.flex_spw_id_array[unique_index]
-                this.Nspws = this.spw_array.size
                 spw_index = np.asarray(
                     [
                         np.nonzero(concat_spw_array == spw)[0][0]
                         for spw in this.spw_array
                     ]
                 )
-                if this.flex_jones_array is not None:
-                    this.flex_jones_array = np.concatenate(
-                        [this.flex_jones_array]
-                        + [obj.flex_jones_array for obj in other]
-                    )
-                    this.flex_jones_array = this.flex_jones_array[spw_index]
-                if np.all(freq_range_exists):
-                    this.freq_range = np.concatenate(
-                        [this.freq_range] + [obj.freq_range for obj in other], axis=0
-                    )
-                    this.freq_range = this.freq_range[spw_index, :]
-                elif np.any(freq_range_exists):
-                    warnings.warn(
-                        "Some objects have the freq_range set and some do not. "
-                        "Combined object will not have it set."
-                    )
-                    this.freq_range = None
-            else:
-                if this_has_spw_id or other_has_spw_id:
-                    this.flex_spw_id_array = np.full(
-                        this.Nfreqs, this.spw_array[0], dtype=int
-                    )
-                if np.all(freq_range_exists):
-                    temp = np.concatenate(
-                        ([this.freq_range] + [obj.freq_range for obj in other])
-                    )
-                    this.freq_range = [np.min(temp), np.max(temp)]
-                    this.freq_range = np.array(this.freq_range)
-                    this.freq_range = this.freq_range[np.newaxis, :]
-                elif np.any(freq_range_exists):
-                    warnings.warn(
-                        "Some objects have the freq_range set and and some do not. "
-                        "Combined object will not have it set."
-                    )
-                    this.freq_range = None
+                this.flex_jones_array = np.concatenate(
+                    [this.flex_jones_array] + [obj.flex_jones_array for obj in other]
+                )
+                this.flex_jones_array = this.flex_jones_array[spw_index]
 
             spacing_error, chanwidth_error = this._check_freq_spacing(
                 raise_errors=False
@@ -4265,12 +4066,7 @@ class UVCal(UVBase):
         if (times is not None or time_range is not None) and (
             self.time_array is not None and self.time_range is not None
         ):
-            warnings.warn(
-                "The time_array and time_range attributes are both set. "
-                "Defaulting to using time_range to determine time selection. "
-                "This will become an error in version 3.0.",
-                DeprecationWarning,
-            )
+            raise ValueError("The time_array and time_range attributes are both set.")
 
         time_inds = uvutils._select_times_helper(
             times=times,
@@ -4336,10 +4132,6 @@ class UVCal(UVBase):
                 spw_inds = None
             else:
                 if not self.wide_band:
-                    assert self.flex_spw is True, (
-                        "The `flex_spw` parameter must be True if there are multiple "
-                        "spectral windows and the `wide_band` parameter is not True."
-                    )
                     # Translate the spws into frequencies
                     freq_chans = uvutils._sorted_unique_union(
                         np.where(np.isin(self.flex_spw_id_array, spws))[0], freq_chans
@@ -4461,7 +4253,7 @@ class UVCal(UVBase):
                 # axis instead of the pol axis
                 jones_inds = None
 
-                if self.flex_spw:
+                if not self.wide_band:
                     jones_chans = np.where(
                         np.isin(self.flex_spw_id_array, self.spw_array[jones_spws])
                     )[0]
@@ -4472,7 +4264,7 @@ class UVCal(UVBase):
 
                 # Trap a corner case here where the frequency and polarization selects
                 # on a flex-pol data set end up with no actual data being selected.
-                if (len(spw_inds) == 0) or (self.flex_spw and len(freq_inds) == 0):
+                if (len(spw_inds) == 0) or (not self.wide_band and len(freq_inds) == 0):
                     raise ValueError(
                         "No data matching this Jones selection in this flex-Jones "
                         " UVCal object."
@@ -4744,18 +4536,6 @@ class UVCal(UVBase):
             jones_inds=jones_inds,
             history_update_string=history_update_string,
         )
-
-        # handle freq_range if selecting on freqs (can go away in v3.0)
-        if (
-            cal_object.freq_range is not None
-            and cal_object.flex_spw is False
-            and freq_inds is not None
-        ):
-            cal_object.freq_range = [
-                np.min(cal_object.freq_array),
-                np.max(cal_object.freq_array),
-            ]
-            cal_object.freq_range = np.asarray(cal_object.freq_range)[np.newaxis, :]
 
         # check if object is self-consistent
         if run_check:

--- a/pyuvdata/uvdata/fhd.py
+++ b/pyuvdata/uvdata/fhd.py
@@ -18,7 +18,7 @@ from scipy.io import readsav
 from .. import Telescope
 from .. import utils as uvutils
 from ..docstrings import copy_replace_short_description
-from .uvdata import UVData, _future_array_shapes_warning
+from .uvdata import UVData
 
 __all__ = ["get_fhd_history", "get_fhd_layout_info", "FHD"]
 
@@ -448,10 +448,11 @@ class FHD(UVData):
         strict_uvw_antpos_check=False,
         check_autos=True,
         fix_autos=True,
-        use_future_array_shapes=False,
+        use_future_array_shapes=None,
         astrometry_library=None,
     ):
         """Read in data from a list of FHD files."""
+        self._set_future_array_shapes(use_future_array_shapes=use_future_array_shapes)
         datafiles_dict = {}
         use_model = None
         if isinstance(vis_files, str):
@@ -574,8 +575,6 @@ class FHD(UVData):
         self.Nfreqs = int(obs["N_FREQ"][0])
         self.Nspws = 1
         self.spw_array = np.array([0])
-
-        # Future proof: set the flex_spw_id_array.
         self.flex_spw_id_array = np.zeros(self.Nfreqs, dtype=int)
 
         self.vis_units = "Jy"
@@ -739,11 +738,10 @@ class FHD(UVData):
                 "Nbls does not match the number of unique baselines in the data"
             )
 
-        # TODO: Spw axis to be collapsed in future release
-        self.freq_array = np.zeros((1, len(bl_info["FREQ"][0])), dtype=np.float64)
-        self.freq_array[0, :] = bl_info["FREQ"][0]
+        self.freq_array = np.zeros(len(bl_info["FREQ"][0]), dtype=np.float64)
+        self.freq_array[:] = bl_info["FREQ"][0]
 
-        self.channel_width = float(obs["FREQ_RES"][0])
+        self.channel_width = np.full(self.Nfreqs, float(obs["FREQ_RES"][0]))
 
         # In FHD, uvws are in seconds not meters.
         # FHD follows the FITS uvw direction convention, which is opposite
@@ -779,37 +777,29 @@ class FHD(UVData):
             self.history += self.pyuvdata_version_str
 
         if read_data:
-            # TODO: Spw axis to be collapsed in future release
             self.data_array = np.zeros(
-                (self.Nblts, 1, self.Nfreqs, self.Npols), dtype=np.complex_
+                (self.Nblts, self.Nfreqs, self.Npols), dtype=np.complex_
             )
-            # TODO: Spw axis to be collapsed in future release
             self.nsample_array = np.zeros(
-                (self.Nblts, 1, self.Nfreqs, self.Npols), dtype=np.float64
+                (self.Nblts, self.Nfreqs, self.Npols), dtype=np.float64
             )
-            # TODO: Spw axis to be collapsed in future release
             self.flag_array = np.zeros(
-                (self.Nblts, 1, self.Nfreqs, self.Npols), dtype=np.bool_
+                (self.Nblts, self.Nfreqs, self.Npols), dtype=np.bool_
             )
             for pol, vis in vis_data.items():
                 pol_i = pol_list.index(linear_pol_dict[pol])
                 # FHD follows the FITS uvw direction convention, which is opposite
                 # ours and Miriad's.
                 # So conjugate the visibilities and flip the uvws:
-                self.data_array[:, 0, :, pol_i] = np.conj(vis)
-                self.flag_array[:, 0, :, pol_i] = vis_weights_data[pol] <= 0
-                self.nsample_array[:, 0, :, pol_i] = np.abs(vis_weights_data[pol])
+                self.data_array[:, :, pol_i] = np.conj(vis)
+                self.flag_array[:, :, pol_i] = vis_weights_data[pol] <= 0
+                self.nsample_array[:, :, pol_i] = np.abs(vis_weights_data[pol])
 
         # wait for LSTs if set in background
         if proc is not None:
             proc.join()
 
         self._set_app_coords_helper()
-
-        if use_future_array_shapes:
-            self.use_future_array_shapes()
-        else:
-            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
 
         # check if object has all required uv_properties set
         if run_check:

--- a/pyuvdata/uvdata/initializers.py
+++ b/pyuvdata/uvdata/initializers.py
@@ -619,7 +619,6 @@ def new_uvdata(
         phase_center_id_array=phase_center_id_array,
         time_array=time_array,
     )
-    obj._set_future_array_shapes()
     obj._set_flex_spw()  # Always True
     obj.set_uvws_from_antenna_positions(update_vis=False)
 

--- a/pyuvdata/uvdata/initializers.py
+++ b/pyuvdata/uvdata/initializers.py
@@ -619,7 +619,6 @@ def new_uvdata(
         phase_center_id_array=phase_center_id_array,
         time_array=time_array,
     )
-    obj._set_flex_spw()  # Always True
     obj.set_uvws_from_antenna_positions(update_vis=False)
 
     # Set optional parameters that the user passes in

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -287,12 +287,6 @@ class Mir(UVData):
             attributes to be of length 1, sets the `flex_spw_polarization_array`
             attribute to define the polarization per spectral window. Default is True.
         """
-        # By default, we will want to assume that MIR datasets are multi-spw.
-        # At present, there is no advantage to allowing this
-        # not to be true on read-in, particularly as in the long-term, this setting
-        # will hopefully become the default for all data sets.
-        self._set_flex_spw()
-
         # Create a simple list for broadcasting values stored on a
         # per-integration basis in MIR into the (tasty) per-blt records in UVDATA.
         bl_in_idx = mir_data.in_data._index_query(header_key=mir_data.bl_data["inhid"])

--- a/pyuvdata/uvdata/mir.py
+++ b/pyuvdata/uvdata/mir.py
@@ -293,9 +293,6 @@ class Mir(UVData):
         # will hopefully become the default for all data sets.
         self._set_flex_spw()
 
-        # Also set future array shapes here
-        self._set_future_array_shapes()
-
         # Create a simple list for broadcasting values stored on a
         # per-integration basis in MIR into the (tasty) per-blt records in UVDATA.
         bl_in_idx = mir_data.in_data._index_query(header_key=mir_data.bl_data["inhid"])

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -168,11 +168,7 @@ class Miriad(UVData):
             ):
                 extra_miriad_variables.append(variable)
 
-        miriad_header_data = {
-            "Nfreqs": "nchan",
-            "Nspws": "nspect",
-            "Npols": "npol",
-        }
+        miriad_header_data = {"Nfreqs": "nchan", "Nspws": "nspect", "Npols": "npol"}
         for item in miriad_header_data:
             header_value = uv[miriad_header_data[item]]
             setattr(self, item, header_value)

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -181,7 +181,6 @@ class Miriad(UVData):
 
         # Deal with the spectral axis now
         if self.Nspws > 1:
-            self._set_flex_spw()
             # Channel widths are described per spw, just need to expand it out to be
             # for each frequency channel.
             self.channel_width = np.concatenate(
@@ -1719,7 +1718,7 @@ class Miriad(UVData):
         uv["nspect"] = self.Nspws
 
         freq_array_use = self.freq_array
-        if self.flex_spw:
+        if self.Nspws > 1:
             win_start_pos = np.insert(
                 np.where(self.flex_spw_id_array[1:] != self.flex_spw_id_array[:-1])[0]
                 + 1,

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -742,7 +742,6 @@ class Miriad(UVData):
         polarizations=None,
         time_range=None,
         read_data=True,
-        phase_type=None,
         projected=None,
         correct_lat_lon=True,
         background_lsts=True,
@@ -764,23 +763,6 @@ class Miriad(UVData):
         if not os.path.exists(filepath):
             raise IOError(filepath + " not found")
         uv = aipy_extracts.UV(filepath)
-
-        if phase_type is not None:
-            warnings.warn(
-                "The phase_type parameter is deprecated, use the projected parameter "
-                "instead. This will become an error in version 3.0.",
-                DeprecationWarning,
-            )
-            if projected is None:
-                if phase_type not in ["phased", "drift"]:
-                    raise ValueError(
-                        "The phase_type was not one of the recognized options: "
-                        "'drift', 'phased'. Instead, use the `projected` parameter."
-                    )
-                if phase_type == "drift":
-                    projected = False
-                else:
-                    projected = True
 
         # load metadata
         (

--- a/pyuvdata/uvdata/ms.py
+++ b/pyuvdata/uvdata/ms.py
@@ -603,9 +603,8 @@ class MS(UVData):
         }
         spw_list = sorted(spw_dict.keys())
 
-        # Here we sort out where the various spectral windows are starting and stoping
-        # in our flex_spw spectrum, if applicable. By default, data are sorted in
-        # spw-number order.
+        # Here we sort out where the various spectral windows are starting and stopping.
+        # By default, data are sorted in spw-number order.
         nfreqs = 0
         spw_id_array = np.array([], dtype=int)
         for key in sorted(spw_dict.keys()):
@@ -923,11 +922,6 @@ class MS(UVData):
             sel_mask = self.flex_spw_id_array == data_desc_dict[key]["SPW_ID"]
             self.freq_array[sel_mask] = data_desc_dict[key]["CHAN_FREQ"]
             self.channel_width[sel_mask] = data_desc_dict[key]["CHAN_WIDTH"]
-
-        # This if/else can go away in version 3.0 when channel width will always be an
-        # array and the flex_spw_id_array will always be required.
-        if (np.unique(self.channel_width).size != 1) or (len(spw_list) != 1):
-            self._set_flex_spw()
 
         self.Ntimes = int(np.unique(self.time_array).size)
         self.Nblts = int(self.data_array.shape[0])

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -22,7 +22,7 @@ from pyuvdata.data import DATA_PATH
 from .. import Telescope, _corr_fits
 from .. import utils as uvutils
 from ..docstrings import copy_replace_short_description
-from .uvdata import UVData, _future_array_shapes_warning
+from .uvdata import UVData
 
 __all__ = ["input_output_mapping", "MWACorrFITS"]
 
@@ -1326,10 +1326,13 @@ class MWACorrFITS(UVData):
         strict_uvw_antpos_check=False,
         check_autos=True,
         fix_autos=True,
-        use_future_array_shapes=False,
+        use_future_array_shapes=None,
         astrometry_library=None,
     ):
         """Read in MWA correlator gpu box files."""
+        # Check for defunct keyword here
+        self._set_future_array_shapes(use_future_array_shapes=use_future_array_shapes)
+
         metafits_file = None
         ppds_file = None
         obs_id = None
@@ -1353,9 +1356,6 @@ class MWACorrFITS(UVData):
         if not isinstance(start_flag, (int, float)):
             if start_flag != "goodtime":
                 raise ValueError("start_flag must be int or float or 'goodtime'")
-
-        # set future array shapes
-        self._set_future_array_shapes()
 
         # iterate through files and organize
         # create a list of included file numbers
@@ -1857,17 +1857,6 @@ class MWACorrFITS(UVData):
                 phase_frame="fk5",
                 cat_name=meta_dict["object_name"],
             )
-
-        # switch to current_array_shape
-        if not use_future_array_shapes:
-            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore",
-                    message="This method will be removed in version 3.0 when the "
-                    "current array shapes are no longer supported.",
-                )
-                self.use_current_array_shapes()
 
         # check if object is self-consistent
         # uvws are calcuated using pyuvdata, so turn off the check for speed.

--- a/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/pyuvdata/uvdata/mwa_corr_fits.py
@@ -1634,12 +1634,10 @@ class MWACorrFITS(UVData):
         if np.any(np.diff(spw_inds) > 1):
             warnings.warn("coarse channels are not contiguous for this observation")
             # add spectral windows
-            self._set_flex_spw()
             self.Nspws = len(spw_inds)
             self.spw_array = meta_dict["coarse_chans"][spw_inds]
             self.flex_spw_id_array = np.repeat(self.spw_array, num_fine_chans)
         else:
-            # future proof: always set the fles_spw_id_array
             self.flex_spw_id_array = np.full(self.Nfreqs, self.spw_array[0], dtype=int)
 
         # warn user if not all coarse channels are included

--- a/pyuvdata/uvdata/tests/conftest.py
+++ b/pyuvdata/uvdata/tests/conftest.py
@@ -26,7 +26,7 @@ def casa_uvfits_main():
     with uvtest.check_warnings(
         UserWarning, "The uvw_array does not match the expected values"
     ):
-        uv_in.read(casa_tutorial_uvfits, use_future_array_shapes=True)
+        uv_in.read(casa_tutorial_uvfits)
 
     yield uv_in
 
@@ -51,12 +51,9 @@ def hera_uvh5_main():
     # read in test file for the resampling in time functions
     uv_object = UVData()
     testfile = os.path.join(DATA_PATH, "zen.2458661.23480.HH.uvh5")
-    uv_object.read(testfile, use_future_array_shapes=True)
+    uv_object.read(testfile)
 
     yield uv_object
-
-    # cleanup
-    del uv_object
 
 
 @pytest.fixture(scope="function")
@@ -66,23 +63,15 @@ def hera_uvh5(hera_uvh5_main):
 
     yield uv_object
 
-    # cleanup
-    del uv_object
-
-    return
-
 
 @pytest.fixture(scope="session")
 def paper_miriad_main():
     """Read in PAPER miriad file."""
     pytest.importorskip("pyuvdata.uvdata.aipy_extracts")
     uv_in = UVData()
-    uv_in.read(paper_miriad_file, use_future_array_shapes=True)
+    uv_in.read(paper_miriad_file)
 
     yield uv_in
-
-    # cleanup
-    del uv_in
 
 
 @pytest.fixture(scope="function")
@@ -108,7 +97,7 @@ def sma_mir_main():
             "The lst_array is not self-consistent with the time_array and telescope ",
         ],
     ):
-        uv_object.read(testfile, use_future_array_shapes=True)
+        uv_object.read(testfile)
     uv_object.set_lsts_from_time_array()
 
     yield uv_object
@@ -195,8 +184,8 @@ def uv_phase_comp_main():
         ]
         * 2,
     ):
-        uvd1 = UVData.from_file(file1, use_future_array_shapes=True)
-        uvd2 = UVData.from_file(file2, use_future_array_shapes=True)
+        uvd1 = UVData.from_file(file1)
+        uvd2 = UVData.from_file(file2)
 
     yield uvd1, uvd2
 

--- a/pyuvdata/uvdata/tests/test_fhd.py
+++ b/pyuvdata/uvdata/tests/test_fhd.py
@@ -328,9 +328,7 @@ def test_read_fhd_latlonalt_match_xyz(fhd_data_files):
             "['layout', 'obs']",
         ],
     ):
-        fhd_uv = UVData.from_file(
-            **fhd_data_files, use_future_array_shapes=True, read_data=False
-        )
+        fhd_uv = UVData.from_file(**fhd_data_files, read_data=False)
 
     mwa_tel = Telescope.from_known_telescopes("mwa")
 

--- a/pyuvdata/uvdata/tests/test_fhd.py
+++ b/pyuvdata/uvdata/tests/test_fhd.py
@@ -17,7 +17,6 @@ import pyuvdata.tests as uvtest
 import pyuvdata.utils as uvutils
 from pyuvdata import Telescope, UVData
 from pyuvdata.data import DATA_PATH
-from pyuvdata.uvdata.uvdata import _future_array_shapes_warning
 
 
 def get_fhd_files(filelist):
@@ -59,7 +58,7 @@ def get_fhd_files(filelist):
 @pytest.fixture(scope="function")
 def fhd_data(fhd_data_files):
     fhd_uv = UVData()
-    fhd_uv.read(**fhd_data_files, use_future_array_shapes=True)
+    fhd_uv.read(**fhd_data_files)
 
     return fhd_uv
 
@@ -67,7 +66,7 @@ def fhd_data(fhd_data_files):
 @pytest.fixture(scope="function")
 def fhd_model(fhd_model_files):
     fhd_uv = UVData()
-    fhd_uv.read(**fhd_model_files, use_future_array_shapes=True)
+    fhd_uv.read(**fhd_model_files)
 
     return fhd_uv
 
@@ -85,7 +84,7 @@ def test_read_fhd_write_read_uvfits(fhd_data, tmp_path, fhd_data_files):
 
     outfile = str(tmp_path / "outtest_FHD_1061316296.uvfits")
     fhd_uv.write_uvfits(outfile)
-    uvfits_uv.read_uvfits(outfile, use_future_array_shapes=True)
+    uvfits_uv.read_uvfits(outfile)
 
     all_testfiles = []
     for fname in fhd_data_files.values():
@@ -111,7 +110,7 @@ def test_read_fhd_write_read_uvfits(fhd_data, tmp_path, fhd_data_files):
 @pytest.mark.filterwarnings("ignore:Telescope location derived from obs")
 def test_read_fhd_metadata_only(fhd_data, fhd_data_files):
     fhd_uv = UVData()
-    fhd_uv.read(**fhd_data_files, read_data=False, use_future_array_shapes=True)
+    fhd_uv.read(**fhd_data_files, read_data=False)
 
     assert fhd_uv.metadata_only
 
@@ -137,7 +136,7 @@ def test_read_fhd_metadata_only_error(fhd_data_files, multi):
     with pytest.raises(
         ValueError, match="The obs_file parameter must be passed if read_data is False."
     ):
-        fhd_uv.read(**fhd_data_files, read_data=False, use_future_array_shapes=True)
+        fhd_uv.read(**fhd_data_files, read_data=False)
 
 
 def test_read_fhd_select(fhd_data_files):
@@ -151,25 +150,23 @@ def test_read_fhd_select(fhd_data_files):
     fhd_uv2 = UVData()
 
     with uvtest.check_warnings(
-        [UserWarning, UserWarning, DeprecationWarning],
+        UserWarning,
         [
             'Warning: select on read keyword set, but file_type is "fhd" which '
             "does not support select on read. Entire file will be read and then "
             "select will be performed",
             "Telescope location derived from obs lat/lon/alt values does not match the "
             "location in the layout file. Using the value from known_telescopes.",
-            _future_array_shapes_warning,
         ],
     ):
         fhd_uv2.read(**fhd_data_files, freq_chans=np.arange(2))
 
     with uvtest.check_warnings(
-        [UserWarning, DeprecationWarning],
-        [
+        UserWarning,
+        (
             "Telescope location derived from obs lat/lon/alt values does not match the "
-            "location in the layout file. Using the value from known_telescopes.",
-            _future_array_shapes_warning,
-        ],
+            "location in the layout file. Using the value from known_telescopes."
+        ),
     ):
         fhd_uv.read(**fhd_data_files)
 
@@ -202,7 +199,7 @@ def test_read_fhd_write_read_uvfits_no_layout(fhd_data_files, multi):
     if multi:
         warn_msg = warn_msg * 2
     with uvtest.check_warnings(UserWarning, match=warn_msg):
-        fhd_uv.read(**fhd_data_files, use_future_array_shapes=True)
+        fhd_uv.read(**fhd_data_files)
 
 
 @pytest.mark.filterwarnings("ignore:Telescope location derived from obs")
@@ -226,7 +223,6 @@ def test_fhd_antenna_pos(fhd_data):
         correct_cable_len=True,
         phase_to_pointing_center=True,
         read_data=False,
-        use_future_array_shapes=True,
     )
 
     assert fhd_data.telescope._antenna_names == mwa_corr_obj.telescope._antenna_names
@@ -237,7 +233,7 @@ def test_fhd_antenna_pos(fhd_data):
 
     cotter_file = os.path.join(DATA_PATH, "1061316296.uvfits")
     cotter_obj = UVData()
-    cotter_obj.read(cotter_file, use_future_array_shapes=True)
+    cotter_obj.read(cotter_file)
 
     # don't test antenna_numbers, they will not match.
     # mwa_corr_fits now uses antenna_numbers that correspond to antenna_names
@@ -279,7 +275,7 @@ def test_read_fhd_write_read_uvfits_variant_flag(tmp_path, fhd_data_files):
             "location in the layout file. Using the value from known_telescopes.",
         ],
     ):
-        fhd_uv.read(**fhd_data_files, use_future_array_shapes=True)
+        fhd_uv.read(**fhd_data_files)
 
     os.makedirs(os.path.join(tmp_path, "vis_data"))
     temp_flag_file = copyfile(
@@ -297,13 +293,13 @@ def test_read_fhd_write_read_uvfits_variant_flag(tmp_path, fhd_data_files):
             "location in the layout file. Using the value from known_telescopes.",
         ],
     ):
-        fhd_uv2 = UVData.from_file(**fhd_data_files, use_future_array_shapes=True)
+        fhd_uv2 = UVData.from_file(**fhd_data_files)
 
     assert fhd_uv == fhd_uv2
 
     outfile = str(tmp_path / "outtest_FHD_1061316296.uvfits")
     fhd_uv.write_uvfits(outfile)
-    uvfits_uv.read_uvfits(outfile, use_future_array_shapes=True)
+    uvfits_uv.read_uvfits(outfile)
 
     uvfits_uv._consolidate_phase_center_catalogs(
         reference_catalog=fhd_uv.phase_center_catalog
@@ -367,7 +363,7 @@ def test_read_fhd_write_read_uvfits_fix_layout(tmp_path, fhd_data_files):
             "for the same data.",
         ],
     ):
-        fhd_uv.read(**fhd_data_files, use_future_array_shapes=True)
+        fhd_uv.read(**fhd_data_files)
 
     os.makedirs(os.path.join(tmp_path, "fhd_vis_data2", "metadata"))
     temp_layout_file = copyfile(
@@ -389,12 +385,12 @@ def test_read_fhd_write_read_uvfits_fix_layout(tmp_path, fhd_data_files):
             "for the same data.",
         ],
     ):
-        fhd_uv.read(**fhd_data_files, use_future_array_shapes=True)
+        fhd_uv.read(**fhd_data_files)
 
     outfile = str(tmp_path / "outtest_FHD_1061316296.uvfits")
 
     fhd_uv.write_uvfits(outfile)
-    uvfits_uv.read_uvfits(outfile, use_future_array_shapes=True)
+    uvfits_uv.read_uvfits(outfile)
 
     uvfits_uv._consolidate_phase_center_catalogs(
         reference_catalog=fhd_uv.phase_center_catalog
@@ -431,11 +427,11 @@ def test_read_fhd_write_read_uvfits_fix_layout_bad_obs_loc(tmp_path, fhd_data_fi
     fhd_data_files["layout_file"] = layout_fixed_file
 
     with uvtest.check_warnings(UserWarning, match=messages):
-        fhd_uv.read(**fhd_data_files, use_future_array_shapes=True)
+        fhd_uv.read(**fhd_data_files)
 
     outfile = str(tmp_path / "outtest_FHD_1061316296.uvfits")
     fhd_uv.write_uvfits(outfile)
-    uvfits_uv.read_uvfits(outfile, use_future_array_shapes=True)
+    uvfits_uv.read_uvfits(outfile)
 
     uvfits_uv._consolidate_phase_center_catalogs(
         reference_catalog=fhd_uv.phase_center_catalog
@@ -467,11 +463,11 @@ def test_read_fhd_write_read_uvfits_bad_obs_loc(tmp_path, fhd_data_files):
     fhd_data_files["filename"] = [bad_obs_loc_file]
 
     with uvtest.check_warnings(UserWarning, match=messages):
-        fhd_uv.read(**fhd_data_files, use_future_array_shapes=True)
+        fhd_uv.read(**fhd_data_files)
 
     outfile = str(tmp_path / "outtest_FHD_1061316296.uvfits")
     fhd_uv.write_uvfits(outfile)
-    uvfits_uv.read_uvfits(outfile, use_future_array_shapes=True)
+    uvfits_uv.read_uvfits(outfile)
 
     uvfits_uv._consolidate_phase_center_catalogs(
         reference_catalog=fhd_uv.phase_center_catalog
@@ -505,11 +501,11 @@ def test_read_fhd_write_read_uvfits_altered_layout(tmp_path, fhd_data_files):
             "for the same data.",
         ],
     ):
-        fhd_uv.read(**fhd_data_files, use_future_array_shapes=True)
+        fhd_uv.read(**fhd_data_files)
 
     outfile = str(tmp_path / "outtest_FHD_1061316296.uvfits")
     fhd_uv.write_uvfits(outfile)
-    uvfits_uv.read_uvfits(outfile, use_future_array_shapes=True)
+    uvfits_uv.read_uvfits(outfile)
 
     uvfits_uv._consolidate_phase_center_catalogs(
         reference_catalog=fhd_uv.phase_center_catalog
@@ -543,7 +539,7 @@ def test_read_fhd_write_read_uvfits_no_settings(tmp_path, fhd_data_files, multi)
                 fhd_data_files[ftype] = [fnames] * 2
 
     with uvtest.check_warnings(UserWarning, match=messages):
-        fhd_uv.read(**fhd_data_files, use_future_array_shapes=True)
+        fhd_uv.read(**fhd_data_files)
 
     if not multi:
         # Check only pyuvdata history with no settings file
@@ -551,7 +547,7 @@ def test_read_fhd_write_read_uvfits_no_settings(tmp_path, fhd_data_files, multi)
 
     outfile = str(tmp_path / "outtest_FHD_1061316296.uvfits")
     fhd_uv.write_uvfits(outfile)
-    uvfits_uv.read_uvfits(outfile, use_future_array_shapes=True)
+    uvfits_uv.read_uvfits(outfile)
 
     uvfits_uv._consolidate_phase_center_catalogs(
         reference_catalog=fhd_uv.phase_center_catalog
@@ -569,7 +565,7 @@ def test_break_read_fhd(fhd_data_files, fhd_model_files):
     with pytest.raises(
         ValueError, match="The flags_file parameter must be passed if read_data is True"
     ):
-        fhd_uv.read(**file_dict, use_future_array_shapes=True)
+        fhd_uv.read(**file_dict)
 
     for ftype, fnames in file_dict.items():
         if isinstance(fnames, list):
@@ -580,7 +576,7 @@ def test_break_read_fhd(fhd_data_files, fhd_model_files):
     with pytest.raises(
         ValueError, match="The flags_file parameter must be passed if read_data is True"
     ):
-        fhd_uv.read(**file_dict, use_future_array_shapes=True)
+        fhd_uv.read(**file_dict)
 
     file_dict = copy.deepcopy(fhd_data_files)
     del file_dict["params_file"]
@@ -588,20 +584,20 @@ def test_break_read_fhd(fhd_data_files, fhd_model_files):
     with pytest.raises(
         ValueError, match="The params_file must be passed for FHD files."
     ):
-        fhd_uv.read(**file_dict, use_future_array_shapes=True)
+        fhd_uv.read(**file_dict)
 
     file_dict = copy.deepcopy(fhd_data_files)
     file_dict["filename"] = ["foo.sav"]
     # No data files
     with pytest.raises(ValueError, match="unrecognized file in vis_files"):
-        fhd_uv.read(**file_dict, use_future_array_shapes=True)
+        fhd_uv.read(**file_dict)
 
     file_dict["filename"] = [None]
     # No data files
     with pytest.raises(
         ValueError, match="The vis_files parameter must be passed if read_data is True"
     ):
-        fhd_uv.read(**file_dict, file_type="fhd", use_future_array_shapes=True)
+        fhd_uv.read(**file_dict, file_type="fhd")
 
     # mix of model & data files
 
@@ -612,7 +608,7 @@ def test_break_read_fhd(fhd_data_files, fhd_model_files):
     with pytest.raises(
         ValueError, match="The vis_files parameter has a mix of model and data files."
     ):
-        fhd_uv.read(**file_dict, file_type="fhd", use_future_array_shapes=True)
+        fhd_uv.read(**file_dict, file_type="fhd")
 
 
 def test_read_fhd_warnings(fhd_data_files):
@@ -637,7 +633,7 @@ def test_read_fhd_warnings(fhd_data_files):
     fhd_data_files["filename"] = broken_data_file
 
     with uvtest.check_warnings(UserWarning, match=warn_messages):
-        fhd_uv.read(**fhd_data_files, run_check=False, use_future_array_shapes=True)
+        fhd_uv.read(**fhd_data_files, run_check=False)
 
     # bad flag file
     broken_flags_file = os.path.join(
@@ -658,7 +654,7 @@ def test_read_fhd_warnings(fhd_data_files):
         with pytest.raises(
             ValueError, match="No recognized key for visibility weights in flags_file."
         ):
-            fhd_uv.read(**fhd_data_files, use_future_array_shapes=True)
+            fhd_uv.read(**fhd_data_files)
 
 
 @pytest.mark.parametrize(
@@ -683,7 +679,7 @@ def test_read_fhd_extra_files(
     fhd_data_files["filename"].extend(new_files)
     fhd_uv = UVData()
     with pytest.raises(ValueError, match=message):
-        fhd_uv.read(**fhd_data_files, use_future_array_shapes=True)
+        fhd_uv.read(**fhd_data_files)
 
 
 @pytest.mark.filterwarnings("ignore:Telescope location derived from obs")
@@ -694,7 +690,7 @@ def test_read_fhd_model(tmp_path, fhd_model):
 
     outfile = str(tmp_path / "outtest_FHD_1061316296_model.uvfits")
     fhd_uv.write_uvfits(outfile)
-    uvfits_uv.read_uvfits(outfile, use_future_array_shapes=True)
+    uvfits_uv.read_uvfits(outfile)
 
     uvfits_uv._consolidate_phase_center_catalogs(
         reference_catalog=fhd_uv.phase_center_catalog
@@ -716,9 +712,7 @@ def test_multi_files(fhd_model, axis, fhd_model_files):
     fhd_model_files["filename"] = np.array(
         [fhd_model_files["filename"][0], fhd_model_files["filename"][1]]
     )
-    fhd_uv1.read(
-        **fhd_model_files, file_type="fhd", axis=axis, use_future_array_shapes=True
-    )
+    fhd_uv1.read(**fhd_model_files, file_type="fhd", axis=axis)
 
     fhd_uv2 = fhd_model
 
@@ -760,12 +754,7 @@ def test_multi_files_errors(fhd_model, fhd_model_files, ftype_err):
 
     msg += " values must match the number of data file sets."
     with pytest.raises(ValueError, match=msg):
-        fhd_uv1.read(
-            **fhd_model_files,
-            file_type="fhd",
-            axis="polarization",
-            use_future_array_shapes=True,
-        )
+        fhd_uv1.read(**fhd_model_files, file_type="fhd", axis="polarization")
 
 
 def test_single_time():
@@ -788,7 +777,7 @@ def test_single_time():
             "'flags', 'layout', 'params', 'settings']",
         ],
     ):
-        fhd_uv.read(**file_dict, use_future_array_shapes=True)
+        fhd_uv.read(**file_dict)
 
     assert np.unique(fhd_uv.time_array).size == 1
 
@@ -803,7 +792,7 @@ def test_conjugation():
     del file_dict["model_files"]
 
     uvfits_uv = UVData()
-    uvfits_uv.read(uvfits_file, use_future_array_shapes=True)
+    uvfits_uv.read(uvfits_file)
 
     fhd_uv = UVData()
     with uvtest.check_warnings(
@@ -815,7 +804,7 @@ def test_conjugation():
             "'flags', 'layout', 'params', 'settings']",
         ],
     ):
-        fhd_uv.read(**file_dict, use_future_array_shapes=True)
+        fhd_uv.read(**file_dict)
 
     uvfits_uv.select(polarizations=fhd_uv.polarization_array)
 

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -619,7 +619,7 @@ def test_miriad_location_handling(paper_miriad_main, tmp_path):
             "present in the file",
         ],
     ):
-        uv_out.read(testfile, use_future_array_shapes=True, run_check=False)
+        uv_out.read(testfile, run_check=False)
 
     # Test for handling when antenna positions have a different mean latitude
     # than the file latitude

--- a/pyuvdata/uvdata/tests/test_miriad.py
+++ b/pyuvdata/uvdata/tests/test_miriad.py
@@ -109,9 +109,6 @@ warn_dict = {
         "Altitude is not present in Miriad file, and telescope foo is not in"
         " known_telescopes."
     ),
-    "phase_type_deprecated": (
-        "The phase_type parameter is deprecated, use the projected parameter instead."
-    ),
     "no_telescope_loc": (
         "Telescope location is not set, but antenna positions are "
         "present. Mean antenna latitude and longitude values match file "
@@ -225,12 +222,9 @@ def test_read_nrao_write_miriad_read_miriad(casa_uvfits, tmp_path):
     assert miriad_uv2 == miriad_uv
 
     # check that setting projected also works
-    with uvtest.check_warnings(
-        [DeprecationWarning, UserWarning],
-        match=[warn_dict["phase_type_deprecated"], warn_dict["uvw_mismatch"]],
-    ):
+    with uvtest.check_warnings(UserWarning, match=warn_dict["uvw_mismatch"]):
         miriad_uv2 = UVData.from_file(
-            writefile, phase_type="phased", use_future_array_shapes=True
+            writefile, projected=True, use_future_array_shapes=True
         )
     assert miriad_uv2 == miriad_uv
 
@@ -464,20 +458,6 @@ def test_miriad_read_warning_lat_lon_corrected():
         miriad_uv.read(
             paper_miriad_file, correct_lat_lon=False, use_future_array_shapes=True
         )
-
-
-def test_read_miriad_phasing_errors():
-    miriad_uv = UVData()
-    # check that setting the phase_type to something wrong errors
-    with pytest.raises(
-        ValueError, match="The phase_type was not one of the recognized options."
-    ):
-        with uvtest.check_warnings(
-            DeprecationWarning, match=warn_dict["phase_type_deprecated"]
-        ):
-            miriad_uv.read(
-                paper_miriad_file, phase_type="foo", use_future_array_shapes=True
-            )
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
@@ -833,12 +813,9 @@ def test_singletimeselect_unprojected(uv_in_paper):
     uv_out.read(testfile, projected=False, use_future_array_shapes=True)
     assert uv_in == uv_out
 
-    # also check that setting phase_type works
-    with uvtest.check_warnings(
-        [DeprecationWarning, UserWarning],
-        match=[warn_dict["phase_type_deprecated"], warn_dict["uvw_mismatch"]],
-    ):
-        uv_out.read(testfile, phase_type="drift", use_future_array_shapes=True)
+    # also check that setting projected works
+    with uvtest.check_warnings(UserWarning, match=warn_dict["uvw_mismatch"]):
+        uv_out.read(testfile, projected=False, use_future_array_shapes=True)
         assert uv_in == uv_out
 
     # check again with more than one time but only 1 unflagged time

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -555,7 +555,6 @@ def test_ms_multi_spw_data_variation(sma_mir, tmp_path):
     assert np.all(ms_uv.integration_time == np.array([1.0]))
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:Writing in the MS file that the units of the data")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_ms_phasing(sma_mir, tmp_path):
@@ -606,10 +605,6 @@ def test_ms_single_chan(sma_mir, tmp_path):
     )
     ms_uv.phase_center_catalog[cat_id]["cat_name"] = cat_name
     ms_uv.phase_center_catalog[cat_id]["info_source"] = "file"
-
-    # Next, turn on flex-spw
-    ms_uv._set_flex_spw()
-    ms_uv.flex_spw_id_array = ms_uv.spw_array.copy()
 
     # Finally, take care of the odds and ends
     ms_uv.extra_keywords = {}

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -11666,6 +11666,7 @@ def test_init_like_hera_cal(hera_uvh5, tmp_path, projected, check_before_write):
         "baseline_array",
         "channel_width",
         "data_array",
+        "extra_keywords",
         "flag_array",
         "flex_spw_id_array",
         "freq_array",
@@ -11694,8 +11695,10 @@ def test_init_like_hera_cal(hera_uvh5, tmp_path, projected, check_before_write):
         "antenna_names",
         "antenna_numbers",
         "antenna_positions",
+        "antenna_diameters",
     ]
 
+    uvd = UVData()
     for par in tel_params:
         setattr(uvd.telescope, par, getattr(hera_uvh5.telescope, par))
 
@@ -11712,21 +11715,15 @@ def test_init_like_hera_cal(hera_uvh5, tmp_path, projected, check_before_write):
         warn_type = None
         msg = None
 
-    uvd = UVData()
     param_dict = {}
     for par in params:
         param_dict[par] = getattr(hera_uvh5, par)
-
-    uvd = UVData()
 
     # set parameters in uvd
     for par in params:
         if par not in param_dict.keys():
             continue
         uvd.__setattr__(par, param_dict[par])
-
-    uvd.telescope.antenna_diameters = hera_uvh5.telescope.antenna_diameters
-    uvd.extra_keywords = hera_uvh5.extra_keywords
 
     if check_before_write:
         with uvtest.check_warnings(warn_type, match=msg):
@@ -11740,7 +11737,6 @@ def test_init_like_hera_cal(hera_uvh5, tmp_path, projected, check_before_write):
                 "cat_name"
             ]
 
-        uvd.flex_spw_id_array = hera_uvh5.flex_spw_id_array
         assert uvd == hera_uvh5
 
     testfile = os.path.join(tmp_path, "outtest.uvh5")

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -10452,10 +10452,15 @@ def test_phase_dict_helper_jpl_lookup_append(sma_mir):
 
 @pytest.mark.parametrize("use_ant_pos", [True, False])
 @pytest.mark.parametrize("phase_frame", ["icrs", "gcrs"])
-def test_fix_phase(hera_uvh5, tmp_path, use_ant_pos, phase_frame):
+@pytest.mark.parametrize("file_type", ["uvh5", "uvfits", "miriad"])
+def test_fix_phase(hera_uvh5, tmp_path, use_ant_pos, phase_frame, file_type):
     """
     Test the phase fixing method fix_phase
     """
+    if file_type == "miriad":
+        if not hasmiriad:
+            pytest.skip("MIRIAD not installed.")
+
     # Make some copies of the data
     uv_in = hera_uvh5.copy()
 
@@ -10482,12 +10487,6 @@ def test_fix_phase(hera_uvh5, tmp_path, use_ant_pos, phase_frame):
 
     read_warn_msg = copy.deepcopy(warn_msg)
     read_warn_type = [UserWarning]
-
-    # need to test uvfits & miriad read options, but only in one run so set the
-    # file_type here (rather than in a parametrize)
-    file_type = "uvh5"
-    if phase_frame == "icrs" and use_ant_pos:
-        file_type = "uvfits"
 
     uv_in_bad = UVData.from_file(bad_data_path, fix_old_proj=False)
     uv_in_bad_copy = uv_in_bad.copy()
@@ -10537,19 +10536,21 @@ def test_fix_phase(hera_uvh5, tmp_path, use_ant_pos, phase_frame):
         uv_in_bad_copy.phase_center_catalog[1]["info_source"]
     )
     uv_in_bad2.extra_keywords = uv_in_bad_copy.extra_keywords
-    assert uv_in_bad2 == uv_in_bad_copy
 
     # We have to handle this case a little carefully, because since the old
     # unproject_phase was _mostly_ accurate, although it does seem to intoduce errors
     # on the order of a part in 1e5, which translates to about a tenth of a degree phase
     # error in the test data set used here. Check that first, make sure it's good
     assert np.allclose(uv_in.data_array, uv_in_bad.data_array, rtol=3e-4)
+    assert np.allclose(uv_in_bad2.data_array, uv_in_bad_copy.data_array, rtol=3e-4)
 
     # Once we know the data are okay, copy over data array and check for equality btw
     # the other attributes of the two objects.
     uv_in_bad.data_array = uv_in.data_array
+    uv_in_bad2.data_array = uv_in_bad_copy.data_array
     uv_in_bad.history = uv_in.history
     assert uv_in == uv_in_bad
+    assert uv_in_bad2 == uv_in_bad_copy
 
 
 def test_fix_phase_error(hera_uvh5):

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -1068,8 +1068,6 @@ def test_phase_to_time(casa_uvfits, telescope_frame, selenoid):
         )
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.filterwarnings("ignore:The original `phase` method is deprecated")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_unphase_drift_data_error(hera_uvh5, sma_mir):
     uv_phase = hera_uvh5.copy()

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -26,7 +26,7 @@ from pyuvdata import UVCal, UVData
 from pyuvdata.data import DATA_PATH
 from pyuvdata.tests.test_utils import frame_selenoid
 from pyuvdata.uvdata.tests.test_mwa_corr_fits import filelist as mwa_corr_files
-from pyuvdata.uvdata.uvdata import _future_array_shapes_warning, old_phase_attrs
+from pyuvdata.uvdata.uvdata import _future_array_shapes_warning
 
 try:
     import pyuvdata._miriad  # noqa F401
@@ -106,8 +106,6 @@ def uvdata_props():
         "antenna_diameters",
         "telescope_location_lat_lon_alt",
         "telescope_location_lat_lon_alt_degrees",
-        "phase_center_ra_degrees",
-        "phase_center_dec_degrees",
         "pyuvdata_version_str",
     ]
 
@@ -271,7 +269,7 @@ def bda_test_file_main():
     uv_object = UVData()
     testfile = os.path.join(DATA_PATH, "simulated_bda_file.uvh5")
     with uvtest.check_warnings(
-        UserWarning, match="Unknown phase types are no longer supported"
+        UserWarning, match="Unknown phase type, assuming object is unprojected"
     ):
         uv_object.read(testfile, use_future_array_shapes=True)
 
@@ -10001,98 +9999,6 @@ def test_parse_ants_x_orientation_kwarg(hera_uvh5):
     assert np.array_equal(pols, pols2)
 
 
-def test_getattr_error(casa_uvfits):
-    with pytest.raises(
-        ValueError,
-        match=(
-            "The older phase attributes, including phase_type, phase_center_ra,"
-            " phase_center_dec, phase_center_frame, phase_center_epoch, object_name"
-            " cannot be used with data phased with the new method. This was phased with"
-            " the new method because it has fk5 phase frames."
-        ),
-    ):
-        casa_uvfits.phase_type
-
-
-@pytest.mark.parametrize(
-    ["old_attr", "msg"],
-    [
-        (
-            "phase_type",
-            (
-                " The phase_type is now represented as the 'cat_type' in the "
-                "phase_center_catalog (the old 'drift' type corresponds to the "
-                "new 'unprojected' type, the old 'phased' type corresponds to the "
-                "new 'sidereal' type, and there is also now support for an 'ephem' "
-                "type to support moving objects and a new 'driftscan' type which "
-                "can point at any alt/az (not just zenith) and which always has "
-                "w-projection applied)."
-            ),
-        ),
-        (
-            "phase_center_ra",
-            (
-                " The phase_center_ra is now represented as the 'cat_lon' in the "
-                "phase_center_catalog."
-            ),
-        ),
-        (
-            "phase_center_dec",
-            (
-                " The phase_center_dec is now represented as the 'cat_lat' in the "
-                "phase_center_catalog."
-            ),
-        ),
-        (
-            "phase_center_frame",
-            (
-                " The phase_center_frame is now represented as the 'cat_frame' in the "
-                "phase_center_catalog."
-            ),
-        ),
-        (
-            "phase_center_epoch",
-            (
-                " The phase_center_epoch is now represented as the 'cat_epoch' in the "
-                "phase_center_catalog."
-            ),
-        ),
-        (
-            "object_name",
-            (
-                " The object_name is now represented as the 'cat_name' in the "
-                "phase_center_catalog."
-            ),
-        ),
-    ],
-)
-def test_getattr(casa_uvfits, old_attr, msg):
-    casa_uvfits.phase_center_catalog[0]["cat_frame"] = "icrs"
-    initial_msg = (
-        "The older phase attributes, including phase_type, phase_center_ra, "
-        "phase_center_dec, phase_center_frame, phase_center_epoch, object_name, are "
-        "deprecated in favor of representing phasing using the phase_center_catalog."
-    )
-    expected_vals = {
-        "phase_type": "phased",
-        "phase_center_ra": casa_uvfits.phase_center_catalog[0]["cat_lon"],
-        "phase_center_dec": casa_uvfits.phase_center_catalog[0]["cat_lat"],
-        "phase_center_frame": casa_uvfits.phase_center_catalog[0]["cat_frame"],
-        "phase_center_epoch": casa_uvfits.phase_center_catalog[0]["cat_epoch"],
-        "object_name": casa_uvfits.phase_center_catalog[0]["cat_name"],
-    }
-
-    with uvtest.check_warnings(DeprecationWarning, match=initial_msg + msg):
-        assert getattr(casa_uvfits, old_attr) == expected_vals[old_attr]
-
-    if old_attr == "phase_type":
-        # also test for drift identification
-        casa_uvfits.unproject_phase()
-
-        with uvtest.check_warnings(DeprecationWarning, match=initial_msg + msg):
-            assert getattr(casa_uvfits, old_attr) == "drift"
-
-
 def test_rephase_to_time():
     uvfits_file = os.path.join(DATA_PATH, "1061316296.uvfits")
     uvd = UVData()
@@ -10115,16 +10021,10 @@ def test_rephase_to_time():
     zenith_dec = obs_zenith_coord.dec.rad
 
     uvd.phase_to_time(phase_time)
+    cat_id = uvd.phase_center_id_array[0]
 
-    with uvtest.check_warnings(
-        DeprecationWarning, match="The older phase attributes, including phase_type"
-    ):
-        assert uvd.phase_center_ra == zenith_ra
-
-    with uvtest.check_warnings(
-        DeprecationWarning, match="The older phase attributes, including phase_type"
-    ):
-        assert uvd.phase_center_dec == zenith_dec
+    assert uvd.phase_center_catalog[cat_id]["cat_lon"] == zenith_ra
+    assert uvd.phase_center_catalog[cat_id]["cat_lat"] == zenith_dec
 
 
 @pytest.mark.parametrize(
@@ -12549,21 +12449,12 @@ def test_split_write_comb_read(tmp_path, multi_phase):
 
 
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.parametrize("set_obj_name", [True, False])
 @pytest.mark.parametrize("projected", [True, False])
 @pytest.mark.parametrize("check_before_write", [True, False])
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_init_like_hera_cal(
-    hera_uvh5, tmp_path, set_obj_name, projected, check_before_write, future_shapes
-):
+def test_init_like_hera_cal(hera_uvh5, tmp_path, projected, check_before_write):
     """Pulled from an error in hera_cal."""
-
-    if not future_shapes:
-        hera_uvh5.use_current_array_shapes()
 
     params = [
         "Nants_data",
@@ -12573,19 +12464,24 @@ def test_init_like_hera_cal(
         "Npols",
         "Nspws",
         "Ntimes",
+        "Nphase",
         "ant_1_array",
         "ant_2_array",
         "baseline_array",
         "channel_width",
         "data_array",
         "flag_array",
+        "flex_spw_id_array",
         "freq_array",
         "history",
         "integration_time",
         "lst_array",
         "nsample_array",
-        "object_name",
-        "phase_type",
+        "phase_center_catalog",
+        "phase_center_id_array",
+        "phase_center_app_ra",
+        "phase_center_app_dec",
+        "phase_center_frame_pa",
         "polarization_array",
         "spw_array",
         "time_array",
@@ -12604,94 +12500,37 @@ def test_init_like_hera_cal(
         "antenna_positions",
     ]
 
-    uvd = UVData()
-    if future_shapes:
-        uvd._set_future_array_shapes()
-    else:
-        hera_uvh5.use_current_array_shapes()
-
-    param_dict = {}
-    for par in params:
-        if par in ["phase_type", "object_name"]:
-            continue
-        param_dict[par] = getattr(hera_uvh5, par)
-
-    if projected:
-        param_dict["phase_type"] = "phased"
-    else:
-        param_dict["phase_type"] = "drift"
-    if set_obj_name:
-        param_dict["object_name"] = hera_uvh5.phase_center_catalog[0]["cat_name"]
-
-    uvd = UVData()
-    if future_shapes:
-        uvd._set_future_array_shapes()
-    # set parameters in uvd
-    for par in params:
-        if par not in param_dict.keys():
-            continue
-        if par in old_phase_attrs:
-            warn_type = DeprecationWarning
-            msg = "The older phase attributes, including"
-        else:
-            warn_type = None
-            msg = ""
-        with uvtest.check_warnings(warn_type, match=msg):
-            uvd.__setattr__(par, param_dict[par])
-
     for par in tel_params:
         setattr(uvd.telescope, par, getattr(hera_uvh5.telescope, par))
 
-    assert uvd.phase_center_catalog is None
-
     if projected:
-        with uvtest.check_warnings(
-            DeprecationWarning, match=["The older phase attributes, including"] * 4
-        ):
-            uvd.phase_center_ra = 0.0
-            uvd.phase_center_dec = 0.0
-            uvd.phase_center_epoch = 2000.0
-            uvd.phase_center_frame = "icrs"
-
         hera_uvh5.phase_center_catalog[0]["cat_type"] = "sidereal"
         hera_uvh5.phase_center_catalog[0]["cat_lon"] = 0.0
         hera_uvh5.phase_center_catalog[0]["cat_lat"] = 0.0
         hera_uvh5.phase_center_catalog[0]["cat_frame"] = "icrs"
         hera_uvh5.phase_center_catalog[0]["cat_epoch"] = 2000.0
         hera_uvh5._set_app_coords_helper()
-        warn_type = [DeprecationWarning, DeprecationWarning, UserWarning]
-        msg = [
-            (
-                "The phase_center_catalog was not set and a complete set of old phase "
-                "attributes (phase_type, phase_center_ra, phase_center_dec, "
-                "phase_center_frame, phase_center_epoch, object_name)"
-            ),
-            "flex_spw_id_array is not set. It will be required starting in version 3.0",
-            "The uvw_array does not match the expected values",
-        ]
-
+        warn_type = UserWarning
+        msg = "The uvw_array does not match the expected values"
     else:
-        warn_type = [DeprecationWarning]
-        msg = [
-            (
-                "The phase_center_catalog was not set and a complete set of old phase "
-                "attributes (phase_type"
-            ),
-            "flex_spw_id_array is not set. It will be required starting in version 3.0",
-        ]
+        warn_type = None
+        msg = None
 
-    if projected and not set_obj_name:
-        with pytest.raises(
-            ValueError,
-            match=re.escape(
-                "The phase_center_catalog was not set and some old phase attributes "
-                "(phase_type, phase_center_ra, phase_center_dec, phase_center_frame, "
-                "phase_center_epoch) were detected, but not enough to define the phase "
-                "status of the object, so they could not be converted "
-            ),
-        ):
-            uvd.check()
-        return
+    hera_uvh5._set_future_array_shapes()
+
+    uvd = UVData()
+    param_dict = {}
+    for par in params:
+        param_dict[par] = getattr(hera_uvh5, par)
+
+    uvd = UVData()
+    uvd._set_future_array_shapes()
+
+    # set parameters in uvd
+    for par in params:
+        if par not in param_dict.keys():
+            continue
+        uvd.__setattr__(par, param_dict[par])
 
     uvd.telescope.antenna_diameters = hera_uvh5.telescope.antenna_diameters
     uvd.extra_keywords = hera_uvh5.extra_keywords
@@ -12702,40 +12541,25 @@ def test_init_like_hera_cal(
 
         if projected:
             assert uvd.phase_center_catalog[0]["cat_type"] == "sidereal"
-        elif not set_obj_name:
-            assert uvd.phase_center_catalog[0]["cat_name"] == "unprojected"
+        else:
+            assert uvd.phase_center_catalog[0]["cat_name"] == "zenith"
             uvd.phase_center_catalog[0]["cat_name"] = hera_uvh5.phase_center_catalog[0][
                 "cat_name"
             ]
-
-        # check that setting an old phase attribute when the phase_center_catalog is
-        # already set will issue the correct warning (and do nothing)
-        with uvtest.check_warnings(
-            DeprecationWarning,
-            match=(
-                "phase_center_catalog is already set, so object_name, which is an "
-                "old phase attribute, cannot be set."
-            ),
-        ):
-            uvd.object_name = "foo"
 
         uvd.flex_spw_id_array = hera_uvh5.flex_spw_id_array
         assert uvd == hera_uvh5
 
     testfile = os.path.join(tmp_path, "outtest.uvh5")
-    if check_before_write:
-        uvd.write_uvh5(testfile)
-    else:
-        with uvtest.check_warnings(warn_type, match=msg):
-            uvd.write_uvh5(testfile)
+    uvd.write_uvh5(testfile)
 
-    uvd2 = UVData.from_file(testfile, use_future_array_shapes=future_shapes)
+    uvd2 = UVData.from_file(testfile, use_future_array_shapes=True)
 
     if not check_before_write:
         if projected:
             assert uvd2.phase_center_catalog[0]["cat_type"] == "sidereal"
-        elif not set_obj_name:
-            assert uvd2.phase_center_catalog[0]["cat_name"] == "unprojected"
+        else:
+            assert uvd2.phase_center_catalog[0]["cat_name"] == "zenith"
             uvd2.phase_center_catalog[0]["cat_name"] = hera_uvh5.phase_center_catalog[
                 0
             ]["cat_name"]

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -9054,13 +9054,7 @@ def test_frequency_average_uneven(
             "`remove_eq_coeffs` before frequency averaging"
         )
     ]
-    if keep_ragged and not future_shapes:
-        warn.append(UserWarning)
-        msg.append(
-            "Ragged frequencies will result in varying channel widths, so "
-            "this object will have future array shapes after averaging. "
-            "Use keep_ragged=False to avoid this."
-        )
+
     with uvtest.check_warnings(warn, match=msg):
         uvobj.frequency_average(
             n_chan_to_avg=n_chan_to_avg,
@@ -9286,17 +9280,7 @@ def test_frequency_average_flagging(
             uvobj.flag_array[inds01[0], 0, 1:n_chan_to_avg, :] = True
         assert np.nonzero(uvobj.flag_array)[0].size == uvobj.Npols * (n_chan_to_avg - 1)
 
-    if keep_ragged and not future_shapes:
-        warn = UserWarning
-        msg = [
-            "Ragged frequencies will result in varying channel widths, so "
-            "this object will have future array shapes after averaging. "
-            "Use keep_ragged=False to avoid this."
-        ]
-    else:
-        warn = None
-        msg = ""
-    with uvtest.check_warnings(warn, match=msg):
+    with uvtest.check_warnings(None):
         uvobj.frequency_average(n_chan_to_avg=n_chan_to_avg, keep_ragged=keep_ragged)
 
     input_freqs = np.squeeze(uvobj2.freq_array)
@@ -9459,17 +9443,7 @@ def test_frequency_average_propagate_flags(casa_uvfits, future_shapes, keep_ragg
 
     assert np.nonzero(uvobj.flag_array)[0].size == uvobj.Npols * (n_chan_to_avg * 2 - 1)
 
-    if keep_ragged and not future_shapes:
-        warn = UserWarning
-        msg = [
-            "Ragged frequencies will result in varying channel widths, so "
-            "this object will have future array shapes after averaging. "
-            "Use keep_ragged=False to avoid this."
-        ]
-    else:
-        warn = None
-        msg = ""
-    with uvtest.check_warnings(warn, match=msg):
+    with uvtest.check_warnings(None):
         uvobj.frequency_average(
             n_chan_to_avg=n_chan_to_avg, propagate_flags=True, keep_ragged=keep_ragged
         )
@@ -9588,18 +9562,12 @@ def test_frequency_average_warnings(casa_uvfits):
     uvd.use_future_array_shapes()
     uvd.freq_array[-1] += uvd.channel_width[0]
     with uvtest.check_warnings(
-        [DeprecationWarning, UserWarning],
+        UserWarning,
         match=[
-            re.escape(
-                "Some spectral windows do not divide evenly by `n_chan_to_avg` and the "
-                "keep_ragged parameter was not set. The current default is False, but "
-                "that will be changing to True in version 2.5. Set `keep_ragged` to "
-                "True or False to silence this warning."
-            ),
             re.escape(
                 "Frequencies spacing and/or channel widths vary, so after averaging "
                 "they will also vary."
-            ),
+            )
         ],
     ):
         uvd.frequency_average(n_chan_to_avg=3)

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -504,7 +504,6 @@ def test_casa_nonascii_bytes_antenna_names():
     assert uv1.telescope.antenna_names == expected_ant_names
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(["telescope_frame", "selenoid"], frame_selenoid)
 def test_readwriteread(tmp_path, casa_uvfits, telescope_frame, selenoid):
@@ -1533,7 +1532,7 @@ def test_readwriteread_reorder_pols(tmp_path, casa_uvfits):
 @pytest.mark.parametrize(
     "freq_val,chan_val,msg",
     [
-        [-1, 1, "Frequency values must be > 0 for UVFITS!"],
+        [-1, 0, "Frequency values must be > 0 for UVFITS!"],
         [1, 0, "Something is wrong, frequency values not"],
     ],
 )

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -1711,7 +1711,7 @@ def test_uvfits_extra_phase_centers(sma_mir, tmp_path):
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvfits_phasing_errors(hera_uvh5, tmp_path):
-    # check error if phase_type is wrong and force_phase not set
+    # check error if data are not phase to a sidereal source and force_phase not set
     with pytest.raises(
         ValueError, match="The data are not all phased to a sidereal source"
     ):

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -2133,7 +2133,7 @@ def test_uvh5_read_header_special_cases(casa_uvfits, tmp_path):
     with uvtest.check_warnings(
         UserWarning,
         [
-            "Unknown phase types are no longer",
+            "Unknown phase type, assuming object is unprojected",
             "The uvw_array does not match the expected values",
         ],
     ):
@@ -2142,6 +2142,9 @@ def test_uvh5_read_header_special_cases(casa_uvfits, tmp_path):
     # make input and output values match now
     uv_in.history = uv_out.history
     uv_in.phase_center_catalog = uv_out.phase_center_catalog
+    uv_in.phase_center_app_ra = uv_out.phase_center_app_ra
+    uv_in.phase_center_app_dec = uv_out.phase_center_app_dec
+    uv_in.phase_center_frame_pa = uv_out.phase_center_frame_pa
     uv_in.vis_units = "uncalib"
 
     # make sure filenames are what we expect
@@ -3715,17 +3718,6 @@ class TestFastUVH5Meta:
         meta = uvh5.FastUVH5Meta(self.fl_singletime, blts_are_rectangular=True)
         assert not meta.time_axis_faster_than_bls
 
-    def test_phase_type_with_pcc(self):
-        meta = uvh5.FastUVH5Meta(self.fl)
-        assert meta.phase_type == "drift"
-
-        uvd = meta.to_uvdata()
-        uvd.initialize_uvh5_file(os.path.join(self.tmp_path.name, "new_pcc.uvh5"))
-
-        meta1 = uvh5.FastUVH5Meta(os.path.join(self.tmp_path.name, "new_pcc.uvh5"))
-        assert meta1.phase_center_catalog is not None
-        assert meta1.phase_type == "drift"
-
     def test_getting_lsts(self):
         meta = uvh5.FastUVH5Meta(self.fl)
 
@@ -3793,12 +3785,6 @@ class TestFastUVH5Meta:
         meta = uvh5.FastUVH5Meta(self.fl)
         uvd = meta.to_uvdata()
         assert np.allclose(meta.antpos_enu, uvd.telescope.get_enu_antpos())
-
-    def test_phased_phase_type(self, sma_mir, tmp_path_factory):
-        testdir = tmp_path_factory.mktemp("test_phased_phase_type")
-        sma_mir.write_uvh5(os.path.join(testdir, "sma_mir.uvh5"))
-        meta = uvh5.FastUVH5Meta(os.path.join(testdir, "sma_mir.uvh5"))
-        assert meta.phase_type == "phased"
 
     def test_rectangularity_roundtrip(self):
         meta = uvh5.FastUVH5Meta(self.fl)

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -3185,6 +3185,10 @@ def test_old_phase_attributes_header(casa_uvfits, tmp_path):
     uvd2.history = casa_uvfits.history
     assert uvd2 == casa_uvfits
 
+    casa_uvfits.phase_center_catalog = None
+    old_phase_compatible, _ = casa_uvfits._old_phase_attributes_compatible()
+    assert old_phase_compatible
+
 
 def test_none_extra_keywords(uv_uvh5, tmp_path):
     """Test that we can round-trip None values in extra_keywords"""

--- a/pyuvdata/uvdata/tests/test_uvh5.py
+++ b/pyuvdata/uvdata/tests/test_uvh5.py
@@ -25,7 +25,6 @@ import pyuvdata.utils as uvutils
 from pyuvdata import UVData
 from pyuvdata.data import DATA_PATH
 from pyuvdata.tests.test_utils import frame_selenoid
-from pyuvdata.uvdata.uvdata import _future_array_shapes_warning
 
 from .. import uvh5
 
@@ -41,7 +40,7 @@ def uv_uvh5_main():
     # read in a uvh5 test file
     uv_uvh5 = UVData()
     uvh5_filename = os.path.join(DATA_PATH, "zen.2458432.34569.uvh5")
-    uv_uvh5.read_uvh5(uvh5_filename, use_future_array_shapes=True)
+    uv_uvh5.read_uvh5(uvh5_filename)
     return uv_uvh5
 
 
@@ -62,7 +61,7 @@ def uv_partial_write(casa_uvfits, tmp_path):
     testfile = str(tmp_path / "outtest.uvh5")
     uv_uvfits.write_uvh5(testfile)
     uv_uvh5 = UVData()
-    uv_uvh5.read(testfile, use_future_array_shapes=True)
+    uv_uvh5.read(testfile)
 
     yield uv_uvh5
 
@@ -122,10 +121,7 @@ def initialize_with_zeros_ints(uvd, filename):
 
 
 def make_old_shapes(filename):
-    """Modify the file to have the old shapes
-
-    (it always writes them with the future shapes)
-    """
+    """Modify the file to have the old shapes"""
     with h5py.File(filename, "r+") as h5f:
         freq_array = h5f["Header/freq_array"][()]
         del h5f["Header/freq_array"]
@@ -148,17 +144,12 @@ def make_old_shapes(filename):
         h5f["Data/nsamples"] = nsamples[:, np.newaxis, :, :]
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_read_miriad_write_uvh5_read_uvh5(paper_miriad, future_shapes, tmp_path):
+def test_read_miriad_write_uvh5_read_uvh5(paper_miriad, tmp_path):
     """
     Test a miriad file round trip.
     """
     uv_in = paper_miriad
-    if not future_shapes:
-        uv_in.use_current_array_shapes()
 
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_miriad.uvh5")
@@ -168,7 +159,7 @@ def test_read_miriad_write_uvh5_read_uvh5(paper_miriad, future_shapes, tmp_path)
         h5file.create_dataset("Test", list(range(10)))
 
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile, use_future_array_shapes=future_shapes)
+    uv_out.read(testfile)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["zen.2456865.60537.xy.uvcRREAA"]
@@ -180,7 +171,7 @@ def test_read_miriad_write_uvh5_read_uvh5(paper_miriad, future_shapes, tmp_path)
     # also test round-tripping phased data
     uv_in.phase_to_time(Time(np.mean(uv_in.time_array), format="jd"))
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read_uvh5(testfile, use_future_array_shapes=future_shapes)
+    uv_out.read_uvh5(testfile)
 
     assert uv_in == uv_out
 
@@ -227,7 +218,7 @@ def test_read_uvfits_write_uvh5_read_uvh5(
     fname = f"outtest_{telescope_frame}_uvfits.uvh5"
     testfile = str(tmp_path / fname)
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile, use_future_array_shapes=True)
+    uv_out.read(testfile)
 
     assert uv_out.telescope._location.frame == telescope_frame
     assert uv_out.telescope._location.ellipsoid == selenoid
@@ -243,7 +234,7 @@ def test_read_uvfits_write_uvh5_read_uvh5(
         with h5py.File(testfile, "r+") as f:
             del f["Header"]["ellipsoid"]
 
-        uv_out.read(testfile, use_future_array_shapes=True)
+        uv_out.read(testfile)
         assert uv_in == uv_out
 
     # clean up
@@ -254,7 +245,7 @@ def test_read_uvfits_write_uvh5_read_uvh5(
 
     uv_in.data_array = uv_in.data_array.astype(np.complex128)
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile, use_future_array_shapes=True)
+    uv_out.read(testfile)
     assert uv_in == uv_out
 
     # clean up
@@ -295,13 +286,11 @@ def test_read_uvh5_errors(tmp_path, casa_uvfits):
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 def test_write_uvh5_errors(casa_uvfits, tmp_path):
     """
     Test raising errors in write_uvh5 function.
     """
     uv_in = casa_uvfits
-    uv_in.use_current_array_shapes()
 
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_uvfits.uvh5")
@@ -315,11 +304,7 @@ def test_write_uvh5_errors(casa_uvfits, tmp_path):
     # use clobber=True to write out anyway
     uv_in.write_uvh5(testfile, clobber=True)
     with uvtest.check_warnings(
-        [UserWarning, DeprecationWarning],
-        match=[
-            "The uvw_array does not match the expected values",
-            _future_array_shapes_warning,
-        ],
+        UserWarning, match="The uvw_array does not match the expected values"
     ):
         uv_out.read(testfile)
 
@@ -357,7 +342,7 @@ def test_uvh5_optional_parameters(casa_uvfits, tmp_path):
 
     # write out and read back in
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile, use_future_array_shapes=True)
+    uv_out.read(testfile)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["day2_TDEM0003_10s_norx_1src_1spw.uvfits"]
@@ -370,7 +355,7 @@ def test_uvh5_optional_parameters(casa_uvfits, tmp_path):
     uv_in.reorder_blts("bda")
 
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile, use_future_array_shapes=True)
+    uv_out.read(testfile)
     assert uv_in == uv_out
 
     # clean up
@@ -379,8 +364,6 @@ def test_uvh5_optional_parameters(casa_uvfits, tmp_path):
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_compression_options(casa_uvfits, tmp_path):
     """
@@ -392,7 +375,6 @@ def test_uvh5_compression_options(casa_uvfits, tmp_path):
     uv_out = UVData()
     testfile = str(tmp_path / "outtest_uvfits_compression.uvh5")
 
-    uv_in.use_current_array_shapes()
     # write out and read back in
     uv_in.write_uvh5(
         testfile,
@@ -412,7 +394,6 @@ def test_uvh5_compression_options(casa_uvfits, tmp_path):
     assert uv_in == uv_out
 
     # test with non-auto chunking
-    uv_in.use_future_array_shapes()
     chunks = (680, 16, 1)
     uv_in.write_uvh5(
         testfile,
@@ -422,7 +403,7 @@ def test_uvh5_compression_options(casa_uvfits, tmp_path):
         flags_compression=None,
         nsample_compression=None,
     )
-    uv_out.read(testfile, use_future_array_shapes=True)
+    uv_out.read(testfile)
     assert uv_in == uv_out
 
     # check that chunks match
@@ -449,9 +430,7 @@ def test_uvh5_read_multiple_files(casa_uvfits, tmp_path):
     uv2.select(freq_chans=np.arange(32, 64))
     uv1.write_uvh5(testfile1, clobber=True)
     uv2.write_uvh5(testfile2, clobber=True)
-    uv1.read(
-        np.array([testfile1, testfile2]), file_type="uvh5", use_future_array_shapes=True
-    )
+    uv1.read(np.array([testfile1, testfile2]), file_type="uvh5")
 
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
@@ -495,8 +474,8 @@ def test_uvh5_read_multiple_files_metadata_only(casa_uvfits, tmp_path):
 
     uvfits_filename = os.path.join(DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits")
     uv_full = UVData()
-    uv_full.read_uvfits(uvfits_filename, read_data=False, use_future_array_shapes=True)
-    uv1.read([testfile1, testfile2], read_data=False, use_future_array_shapes=True)
+    uv_full.read_uvfits(uvfits_filename, read_data=False)
+    uv1.read([testfile1, testfile2], read_data=False)
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
         uv_full.history + "  Downselected to "
@@ -536,7 +515,7 @@ def test_uvh5_read_multiple_files_axis(casa_uvfits, tmp_path):
     uv2.select(freq_chans=np.arange(32, 64))
     uv1.write_uvh5(testfile1, clobber=True)
     uv2.write_uvh5(testfile2, clobber=True)
-    uv1.read([testfile1, testfile2], axis="freq", use_future_array_shapes=True)
+    uv1.read([testfile1, testfile2], axis="freq")
     # Check history is correct, before replacing and doing a full object check
     assert uvutils._check_histories(
         uv_in.history + "  Downselected to "
@@ -575,12 +554,12 @@ def test_uvh5_partial_read_antennas(casa_uvfits, tmp_path):
     # change telescope name to avoid errors
     uv_in.telescope.name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
-    uvh5_uv.read(testfile, use_future_array_shapes=True)
+    uvh5_uv.read(testfile)
 
     # select on antennas
     ants_to_keep = np.array([1, 20, 12, 25, 4, 24, 2, 21, 22])
-    uvh5_uv.read(testfile, antenna_nums=ants_to_keep, use_future_array_shapes=True)
-    uvh5_uv2.read(testfile, use_future_array_shapes=True)
+    uvh5_uv.read(testfile, antenna_nums=ants_to_keep)
+    uvh5_uv2.read(testfile)
     uvh5_uv2.select(antenna_nums=ants_to_keep)
     assert uvh5_uv == uvh5_uv2
 
@@ -604,12 +583,12 @@ def test_uvh5_partial_read_freqs(casa_uvfits, tmp_path):
     uv_in.telescope.name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
 
-    uvh5_uv.read(testfile, use_future_array_shapes=True)
+    uvh5_uv.read(testfile)
 
     # select on frequency channels
     chans_to_keep = np.arange(12, 22)
-    uvh5_uv.read(testfile, freq_chans=chans_to_keep, use_future_array_shapes=True)
-    uvh5_uv2.read(testfile, use_future_array_shapes=True)
+    uvh5_uv.read(testfile, freq_chans=chans_to_keep)
+    uvh5_uv2.read(testfile)
     uvh5_uv2.select(freq_chans=chans_to_keep)
     assert uvh5_uv == uvh5_uv2
 
@@ -633,25 +612,20 @@ def test_uvh5_partial_read_pols(casa_uvfits, tmp_path):
     # change telescope name to avoid errors
     uv_in.telescope.name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
-    uvh5_uv.read(testfile, use_future_array_shapes=True)
+    uvh5_uv.read(testfile)
 
     # select on pols
     pols_to_keep = [-1, -2]
-    uvh5_uv.read(testfile, polarizations=pols_to_keep, use_future_array_shapes=True)
-    uvh5_uv2.read(testfile, use_future_array_shapes=True)
+    uvh5_uv.read(testfile, polarizations=pols_to_keep)
+    uvh5_uv2.read(testfile)
     uvh5_uv2.select(polarizations=pols_to_keep)
     assert uvh5_uv == uvh5_uv2
 
     # select on pols (non contiguous in file)
     # and check consistent results with and without multidim_index
     pols_to_keep = [-1, -2, -4]
-    uvh5_uv.read(
-        testfile,
-        polarizations=pols_to_keep,
-        multidim_index=True,
-        use_future_array_shapes=True,
-    )
-    uvh5_uv2.read(testfile, multidim_index=False, use_future_array_shapes=True)
+    uvh5_uv.read(testfile, polarizations=pols_to_keep, multidim_index=True)
+    uvh5_uv2.read(testfile, multidim_index=False)
     uvh5_uv2.select(polarizations=pols_to_keep)
     assert uvh5_uv == uvh5_uv2
 
@@ -671,16 +645,12 @@ def test_uvh5_partial_read_times(casa_uvfits, tmp_path):
     # change telescope name to avoid errors
     uv_in.telescope.name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
-    uvh5_uv.read(testfile, use_future_array_shapes=True)
+    uvh5_uv.read(testfile)
 
     # select on read using time_range
     unique_times = np.unique(uvh5_uv.time_array)
-    uvh5_uv.read(
-        testfile,
-        time_range=[unique_times[0], unique_times[1]],
-        use_future_array_shapes=True,
-    )
-    uvh5_uv2.read(testfile, use_future_array_shapes=True)
+    uvh5_uv.read(testfile, time_range=[unique_times[0], unique_times[1]])
+    uvh5_uv2.read(testfile)
     uvh5_uv2.select(time_range=[unique_times[0], unique_times[1]])
     assert uvh5_uv == uvh5_uv2
 
@@ -703,16 +673,12 @@ def test_uvh5_partial_read_lsts(casa_uvfits, tmp_path):
     # change telescope name to avoid errors
     uv_in.telescope.name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
-    uvh5_uv.read(testfile, use_future_array_shapes=True)
+    uvh5_uv.read(testfile)
 
     # select on read using lst_range
     unique_lsts = np.unique(uvh5_uv.lst_array)
-    uvh5_uv.read(
-        testfile,
-        lst_range=[unique_lsts[0], unique_lsts[2]],
-        use_future_array_shapes=True,
-    )
-    uvh5_uv2.read(testfile, use_future_array_shapes=True)
+    uvh5_uv.read(testfile, lst_range=[unique_lsts[0], unique_lsts[2]])
+    uvh5_uv2.read(testfile)
     uvh5_uv2.select(lst_range=[unique_lsts[0], unique_lsts[2]])
     assert uvh5_uv == uvh5_uv2
 
@@ -722,18 +688,14 @@ def test_uvh5_partial_read_lsts(casa_uvfits, tmp_path):
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected polarization values are not evenly spaced")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_read_multi1(casa_uvfits, future_shapes, tmp_path):
+@pytest.mark.parametrize("old_shapes", [True, False])
+def test_uvh5_partial_read_multi1(casa_uvfits, old_shapes, tmp_path):
     """
     Test select-on-read for multiple axes, frequencies being smallest fraction.
     """
     uv_in = casa_uvfits
-    if not future_shapes:
-        uv_in.use_current_array_shapes()
 
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
@@ -742,10 +704,10 @@ def test_uvh5_partial_read_multi1(casa_uvfits, future_shapes, tmp_path):
     uv_in.telescope.name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
 
-    if not future_shapes:
+    if old_shapes:
         make_old_shapes(testfile)
 
-    uvh5_uv.read(testfile, use_future_array_shapes=future_shapes)
+    uvh5_uv.read(testfile)
 
     # now test selecting on multiple axes
     # read frequencies first
@@ -757,9 +719,8 @@ def test_uvh5_partial_read_multi1(casa_uvfits, future_shapes, tmp_path):
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
-        use_future_array_shapes=future_shapes,
     )
-    uvh5_uv2.read(testfile, use_future_array_shapes=future_shapes)
+    uvh5_uv2.read(testfile)
     uvh5_uv2.select(
         antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
     )
@@ -780,9 +741,8 @@ def test_uvh5_partial_read_multi1(casa_uvfits, future_shapes, tmp_path):
                 polarizations=pols_to_keep,
                 freq_chans=chans_to_keep,
                 multidim_index=True,
-                use_future_array_shapes=future_shapes,
             )
-            uvh5_uv4.read(testfile, use_future_array_shapes=future_shapes)
+            uvh5_uv4.read(testfile)
             uvh5_uv4.select(
                 blt_inds=blts_to_keep,
                 polarizations=pols_to_keep,
@@ -796,19 +756,15 @@ def test_uvh5_partial_read_multi1(casa_uvfits, future_shapes, tmp_path):
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected polarization values are not evenly spaced")
 @pytest.mark.filterwarnings("ignore:Selected frequencies are not evenly spaced")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_read_multi2(casa_uvfits, future_shapes, tmp_path):
+@pytest.mark.parametrize("old_shapes", [True, False])
+def test_uvh5_partial_read_multi2(casa_uvfits, old_shapes, tmp_path):
     """
     Test select-on-read for multiple axes, baselines being smallest fraction.
     """
     uv_in = casa_uvfits
-    if not future_shapes:
-        uv_in.use_current_array_shapes()
 
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
@@ -817,10 +773,10 @@ def test_uvh5_partial_read_multi2(casa_uvfits, future_shapes, tmp_path):
     uv_in.telescope.name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
 
-    if not future_shapes:
+    if old_shapes:
         make_old_shapes(testfile)
 
-    uvh5_uv.read(testfile, use_future_array_shapes=future_shapes)
+    uvh5_uv.read(testfile)
 
     # now test selecting on multiple axes
     # read baselines first
@@ -832,9 +788,8 @@ def test_uvh5_partial_read_multi2(casa_uvfits, future_shapes, tmp_path):
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
-        use_future_array_shapes=future_shapes,
     )
-    uvh5_uv2.read(testfile, use_future_array_shapes=future_shapes)
+    uvh5_uv2.read(testfile)
     uvh5_uv2.select(
         antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
     )
@@ -855,9 +810,8 @@ def test_uvh5_partial_read_multi2(casa_uvfits, future_shapes, tmp_path):
                 freq_chans=chans_to_keep,
                 polarizations=pols_to_keep,
                 multidim_index=True,
-                use_future_array_shapes=future_shapes,
             )
-            uvh5_uv4.read(testfile, use_future_array_shapes=future_shapes)
+            uvh5_uv4.read(testfile)
             uvh5_uv4.select(
                 blt_inds=blts_to_keep,
                 freq_chans=chans_to_keep,
@@ -871,19 +825,14 @@ def test_uvh5_partial_read_multi2(casa_uvfits, future_shapes, tmp_path):
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected frequencies are not evenly spaced")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_read_multi3(casa_uvfits, future_shapes, tmp_path):
+@pytest.mark.parametrize("old_shapes", [True, False])
+def test_uvh5_partial_read_multi3(casa_uvfits, old_shapes, tmp_path):
     """
     Test select-on-read for multiple axes, polarizations being smallest fraction.
     """
     uv_in = casa_uvfits
-    if not future_shapes:
-        uv_in.use_current_array_shapes()
-
     uvh5_uv = UVData()
     uvh5_uv2 = UVData()
     testfile = str(tmp_path / "outtest.uvh5")
@@ -891,10 +840,10 @@ def test_uvh5_partial_read_multi3(casa_uvfits, future_shapes, tmp_path):
     uv_in.telescope.name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
 
-    if not future_shapes:
+    if old_shapes:
         make_old_shapes(testfile)
 
-    uvh5_uv.read(testfile, use_future_array_shapes=future_shapes)
+    uvh5_uv.read(testfile)
 
     # now test selecting on multiple axes
     # read polarizations first
@@ -906,9 +855,8 @@ def test_uvh5_partial_read_multi3(casa_uvfits, future_shapes, tmp_path):
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
-        use_future_array_shapes=future_shapes,
     )
-    uvh5_uv2.read(testfile, use_future_array_shapes=future_shapes)
+    uvh5_uv2.read(testfile)
     uvh5_uv2.select(
         antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
     )
@@ -930,9 +878,8 @@ def test_uvh5_partial_read_multi3(casa_uvfits, future_shapes, tmp_path):
                 freq_chans=chans_to_keep,
                 polarizations=pols_to_keep,
                 multidim_index=True,
-                use_future_array_shapes=future_shapes,
             )
-            uvh5_uv4.read(testfile, use_future_array_shapes=future_shapes)
+            uvh5_uv4.read(testfile)
             uvh5_uv4.select(
                 blt_inds=blts_to_keep,
                 freq_chans=chans_to_keep,
@@ -946,37 +893,27 @@ def test_uvh5_partial_read_multi3(casa_uvfits, future_shapes, tmp_path):
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Selected frequencies are not evenly spaced")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_read_multdim_index(tmp_path, future_shapes, casa_uvfits):
+def test_uvh5_read_multdim_index(tmp_path, casa_uvfits):
     """
     Test some odd cases for UVH5 multdim indexing
     """
     uv_in = casa_uvfits
-    if not future_shapes:
-        uv_in.use_current_array_shapes()
 
     testfile = str(tmp_path / "outtest.uvh5")
     # change telescope name to avoid errors
     uv_in.telescope.name = "PAPER"
     uv_in.write_uvh5(testfile, clobber=True)
     uvh5_uv = UVData()
-    uvh5_uv.read(testfile, use_future_array_shapes=future_shapes)
+    uvh5_uv.read(testfile)
 
     # check that non sliceable multidim index is caught
     # and does not fail
     ants_to_keep = np.array([1, 20, 12, 25, 4, 24, 2, 21, 22])
     chans_to_keep = [15, 17, 20]
     uvh5_uv = UVData()
-    uvh5_uv.read(
-        testfile,
-        antenna_nums=ants_to_keep,
-        freq_chans=chans_to_keep,
-        use_future_array_shapes=future_shapes,
-    )
+    uvh5_uv.read(testfile, antenna_nums=ants_to_keep, freq_chans=chans_to_keep)
 
     # clean up
     os.remove(testfile)
@@ -984,17 +921,12 @@ def test_uvh5_read_multdim_index(tmp_path, future_shapes, casa_uvfits):
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_write_antpairs(uv_partial_write, future_shapes, tmp_path):
+def test_uvh5_partial_write_antpairs(uv_partial_write, tmp_path):
     """
     Test writing an entire UVH5 file in pieces by antpairs.
     """
     full_uvh5 = uv_partial_write
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     # delete data arrays in partial file
     partial_uvh5 = full_uvh5.copy()
@@ -1020,7 +952,7 @@ def test_uvh5_partial_write_antpairs(uv_partial_write, future_shapes, tmp_path):
             bls=key,
         )
     # now read in the full file and make sure that it matches the original
-    partial_uvh5.read(partial_testfile, use_future_array_shapes=future_shapes)
+    partial_uvh5.read(partial_testfile)
 
     # make sure filename is what we expect
     assert full_uvh5.filename == ["outtest.uvh5"]
@@ -1051,17 +983,12 @@ def test_uvh5_partial_write_antpairs(uv_partial_write, future_shapes, tmp_path):
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_write_frequencies(uv_partial_write, future_shapes, tmp_path):
+def test_uvh5_partial_write_frequencies(uv_partial_write, tmp_path):
     """
     Test writing an entire UVH5 file in pieces by frequencies.
     """
     full_uvh5 = uv_partial_write
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     # start over, and write frequencies
     partial_uvh5 = full_uvh5.copy()
@@ -1077,14 +1004,9 @@ def test_uvh5_partial_write_frequencies(uv_partial_write, future_shapes, tmp_pat
     Hfreqs = Nfreqs // 2
     freqs1 = np.arange(Hfreqs)
     freqs2 = np.arange(Hfreqs, Nfreqs)
-    if future_shapes:
-        data = full_uvh5.data_array[:, freqs1, :]
-        flags = full_uvh5.flag_array[:, freqs1, :]
-        nsamples = full_uvh5.nsample_array[:, freqs1, :]
-    else:
-        data = full_uvh5.data_array[:, :, freqs1, :]
-        flags = full_uvh5.flag_array[:, :, freqs1, :]
-        nsamples = full_uvh5.nsample_array[:, :, freqs1, :]
+    data = full_uvh5.data_array[:, freqs1, :]
+    flags = full_uvh5.flag_array[:, freqs1, :]
+    nsamples = full_uvh5.nsample_array[:, freqs1, :]
     partial_uvh5.write_uvh5_part(
         partial_testfile,
         data_array=data,
@@ -1092,14 +1014,9 @@ def test_uvh5_partial_write_frequencies(uv_partial_write, future_shapes, tmp_pat
         nsample_array=nsamples,
         freq_chans=freqs1,
     )
-    if future_shapes:
-        data = full_uvh5.data_array[:, freqs2, :]
-        flags = full_uvh5.flag_array[:, freqs2, :]
-        nsamples = full_uvh5.nsample_array[:, freqs2, :]
-    else:
-        data = full_uvh5.data_array[:, :, freqs2, :]
-        flags = full_uvh5.flag_array[:, :, freqs2, :]
-        nsamples = full_uvh5.nsample_array[:, :, freqs2, :]
+    data = full_uvh5.data_array[:, freqs2, :]
+    flags = full_uvh5.flag_array[:, freqs2, :]
+    nsamples = full_uvh5.nsample_array[:, freqs2, :]
     partial_uvh5.write_uvh5_part(
         partial_testfile,
         data_array=data,
@@ -1109,7 +1026,7 @@ def test_uvh5_partial_write_frequencies(uv_partial_write, future_shapes, tmp_pat
     )
 
     # read in the full file and make sure it matches
-    partial_uvh5.read(partial_testfile, use_future_array_shapes=future_shapes)
+    partial_uvh5.read(partial_testfile)
 
     # make sure filenames match what we expect
     assert full_uvh5.filename == ["outtest.uvh5"]
@@ -1124,17 +1041,12 @@ def test_uvh5_partial_write_frequencies(uv_partial_write, future_shapes, tmp_pat
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_write_blts(uv_partial_write, future_shapes, tmp_path):
+def test_uvh5_partial_write_blts(uv_partial_write, tmp_path):
     """
     Test writing an entire UVH5 file in pieces by blt.
     """
     full_uvh5 = uv_partial_write
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     # start over, write chunks of blts
     partial_uvh5 = full_uvh5.copy()
@@ -1172,7 +1084,7 @@ def test_uvh5_partial_write_blts(uv_partial_write, future_shapes, tmp_path):
     )
 
     # read in the full file and make sure it matches
-    partial_uvh5.read(partial_testfile, use_future_array_shapes=future_shapes)
+    partial_uvh5.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert full_uvh5.filename == ["outtest.uvh5"]
@@ -1187,17 +1099,12 @@ def test_uvh5_partial_write_blts(uv_partial_write, future_shapes, tmp_path):
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_write_pols(uv_partial_write, future_shapes, tmp_path):
+def test_uvh5_partial_write_pols(uv_partial_write, tmp_path):
     """
     Test writing an entire UVH5 file in pieces by pol.
     """
     full_uvh5 = uv_partial_write
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     # start over, write groups of pols
     partial_uvh5 = full_uvh5.copy()
@@ -1213,14 +1120,9 @@ def test_uvh5_partial_write_pols(uv_partial_write, future_shapes, tmp_path):
     Hpols = Npols // 2
     pols1 = np.arange(Hpols)
     pols2 = np.arange(Hpols, Npols)
-    if future_shapes:
-        data = full_uvh5.data_array[:, :, pols1]
-        flags = full_uvh5.flag_array[:, :, pols1]
-        nsamples = full_uvh5.nsample_array[:, :, pols1]
-    else:
-        data = full_uvh5.data_array[:, :, :, pols1]
-        flags = full_uvh5.flag_array[:, :, :, pols1]
-        nsamples = full_uvh5.nsample_array[:, :, :, pols1]
+    data = full_uvh5.data_array[:, :, pols1]
+    flags = full_uvh5.flag_array[:, :, pols1]
+    nsamples = full_uvh5.nsample_array[:, :, pols1]
     partial_uvh5.write_uvh5_part(
         partial_testfile,
         data_array=data,
@@ -1228,14 +1130,9 @@ def test_uvh5_partial_write_pols(uv_partial_write, future_shapes, tmp_path):
         nsample_array=nsamples,
         polarizations=full_uvh5.polarization_array[:Hpols],
     )
-    if future_shapes:
-        data = full_uvh5.data_array[:, :, pols2]
-        flags = full_uvh5.flag_array[:, :, pols2]
-        nsamples = full_uvh5.nsample_array[:, :, pols2]
-    else:
-        data = full_uvh5.data_array[:, :, :, pols2]
-        flags = full_uvh5.flag_array[:, :, :, pols2]
-        nsamples = full_uvh5.nsample_array[:, :, :, pols2]
+    data = full_uvh5.data_array[:, :, pols2]
+    flags = full_uvh5.flag_array[:, :, pols2]
+    nsamples = full_uvh5.nsample_array[:, :, pols2]
     partial_uvh5.write_uvh5_part(
         partial_testfile,
         data_array=data,
@@ -1245,7 +1142,7 @@ def test_uvh5_partial_write_pols(uv_partial_write, future_shapes, tmp_path):
     )
 
     # read in the full file and make sure it matches
-    partial_uvh5.read(partial_testfile, use_future_array_shapes=future_shapes)
+    partial_uvh5.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert full_uvh5.filename == ["outtest.uvh5"]
@@ -1305,7 +1202,7 @@ def test_uvh5_partial_write_irregular_blt(uv_partial_write, tmp_path):
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=True)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1365,7 +1262,7 @@ def test_uvh5_partial_write_irregular_freq(uv_partial_write, tmp_path):
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=True)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1425,7 +1322,7 @@ def test_uvh5_partial_write_irregular_pol(uv_partial_write, tmp_path):
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=True)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1440,18 +1337,13 @@ def test_uvh5_partial_write_irregular_pol(uv_partial_write, tmp_path):
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_write_irregular_multi1(uv_partial_write, future_shapes, tmp_path):
+def test_uvh5_partial_write_irregular_multi1(uv_partial_write, tmp_path):
     """
     Test writing a uvh5 file using irregular intervals for blts and freqs.
     """
     full_uvh5 = uv_partial_write
     full_uvh5.telescope.name = "PAPER"
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     # delete data arrays in partial file
     partial_uvh5 = full_uvh5.copy()
@@ -1473,25 +1365,15 @@ def test_uvh5_partial_write_irregular_multi1(uv_partial_write, future_shapes, tm
     # define blts and freqs
     blt_inds = [0, 1, 2, 7]
     freq_inds = [0, 2, 3, 4]
-    if future_shapes:
-        data_shape = (len(blt_inds), len(freq_inds), full_uvh5.Npols)
-    else:
-        data_shape = (len(blt_inds), 1, len(freq_inds), full_uvh5.Npols)
+    data_shape = (len(blt_inds), len(freq_inds), full_uvh5.Npols)
     data = np.zeros(data_shape, dtype=np.complex64)
     flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for iblt, blt_idx in enumerate(blt_inds):
         for ifreq, freq_idx in enumerate(freq_inds):
-            if future_shapes:
-                data[iblt, ifreq, :] = full_uvh5.data_array[blt_idx, freq_idx, :]
-                flags[iblt, ifreq, :] = full_uvh5.flag_array[blt_idx, freq_idx, :]
-                nsamples[iblt, ifreq, :] = full_uvh5.nsample_array[blt_idx, freq_idx, :]
-            else:
-                data[iblt, :, ifreq, :] = full_uvh5.data_array[blt_idx, :, freq_idx, :]
-                flags[iblt, :, ifreq, :] = full_uvh5.flag_array[blt_idx, :, freq_idx, :]
-                nsamples[iblt, :, ifreq, :] = full_uvh5.nsample_array[
-                    blt_idx, :, freq_idx, :
-                ]
+            data[iblt, ifreq, :] = full_uvh5.data_array[blt_idx, freq_idx, :]
+            flags[iblt, ifreq, :] = full_uvh5.flag_array[blt_idx, freq_idx, :]
+            nsamples[iblt, ifreq, :] = full_uvh5.nsample_array[blt_idx, freq_idx, :]
     with uvtest.check_warnings(
         UserWarning, "Selected frequencies are not evenly spaced"
     ):
@@ -1507,26 +1389,13 @@ def test_uvh5_partial_write_irregular_multi1(uv_partial_write, future_shapes, tm
     # also write the arrays to the partial object
     for iblt, blt_idx in enumerate(blt_inds):
         for ifreq, freq_idx in enumerate(freq_inds):
-            if future_shapes:
-                partial_uvh5.data_array[blt_idx, freq_idx, :] = data[iblt, ifreq, :]
-                partial_uvh5.flag_array[blt_idx, freq_idx, :] = flags[iblt, ifreq, :]
-                partial_uvh5.nsample_array[blt_idx, freq_idx, :] = nsamples[
-                    iblt, ifreq, :
-                ]
-            else:
-                partial_uvh5.data_array[blt_idx, :, freq_idx, :] = data[
-                    iblt, :, ifreq, :
-                ]
-                partial_uvh5.flag_array[blt_idx, :, freq_idx, :] = flags[
-                    iblt, :, ifreq, :
-                ]
-                partial_uvh5.nsample_array[blt_idx, :, freq_idx, :] = nsamples[
-                    iblt, :, ifreq, :
-                ]
+            partial_uvh5.data_array[blt_idx, freq_idx, :] = data[iblt, ifreq, :]
+            partial_uvh5.flag_array[blt_idx, freq_idx, :] = flags[iblt, ifreq, :]
+            partial_uvh5.nsample_array[blt_idx, freq_idx, :] = nsamples[iblt, ifreq, :]
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1541,18 +1410,13 @@ def test_uvh5_partial_write_irregular_multi1(uv_partial_write, future_shapes, tm
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_write_irregular_multi2(uv_partial_write, future_shapes, tmp_path):
+def test_uvh5_partial_write_irregular_multi2(uv_partial_write, tmp_path):
     """
     Test writing a uvh5 file using irregular intervals for freqs and pols.
     """
     full_uvh5 = uv_partial_write
     full_uvh5.telescope.name = "PAPER"
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     # delete data arrays in partial file
     partial_uvh5 = full_uvh5.copy()
@@ -1574,25 +1438,15 @@ def test_uvh5_partial_write_irregular_multi2(uv_partial_write, future_shapes, tm
     # define freqs and pols
     freq_inds = [0, 1, 2, 7]
     pol_inds = [0, 1, 3]
-    if future_shapes:
-        data_shape = (full_uvh5.Nblts, len(freq_inds), len(pol_inds))
-    else:
-        data_shape = (full_uvh5.Nblts, 1, len(freq_inds), len(pol_inds))
+    data_shape = (full_uvh5.Nblts, len(freq_inds), len(pol_inds))
     data = np.zeros(data_shape, dtype=np.complex64)
     flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for ifreq, freq_idx in enumerate(freq_inds):
         for ipol, pol_idx in enumerate(pol_inds):
-            if future_shapes:
-                data[:, ifreq, ipol] = full_uvh5.data_array[:, freq_idx, pol_idx]
-                flags[:, ifreq, ipol] = full_uvh5.flag_array[:, freq_idx, pol_idx]
-                nsamples[:, ifreq, ipol] = full_uvh5.nsample_array[:, freq_idx, pol_idx]
-            else:
-                data[:, :, ifreq, ipol] = full_uvh5.data_array[:, :, freq_idx, pol_idx]
-                flags[:, :, ifreq, ipol] = full_uvh5.flag_array[:, :, freq_idx, pol_idx]
-                nsamples[:, :, ifreq, ipol] = full_uvh5.nsample_array[
-                    :, :, freq_idx, pol_idx
-                ]
+            data[:, ifreq, ipol] = full_uvh5.data_array[:, freq_idx, pol_idx]
+            flags[:, ifreq, ipol] = full_uvh5.flag_array[:, freq_idx, pol_idx]
+            nsamples[:, ifreq, ipol] = full_uvh5.nsample_array[:, freq_idx, pol_idx]
     with uvtest.check_warnings(
         UserWarning,
         [
@@ -1612,26 +1466,13 @@ def test_uvh5_partial_write_irregular_multi2(uv_partial_write, future_shapes, tm
     # also write the arrays to the partial object
     for ifreq, freq_idx in enumerate(freq_inds):
         for ipol, pol_idx in enumerate(pol_inds):
-            if future_shapes:
-                partial_uvh5.data_array[:, freq_idx, pol_idx] = data[:, ifreq, ipol]
-                partial_uvh5.flag_array[:, freq_idx, pol_idx] = flags[:, ifreq, ipol]
-                partial_uvh5.nsample_array[:, freq_idx, pol_idx] = nsamples[
-                    :, ifreq, ipol
-                ]
-            else:
-                partial_uvh5.data_array[:, :, freq_idx, pol_idx] = data[
-                    :, :, ifreq, ipol
-                ]
-                partial_uvh5.flag_array[:, :, freq_idx, pol_idx] = flags[
-                    :, :, ifreq, ipol
-                ]
-                partial_uvh5.nsample_array[:, :, freq_idx, pol_idx] = nsamples[
-                    :, :, ifreq, ipol
-                ]
+            partial_uvh5.data_array[:, freq_idx, pol_idx] = data[:, ifreq, ipol]
+            partial_uvh5.flag_array[:, freq_idx, pol_idx] = flags[:, ifreq, ipol]
+            partial_uvh5.nsample_array[:, freq_idx, pol_idx] = nsamples[:, ifreq, ipol]
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1646,18 +1487,13 @@ def test_uvh5_partial_write_irregular_multi2(uv_partial_write, future_shapes, tm
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_write_irregular_multi3(uv_partial_write, future_shapes, tmp_path):
+def test_uvh5_partial_write_irregular_multi3(uv_partial_write, tmp_path):
     """
     Test writing a uvh5 file using irregular intervals for blts and pols.
     """
     full_uvh5 = uv_partial_write
     full_uvh5.telescope.name = "PAPER"
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     # delete data arrays in partial file
     partial_uvh5 = full_uvh5.copy()
@@ -1679,25 +1515,15 @@ def test_uvh5_partial_write_irregular_multi3(uv_partial_write, future_shapes, tm
     # define blts and freqs
     blt_inds = [0, 1, 2, 7]
     pol_inds = [0, 1, 3]
-    if future_shapes:
-        data_shape = (len(blt_inds), full_uvh5.Nfreqs, len(pol_inds))
-    else:
-        data_shape = (len(blt_inds), 1, full_uvh5.Nfreqs, len(pol_inds))
+    data_shape = (len(blt_inds), full_uvh5.Nfreqs, len(pol_inds))
     data = np.zeros(data_shape, dtype=np.complex64)
     flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for iblt, blt_idx in enumerate(blt_inds):
         for ipol, pol_idx in enumerate(pol_inds):
-            if future_shapes:
-                data[iblt, :, ipol] = full_uvh5.data_array[blt_idx, :, pol_idx]
-                flags[iblt, :, ipol] = full_uvh5.flag_array[blt_idx, :, pol_idx]
-                nsamples[iblt, :, ipol] = full_uvh5.nsample_array[blt_idx, :, pol_idx]
-            else:
-                data[iblt, :, :, ipol] = full_uvh5.data_array[blt_idx, :, :, pol_idx]
-                flags[iblt, :, :, ipol] = full_uvh5.flag_array[blt_idx, :, :, pol_idx]
-                nsamples[iblt, :, :, ipol] = full_uvh5.nsample_array[
-                    blt_idx, :, :, pol_idx
-                ]
+            data[iblt, :, ipol] = full_uvh5.data_array[blt_idx, :, pol_idx]
+            flags[iblt, :, ipol] = full_uvh5.flag_array[blt_idx, :, pol_idx]
+            nsamples[iblt, :, ipol] = full_uvh5.nsample_array[blt_idx, :, pol_idx]
     with uvtest.check_warnings(
         UserWarning, "Selected polarization values are not evenly spaced"
     ):
@@ -1713,24 +1539,13 @@ def test_uvh5_partial_write_irregular_multi3(uv_partial_write, future_shapes, tm
     # also write the arrays to the partial object
     for iblt, blt_idx in enumerate(blt_inds):
         for ipol, pol_idx in enumerate(pol_inds):
-            if future_shapes:
-                partial_uvh5.data_array[blt_idx, :, pol_idx] = data[iblt, :, ipol]
-                partial_uvh5.flag_array[blt_idx, :, pol_idx] = flags[iblt, :, ipol]
-                partial_uvh5.nsample_array[blt_idx, :, pol_idx] = nsamples[
-                    iblt, :, ipol
-                ]
-            else:
-                partial_uvh5.data_array[blt_idx, :, :, pol_idx] = data[iblt, :, :, ipol]
-                partial_uvh5.flag_array[blt_idx, :, :, pol_idx] = flags[
-                    iblt, :, :, ipol
-                ]
-                partial_uvh5.nsample_array[blt_idx, :, :, pol_idx] = nsamples[
-                    iblt, :, :, ipol
-                ]
+            partial_uvh5.data_array[blt_idx, :, pol_idx] = data[iblt, :, ipol]
+            partial_uvh5.flag_array[blt_idx, :, pol_idx] = flags[iblt, :, ipol]
+            partial_uvh5.nsample_array[blt_idx, :, pol_idx] = nsamples[iblt, :, ipol]
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1742,18 +1557,13 @@ def test_uvh5_partial_write_irregular_multi3(uv_partial_write, future_shapes, tm
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_write_irregular_multi4(uv_partial_write, future_shapes, tmp_path):
+def test_uvh5_partial_write_irregular_multi4(uv_partial_write, tmp_path):
     """
     Test writing a uvh5 file using irregular intervals for all axes.
     """
     full_uvh5 = uv_partial_write
     full_uvh5.telescope.name = "PAPER"
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     # delete data arrays in partial file
     partial_uvh5 = full_uvh5.copy()
@@ -1776,36 +1586,22 @@ def test_uvh5_partial_write_irregular_multi4(uv_partial_write, future_shapes, tm
     blt_inds = [0, 1, 2, 7]
     freq_inds = [0, 2, 3, 4]
     pol_inds = [0, 1, 3]
-    if future_shapes:
-        data_shape = (len(blt_inds), len(freq_inds), len(pol_inds))
-    else:
-        data_shape = (len(blt_inds), 1, len(freq_inds), len(pol_inds))
+    data_shape = (len(blt_inds), len(freq_inds), len(pol_inds))
     data = np.zeros(data_shape, dtype=np.complex64)
     flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for iblt, blt_idx in enumerate(blt_inds):
         for ifreq, freq_idx in enumerate(freq_inds):
             for ipol, pol_idx in enumerate(pol_inds):
-                if future_shapes:
-                    data[iblt, ifreq, ipol] = full_uvh5.data_array[
-                        blt_idx, freq_idx, pol_idx
-                    ]
-                    flags[iblt, ifreq, ipol] = full_uvh5.flag_array[
-                        blt_idx, freq_idx, pol_idx
-                    ]
-                    nsamples[iblt, ifreq, ipol] = full_uvh5.nsample_array[
-                        blt_idx, freq_idx, pol_idx
-                    ]
-                else:
-                    data[iblt, :, ifreq, ipol] = full_uvh5.data_array[
-                        blt_idx, :, freq_idx, pol_idx
-                    ]
-                    flags[iblt, :, ifreq, ipol] = full_uvh5.flag_array[
-                        blt_idx, :, freq_idx, pol_idx
-                    ]
-                    nsamples[iblt, :, ifreq, ipol] = full_uvh5.nsample_array[
-                        blt_idx, :, freq_idx, pol_idx
-                    ]
+                data[iblt, ifreq, ipol] = full_uvh5.data_array[
+                    blt_idx, freq_idx, pol_idx
+                ]
+                flags[iblt, ifreq, ipol] = full_uvh5.flag_array[
+                    blt_idx, freq_idx, pol_idx
+                ]
+                nsamples[iblt, ifreq, ipol] = full_uvh5.nsample_array[
+                    blt_idx, freq_idx, pol_idx
+                ]
     with uvtest.check_warnings(
         UserWarning,
         [
@@ -1827,30 +1623,19 @@ def test_uvh5_partial_write_irregular_multi4(uv_partial_write, future_shapes, tm
     for iblt, blt_idx in enumerate(blt_inds):
         for ifreq, freq_idx in enumerate(freq_inds):
             for ipol, pol_idx in enumerate(pol_inds):
-                if future_shapes:
-                    partial_uvh5.data_array[blt_idx, freq_idx, pol_idx] = data[
-                        iblt, ifreq, ipol
-                    ]
-                    partial_uvh5.flag_array[blt_idx, freq_idx, pol_idx] = flags[
-                        iblt, ifreq, ipol
-                    ]
-                    partial_uvh5.nsample_array[blt_idx, freq_idx, pol_idx] = nsamples[
-                        iblt, ifreq, ipol
-                    ]
-                else:
-                    partial_uvh5.data_array[blt_idx, :, freq_idx, pol_idx] = data[
-                        iblt, :, ifreq, ipol
-                    ]
-                    partial_uvh5.flag_array[blt_idx, :, freq_idx, pol_idx] = flags[
-                        iblt, :, ifreq, ipol
-                    ]
-                    partial_uvh5.nsample_array[blt_idx, :, freq_idx, pol_idx] = (
-                        nsamples[iblt, :, ifreq, ipol]
-                    )
+                partial_uvh5.data_array[blt_idx, freq_idx, pol_idx] = data[
+                    iblt, ifreq, ipol
+                ]
+                partial_uvh5.flag_array[blt_idx, freq_idx, pol_idx] = flags[
+                    iblt, ifreq, ipol
+                ]
+                partial_uvh5.nsample_array[blt_idx, freq_idx, pol_idx] = nsamples[
+                    iblt, ifreq, ipol
+                ]
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -1958,17 +1743,12 @@ def test_uvh5_partial_write_errors(uv_partial_write, tmp_path):
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_initialize_uvh5_file(uv_partial_write, future_shapes, tmp_path):
+def test_initialize_uvh5_file(uv_partial_write, tmp_path):
     """
     Test initializing a UVH5 file on disk.
     """
     full_uvh5 = uv_partial_write
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     full_uvh5.data_array = None
     full_uvh5.flag_array = None
@@ -1980,9 +1760,7 @@ def test_initialize_uvh5_file(uv_partial_write, future_shapes, tmp_path):
     partial_uvh5.initialize_uvh5_file(partial_testfile, clobber=True)
 
     # read it in and make sure that the metadata matches the original
-    partial_uvh5.read(
-        partial_testfile, read_data=False, use_future_array_shapes=future_shapes
-    )
+    partial_uvh5.read(partial_testfile, read_data=False)
 
     # make sure filenames are what we expect
     assert partial_uvh5.filename == ["outtest_partial.uvh5"]
@@ -2047,7 +1825,7 @@ def test_initialize_uvh5_file_compression_opts(uv_partial_write, tmp_path):
         flags_compression=None,
         nsample_compression=None,
     )
-    partial_uvh5.read(partial_testfile, read_data=False, use_future_array_shapes=True)
+    partial_uvh5.read(partial_testfile, read_data=False)
 
     # make sure filenames are what we expect
     assert partial_uvh5.filename == ["outtest_partial.uvh5"]
@@ -2076,7 +1854,7 @@ def test_uvh5_lst_array(casa_uvfits, tmp_path):
     # remove lst_array from file; check that it's correctly computed on read
     with h5py.File(testfile, "r+") as h5f:
         del h5f["/Header/lst_array"]
-    uv_out.read_uvh5(testfile, use_future_array_shapes=True)
+    uv_out.read_uvh5(testfile)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["day2_TDEM0003_10s_norx_1src_1spw.uvfits"]
@@ -2103,7 +1881,7 @@ def test_uvh5_lst_array(casa_uvfits, tmp_path):
         ]
         * 2,
     ):
-        uv_out.read_uvh5(testfile, use_future_array_shapes=True)
+        uv_out.read_uvh5(testfile)
     uv_out.lst_array = lst_array
     assert uv_in == uv_out
 
@@ -2137,7 +1915,7 @@ def test_uvh5_read_header_special_cases(casa_uvfits, tmp_path):
             "The uvw_array does not match the expected values",
         ],
     ):
-        uv_out.read_uvh5(testfile, use_future_array_shapes=True)
+        uv_out.read_uvh5(testfile)
 
     # make input and output values match now
     uv_in.history = uv_out.history
@@ -2170,7 +1948,7 @@ def test_uvh5_read_ints(uv_uvh5, tmp_path):
     uv_in.write_uvh5(testfile, clobber=True)
 
     # read it back in to make sure data is the same
-    uv_out.read(testfile, use_future_array_shapes=True)
+    uv_out.read(testfile)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["zen.2458432.34569.uvh5"]
@@ -2181,9 +1959,7 @@ def test_uvh5_read_ints(uv_uvh5, tmp_path):
 
     # now read in as np.complex128
     uvh5_filename = os.path.join(DATA_PATH, "zen.2458432.34569.uvh5")
-    uv_in.read_uvh5(
-        uvh5_filename, data_array_dtype=np.complex128, use_future_array_shapes=True
-    )
+    uv_in.read_uvh5(uvh5_filename, data_array_dtype=np.complex128)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["zen.2458432.34569.uvh5"]
@@ -2210,30 +1986,22 @@ def test_uvh5_read_ints_error():
     with pytest.raises(
         ValueError, match="data_array_dtype must be np.complex64 or np.complex128"
     ):
-        uv_in.read_uvh5(
-            uvh5_filename, data_array_dtype=np.int32, use_future_array_shapes=True
-        )
+        uv_in.read_uvh5(uvh5_filename, data_array_dtype=np.int32)
 
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_write_ints(uv_uvh5, future_shapes, tmp_path):
+def test_uvh5_write_ints(uv_uvh5, tmp_path):
     """
     Test writing visibility data as integers.
     """
     uv_in = uv_uvh5
-    if not future_shapes:
-        uv_in.use_current_array_shapes()
-
     uv_out = UVData()
     testfile = str(tmp_path / "outtest.uvh5")
     uv_in.write_uvh5(testfile, clobber=True, data_write_dtype=uvh5._hera_corr_dtype)
 
     # read it back in to make sure data is the same
-    uv_out.read(testfile, use_future_array_shapes=future_shapes)
+    uv_out.read(testfile)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["zen.2458432.34569.uvh5"]
@@ -2269,8 +2037,8 @@ def test_uvh5_partial_read_ints_antennas():
 
     # select on antennas
     ants_to_keep = np.array([0, 1])
-    uvh5_uv.read(uvh5_file, antenna_nums=ants_to_keep, use_future_array_shapes=True)
-    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
+    uvh5_uv.read(uvh5_file, antenna_nums=ants_to_keep)
+    uvh5_uv2.read(uvh5_file)
     uvh5_uv2.select(antenna_nums=ants_to_keep)
     assert uvh5_uv == uvh5_uv2
 
@@ -2290,8 +2058,8 @@ def test_uvh5_partial_read_ints_freqs():
 
     # select on frequency channels
     chans_to_keep = np.arange(12, 22)
-    uvh5_uv.read(uvh5_file, freq_chans=chans_to_keep, use_future_array_shapes=True)
-    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
+    uvh5_uv.read(uvh5_file, freq_chans=chans_to_keep)
+    uvh5_uv2.read(uvh5_file)
     uvh5_uv2.select(freq_chans=chans_to_keep)
     assert uvh5_uv == uvh5_uv2
 
@@ -2311,8 +2079,8 @@ def test_uvh5_partial_read_ints_pols():
 
     # select on pols
     pols_to_keep = [-5, -6]
-    uvh5_uv.read(uvh5_file, polarizations=pols_to_keep, use_future_array_shapes=True)
-    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
+    uvh5_uv.read(uvh5_file, polarizations=pols_to_keep)
+    uvh5_uv2.read(uvh5_file)
     uvh5_uv2.select(polarizations=pols_to_keep)
     assert uvh5_uv == uvh5_uv2
 
@@ -2331,14 +2099,10 @@ def test_uvh5_partial_read_ints_times():
     # which breaks the phasing when trying to check if the uvws match the antpos.
 
     # select on read using time_range
-    uvh5_uv.read_uvh5(uvh5_file, read_data=False, use_future_array_shapes=True)
+    uvh5_uv.read_uvh5(uvh5_file, read_data=False)
     unique_times = np.unique(uvh5_uv.time_array)
-    uvh5_uv.read(
-        uvh5_file,
-        time_range=[unique_times[0], unique_times[1]],
-        use_future_array_shapes=True,
-    )
-    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
+    uvh5_uv.read(uvh5_file, time_range=[unique_times[0], unique_times[1]])
+    uvh5_uv2.read(uvh5_file)
     uvh5_uv2.select(times=unique_times[0:2])
     assert uvh5_uv == uvh5_uv2
 
@@ -2365,9 +2129,8 @@ def test_uvh5_partial_read_ints_multi1():
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
-        use_future_array_shapes=True,
     )
-    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
+    uvh5_uv2.read(uvh5_file)
     uvh5_uv2.select(
         antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
     )
@@ -2396,9 +2159,8 @@ def test_uvh5_partial_read_ints_multi2():
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
-        use_future_array_shapes=True,
     )
-    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
+    uvh5_uv2.read(uvh5_file)
     uvh5_uv2.select(
         antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
     )
@@ -2427,9 +2189,8 @@ def test_uvh5_partial_read_ints_multi3():
         antenna_nums=ants_to_keep,
         freq_chans=chans_to_keep,
         polarizations=pols_to_keep,
-        use_future_array_shapes=True,
     )
-    uvh5_uv2.read(uvh5_file, use_future_array_shapes=True)
+    uvh5_uv2.read(uvh5_file)
     uvh5_uv2.select(
         antenna_nums=ants_to_keep, freq_chans=chans_to_keep, polarizations=pols_to_keep
     )
@@ -2471,7 +2232,7 @@ def test_uvh5_partial_write_ints_antpairs(uv_uvh5, tmp_path):
         )
 
     # now read in the full file and make sure that it matches the original
-    partial_uvh5.read(partial_testfile, use_future_array_shapes=True)
+    partial_uvh5.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert full_uvh5.filename == ["zen.2458432.34569.uvh5"]
@@ -2531,7 +2292,7 @@ def test_uvh5_partial_write_ints_frequencies(uv_uvh5, tmp_path):
     )
 
     # read in the full file and make sure it matches
-    partial_uvh5.read(partial_testfile, use_future_array_shapes=True)
+    partial_uvh5.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert full_uvh5.filename == ["zen.2458432.34569.uvh5"]
@@ -2591,7 +2352,7 @@ def test_uvh5_partial_write_ints_blts(uv_uvh5, tmp_path):
     )
 
     # read in the full file and make sure it matches
-    partial_uvh5.read(partial_testfile, use_future_array_shapes=True)
+    partial_uvh5.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert full_uvh5.filename == ["zen.2458432.34569.uvh5"]
@@ -2651,7 +2412,7 @@ def test_uvh5_partial_write_ints_pols(uv_uvh5, tmp_path):
     )
 
     # read in the full file and make sure it matches
-    partial_uvh5.read(partial_testfile, use_future_array_shapes=True)
+    partial_uvh5.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert full_uvh5.filename == ["zen.2458432.34569.uvh5"]
@@ -2814,7 +2575,7 @@ def test_uvh5_partial_write_ints_irregular_blt(uv_uvh5, tmp_path):
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=True)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -2871,7 +2632,7 @@ def test_uvh5_partial_write_ints_irregular_freq(uv_uvh5, tmp_path):
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=True)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -2928,7 +2689,7 @@ def test_uvh5_partial_write_ints_irregular_pol(uv_uvh5, tmp_path):
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=True)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -2943,17 +2704,12 @@ def test_uvh5_partial_write_ints_irregular_pol(uv_uvh5, tmp_path):
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, future_shapes, tmp_path):
+def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, tmp_path):
     """
     Test writing a uvh5 file using irregular interval for blt and freq and
     integer dtype.
     """
     full_uvh5 = uv_uvh5
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     partial_uvh5 = full_uvh5.copy()
     partial_uvh5.data_array = None
@@ -2974,25 +2730,15 @@ def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, future_shapes, tmp_pa
     # define blts and freqs
     blt_inds = [0, 1, 2, 7]
     freq_inds = [0, 2, 3, 4]
-    if future_shapes:
-        data_shape = (len(blt_inds), len(freq_inds), full_uvh5.Npols)
-    else:
-        data_shape = (len(blt_inds), 1, len(freq_inds), full_uvh5.Npols)
+    data_shape = (len(blt_inds), len(freq_inds), full_uvh5.Npols)
     data = np.zeros(data_shape, dtype=np.complex64)
     flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for iblt, blt_idx in enumerate(blt_inds):
         for ifreq, freq_idx in enumerate(freq_inds):
-            if future_shapes:
-                data[iblt, ifreq, :] = full_uvh5.data_array[blt_idx, freq_idx, :]
-                flags[iblt, ifreq, :] = full_uvh5.flag_array[blt_idx, freq_idx, :]
-                nsamples[iblt, ifreq, :] = full_uvh5.nsample_array[blt_idx, freq_idx, :]
-            else:
-                data[iblt, :, ifreq, :] = full_uvh5.data_array[blt_idx, :, freq_idx, :]
-                flags[iblt, :, ifreq, :] = full_uvh5.flag_array[blt_idx, :, freq_idx, :]
-                nsamples[iblt, :, ifreq, :] = full_uvh5.nsample_array[
-                    blt_idx, :, freq_idx, :
-                ]
+            data[iblt, ifreq, :] = full_uvh5.data_array[blt_idx, freq_idx, :]
+            flags[iblt, ifreq, :] = full_uvh5.flag_array[blt_idx, freq_idx, :]
+            nsamples[iblt, ifreq, :] = full_uvh5.nsample_array[blt_idx, freq_idx, :]
     with uvtest.check_warnings(
         UserWarning, "Selected frequencies are not evenly spaced"
     ):
@@ -3008,27 +2754,14 @@ def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, future_shapes, tmp_pa
     # also write the arrays to the partial object
     for iblt, blt_idx in enumerate(blt_inds):
         for ifreq, freq_idx in enumerate(freq_inds):
-            if future_shapes:
-                partial_uvh5.data_array[blt_idx, freq_idx, :] = data[iblt, ifreq, :]
-                partial_uvh5.flag_array[blt_idx, freq_idx, :] = flags[iblt, ifreq, :]
-                partial_uvh5.nsample_array[blt_idx, freq_idx, :] = nsamples[
-                    iblt, ifreq, :
-                ]
-            else:
-                partial_uvh5.data_array[blt_idx, :, freq_idx, :] = data[
-                    iblt, :, ifreq, :
-                ]
-                partial_uvh5.flag_array[blt_idx, :, freq_idx, :] = flags[
-                    iblt, :, ifreq, :
-                ]
-                partial_uvh5.nsample_array[blt_idx, :, freq_idx, :] = nsamples[
-                    iblt, :, ifreq, :
-                ]
+            partial_uvh5.data_array[blt_idx, freq_idx, :] = data[iblt, ifreq, :]
+            partial_uvh5.flag_array[blt_idx, freq_idx, :] = flags[iblt, ifreq, :]
+            partial_uvh5.nsample_array[blt_idx, freq_idx, :] = nsamples[iblt, ifreq, :]
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -3043,17 +2776,12 @@ def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, future_shapes, tmp_pa
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, future_shapes, tmp_path):
+def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, tmp_path):
     """
     Test writing a uvh5 file using irregular interval for freq and pol and
     integer dtype.
     """
     full_uvh5 = uv_uvh5
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     partial_uvh5 = full_uvh5.copy()
     partial_uvh5.data_array = None
@@ -3074,25 +2802,15 @@ def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, future_shapes, tmp_pa
     # define freqs and pols
     freq_inds = [0, 1, 2, 7]
     pol_inds = [0, 1, 3]
-    if future_shapes:
-        data_shape = (full_uvh5.Nblts, len(freq_inds), len(pol_inds))
-    else:
-        data_shape = (full_uvh5.Nblts, 1, len(freq_inds), len(pol_inds))
+    data_shape = (full_uvh5.Nblts, len(freq_inds), len(pol_inds))
     data = np.zeros(data_shape, dtype=np.complex64)
     flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for ifreq, freq_idx in enumerate(freq_inds):
         for ipol, pol_idx in enumerate(pol_inds):
-            if future_shapes:
-                data[:, ifreq, ipol] = full_uvh5.data_array[:, freq_idx, pol_idx]
-                flags[:, ifreq, ipol] = full_uvh5.flag_array[:, freq_idx, pol_idx]
-                nsamples[:, ifreq, ipol] = full_uvh5.nsample_array[:, freq_idx, pol_idx]
-            else:
-                data[:, :, ifreq, ipol] = full_uvh5.data_array[:, :, freq_idx, pol_idx]
-                flags[:, :, ifreq, ipol] = full_uvh5.flag_array[:, :, freq_idx, pol_idx]
-                nsamples[:, :, ifreq, ipol] = full_uvh5.nsample_array[
-                    :, :, freq_idx, pol_idx
-                ]
+            data[:, ifreq, ipol] = full_uvh5.data_array[:, freq_idx, pol_idx]
+            flags[:, ifreq, ipol] = full_uvh5.flag_array[:, freq_idx, pol_idx]
+            nsamples[:, ifreq, ipol] = full_uvh5.nsample_array[:, freq_idx, pol_idx]
     with uvtest.check_warnings(
         UserWarning,
         [
@@ -3112,27 +2830,14 @@ def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, future_shapes, tmp_pa
     # also write the arrays to the partial object
     for ifreq, freq_idx in enumerate(freq_inds):
         for ipol, pol_idx in enumerate(pol_inds):
-            if future_shapes:
-                partial_uvh5.data_array[:, freq_idx, pol_idx] = data[:, ifreq, ipol]
-                partial_uvh5.flag_array[:, freq_idx, pol_idx] = flags[:, ifreq, ipol]
-                partial_uvh5.nsample_array[:, freq_idx, pol_idx] = nsamples[
-                    :, ifreq, ipol
-                ]
-            else:
-                partial_uvh5.data_array[:, :, freq_idx, pol_idx] = data[
-                    :, :, ifreq, ipol
-                ]
-                partial_uvh5.flag_array[:, :, freq_idx, pol_idx] = flags[
-                    :, :, ifreq, ipol
-                ]
-                partial_uvh5.nsample_array[:, :, freq_idx, pol_idx] = nsamples[
-                    :, :, ifreq, ipol
-                ]
+            partial_uvh5.data_array[:, freq_idx, pol_idx] = data[:, ifreq, ipol]
+            partial_uvh5.flag_array[:, freq_idx, pol_idx] = flags[:, ifreq, ipol]
+            partial_uvh5.nsample_array[:, freq_idx, pol_idx] = nsamples[:, ifreq, ipol]
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -3147,16 +2852,11 @@ def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, future_shapes, tmp_pa
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_write_ints_irregular_multi3(uv_uvh5, future_shapes, tmp_path):
+def test_uvh5_partial_write_ints_irregular_multi3(uv_uvh5, tmp_path):
     """
     Test writing a uvh5 file using irregular interval for blt and pol and integer dtype.
     """
     full_uvh5 = uv_uvh5
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     partial_uvh5 = full_uvh5.copy()
     partial_uvh5.data_array = None
@@ -3177,25 +2877,15 @@ def test_uvh5_partial_write_ints_irregular_multi3(uv_uvh5, future_shapes, tmp_pa
     # define blts and pols
     blt_inds = [0, 1, 2, 7]
     pol_inds = [0, 1, 3]
-    if future_shapes:
-        data_shape = (len(blt_inds), full_uvh5.Nfreqs, len(pol_inds))
-    else:
-        data_shape = (len(blt_inds), 1, full_uvh5.Nfreqs, len(pol_inds))
+    data_shape = (len(blt_inds), full_uvh5.Nfreqs, len(pol_inds))
     data = np.zeros(data_shape, dtype=np.complex64)
     flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for iblt, blt_idx in enumerate(blt_inds):
         for ipol, pol_idx in enumerate(pol_inds):
-            if future_shapes:
-                data[iblt, :, ipol] = full_uvh5.data_array[blt_idx, :, pol_idx]
-                flags[iblt, :, ipol] = full_uvh5.flag_array[blt_idx, :, pol_idx]
-                nsamples[iblt, :, ipol] = full_uvh5.nsample_array[blt_idx, :, pol_idx]
-            else:
-                data[iblt, :, :, ipol] = full_uvh5.data_array[blt_idx, :, :, pol_idx]
-                flags[iblt, :, :, ipol] = full_uvh5.flag_array[blt_idx, :, :, pol_idx]
-                nsamples[iblt, :, :, ipol] = full_uvh5.nsample_array[
-                    blt_idx, :, :, pol_idx
-                ]
+            data[iblt, :, ipol] = full_uvh5.data_array[blt_idx, :, pol_idx]
+            flags[iblt, :, ipol] = full_uvh5.flag_array[blt_idx, :, pol_idx]
+            nsamples[iblt, :, ipol] = full_uvh5.nsample_array[blt_idx, :, pol_idx]
     with uvtest.check_warnings(
         UserWarning, "Selected polarization values are not evenly spaced"
     ):
@@ -3211,25 +2901,14 @@ def test_uvh5_partial_write_ints_irregular_multi3(uv_uvh5, future_shapes, tmp_pa
     # also write the arrays to the partial object
     for iblt, blt_idx in enumerate(blt_inds):
         for ipol, pol_idx in enumerate(pol_inds):
-            if future_shapes:
-                partial_uvh5.data_array[blt_idx, :, pol_idx] = data[iblt, :, ipol]
-                partial_uvh5.flag_array[blt_idx, :, pol_idx] = flags[iblt, :, ipol]
-                partial_uvh5.nsample_array[blt_idx, :, pol_idx] = nsamples[
-                    iblt, :, ipol
-                ]
-            else:
-                partial_uvh5.data_array[blt_idx, :, :, pol_idx] = data[iblt, :, :, ipol]
-                partial_uvh5.flag_array[blt_idx, :, :, pol_idx] = flags[
-                    iblt, :, :, ipol
-                ]
-                partial_uvh5.nsample_array[blt_idx, :, :, pol_idx] = nsamples[
-                    iblt, :, :, ipol
-                ]
+            partial_uvh5.data_array[blt_idx, :, pol_idx] = data[iblt, :, ipol]
+            partial_uvh5.flag_array[blt_idx, :, pol_idx] = flags[iblt, :, ipol]
+            partial_uvh5.nsample_array[blt_idx, :, pol_idx] = nsamples[iblt, :, ipol]
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -3244,16 +2923,11 @@ def test_uvh5_partial_write_ints_irregular_multi3(uv_uvh5, future_shapes, tmp_pa
     return
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_uvh5_partial_write_ints_irregular_multi4(uv_uvh5, future_shapes, tmp_path):
+def test_uvh5_partial_write_ints_irregular_multi4(uv_uvh5, tmp_path):
     """
     Test writing a uvh5 file using irregular interval for all axes and integer dtype.
     """
     full_uvh5 = uv_uvh5
-    if not future_shapes:
-        full_uvh5.use_current_array_shapes()
 
     partial_uvh5 = full_uvh5.copy()
     partial_uvh5.data_array = None
@@ -3275,36 +2949,22 @@ def test_uvh5_partial_write_ints_irregular_multi4(uv_uvh5, future_shapes, tmp_pa
     blt_inds = [0, 1, 2, 7]
     freq_inds = [0, 2, 3, 4]
     pol_inds = [0, 1, 3]
-    if future_shapes:
-        data_shape = (len(blt_inds), len(freq_inds), len(pol_inds))
-    else:
-        data_shape = (len(blt_inds), 1, len(freq_inds), len(pol_inds))
+    data_shape = (len(blt_inds), len(freq_inds), len(pol_inds))
     data = np.zeros(data_shape, dtype=np.complex64)
     flags = np.zeros(data_shape, dtype=np.bool_)
     nsamples = np.zeros(data_shape, dtype=np.float32)
     for iblt, blt_idx in enumerate(blt_inds):
         for ifreq, freq_idx in enumerate(freq_inds):
             for ipol, pol_idx in enumerate(pol_inds):
-                if future_shapes:
-                    data[iblt, ifreq, ipol] = full_uvh5.data_array[
-                        blt_idx, freq_idx, pol_idx
-                    ]
-                    flags[iblt, ifreq, ipol] = full_uvh5.flag_array[
-                        blt_idx, freq_idx, pol_idx
-                    ]
-                    nsamples[iblt, ifreq, ipol] = full_uvh5.nsample_array[
-                        blt_idx, freq_idx, pol_idx
-                    ]
-                else:
-                    data[iblt, :, ifreq, ipol] = full_uvh5.data_array[
-                        blt_idx, :, freq_idx, pol_idx
-                    ]
-                    flags[iblt, :, ifreq, ipol] = full_uvh5.flag_array[
-                        blt_idx, :, freq_idx, pol_idx
-                    ]
-                    nsamples[iblt, :, ifreq, ipol] = full_uvh5.nsample_array[
-                        blt_idx, :, freq_idx, pol_idx
-                    ]
+                data[iblt, ifreq, ipol] = full_uvh5.data_array[
+                    blt_idx, freq_idx, pol_idx
+                ]
+                flags[iblt, ifreq, ipol] = full_uvh5.flag_array[
+                    blt_idx, freq_idx, pol_idx
+                ]
+                nsamples[iblt, ifreq, ipol] = full_uvh5.nsample_array[
+                    blt_idx, freq_idx, pol_idx
+                ]
     with uvtest.check_warnings(
         UserWarning,
         [
@@ -3326,31 +2986,20 @@ def test_uvh5_partial_write_ints_irregular_multi4(uv_uvh5, future_shapes, tmp_pa
     for iblt, blt_idx in enumerate(blt_inds):
         for ifreq, freq_idx in enumerate(freq_inds):
             for ipol, pol_idx in enumerate(pol_inds):
-                if future_shapes:
-                    partial_uvh5.data_array[blt_idx, freq_idx, pol_idx] = data[
-                        iblt, ifreq, ipol
-                    ]
-                    partial_uvh5.flag_array[blt_idx, freq_idx, pol_idx] = flags[
-                        iblt, ifreq, ipol
-                    ]
-                    partial_uvh5.nsample_array[blt_idx, freq_idx, pol_idx] = nsamples[
-                        iblt, ifreq, ipol
-                    ]
-                else:
-                    partial_uvh5.data_array[blt_idx, :, freq_idx, pol_idx] = data[
-                        iblt, :, ifreq, ipol
-                    ]
-                    partial_uvh5.flag_array[blt_idx, :, freq_idx, pol_idx] = flags[
-                        iblt, :, ifreq, ipol
-                    ]
-                    partial_uvh5.nsample_array[blt_idx, :, freq_idx, pol_idx] = (
-                        nsamples[iblt, :, ifreq, ipol]
-                    )
+                partial_uvh5.data_array[blt_idx, freq_idx, pol_idx] = data[
+                    iblt, ifreq, ipol
+                ]
+                partial_uvh5.flag_array[blt_idx, freq_idx, pol_idx] = flags[
+                    iblt, ifreq, ipol
+                ]
+                partial_uvh5.nsample_array[blt_idx, freq_idx, pol_idx] = nsamples[
+                    iblt, ifreq, ipol
+                ]
 
     # read in the file and make sure it matches
     partial_uvh5_file = UVData()
     # read in the full file and make sure it matches
-    partial_uvh5_file.read(partial_testfile, use_future_array_shapes=future_shapes)
+    partial_uvh5_file.read(partial_testfile)
 
     # make sure filenames are what we expect
     assert partial_uvh5_file.filename == ["outtest_partial.uvh5"]
@@ -3379,7 +3028,7 @@ def test_antenna_names_not_list(casa_uvfits, tmp_path):
     uv_in.telescope.antenna_names = np.array(uv_in.telescope.antenna_names, dtype="U")
 
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile, use_future_array_shapes=True)
+    uv_out.read(testfile)
 
     # recast as list since antenna names should be a list and will be cast as
     # list on read
@@ -3407,7 +3056,7 @@ def test_eq_coeffs_roundtrip(casa_uvfits, tmp_path):
     uv_in.eq_coeffs = np.ones((uv_in.telescope.Nants, uv_in.Nfreqs))
     uv_in.eq_coeffs_convention = "divide"
     uv_in.write_uvh5(testfile, clobber=True)
-    uv_out.read(testfile, use_future_array_shapes=True)
+    uv_out.read(testfile)
 
     # make sure filenames are what we expect
     assert uv_in.filename == ["day2_TDEM0003_10s_norx_1src_1spw.uvfits"]
@@ -3436,7 +3085,7 @@ def test_read_metadata(casa_uvfits, tmp_path):
         f["Header"]["telescope_name"] = bytes(tname)
     # now read
     uv_out = UVData()
-    uv_out.read(testfile, use_future_array_shapes=True)
+    uv_out.read(testfile)
     assert isinstance(uv_out.telescope.name, str)
 
     # clean up when done
@@ -3452,7 +3101,7 @@ def test_cast_to_multiphase(uv_uvh5, tmp_path):
     testfile = os.path.join(tmp_path, "out_cast_to_multiphase.uvh5")
 
     uv_uvh5.write_uvh5(testfile)
-    test_uvh5.read(testfile, use_future_array_shapes=True)
+    test_uvh5.read(testfile)
 
     assert test_uvh5 == uv_uvh5
 
@@ -3474,7 +3123,7 @@ def test_old_phase_center_catalog_format(sma_mir, tmp_path):
             temp_name = temp_dict.pop("cat_name")
             phase_dict[temp_name] = np.string_(json.dumps(temp_dict))
 
-    uvd = UVData.from_file(testfile, use_future_array_shapes=True)
+    uvd = UVData.from_file(testfile)
     uvd.history = sma_mir.history
     assert uvd == sma_mir
 
@@ -3520,16 +3169,14 @@ def test_old_phase_attributes_header(casa_uvfits, tmp_path):
             "to address this issue."
         ],
     ):
-        uvd = UVData.from_file(
-            testfile, fix_old_proj=False, use_future_array_shapes=True
-        )
+        uvd = UVData.from_file(testfile, fix_old_proj=False)
     uvd.history = casa_uvfits.history
     assert uvd == casa_uvfits
 
     with uvtest.check_warnings(
         UserWarning, match=["Fixing phases using antenna positions."]
     ):
-        uvd2 = UVData.from_file(testfile, use_future_array_shapes=True)
+        uvd2 = UVData.from_file(testfile)
 
     with uvtest.check_warnings(
         UserWarning, match="Fixing phases using antenna positions."
@@ -3547,7 +3194,7 @@ def test_none_extra_keywords(uv_uvh5, tmp_path):
     uv_uvh5.extra_keywords["foo"] = None
 
     uv_uvh5.write_uvh5(testfile)
-    test_uvh5.read(testfile, use_future_array_shapes=True)
+    test_uvh5.read(testfile)
 
     assert test_uvh5 == uv_uvh5
 
@@ -3584,7 +3231,7 @@ def test_write_uvh5_part_fix_autos(uv_uvh5, tmp_path):
     uv_uvh5.data_array[uv_uvh5.ant_1_array == uv_uvh5.ant_2_array] = auto_data
 
     # Read in the data on disk, make sure it looks like our manually repaired data
-    test_uvh5.read(testfile, use_future_array_shapes=True)
+    test_uvh5.read(testfile)
 
     assert uv_uvh5 == test_uvh5
 
@@ -3611,7 +3258,7 @@ def test_uvh5_bitshuffle(uv_phase_comp, tmp_path):
         dgrp = f["/Data"]
         assert "32008" in dgrp["visdata"]._filters
 
-    uvd2 = UVData.from_file(outfile, use_future_array_shapes=True)
+    uvd2 = UVData.from_file(outfile)
     assert uvd == uvd2
 
 
@@ -3623,12 +3270,12 @@ class TestFastUVH5Meta:
 
         self.tmp_path = tempfile.TemporaryDirectory("fastuvh5meta")
 
-        uvd = UVData.from_file(self.fl, bls=[(26, 26)], use_future_array_shapes=True)
+        uvd = UVData.from_file(self.fl, bls=[(26, 26)])
         self.fl_singlebl = os.path.join(self.tmp_path.name, "singlebl.uvh5")
         uvd.write_uvh5(self.fl_singlebl)
 
         time_keep = np.min(uvd.time_array)
-        uvd2 = UVData.from_file(self.fl, times=time_keep, use_future_array_shapes=True)
+        uvd2 = UVData.from_file(self.fl, times=time_keep)
         self.fl_singletime = os.path.join(self.tmp_path.name, "singletime.uvh5")
         uvd2.write_uvh5(self.fl_singletime)
 

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -2187,19 +2187,6 @@ class UVData(UVBase):
         """
         self._set_telescope_requirements()
 
-        if self.flex_spw_id_array is None:
-            warnings.warn(
-                "flex_spw_id_array is not set. It will be required starting in version "
-                "3.0",
-                DeprecationWarning,
-            )
-        else:
-            # Check that all values in flex_spw_id_array are entries in the spw_array
-            if not np.all(np.isin(self.flex_spw_id_array, self.spw_array)):
-                raise ValueError(
-                    "All values in the flex_spw_id_array must exist in the spw_array."
-                )
-
         # call metadata_only to make sure that parameter requirements are set properly
         self.metadata_only
 
@@ -2215,6 +2202,12 @@ class UVData(UVBase):
         self.telescope.check(
             check_extra=check_extra, run_check_acceptability=run_check_acceptability
         )
+
+        # Check that all values in flex_spw_id_array are entries in the spw_array
+        if not np.all(np.isin(self.flex_spw_id_array, self.spw_array)):
+            raise ValueError(
+                "All values in the flex_spw_id_array must exist in the spw_array."
+            )
 
         # Check blt axis rectangularity arguments
         if self.time_axis_faster_than_bls and not self.blts_are_rectangular:
@@ -5248,14 +5241,6 @@ class UVData(UVBase):
             run_check_acceptability=run_check_acceptability,
             strict_uvw_antpos_check=strict_uvw_antpos_check,
         )
-
-        this_has_spw_id = this.flex_spw_id_array is not None
-        other_has_spw_id = other.flex_spw_id_array is not None
-        if this_has_spw_id != other_has_spw_id:
-            warnings.warn(
-                "One object has the flex_spw_id_array set and one does not. Combined "
-                "object will have it set."
-            )
 
         # Define parameters that must be the same to add objects
         compatibility_params = ["_vis_units", "_telescope"]

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -8720,7 +8720,7 @@ class UVData(UVBase):
         summing_correlator_mode=False,
         propagate_flags=False,
         respect_spws=True,
-        keep_ragged=None,
+        keep_ragged=True,
     ):
         """
         Average in frequency.
@@ -8756,19 +8756,9 @@ class UVData(UVBase):
             respect_spw=False) does not divide evenly by n_chan_to_avg, this
             option controls whether the frequencies at the end of the spectral window
             will be dropped to make it evenly divisable (keep_ragged=False) or will be
-            combined into a smaller frequency bin (keep_ragged=True). Note that if
-            ragged frequencies are kept, the final averaged object will have
-            future_array_shapes=True because it will have varying channel widths.
+            combined into a smaller frequency bin (keep_ragged=True). Default is True.
 
         """
-        # The default will be changing soon, so it's currently set to None in the
-        # function signature so we can detect that it's not set and warn about the
-        # changing default.
-        kr_use_default = False
-        if keep_ragged is None:
-            kr_use_default = True
-            keep_ragged = False
-
         # All the logic with future array shapes.
         # Test to see if we need to restore it to current shapes at the end.
         reset_cs = False
@@ -8829,24 +8819,6 @@ class UVData(UVBase):
                 final_nchan, final_nchan + this_final_nchan
             )
             final_nchan += this_final_nchan
-
-        # Warn about changing keep_ragged default if it applies
-        if some_uneven and kr_use_default:
-            warnings.warn(
-                "Some spectral windows do not divide evenly by `n_chan_to_avg` and the "
-                "keep_ragged parameter was not set. The current default is False, but "
-                "that will be changing to True in version 2.5. Set `keep_ragged` to "
-                "True or False to silence this warning.",
-                DeprecationWarning,
-            )
-        # Cannot go back to current array shapes if we have ragged channels that we're
-        # keeping
-        if some_uneven and keep_ragged and reset_cs:
-            warnings.warn(
-                "Ragged frequencies will result in varying channel widths, so "
-                "this object will have future array shapes after averaging. "
-                "Use keep_ragged=False to avoid this."
-            )
 
         # Since we have to loop through the spws, we cannot do the averaging with a
         # simple reshape and average. So we need to create arrays to hold the

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -50,8 +50,7 @@ class UVData(UVBase):
     UVParameter objects :
         For full list see the documentation on ReadTheDocs:
         http://pyuvdata.readthedocs.io/en/latest/.
-        Some are always required, some are required only for flex_spw data
-        and others are always optional.
+        Some are always required, and others are always optional.
 
     """
 
@@ -297,34 +296,17 @@ class UVData(UVBase):
         # --- flexible spectral window information ---
 
         desc = (
-            'Option to construct a "flexible spectral window", which stores'
-            "all spectral channels across the frequency axis of data_array. "
-            "Allows for spectral windows of variable sizes, and channels of "
-            "varying widths."
-        )
-        self._flex_spw = uvp.UVParameter(
-            "flex_spw", description=desc, expected_type=bool, value=False
-        )
-
-        desc = (
-            "Required if flex_spw = True and will always be required starting in "
-            "version 3.0. Maps individual channels along the frequency axis to "
-            "individual spectral windows, as listed in the spw_array. Shape (Nfreqs), "
-            "type = int."
+            "Maps individual channels along the frequency axis to individual spectral "
+            "windows, as listed in the spw_array. Shape (Nfreqs), type = int."
         )
         self._flex_spw_id_array = uvp.UVParameter(
-            "flex_spw_id_array",
-            description=desc,
-            form=("Nfreqs",),
-            expected_type=int,
-            required=False,
+            "flex_spw_id_array", description=desc, form=("Nfreqs",), expected_type=int
         )
 
         desc = (
-            "Optional, only used if flex_spw = True. Allows for labeling individual "
-            "spectral windows with different polarizations. If set, Npols must be set "
-            "to 1 (i.e., only one polarization per spectral window allowed). Shape "
-            "(Nspws), type = int."
+            "Optional parameter, allows for labeling individual spectral windows with "
+            "different polarizations. If set, Npols must be set to 1 (i.e., only one "
+            "polarization per spectral window allowed). Shape (Nspws), type = int."
         )
         self._flex_spw_polarization_array = uvp.UVParameter(
             "flex_spw_polarization_array",
@@ -646,21 +628,6 @@ class UVData(UVBase):
     @combine_docstrings(new_uvdata, style=DocstringStyle.NUMPYDOC)
     def new(**kwargs):  # noqa: D102
         return new_uvdata(**kwargs)
-
-    def _set_flex_spw(self):
-        """
-        Set flex_spw to True, and adjust required parameters.
-
-        This method should not be called directly by users; instead it is called
-        by the file-reading methods to indicate that an object has multiple spectral
-        windows concatenated together across the frequency axis.
-        """
-        # Mark once-optional arrays as now required
-        self.flex_spw = True
-        self._flex_spw_id_array.required = True
-
-        # Now make sure that chan_width is set to be an array
-        self._channel_width.form = ("Nfreqs",)
 
     def _set_scan_numbers(self, override=False):
         """
@@ -1696,7 +1663,7 @@ class UVData(UVBase):
 
     def _check_flex_spw_contiguous(self):
         """
-        Check if the spectral windows are contiguous for flex_spw datasets.
+        Check if the spectral windows are contiguous.
 
         This checks the flex_spw_id_array to make sure that all channels for each
         spectral window are together in one block, versus being interspersed (e.g.,
@@ -1704,10 +1671,9 @@ class UVData(UVBase):
         UVH5 and UVData objects can handle this, but MIRIAD, MIR, UVFITS, and MS file
         formats cannot, so we just consider it forbidden.
         """
-        if self.flex_spw:
-            uvutils._check_flex_spw_contiguous(
-                spw_array=self.spw_array, flex_spw_id_array=self.flex_spw_id_array
-            )
+        uvutils._check_flex_spw_contiguous(
+            spw_array=self.spw_array, flex_spw_id_array=self.flex_spw_id_array
+        )
 
     def _check_freq_spacing(self, *, raise_errors=True):
         """
@@ -1733,7 +1699,6 @@ class UVData(UVBase):
             freq_tols=self._freq_array.tols,
             channel_width=self.channel_width,
             channel_width_tols=self._channel_width.tols,
-            flex_spw=self.flex_spw,
             spw_array=self.spw_array,
             flex_spw_id_array=self.flex_spw_id_array,
             raise_errors=raise_errors,
@@ -2006,14 +1971,6 @@ class UVData(UVBase):
             If an object cannot be converted to flex-pol, and `raise_error=False`, then
             raise a warning that the conversion failed. Default is True.
         """
-        if not self.flex_spw:
-            msg = "Cannot make a flex-pol UVData object if flex_spw=False."
-            if raise_error:
-                raise ValueError(msg)
-            if raise_warning:
-                warnings.warn(msg)
-            return
-
         if self.metadata_only:
             msg = (
                 "Cannot make a metadata_only UVData object flex-pol because flagging "
@@ -2103,10 +2060,6 @@ class UVData(UVBase):
         """
         if self.flex_spw_polarization_array is not None:
             raise ValueError("This is already a flex-pol object")
-
-        if not self.flex_spw:
-            self._set_flex_spw()
-            self.flex_spw_id_array = np.zeros(self.Nfreqs, dtype=int)
 
         new_spw_array = self.spw_array
         new_flex_pol_array = np.full(self.Nspws, self.polarization_array[0])
@@ -4156,7 +4109,6 @@ class UVData(UVBase):
             freq_array=self.freq_array,
             Nspws=self.Nspws,
             spw_array=self.spw_array,
-            flex_spw=self.flex_spw,
             flex_spw_id_array=self.flex_spw_id_array,
             spw_order=spw_order,
             channel_order=channel_order,
@@ -4620,6 +4572,7 @@ class UVData(UVBase):
     def phase(
         self,
         *,
+        cat_name,
         lon=None,
         lat=None,
         epoch="J2000",
@@ -4632,7 +4585,6 @@ class UVData(UVBase):
         pm_dec=None,
         dist=None,
         vrad=None,
-        cat_name=None,
         lookup_name=False,
         use_ant_pos=True,
         select_mask=None,
@@ -4715,11 +4667,6 @@ class UVData(UVBase):
             If the `cat_name` is None.
 
         """
-        # TODO: move this up to a required (non-defaulted) parameter in function
-        # signature when we require keywords to be passed by name in version 3.0
-        if cat_name is None:
-            raise ValueError("The cat_name must be provided.")
-
         if cat_type != "unprojected":
             if lon is None:
                 if ra is None:
@@ -5336,13 +5283,6 @@ class UVData(UVBase):
             strict_uvw_antpos_check=strict_uvw_antpos_check,
         )
 
-        # Check to make sure that both objects are consistent w/ use of flex_spw
-        if this.flex_spw != other.flex_spw:
-            raise ValueError(
-                "To combine these data, flex_spw must be set to the same "
-                "value (True or False) for both objects."
-            )
-
         this_has_spw_id = this.flex_spw_id_array is not None
         other_has_spw_id = other.flex_spw_id_array is not None
         if this_has_spw_id != other_has_spw_id:
@@ -5387,26 +5327,21 @@ class UVData(UVBase):
         # belong to different spectral windows (one real-life example: you might want
         # to preserve guard bands in the correlator, which can have overlaping RF
         # frequency channels)
-        if this.flex_spw:
-            this_freq_ind = np.array([], dtype=np.int64)
-            other_freq_ind = np.array([], dtype=np.int64)
-            both_freq = np.array([], dtype=float)
-            both_spw = np.intersect1d(this.spw_array, other.spw_array)
-            for idx in both_spw:
-                this_mask = np.where(this.flex_spw_id_array == idx)[0]
-                other_mask = np.where(other.flex_spw_id_array == idx)[0]
-                both_spw_freq, this_spw_ind, other_spw_ind = np.intersect1d(
-                    this.freq_array[this_mask],
-                    other.freq_array[other_mask],
-                    return_indices=True,
-                )
-                this_freq_ind = np.append(this_freq_ind, this_mask[this_spw_ind])
-                other_freq_ind = np.append(other_freq_ind, other_mask[other_spw_ind])
-                both_freq = np.append(both_freq, both_spw_freq)
-        else:
-            both_freq, this_freq_ind, other_freq_ind = np.intersect1d(
-                this.freq_array, other.freq_array, return_indices=True
+        this_freq_ind = np.array([], dtype=np.int64)
+        other_freq_ind = np.array([], dtype=np.int64)
+        both_freq = np.array([], dtype=float)
+        both_spw = np.intersect1d(this.spw_array, other.spw_array)
+        for idx in both_spw:
+            this_mask = np.where(this.flex_spw_id_array == idx)[0]
+            other_mask = np.where(other.flex_spw_id_array == idx)[0]
+            both_spw_freq, this_spw_ind, other_spw_ind = np.intersect1d(
+                this.freq_array[this_mask],
+                other.freq_array[other_mask],
+                return_indices=True,
             )
+            this_freq_ind = np.append(this_freq_ind, this_mask[this_spw_ind])
+            other_freq_ind = np.append(other_freq_ind, other_mask[other_spw_ind])
+            both_freq = np.append(both_freq, both_spw_freq)
 
         both_blts, this_blts_ind, other_blts_ind = np.intersect1d(
             this_blts, other_blts, return_indices=True
@@ -5479,44 +5414,41 @@ class UVData(UVBase):
             compatibility_params.extend(extra_params)
 
         # find the freq indices in "other" but not in "this"
-        if this.flex_spw:
-            if (this.flex_spw_polarization_array is None) != (
-                other.flex_spw_polarization_array is None
-            ):
-                raise ValueError(
-                    "Cannot add a flex-pol and non-flex-pol UVData objects. Use "
-                    "the `remove_flex_pol` method to convert the objects to "
-                    "have a regular polarization axis."
-                )
-            elif this.flex_spw_polarization_array is not None:
-                this_flexpol_dict = dict(
-                    zip(this.spw_array, this.flex_spw_polarization_array)
-                )
-                other_flexpol_dict = dict(
-                    zip(other.spw_array, other.flex_spw_polarization_array)
-                )
-                for key in other_flexpol_dict.keys():
-                    try:
-                        if this_flexpol_dict[key] != other_flexpol_dict[key]:
-                            raise ValueError(
-                                "Cannot add a flex-pol UVData objects where the same "
-                                "spectral window contains different polarizations. Use "
-                                "the `remove_flex_pol` method to convert the objects "
-                                "to have a regular polarization axis."
-                            )
-                    except KeyError:
-                        this_flexpol_dict[key] = other_flexpol_dict[key]
+        if (this.flex_spw_polarization_array is None) != (
+            other.flex_spw_polarization_array is None
+        ):
+            raise ValueError(
+                "Cannot add a flex-pol and non-flex-pol UVData objects. Use "
+                "the `remove_flex_pol` method to convert the objects to "
+                "have a regular polarization axis."
+            )
+        elif this.flex_spw_polarization_array is not None:
+            this_flexpol_dict = dict(
+                zip(this.spw_array, this.flex_spw_polarization_array)
+            )
+            other_flexpol_dict = dict(
+                zip(other.spw_array, other.flex_spw_polarization_array)
+            )
+            for key in other_flexpol_dict.keys():
+                try:
+                    if this_flexpol_dict[key] != other_flexpol_dict[key]:
+                        raise ValueError(
+                            "Cannot add a flex-pol UVData objects where the same "
+                            "spectral window contains different polarizations. Use "
+                            "the `remove_flex_pol` method to convert the objects "
+                            "to have a regular polarization axis."
+                        )
+                except KeyError:
+                    this_flexpol_dict[key] = other_flexpol_dict[key]
 
-            other_mask = np.ones_like(other.flex_spw_id_array, dtype=bool)
-            for idx in np.intersect1d(this.spw_array, other.spw_array):
-                other_mask[other.flex_spw_id_array == idx] = np.isin(
-                    other.freq_array[other.flex_spw_id_array == idx],
-                    this.freq_array[this.flex_spw_id_array == idx],
-                    invert=True,
-                )
-            temp = np.where(other_mask)[0]
-        else:
-            temp = np.nonzero(~np.in1d(other.freq_array, this.freq_array))[0]
+        other_mask = np.ones_like(other.flex_spw_id_array, dtype=bool)
+        for idx in np.intersect1d(this.spw_array, other.spw_array):
+            other_mask[other.flex_spw_id_array == idx] = np.isin(
+                other.freq_array[other.flex_spw_id_array == idx],
+                this.freq_array[this.flex_spw_id_array == idx],
+                invert=True,
+            )
+        temp = np.where(other_mask)[0]
         if len(temp) > 0:
             fnew_inds = temp
             if n_axes > 0:
@@ -5692,49 +5624,41 @@ class UVData(UVBase):
                 [this.channel_width, other.channel_width[fnew_inds]]
             )
 
-            if this.flex_spw:
-                this.flex_spw_id_array = np.concatenate(
-                    [this.flex_spw_id_array, other.flex_spw_id_array[fnew_inds]]
-                )
-                this.spw_array = np.concatenate([this.spw_array, other.spw_array])
-                # We want to preserve per-spw information based on first appearance
-                # in the concatenated array.
-                unique_index = np.sort(
-                    np.unique(this.flex_spw_id_array, return_index=True)[1]
-                )
-                this.spw_array = this.flex_spw_id_array[unique_index]
-                this.Nspws = len(this.spw_array)
+            this.flex_spw_id_array = np.concatenate(
+                [this.flex_spw_id_array, other.flex_spw_id_array[fnew_inds]]
+            )
+            this.spw_array = np.concatenate([this.spw_array, other.spw_array])
+            # We want to preserve per-spw information based on first appearance
+            # in the concatenated array.
+            unique_index = np.sort(
+                np.unique(this.flex_spw_id_array, return_index=True)[1]
+            )
+            this.spw_array = this.flex_spw_id_array[unique_index]
+            this.Nspws = len(this.spw_array)
 
-                if this.flex_spw_polarization_array is not None:
-                    this.flex_spw_polarization_array = np.array(
-                        [this_flexpol_dict[key] for key in this.spw_array]
-                    )
-                # Need to sort out the order of the individual windows first.
-                f_order = np.concatenate(
-                    [
-                        np.where(this.flex_spw_id_array == idx)[0]
-                        for idx in sorted(this.spw_array)
-                    ]
+            if this.flex_spw_polarization_array is not None:
+                this.flex_spw_polarization_array = np.array(
+                    [this_flexpol_dict[key] for key in this.spw_array]
                 )
+            # Need to sort out the order of the individual windows first.
+            f_order = np.concatenate(
+                [
+                    np.where(this.flex_spw_id_array == idx)[0]
+                    for idx in sorted(this.spw_array)
+                ]
+            )
 
-                # With spectral windows sorted, check and see if channels within
-                # windows need sorting. If they are ordered in ascending or descending
-                # fashion, leave them be. If not, sort in ascending order
-                for idx in this.spw_array:
-                    select_mask = this.flex_spw_id_array[f_order] == idx
-                    check_freqs = this.freq_array[f_order[select_mask]]
-                    if (not np.all(check_freqs[1:] > check_freqs[:-1])) and (
-                        not np.all(check_freqs[1:] < check_freqs[:-1])
-                    ):
-                        subsort_order = f_order[select_mask]
-                        f_order[select_mask] = subsort_order[np.argsort(check_freqs)]
-            else:
-                if this_has_spw_id or other_has_spw_id:
-                    this.flex_spw_id_array = np.full(
-                        this.freq_array.size, this.spw_array[0], dtype=int
-                    )
-
-                f_order = np.argsort(this.freq_array)
+            # With spectral windows sorted, check and see if channels within
+            # windows need sorting. If they are ordered in ascending or descending
+            # fashion, leave them be. If not, sort in ascending order
+            for idx in this.spw_array:
+                select_mask = this.flex_spw_id_array[f_order] == idx
+                check_freqs = this.freq_array[f_order[select_mask]]
+                if (not np.all(check_freqs[1:] > check_freqs[:-1])) and (
+                    not np.all(check_freqs[1:] < check_freqs[:-1])
+                ):
+                    subsort_order = f_order[select_mask]
+                    f_order[select_mask] = subsort_order[np.argsort(check_freqs)]
 
             if not self.metadata_only:
                 zero_pad = np.zeros(
@@ -5770,20 +5694,16 @@ class UVData(UVBase):
         pol_t2o = np.nonzero(
             np.in1d(this.polarization_array, other.polarization_array)
         )[0]
-        # Special handling here needed for flex_spw data
         this_freqs = this.freq_array
         other_freqs = other.freq_array
 
-        if this.flex_spw:
-            freq_t2o = np.zeros(this_freqs.shape, dtype=bool)
-            for spw_id in set(this.spw_array).intersection(other.spw_array):
-                mask = this.flex_spw_id_array == spw_id
-                freq_t2o[mask] |= np.in1d(
-                    this_freqs[mask], other_freqs[other.flex_spw_id_array == spw_id]
-                )
-            freq_t2o = np.nonzero(freq_t2o)[0]
-        else:
-            freq_t2o = np.nonzero(np.in1d(this_freqs, other_freqs))[0]
+        freq_t2o = np.zeros(this_freqs.shape, dtype=bool)
+        for spw_id in set(this.spw_array).intersection(other.spw_array):
+            mask = this.flex_spw_id_array == spw_id
+            freq_t2o[mask] |= np.in1d(
+                this_freqs[mask], other_freqs[other.flex_spw_id_array == spw_id]
+            )
+        freq_t2o = np.nonzero(freq_t2o)[0]
         blt_t2o = np.nonzero(np.in1d(this_blts, other_blts))[0]
 
         if not self.metadata_only:
@@ -5809,8 +5729,7 @@ class UVData(UVBase):
         if len(fnew_inds) > 0:
             this.freq_array = this.freq_array[f_order]
             this.channel_width = this.channel_width[f_order]
-            if this.flex_spw:
-                this.flex_spw_id_array = this.flex_spw_id_array[f_order]
+            this.flex_spw_id_array = this.flex_spw_id_array[f_order]
 
         if len(pnew_inds) > 0:
             this.polarization_array = this.polarization_array[p_order]
@@ -6048,24 +5967,6 @@ class UVData(UVBase):
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
             )
 
-        # Check to make sure that both objects are consistent w/ use of flex_spw
-        for obj in other:
-            if this.flex_spw != obj.flex_spw:
-                raise ValueError(
-                    "All objects must have the same `flex_spw` value (True or False)."
-                )
-
-        this_has_spw_id = this.flex_spw_id_array is not None
-        other_has_spw_id = np.array(
-            [obj.flex_spw_id_array is not None for obj in other]
-        )
-
-        if not np.all(other_has_spw_id == this_has_spw_id):
-            warnings.warn(
-                "Some objects have the flex_spw_id_array set and some do not. Combined "
-                "object will have it set."
-            )
-
         # update the phase_center_catalog to make them consistent across objects
         # Doing this as a binary tree merge
         # The left object in each loop will have its phase center IDs updated.
@@ -6099,6 +6000,7 @@ class UVData(UVBase):
             compatibility_params += [
                 "_freq_array",
                 "_channel_width",
+                "_flex_spw_id_array",
                 "_ant_1_array",
                 "_ant_2_array",
                 "_integration_time",
@@ -6108,7 +6010,11 @@ class UVData(UVBase):
             ]
         elif axis == "blt":
             history_update_string += "baseline-time"
-            compatibility_params += ["_freq_array", "_polarization_array"]
+            compatibility_params += [
+                "_freq_array",
+                "_polarization_array",
+                "_flex_spw_id_array",
+            ]
 
         history_update_string += " axis using pyuvdata."
 
@@ -6151,25 +6057,20 @@ class UVData(UVBase):
             this.channel_width = np.concatenate(
                 [this.channel_width] + [obj.channel_width for obj in other]
             )
-            if this.flex_spw:
-                this.flex_spw_id_array = np.concatenate(
-                    [this.flex_spw_id_array] + [obj.flex_spw_id_array for obj in other]
-                )
-                this.spw_array = np.concatenate(
-                    [this.spw_array] + [obj.spw_array for obj in other]
-                )
-                # We want to preserve per-spw information based on first appearance
-                # in the concatenated array.
-                unique_index = np.sort(
-                    np.unique(this.flex_spw_id_array, return_index=True)[1]
-                )
-                this.spw_array = this.flex_spw_id_array[unique_index]
+            this.flex_spw_id_array = np.concatenate(
+                [this.flex_spw_id_array] + [obj.flex_spw_id_array for obj in other]
+            )
+            this.spw_array = np.concatenate(
+                [this.spw_array] + [obj.spw_array for obj in other]
+            )
+            # We want to preserve per-spw information based on first appearance
+            # in the concatenated array.
+            unique_index = np.sort(
+                np.unique(this.flex_spw_id_array, return_index=True)[1]
+            )
+            this.spw_array = this.flex_spw_id_array[unique_index]
 
-                this.Nspws = len(this.spw_array)
-            elif this_has_spw_id or np.any(other_has_spw_id):
-                this.flex_spw_id_array = np.full(
-                    this.Nfreqs, this.spw_array[0], dtype=int
-                )
+            this.Nspws = len(this.spw_array)
 
             spacing_error, chanwidth_error = this._check_freq_spacing(
                 raise_errors=False
@@ -6986,10 +6887,9 @@ class UVData(UVBase):
 
             if len(frequencies) > 1:
                 freq_ind_separation = freq_inds[1:] - freq_inds[:-1]
-                if self.flex_spw_id_array is not None:
-                    freq_ind_separation = freq_ind_separation[
-                        np.diff(self.flex_spw_id_array[freq_inds]) == 0
-                    ]
+                freq_ind_separation = freq_ind_separation[
+                    np.diff(self.flex_spw_id_array[freq_inds]) == 0
+                ]
                 if not uvutils._test_array_constant(freq_ind_separation):
                     warnings.warn(
                         "Selected frequencies are not evenly spaced. This "

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -49,66 +49,6 @@ _future_array_shapes_warning = (
     "shape changes."
 )
 
-old_phase_attrs = [
-    "phase_type",
-    "phase_center_ra",
-    "phase_center_dec",
-    "phase_center_frame",
-    "phase_center_epoch",
-    "object_name",
-]
-
-
-def _warn_old_phase_attr(__name):
-    warn_str = (
-        "The older phase attributes, including "
-        + ", ".join(old_phase_attrs)
-        + ", are deprecated in favor of representing phasing using the "
-        "phase_center_catalog."
-    )
-
-    if __name == "phase_type":
-        warn_str += (
-            " The phase_type is now represented as the 'cat_type' in the "
-            "phase_center_catalog (the old 'drift' type corresponds to the "
-            "new 'unprojected' type, the old 'phased' type corresponds to the "
-            "new 'sidereal' type, and there is also now support for an 'ephem' "
-            "type to support moving objects and a new 'driftscan' type which "
-            "can point at any alt/az (not just zenith) and which always has "
-            "w-projection applied)."
-        )
-    elif __name == "phase_center_ra":
-        warn_str += (
-            " The phase_center_ra is now represented as the 'cat_lon' in the "
-            "phase_center_catalog."
-        )
-    elif __name == "phase_center_dec":
-        warn_str += (
-            " The phase_center_dec is now represented as the 'cat_lat' in the "
-            "phase_center_catalog."
-        )
-    elif __name == "phase_center_frame":
-        warn_str += (
-            " The phase_center_frame is now represented as the 'cat_frame' in "
-            "the phase_center_catalog."
-        )
-    elif __name == "phase_center_epoch":
-        warn_str += (
-            " The phase_center_epoch is now represented as the 'cat_epoch' in "
-            "the phase_center_catalog."
-        )
-    elif __name == "object_name":
-        warn_str += (
-            " The object_name is now represented as the 'cat_name' in "
-            "the phase_center_catalog."
-        )
-    warn_str += (
-        " To see a nice representation of the phase_center_catalog, use the "
-        "`print_phase_center_info` method. The older attributes will be "
-        "removed in version 3.0"
-    )
-    warnings.warn(warn_str, DeprecationWarning)
-
 
 class UVData(UVBase):
     """
@@ -1555,61 +1495,6 @@ class UVData(UVBase):
         else:
             return True, None
 
-    def __getattribute__(self, __name):
-        """Issue deprecation warnings for old phasing attributes."""
-        if __name in old_phase_attrs:
-            compatible, reason = self._old_phase_attributes_compatible()
-            if not compatible:
-                raise ValueError(
-                    "The older phase attributes, including "
-                    + ", ".join(old_phase_attrs)
-                    + " cannot be used with data phased with the new method. This was "
-                    + "phased with the new method because it has "
-                    + reason
-                    + "."
-                )
-            _warn_old_phase_attr(__name)
-
-            if self.phase_center_catalog is not None:
-                phase_dict = next(iter(self.phase_center_catalog.values()))
-                if __name == "phase_type":
-                    if phase_dict["cat_type"] == "unprojected":
-                        ret_val = "drift"
-                    else:
-                        ret_val = "phased"
-                elif __name == "phase_center_ra":
-                    ret_val = phase_dict["cat_lon"]
-                elif __name == "phase_center_dec":
-                    ret_val = phase_dict["cat_lat"]
-                elif __name == "phase_center_frame":
-                    ret_val = phase_dict["cat_frame"]
-                elif __name == "phase_center_epoch":
-                    ret_val = phase_dict["cat_epoch"]
-                elif __name == "object_name":
-                    ret_val = phase_dict["cat_name"]
-                return ret_val
-
-        return super().__getattribute__(__name)
-
-    def __setattr__(self, __name, __value) -> None:
-        """Issue deprecation warnings for old phasing attributes."""
-        if __name in old_phase_attrs:
-            if (
-                self.phase_center_catalog is not None
-                and len(self.phase_center_catalog) > 0
-            ):
-                warnings.warn(
-                    f"phase_center_catalog is already set, so {__name}, which is an "
-                    "old phase attribute, cannot be set. This will become an error in "
-                    "version 3.0",
-                    DeprecationWarning,
-                )
-                return
-
-            _warn_old_phase_attr(__name)
-
-        return super().__setattr__(__name, __value)
-
     def _set_future_array_shapes(self):
         """
         Set future_array_shapes to True and adjust required parameters.
@@ -2440,85 +2325,6 @@ class UVData(UVBase):
             # Finally, plug the modified values back into data_array
             self.data_array[auto_screen] = auto_data
 
-    def _convert_old_phase_attributes(self):
-        """
-        Convert old phase attributes set on object to the phase_center_catalog.
-
-        This method can be removed in version 3.0.
-        """
-        if self.phase_center_catalog is None or len(self.phase_center_catalog) == 0:
-            # first handle any old phase parameters that have been added to the object
-            old_phase_attrs = [
-                "phase_type",
-                "phase_center_ra",
-                "phase_center_dec",
-                "phase_center_frame",
-                "phase_center_epoch",
-                "object_name",
-            ]
-            old_phase_info = {}
-            for attr in old_phase_attrs:
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        "ignore", "The older phase attributes, including"
-                    )
-                    if hasattr(self, attr):
-                        old_phase_info[attr] = getattr(self, attr)
-            if len(old_phase_info) > 0:
-                converted = False
-                if "phase_type" in old_phase_info.keys():
-                    if old_phase_info["phase_type"] != "phased":
-                        if "object_name" in old_phase_info.keys():
-                            cat_name = old_phase_info["object_name"]
-                        else:
-                            cat_name = "unprojected"
-                        cat_id = self._add_phase_center(
-                            cat_name=cat_name, cat_type="unprojected"
-                        )
-                        converted = True
-                    else:
-                        if (
-                            "phase_center_ra" in old_phase_info.keys()
-                            and "phase_center_dec" in old_phase_info.keys()
-                            and "phase_center_frame" in old_phase_info.keys()
-                            and "phase_center_epoch" in old_phase_info.keys()
-                            and "object_name" in old_phase_info.keys()
-                        ):
-                            cat_id = self._add_phase_center(
-                                cat_name=old_phase_info["object_name"],
-                                cat_type="sidereal",
-                                cat_lon=old_phase_info["phase_center_ra"],
-                                cat_lat=old_phase_info["phase_center_dec"],
-                                cat_frame=old_phase_info["phase_center_frame"],
-                                cat_epoch=old_phase_info["phase_center_epoch"],
-                            )
-                            converted = True
-
-                if converted:
-                    warnings.warn(
-                        "The phase_center_catalog was not set and a complete set of "
-                        f"old phase attributes ({', '.join(old_phase_info.keys())}) "
-                        "were detected so the old phase attributes were converted into "
-                        "the phase_center_catalog. "
-                        f"The older attributes including {', '.join(old_phase_attrs)} "
-                        "will be removed in version 3.0",
-                        DeprecationWarning,
-                    )
-                    self.phase_center_id_array = np.full(self.Nblts, cat_id, dtype=int)
-                    self._set_app_coords_helper()
-                    for attr in old_phase_attrs:
-                        if attr in old_phase_info.keys():
-                            delattr(self, attr)
-                else:
-                    raise ValueError(
-                        "The phase_center_catalog was not set and some old phase "
-                        f"attributes ({', '.join(old_phase_info.keys())}) were "
-                        "detected, but not enough to define the phase status of the "
-                        "object, so they could not be converted into the "
-                        "phase_center_catalog. You can use `_add_phase_center_catalog` "
-                        "to set the phase_center_catalog."
-                    )
-
     def check(
         self,
         *,
@@ -2584,9 +2390,6 @@ class UVData(UVBase):
             values (if run_check_acceptability is True)
 
         """
-        # first check for any old phase attributes set on the object and move the info
-        # into the phase_center_catalog.
-        self._convert_old_phase_attributes()
         self._set_telescope_requirements()
 
         if self.flex_spw_id_array is None:
@@ -9795,16 +9598,9 @@ class UVData(UVBase):
         else:
             raise ValueError("filetype must be uvfits, mir, miriad, ms, fhd, or uvh5")
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "The older phase attributes, including")
-            for par in self:
-                param = getattr(self, par)
-                setattr(other_obj, par, param)
-            if self.phase_center_catalog is None or len(self.phase_center_catalog) == 0:
-                for attr in old_phase_attrs:
-                    if hasattr(self, attr):
-                        attr_val = getattr(self, attr)
-                        setattr(other_obj, attr, attr_val)
+        for par in self:
+            setattr(other_obj, par, getattr(self, par))
+
         return other_obj
 
     def read_fhd(self, vis_files, *, params_file, **kwargs):
@@ -10047,12 +9843,6 @@ class UVData(UVBase):
             are not fast to read in (e.g. uvws, times) so will not be read in
             if this keyword is False. Therefore, setting read_data to False
             results in an incompletely defined object (check will not pass).
-        phase_type : str, optional
-            Deprecated, use the `projected` parameter insted. Option to specify the
-            phasing status of the data. Options are 'drift', 'phased' or None. 'drift'
-            is the same as setting the projected parameter to False, 'phased' is the
-            same as setting the projected parameter to True. Ignored if `projected`
-            is set.
         projected : bool or None
             Option to force the dataset to be labelled as projected or unprojected
             regardless of the evidence in the file. The default is None which means that
@@ -10758,7 +10548,6 @@ class UVData(UVBase):
         fix_autos=True,
         # file-type specific parameters
         # miriad
-        phase_type=None,
         projected=None,
         correct_lat_lon=True,
         calc_lst=True,
@@ -10982,12 +10771,6 @@ class UVData(UVBase):
 
         Miriad
         ------
-        phase_type : str, optional
-            Deprecated, use the `projected` parameter insted. Option to specify the
-            phasing status of the data. Options are 'drift', 'phased' or None. 'drift'
-            is the same as setting the projected parameter to False, 'phased' is the
-            same as setting the projected parameter to True. Ignored if `projected`
-            is set.
         projected : bool or None
             Option to force the dataset to be labelled as projected or unprojected
             regardless of the evidence in the file. The default is None which means that
@@ -11458,7 +11241,6 @@ class UVData(UVBase):
                         fix_autos=fix_autos,
                         # file-type specific parameters
                         # miriad
-                        phase_type=phase_type,
                         projected=projected,
                         correct_lat_lon=correct_lat_lon,
                         calc_lst=calc_lst,
@@ -11596,7 +11378,6 @@ class UVData(UVBase):
                             fix_autos=fix_autos,
                             # file-type specific parameters
                             # miriad
-                            phase_type=phase_type,
                             projected=projected,
                             correct_lat_lon=correct_lat_lon,
                             calc_lst=calc_lst,
@@ -11920,7 +11701,6 @@ class UVData(UVBase):
                     polarizations=polarizations,
                     time_range=time_range,
                     read_data=read_data,
-                    phase_type=phase_type,
                     projected=projected,
                     correct_lat_lon=correct_lat_lon,
                     background_lsts=background_lsts,

--- a/pyuvdata/uvdata/uvdata.py
+++ b/pyuvdata/uvdata/uvdata.py
@@ -1443,40 +1443,6 @@ class UVData(UVBase):
         else:
             return True, None
 
-    def _set_future_array_shapes(self, use_future_array_shapes=None):
-        """
-        Set future_array_shapes to True and adjust required parameters.
-
-        This method should not be called directly by users; instead it is called
-        by file-reading methods and `use_future_array_shapes` to indicate the
-        `future_array_shapes` is True and define expected parameter shapes.
-        This function has been deprecated, and will result in an error in version 3.2.
-        """
-        if use_future_array_shapes is None:
-            # This basically wraps no-ops when no argument is passed.
-            return
-
-        if not use_future_array_shapes:
-            raise ValueError(
-                'The future is now! So-called "current" array shapes no longer '
-                'supported, must use "future" array shapes (spw-axis dropped).'
-            )
-        warnings.warn(
-            (
-                "Future array shapes are now always used, setting/calling "
-                "use_future_array_shapes will result in an error in version 3.2."
-            ),
-            DeprecationWarning,
-        )
-
-    def use_future_array_shapes(self):
-        """
-        Change the array shapes of this object to match the planned future shapes.
-
-        This function has been deprecated, and will result in an error in version 3.2.
-        """
-        self._set_future_array_shapes(True)
-
     def known_telescopes(self):
         """
         Get a list of telescopes known to pyuvdata.

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -878,8 +878,7 @@ class UVFITS(UVData):
         Raises
         ------
         ValueError
-            The `phase_type` of the object is "drift" and the `force_phase`
-            keyword is not set.
+            The object contains unprojected data and `force_phase` keyword is not set.
             If the frequencies are not evenly spaced or are separated by more
             than their channel width.
             The polarization values are not evenly spaced.

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -427,7 +427,7 @@ class UVFITS(UVData):
             self.Npols = vis_hdr.pop("NAXIS3")
             self.Nblts = vis_hdr.pop("GCOUNT")
 
-            if self.Nspws > 1:
+            if "AIPS FQ" in hdunames:
                 # If this is multi-spw, get details from the FQ table
                 uvfits_nchan = vis_hdr.pop("NAXIS4")
                 self.Nfreqs = uvfits_nchan * self.Nspws

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -19,7 +19,7 @@ from .. import hdf5_utils
 from .. import utils as uvutils
 from ..docstrings import copy_replace_short_description
 from ..telescopes import Telescope
-from .uvdata import UVData, _future_array_shapes_warning
+from .uvdata import UVData
 
 __all__ = ["UVH5", "FastUVH5Meta"]
 
@@ -446,7 +446,6 @@ class FastUVH5Meta(hdf5_utils.HDF5Meta):
             self,
             read_data=False,
             run_check_acceptability=check_lsts,
-            use_future_array_shapes=True,
             astrometry_library=astrometry_library,
         )
         return uvd
@@ -567,16 +566,19 @@ class UVH5(UVData):
                 raise KeyError(str(e)) from e
 
         # check this as soon as we have the inputs
-        if self.freq_array.ndim == 1:
-            arr_shape_msg = (
-                "The size of arrays in this file are not internally consistent, "
-                "which should not happen. Please file an issue in our GitHub issue "
-                "log so that we can fix it."
-            )
-            assert (
-                np.asarray(self.channel_width).size == self.freq_array.size
-            ), arr_shape_msg
-            self._set_future_array_shapes()
+        if self.freq_array.ndim == 2:
+            # This is an old-shaped data set, remove the old spw axis
+            self.freq_array = self.freq_array[0]
+            self.channel_width = np.full(self.freq_array.size, self.channel_width)
+
+        arr_shape_msg = (
+            "The size of arrays in this file are not internally consistent, "
+            "which should not happen. Please file an issue in our GitHub issue "
+            "log so that we can fix it."
+        )
+        assert (
+            np.asarray(self.channel_width).size == self.freq_array.size
+        ), arr_shape_msg
 
         # For now, only set the rectangularity parameters if they exist in the header of
         # the file. These could be set automatically later on, but for now we'll leave
@@ -783,7 +785,6 @@ class UVH5(UVData):
         if dgrp["visdata"].ndim == 3:
             assert self.freq_array.ndim == 1, arr_shape_msg
             assert self.channel_width.size == self.freq_array.size, arr_shape_msg
-            self._set_future_array_shapes()
 
         # get the fundamental datatype of the visdata; if integers, we need to
         # cast to floats
@@ -889,23 +890,13 @@ class UVH5(UVData):
                 # down select on other dimensions if necessary
                 # use indices not slices here: generally not the bottleneck
                 if not multidim_index and freq_frac < 1:
-                    if self.future_array_shapes:
-                        visdata = visdata[:, freq_inds, :]
-                        flags = flags[:, freq_inds, :]
-                        nsamples = nsamples[:, freq_inds, :]
-                    else:
-                        visdata = visdata[:, :, freq_inds, :]
-                        flags = flags[:, :, freq_inds, :]
-                        nsamples = nsamples[:, :, freq_inds, :]
+                    visdata = visdata[..., freq_inds, :]
+                    flags = flags[..., freq_inds, :]
+                    nsamples = nsamples[..., freq_inds, :]
                 if not multidim_index and pol_frac < 1:
-                    if self.future_array_shapes:
-                        visdata = visdata[:, :, pol_inds]
-                        flags = flags[:, :, pol_inds]
-                        nsamples = nsamples[:, :, pol_inds]
-                    else:
-                        visdata = visdata[:, :, :, pol_inds]
-                        flags = flags[:, :, :, pol_inds]
-                        nsamples = nsamples[:, :, :, pol_inds]
+                    visdata = visdata[..., :, pol_inds]
+                    flags = flags[..., :, pol_inds]
+                    nsamples = nsamples[..., :, pol_inds]
 
             elif freq_frac == min_frac:
                 # construct inds list given simultaneous sliceability
@@ -942,15 +933,9 @@ class UVH5(UVData):
                     flags = flags[blt_inds]
                     nsamples = nsamples[blt_inds]
                 if not multidim_index and pol_frac < 1:
-                    if self.future_array_shapes:
-                        visdata = visdata[:, :, pol_inds]
-                        flags = flags[:, :, pol_inds]
-                        nsamples = nsamples[:, :, pol_inds]
-                    else:
-                        visdata = visdata[:, :, :, pol_inds]
-                        flags = flags[:, :, :, pol_inds]
-                        nsamples = nsamples[:, :, :, pol_inds]
-
+                    visdata = visdata[..., pol_inds]
+                    flags = flags[..., pol_inds]
+                    nsamples = nsamples[..., pol_inds]
             else:
                 # construct inds list given simultaneous sliceability
                 inds = [np.s_[:], np.s_[:], pol_inds]
@@ -986,26 +971,23 @@ class UVH5(UVData):
                     flags = flags[blt_inds]
                     nsamples = nsamples[blt_inds]
                 if not multidim_index and freq_frac < 1:
-                    if self.future_array_shapes:
-                        visdata = visdata[:, freq_inds, :]
-                        flags = flags[:, freq_inds, :]
-                        nsamples = nsamples[:, freq_inds, :]
-                    else:
-                        visdata = visdata[:, :, freq_inds, :]
-                        flags = flags[:, :, freq_inds, :]
-                        nsamples = nsamples[:, :, freq_inds, :]
+                    visdata = visdata[..., freq_inds, :]
+                    flags = flags[..., freq_inds, :]
+                    nsamples = nsamples[..., freq_inds, :]
 
             # save arrays in object
             self.data_array = visdata
             self.flag_array = flags
             self.nsample_array = nsamples
 
-        if self.data_array.ndim == 3:
-            assert self.freq_array.ndim == 1, arr_shape_msg
-            assert self.channel_width.size == self.freq_array.size, arr_shape_msg
-            self._set_future_array_shapes()
+        if self.data_array.ndim == 4:
+            # This is a dataset with old shapes -- squeeze out the former spw axis
+            self.data_array = np.squeeze(self.data_array, axis=1)
+            self.flag_array = np.squeeze(self.flag_array, axis=1)
+            self.nsample_array = np.squeeze(self.nsample_array, axis=1)
 
-        return
+        assert self.freq_array.ndim == 1, arr_shape_msg
+        assert self.channel_width.size == self.freq_array.size, arr_shape_msg
 
     @copy_replace_short_description(UVData.read_uvh5, style=DocstringStyle.NUMPYDOC)
     def read_uvh5(
@@ -1040,7 +1022,7 @@ class UVH5(UVData):
         fix_use_ant_pos=True,
         check_autos=True,
         fix_autos=True,
-        use_future_array_shapes=False,
+        use_future_array_shapes=None,
         blt_order: tuple[str] | Literal["determine"] | None = None,
         blts_are_rectangular: bool | None = None,
         time_axis_faster_than_bls: bool | None = None,
@@ -1048,6 +1030,9 @@ class UVH5(UVData):
         astrometry_library: str | None = None,
     ):
         """Read in data from a UVH5 file."""
+        # Check for defunct keyword
+        self._set_future_array_shapes(use_future_array_shapes=use_future_array_shapes)
+
         if isinstance(filename, FastUVH5Meta):
             meta = filename
             filename = str(meta.path)
@@ -1131,20 +1116,6 @@ class UVH5(UVData):
         if remove_flex_pol:
             self.remove_flex_pol()
 
-        if use_future_array_shapes:
-            if not self.future_array_shapes:
-                self.use_future_array_shapes()
-        else:
-            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
-            if self.future_array_shapes:
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        "ignore",
-                        message="This method will be removed in version 3.0 when the "
-                        "current array shapes are no longer supported.",
-                    )
-                    self.use_current_array_shapes()
-
         # check if object has all required UVParameters set
         if run_check:
             self.check(
@@ -1173,11 +1144,6 @@ class UVH5(UVData):
         None
         """
         # write out UVH5 version information
-        assert_err_msg = (
-            "This is a bug, please make an issue in our issue log at "
-            "https://github.com/RadioAstronomySoftwareGroup/pyuvdata/issues"
-        )
-        assert self.future_array_shapes, assert_err_msg
         header["version"] = np.string_("1.2")
 
         # write out telescope and source information
@@ -1381,13 +1347,6 @@ class UVH5(UVData):
             else:
                 raise IOError("File exists; skipping")
 
-        revert_fas = False
-        if not self.future_array_shapes:
-            # We force using future array shapes here to always write version 1.* files.
-            # We capture the current state so that it can be reverted later if needed.
-            revert_fas = True
-            self.use_future_array_shapes()
-
         data_compression, data_compression_opts = hdf5_utils._get_compression(
             data_compression
         )
@@ -1438,15 +1397,6 @@ class UVH5(UVData):
                 data=self.nsample_array.astype(np.float32),
                 compression=nsample_compression,
             )
-
-        if revert_fas:
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore",
-                    message="This method will be removed in version 3.0 when the "
-                    "current array shapes are no longer supported.",
-                )
-                self.use_current_array_shapes()
 
         return
 
@@ -1536,13 +1486,6 @@ class UVH5(UVData):
             data_compression
         )
 
-        revert_fas = False
-        if not self.future_array_shapes:
-            # We force using future array shapes here to always write version 1.* files.
-            # We capture the current state so that it can be reverted later if needed.
-            revert_fas = True
-            self.use_future_array_shapes()
-
         # write header and empty arrays to file
         with h5py.File(filename, "w") as f:
             # write header
@@ -1580,15 +1523,6 @@ class UVH5(UVData):
                 dtype="f4",
                 compression=nsample_compression,
             )
-
-        if revert_fas:
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore",
-                    message="This method will be removed in version 3.0 when the "
-                    "current array shapes are no longer supported.",
-                )
-                self.use_current_array_shapes()
 
         return
 
@@ -1812,13 +1746,6 @@ class UVH5(UVData):
                 "initialize_uvh5_file".format(filename)
             )
 
-        revert_fas = False
-        if not self.future_array_shapes:
-            # We force using future array shapes here to always write version 1.* files.
-            # We capture the current state so that it can be reverted later if needed.
-            revert_fas = True
-            self.use_future_array_shapes()
-
         if check_header:
             self._check_header(
                 filename, run_check_acceptability=run_check_acceptability
@@ -1913,16 +1840,11 @@ class UVH5(UVData):
         # check for proper size of input arrays
         proper_shape = (Nblts, Nfreqs, Npols)
         if data_array.shape != proper_shape:
-            if revert_fas and data_array.shape == (Nblts, 1, Nfreqs, Npols):
-                data_array = data_array[:, 0, :, :]
-                flag_array = flag_array[:, 0, :, :]
-                nsample_array = nsample_array[:, 0, :, :]
-            else:
-                raise AssertionError(
-                    "data_array has shape {0}; was expecting {1}".format(
-                        data_array.shape, proper_shape
-                    )
+            raise AssertionError(
+                "data_array has shape {0}; was expecting {1}".format(
+                    data_array.shape, proper_shape
                 )
+            )
 
         # actually write the data
         with h5py.File(filename, "r+") as f:
@@ -2035,14 +1957,5 @@ class UVH5(UVData):
                     # erase dataset first b/c it has fixed-length string datatype
                     del f["Header"]["history"]
                 f["Header"]["history"] = np.string_(history)
-
-        if revert_fas:
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore",
-                    message="This method will be removed in version 3.0 when the "
-                    "current array shapes are no longer supported.",
-                )
-                self.use_current_array_shapes()
 
         return

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -112,7 +112,7 @@ class FastUVH5Meta(hdf5_utils.HDF5Meta):
         }
     )
 
-    _defaults = {"x_orientation": None, "flex_spw": False}
+    _defaults = {"x_orientation": None}
 
     _int_attrs = frozenset(
         {
@@ -137,7 +137,6 @@ class FastUVH5Meta(hdf5_utils.HDF5Meta):
             "phase_center_epoch",
         }
     )
-    _bool_attrs = frozenset(("flex_spw",))
 
     def __init__(
         self,
@@ -320,7 +319,7 @@ class FastUVH5Meta(hdf5_utils.HDF5Meta):
         # Pull in the channel_width parameter as either an array or as a single float,
         # depending on whether or not the data is stored with a flexible spw.
         h = self.header
-        if self.flex_spw or np.asarray(h["channel_width"]).ndim == 1:
+        if np.asarray(h["channel_width"]).ndim == 1:
             return h["channel_width"][:]
         else:
             return float(h["channel_width"][()])
@@ -614,13 +613,7 @@ class UVH5(UVData):
         if self.blt_order is not None:
             self._blt_order.form = (len(self.blt_order),)
 
-        # We've added a few new keywords that did not exist before, so check to see if
-        # any of them are in the header, and if not, mark the data set as being
-        # "regular" (e.g., not a flexible spectral window setup, single source only).
-        if obj.flex_spw:
-            self._set_flex_spw()
-
-        if self.flex_spw_id_array is None and not self.flex_spw:
+        if self.flex_spw_id_array is None:
             self.flex_spw_id_array = np.full(self.Nfreqs, self.spw_array[0], dtype=int)
 
         # Here is where we start handling phase center information.  If we have a
@@ -1168,7 +1161,6 @@ class UVH5(UVData):
         header["spw_array"] = self.spw_array
         header["ant_1_array"] = self.ant_1_array
         header["ant_2_array"] = self.ant_2_array
-        header["flex_spw"] = self.flex_spw
         # handle antenna_names; works for lists or arrays
 
         # write out phasing information

--- a/pyuvdata/uvdata/uvh5.py
+++ b/pyuvdata/uvdata/uvh5.py
@@ -1007,9 +1007,7 @@ class UVH5(UVData):
 
         return
 
-    @copy_replace_short_description(
-        UVData.read_mwa_corr_fits, style=DocstringStyle.NUMPYDOC
-    )
+    @copy_replace_short_description(UVData.read_uvh5, style=DocstringStyle.NUMPYDOC)
     def read_uvh5(
         self,
         filename,

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -48,7 +48,7 @@ def uvdata_obj_main():
             "The uvw_array does not match the expected",
         ],
     ):
-        uvdata_object.read(test_d_file, use_future_array_shapes=True)
+        uvdata_object.read(test_d_file)
 
     yield uvdata_object
 
@@ -97,7 +97,7 @@ def uvcal_obj_main():
         "not set or are being overwritten. telescope_location, antenna_positions, "
         "antenna_diameters are set using values from known telescopes for HERA.",
     ):
-        uvc.read_calfits(test_c_file, use_future_array_shapes=True)
+        uvc.read_calfits(test_c_file)
 
     yield uvc
 
@@ -587,7 +587,6 @@ def test_init_invalid_input():
         UVFlag(14)
 
 
-@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_from_uvcal_error(uvdata_obj):
     uv = uvdata_obj
     uvf = UVFlag()
@@ -604,14 +603,13 @@ def test_from_uvcal_error(uvdata_obj):
     # convert delay object to future array shapes, drop freq_array, set Nfreqs=1
     with uvtest.check_warnings(
         UserWarning,
-        match=[
+        match=(
             "telescope_location, antenna_positions, antenna_diameters are not "
             "set or are being overwritten. telescope_location, antenna_positions, "
-            "antenna_diameters are set using values from known telescopes for HERA.",
-            "When converting a delay-style cal to future array shapes",
-        ],
+            "antenna_diameters are set using values from known telescopes for HERA."
+        ),
     ):
-        delay_object.read_calfits(delayfile, use_future_array_shapes=True)
+        delay_object.read_calfits(delayfile)
 
     delay_object.freq_array = None
     delay_object.channel_width = None
@@ -1011,7 +1009,7 @@ def test_read_write_loop_missing_telescope_info(
 ):
     if uvf_type == "antenna":
         uv = UVCal()
-        uv.read_calfits(test_c_file, use_future_array_shapes=True)
+        uv.read_calfits(test_c_file)
     else:
         uv = uvdata_obj_weird_telparams
 
@@ -1122,7 +1120,7 @@ def test_read_write_loop_missing_telescope_info(
 def test_missing_telescope_info_mwa(test_outfile):
     mwa_uvfits = os.path.join(DATA_PATH, "1133866760.uvfits")
     metafits = os.path.join(DATA_PATH, "mwa_corr_fits_testfiles", "1131733552.metafits")
-    uvd = UVData.from_file(mwa_uvfits, use_future_array_shapes=True)
+    uvd = UVData.from_file(mwa_uvfits)
     uvf = UVFlag(uvd, waterfall=True)
 
     uvf.write(test_outfile, clobber=True)

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -1779,16 +1779,7 @@ def test_add_frequency():
     uv2 = uv1.copy()
     uv2.freq_array += 1e4  # Arbitrary
 
-    uv1.flex_spw_id_array = None
-
-    with uvtest.check_warnings(
-        UserWarning,
-        match=(
-            "One object has the flex_spw_id_array set and one does not. Combined "
-            "object will have it set."
-        ),
-    ):
-        uv3 = uv1.__add__(uv2, axis="frequency")
+    uv3 = uv1.__add__(uv2, axis="frequency")
     assert np.array_equal(
         np.concatenate((uv1.freq_array, uv2.freq_array), axis=-1), uv3.freq_array
     )
@@ -4010,6 +4001,21 @@ def test_to_antenna_collapsed_pols(uvf_from_uvcal, uvcal_obj):
     uvf.to_antenna(uvc, force_pol=True)
     assert not uvf.pol_collapsed
     uvf.check()
+
+
+def test_to_antenna_spw_fill(uvf_from_uvcal, uvcal_obj):
+    uvf = uvf_from_uvcal
+    uvc = uvcal_obj
+
+    uvf.to_waterfall()
+    # Muck spw-related attributes to see if it gets pulled from main object
+    uvf.Nspws = uvf.spw_array = uvf.flex_spw_id_array = None
+    uvf.to_antenna(uvc)
+
+    uvf.check()
+    assert np.array_equal(uvf.spw_array, uvc.spw_array)
+    assert np.array_equal(uvf.flex_spw_id_array, uvc.flex_spw_id_array)
+    assert uvf.Nspws == uvc.Nspws
 
 
 def test_get_ants_error(uvf_from_waterfall):

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -20,7 +20,6 @@ from pyuvdata import UVCal, UVData, UVFlag, __version__, hdf5_utils
 from pyuvdata import utils as uvutils
 from pyuvdata.data import DATA_PATH
 from pyuvdata.tests.test_utils import frame_selenoid, hasmoon
-from pyuvdata.uvflag.uvflag import _future_array_shapes_warning
 
 from ...uvbase import old_telescope_metadata_attrs
 from ..uvflag import and_rows_cols, flags2waterfall
@@ -118,11 +117,6 @@ def uvcal_obj(uvcal_obj_main):
     uvc.set_telescope_params(overwrite=True, warn=False)
     yield uvc
 
-    # cleanup
-    del uvc
-
-    return
-
 
 # The following three fixtures are used regularly
 # to initizize UVFlag objects from standard files
@@ -131,7 +125,7 @@ def uvcal_obj(uvcal_obj_main):
 @pytest.fixture(scope="function")
 def uvf_from_data(uvdata_obj):
     uvf = UVFlag()
-    uvf.from_uvdata(uvdata_obj, use_future_array_shapes=True)
+    uvf.from_uvdata(uvdata_obj)
 
     # yield the object for the test
     yield uvf
@@ -143,7 +137,7 @@ def uvf_from_data(uvdata_obj):
 @pytest.fixture(scope="function")
 def uvf_from_uvcal(uvcal_obj):
     uvf = UVFlag()
-    uvf.from_uvcal(uvcal_obj, use_future_array_shapes=True)
+    uvf.from_uvcal(uvcal_obj)
 
     # the antenna type test file is large, so downselect to speed up
     if uvf.type == "antenna":
@@ -157,12 +151,12 @@ def uvf_from_uvcal(uvcal_obj):
 
 
 @pytest.fixture(scope="function")
-def uvf_from_file_future_main():
+def uvf_from_file_main():
     with uvtest.check_warnings(
         [UserWarning] * 4 + [DeprecationWarning] * 5,
         match=["channel_width not available in file, computing it from the freq_array"],
     ):
-        uvf = UVFlag(test_f_file, use_future_array_shapes=True, telescope_name="HERA")
+        uvf = UVFlag(test_f_file, telescope_name="HERA")
     uvf.telescope.name = "HERA"
     uvf.telescope.antenna_numbers = None
     uvf.telescope.antenna_names = None
@@ -172,14 +166,14 @@ def uvf_from_file_future_main():
 
 
 @pytest.fixture(scope="function")
-def uvf_from_file_future(uvf_from_file_future_main):
-    yield uvf_from_file_future_main.copy()
+def uvf_from_file(uvf_from_file_main):
+    yield uvf_from_file_main.copy()
 
 
 @pytest.fixture(scope="function")
 def uvf_from_waterfall(uvdata_obj):
     uvf = UVFlag()
-    uvf.from_uvdata(uvdata_obj, waterfall=True, use_future_array_shapes=True)
+    uvf.from_uvdata(uvdata_obj, waterfall=True)
 
     # yield the object for the test
     yield uvf
@@ -236,50 +230,9 @@ def test_outfile(tmp_path):
 
 @pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("obj_type", ["baseline", "antenna", "waterfall"])
-def test_future_shapes(obj_type, uvf_from_data, uvf_from_uvcal, uvf_from_waterfall):
-    if obj_type == "baseline":
-        uvf = uvf_from_data
-    elif obj_type == "antenna":
-        uvf = uvf_from_uvcal
-    else:
-        uvf = uvf_from_waterfall
-
-    uvf.weights_square_array = np.ones(
-        uvf._weights_square_array.expected_shape(uvf), dtype=float
-    )
-    uvf2 = uvf.copy()
-    # test no-op
-    uvf.use_future_array_shapes()
-    assert uvf == uvf2
-
-    with uvtest.check_warnings(
-        DeprecationWarning,
-        match="This method will be removed in version 3.0 when the current array",
-    ):
-        uvf.use_current_array_shapes()
-    uvf.check()
-
-    # test no-op
-    uvf3 = uvf.copy()
-    with uvtest.check_warnings(
-        DeprecationWarning,
-        match="This method will be removed in version 3.0 when the current array",
-    ):
-        uvf.use_current_array_shapes()
-    assert uvf3 == uvf
-
-    uvf.use_future_array_shapes()
-    uvf.check()
-
-    assert uvf == uvf2
-
-
-@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
-@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_check_flag_array(uvdata_obj):
     uvf = UVFlag()
-    uvf.from_uvdata(uvdata_obj, mode="flag", use_future_array_shapes=True)
+    uvf.from_uvdata(uvdata_obj, mode="flag")
 
     uvf.flag_array = np.ones((uvf.flag_array.shape), dtype=int)
 
@@ -346,13 +299,12 @@ def test_check_flex_spw_id_array(uvf_from_data):
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
-def test_init_bad_mode(uvdata_obj):
+def test_init_bad_mode(uvdata_obj, uvcal_obj):
     uv = uvdata_obj
     with pytest.raises(ValueError, match="Input mode must be within acceptable"):
         UVFlag(uv, mode="bad_mode", history="I made a UVFlag object", label="test")
 
-    uv = UVCal()
-    uv.read_calfits(test_c_file, use_future_array_shapes=True)
+    uv = uvcal_obj
     with pytest.raises(ValueError, match="Input mode must be within acceptable"):
         UVFlag(uv, mode="bad_mode", history="I made a UVFlag object", label="test")
 
@@ -360,9 +312,7 @@ def test_init_bad_mode(uvdata_obj):
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_init_uvdata(uvdata_obj):
     uv = uvdata_obj
-    uvf = UVFlag(
-        uv, history="I made a UVFlag object", label="test", use_future_array_shapes=True
-    )
+    uvf = UVFlag(uv, history="I made a UVFlag object", label="test")
     assert uvf.metric_array.shape == uv.flag_array.shape
     assert np.all(uvf.metric_array == 0)
     assert uvf.weights_array.shape == uv.flag_array.shape
@@ -385,9 +335,7 @@ def test_init_uvdata(uvdata_obj):
 
 def test_add_extra_keywords(uvdata_obj):
     uv = uvdata_obj
-    uvf = UVFlag(
-        uv, history="I made a UVFlag object", label="test", use_future_array_shapes=True
-    )
+    uvf = UVFlag(uv, history="I made a UVFlag object", label="test")
     uvf.extra_keywords = {"keyword1": 1, "keyword2": 2}
     assert "keyword1" in uvf.extra_keywords
     assert "keyword2" in uvf.extra_keywords
@@ -403,9 +351,7 @@ def test_read_extra_keywords(uvdata_obj):
     uv.extra_keywords = {"keyword1": 1, "keyword2": 2}
     assert "keyword1" in uv.extra_keywords
     assert "keyword2" in uv.extra_keywords
-    uvf = UVFlag(
-        uv, history="I made a UVFlag object", label="test", use_future_array_shapes=True
-    )
+    uvf = UVFlag(uv, history="I made a UVFlag object", label="test")
     assert "keyword1" in uvf.extra_keywords
     assert "keyword2" in uvf.extra_keywords
 
@@ -414,56 +360,31 @@ def test_read_extra_keywords(uvdata_obj):
 def test_init_uvdata_x_orientation(uvdata_obj):
     uv = uvdata_obj
     uv.telescope.x_orientation = "east"
-    uvf = UVFlag(
-        uv, history="I made a UVFlag object", label="test", use_future_array_shapes=True
-    )
+    uvf = UVFlag(uv, history="I made a UVFlag object", label="test")
     assert uvf.telescope.x_orientation == uv.telescope.x_orientation
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
-@pytest.mark.parametrize("uvd_future_shapes", [True, False])
-@pytest.mark.parametrize("uvf_future_shapes", [True, False])
-def test_init_uvdata_copy_flags(uvdata_obj, uvd_future_shapes, uvf_future_shapes):
+def test_init_uvdata_copy_flags(uvdata_obj):
     uv = uvdata_obj
-
-    if not uvd_future_shapes:
-        uv.use_current_array_shapes()
 
     warn_type = [UserWarning]
     warn_msg = ['Copying flags to type=="baseline"']
-    if not uvf_future_shapes:
-        warn_type.append(DeprecationWarning)
-        warn_msg.append(_future_array_shapes_warning)
 
     with uvtest.check_warnings(warn_type, match=warn_msg):
-        uvf = UVFlag(
-            uv,
-            copy_flags=True,
-            mode="metric",
-            use_future_array_shapes=uvf_future_shapes,
-        )
+        uvf = UVFlag(uv, copy_flags=True, mode="metric")
+
     #  with copy flags uvf.metric_array should be none
     assert hasattr(uvf, "metric_array")
     assert uvf.metric_array is None
-    if uvd_future_shapes == uvf_future_shapes:
-        assert np.array_equal(uvf.flag_array, uv.flag_array)
-    elif uvd_future_shapes:
-        assert np.array_equal(uvf.flag_array[:, 0], uv.flag_array)
-    else:
-        assert np.array_equal(uvf.flag_array, uv.flag_array[:, 0])
+    assert np.array_equal(uvf.flag_array, uv.flag_array)
     assert uvf.weights_array is None
     assert uvf.type == "baseline"
     assert uvf.mode == "flag"
     assert np.all(uvf.time_array == uv.time_array)
     assert np.all(uvf.lst_array == uv.lst_array)
-    if uvd_future_shapes == uvf_future_shapes:
-        assert np.all(uvf.freq_array == uv.freq_array)
-    elif uvd_future_shapes:
-        assert np.all(uvf.freq_array[0] == uv.freq_array)
-    else:
-        assert np.all(uvf.freq_array == uv.freq_array[0])
+    assert np.all(uvf.freq_array == uv.freq_array)
     assert np.all(uvf.polarization_array == uv.polarization_array)
     assert np.all(uvf.baseline_array == uv.baseline_array)
     assert np.all(uvf.ant_1_array == uv.ant_1_array)
@@ -472,16 +393,9 @@ def test_init_uvdata_copy_flags(uvdata_obj, uvd_future_shapes, uvf_future_shapes
     assert pyuvdata_version_str in uvf.history
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("uvd_future_shapes", [True, False])
-@pytest.mark.parametrize("uvf_future_shapes", [True, False])
-def test_init_uvdata_mode_flag(uvdata_obj, uvd_future_shapes, uvf_future_shapes):
+def test_init_uvdata_mode_flag(uvdata_obj):
     uv = uvdata_obj
-
-    if not uvd_future_shapes:
-        uv.use_current_array_shapes()
 
     # add spectral windows to test handling
     uv.Nspws = 2
@@ -491,29 +405,17 @@ def test_init_uvdata_mode_flag(uvdata_obj, uvd_future_shapes, uvf_future_shapes)
     uv.check()
 
     uvf = UVFlag()
-    uvf.from_uvdata(
-        uv, copy_flags=False, mode="flag", use_future_array_shapes=uvf_future_shapes
-    )
+    uvf.from_uvdata(uv, copy_flags=False, mode="flag")
     #  with copy flags uvf.metric_array should be none
     assert hasattr(uvf, "metric_array")
     assert uvf.metric_array is None
-    if uvd_future_shapes == uvf_future_shapes:
-        assert np.array_equal(uvf.flag_array, uv.flag_array)
-    elif uvd_future_shapes:
-        assert np.array_equal(uvf.flag_array[:, 0], uv.flag_array)
-    else:
-        assert np.array_equal(uvf.flag_array, uv.flag_array[:, 0])
+    assert np.array_equal(uvf.flag_array, uv.flag_array)
     assert uvf.weights_array is None
     assert uvf.type == "baseline"
     assert uvf.mode == "flag"
     assert np.all(uvf.time_array == uv.time_array)
     assert np.all(uvf.lst_array == uv.lst_array)
-    if uvd_future_shapes == uvf_future_shapes:
-        assert np.all(uvf.freq_array == uv.freq_array)
-    elif uvd_future_shapes:
-        assert np.all(uvf.freq_array[0] == uv.freq_array)
-    else:
-        assert np.all(uvf.freq_array == uv.freq_array[0])
+    assert np.all(uvf.freq_array == uv.freq_array)
     assert np.all(uvf.polarization_array == uv.polarization_array)
     assert np.all(uvf.baseline_array == uv.baseline_array)
     assert np.all(uvf.ant_1_array == uv.ant_1_array)
@@ -523,9 +425,8 @@ def test_init_uvdata_mode_flag(uvdata_obj, uvd_future_shapes, uvf_future_shapes)
 
 
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
-def test_init_uvcal():
-    uvc = UVCal()
-    uvc.read_calfits(test_c_file, use_future_array_shapes=True)
+def test_init_uvcal(uvcal_obj):
+    uvc = uvcal_obj
 
     # add spectral windows to test handling
     uvc.Nspws = 2
@@ -534,7 +435,7 @@ def test_init_uvcal():
     uvc.flex_spw_id_array[: uvc.Nfreqs // 2] = 1
     uvc.check()
 
-    uvf = UVFlag(uvc, use_future_array_shapes=True)
+    uvf = UVFlag(uvc)
     assert uvf.metric_array.shape == uvc.flag_array.shape
     assert np.all(uvf.metric_array == 0)
     assert uvf.weights_array.shape == uvc.flag_array.shape
@@ -552,38 +453,19 @@ def test_init_uvcal():
     assert uvf.filename == uvc.filename
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.parametrize("uvc_future_shapes", [True, False])
-@pytest.mark.parametrize("uvf_future_shapes", [True, False])
-def test_init_uvcal_mode_flag(uvcal_obj, uvc_future_shapes, uvf_future_shapes):
+def test_init_uvcal_mode_flag(uvcal_obj):
     uvc = uvcal_obj
-    if not uvc_future_shapes:
-        uvc.use_current_array_shapes()
-
-    uvf = UVFlag(
-        uvc, copy_flags=False, mode="flag", use_future_array_shapes=uvf_future_shapes
-    )
+    uvf = UVFlag(uvc, copy_flags=False, mode="flag")
     assert hasattr(uvf, "metric_array")
     assert uvf.metric_array is None
-    if uvc_future_shapes == uvf_future_shapes:
-        assert np.array_equal(uvf.flag_array, uvc.flag_array)
-    elif uvc_future_shapes:
-        assert np.array_equal(uvf.flag_array[:, 0], uvc.flag_array)
-    else:
-        assert np.array_equal(uvf.flag_array, uvc.flag_array[:, 0])
+    assert np.array_equal(uvf.flag_array, uvc.flag_array)
 
     assert uvf.weights_array is None
     assert uvf.type == "antenna"
     assert uvf.mode == "flag"
     assert np.all(uvf.time_array == uvc.time_array)
     assert np.all(uvf.lst_array == uvc.lst_array)
-    if uvc_future_shapes == uvf_future_shapes:
-        assert np.all(uvf.freq_array == uvc.freq_array)
-    elif uvc_future_shapes:
-        assert np.all(uvf.freq_array[0] == uvc.freq_array)
-    else:
-        assert np.all(uvf.freq_array == uvc.freq_array[0])
+    assert np.all(uvf.freq_array == uvc.freq_array)
     assert np.all(uvf.polarization_array == uvc.jones_array)
     assert np.all(uvf.ant_array == uvc.ant_array)
     assert 'Flag object with type "antenna"' in uvf.history
@@ -592,60 +474,31 @@ def test_init_uvcal_mode_flag(uvcal_obj, uvc_future_shapes, uvf_future_shapes):
 
 @pytest.mark.filterwarnings("ignore:The shapes of several attributes will be changing")
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
-@pytest.mark.parametrize("uvc_future_shapes", [True, False])
-@pytest.mark.parametrize("uvf_future_shapes", [True, False])
-def test_init_cal_copy_flags(uvc_future_shapes, uvf_future_shapes):
-    uv = UVCal()
-    uv.read_calfits(test_c_file, use_future_array_shapes=uvc_future_shapes)
+def test_init_cal_copy_flags(uvcal_obj):
+    uv = uvcal_obj
 
     warn_type = [UserWarning]
     warn_msg = ['Copying flags to type=="antenna"']
-    if not uvf_future_shapes:
-        warn_type.append(DeprecationWarning)
-        warn_msg.append(_future_array_shapes_warning)
 
     with uvtest.check_warnings(warn_type, match=warn_msg):
-        uvf = UVFlag(
-            uv,
-            copy_flags=True,
-            mode="metric",
-            use_future_array_shapes=uvf_future_shapes,
-        )
+        uvf = UVFlag(uv, copy_flags=True, mode="metric")
     #  with copy flags uvf.metric_array should be none
     assert hasattr(uvf, "metric_array")
     assert uvf.metric_array is None
-    if uvc_future_shapes == uvf_future_shapes:
-        assert np.array_equal(uvf.flag_array, uv.flag_array)
-    elif uvc_future_shapes:
-        assert np.array_equal(uvf.flag_array[:, 0], uv.flag_array)
-    else:
-        assert np.array_equal(uvf.flag_array, uv.flag_array[:, 0])
+    assert np.array_equal(uvf.flag_array, uv.flag_array)
     assert uvf.type == "antenna"
     assert uvf.mode == "flag"
     assert np.all(uvf.time_array == np.unique(uv.time_array))
-    if uvc_future_shapes == uvf_future_shapes:
-        assert np.all(uvf.freq_array == uv.freq_array)
-    elif uvc_future_shapes:
-        assert np.all(uvf.freq_array[0] == uv.freq_array)
-    else:
-        assert np.all(uvf.freq_array == uv.freq_array[0])
+    assert np.all(uvf.freq_array == uv.freq_array)
 
     assert np.all(uvf.polarization_array == uv.jones_array)
     assert pyuvdata_version_str in uvf.history
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("uvd_future_shapes", [True, False])
-@pytest.mark.parametrize("uvf_future_shapes", [True, False])
-def test_init_waterfall_uvd(uvdata_obj, uvd_future_shapes, uvf_future_shapes):
+def test_init_waterfall_uvd(uvdata_obj):
     uv = uvdata_obj
-
-    if not uvd_future_shapes:
-        uv.use_current_array_shapes()
-
-    uvf = UVFlag(uv, waterfall=True, use_future_array_shapes=uvf_future_shapes)
+    uvf = UVFlag(uv, waterfall=True)
     assert uvf.metric_array.shape == (uv.Ntimes, uv.Nfreqs, uv.Npols)
     assert np.all(uvf.metric_array == 0)
     assert uvf.weights_array.shape == (uv.Ntimes, uv.Nfreqs, uv.Npols)
@@ -654,10 +507,7 @@ def test_init_waterfall_uvd(uvdata_obj, uvd_future_shapes, uvf_future_shapes):
     assert uvf.mode == "metric"
     assert np.all(uvf.time_array == np.unique(uv.time_array))
     assert np.all(uvf.lst_array == np.unique(uv.lst_array))
-    if uvd_future_shapes:
-        assert np.all(uvf.freq_array == uv.freq_array)
-    else:
-        assert np.all(uvf.freq_array == uv.freq_array[0])
+    assert np.all(uvf.freq_array == uv.freq_array)
     assert np.all(uvf.polarization_array == uv.polarization_array)
     assert 'Flag object with type "waterfall"' in uvf.history
     assert pyuvdata_version_str in uvf.history
@@ -665,11 +515,8 @@ def test_init_waterfall_uvd(uvdata_obj, uvd_future_shapes, uvf_future_shapes):
 
 @pytest.mark.filterwarnings("ignore:The shapes of several attributes will be changing")
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
-@pytest.mark.parametrize("uvc_future_shapes", [True, False])
-@pytest.mark.parametrize("uvf_future_shapes", [True, False])
-def test_init_waterfall_uvc(uvc_future_shapes, uvf_future_shapes):
-    uv = UVCal()
-    uv.read_calfits(test_c_file, use_future_array_shapes=uvc_future_shapes)
+def test_init_waterfall_uvc(uvcal_obj):
+    uv = uvcal_obj
 
     uvf = UVFlag(uv, waterfall=True, history="input history check")
     assert uvf.metric_array.shape == (uv.Ntimes, uv.Nfreqs, uv.Njones)
@@ -679,10 +526,7 @@ def test_init_waterfall_uvc(uvc_future_shapes, uvf_future_shapes):
     assert uvf.type == "waterfall"
     assert uvf.mode == "metric"
     assert np.all(uvf.time_array == np.unique(uv.time_array))
-    if uvc_future_shapes:
-        assert np.all(uvf.freq_array == uv.freq_array)
-    else:
-        assert np.all(uvf.freq_array == uv.freq_array[0])
+    assert np.all(uvf.freq_array == uv.freq_array)
     assert np.all(uvf.polarization_array == uv.jones_array)
     assert 'Flag object with type "waterfall"' in uvf.history
     assert "input history check" in uvf.history
@@ -690,10 +534,9 @@ def test_init_waterfall_uvc(uvc_future_shapes, uvf_future_shapes):
 
 
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
-def test_init_waterfall_flag_uvcal():
-    uv = UVCal()
-    uv.read_calfits(test_c_file, use_future_array_shapes=True)
-    uvf = UVFlag(uv, waterfall=True, mode="flag", use_future_array_shapes=True)
+def test_init_waterfall_flag_uvcal(uvcal_obj):
+    uv = uvcal_obj
+    uvf = UVFlag(uv, waterfall=True, mode="flag")
     assert uvf.flag_array.shape == (uv.Ntimes, uv.Nfreqs, uv.Njones)
     assert not np.any(uvf.flag_array)
     assert uvf.weights_array is None
@@ -709,7 +552,7 @@ def test_init_waterfall_flag_uvcal():
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_init_waterfall_flag_uvdata(uvdata_obj):
     uv = uvdata_obj
-    uvf = UVFlag(uv, waterfall=True, mode="flag", use_future_array_shapes=True)
+    uvf = UVFlag(uv, waterfall=True, mode="flag")
     assert uvf.flag_array.shape == (uv.Ntimes, uv.Nfreqs, uv.Npols)
     assert not np.any(uvf.flag_array)
     assert uvf.weights_array is None
@@ -724,9 +567,8 @@ def test_init_waterfall_flag_uvdata(uvdata_obj):
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
-def test_init_waterfall_copy_flags(uvdata_obj):
-    uv = UVCal()
-    uv.read_calfits(test_c_file, use_future_array_shapes=True)
+def test_init_waterfall_copy_flags(uvdata_obj, uvcal_obj):
+    uv = uvcal_obj
     with pytest.raises(
         NotImplementedError, match="Cannot copy flags when initializing"
     ):
@@ -754,7 +596,7 @@ def test_from_uvcal_error(uvdata_obj):
         match="from_uvcal can only initialize a UVFlag object from an input "
         "UVCal object or a subclass of a UVCal object.",
     ):
-        uvf.from_uvcal(uv, use_future_array_shapes=True)
+        uvf.from_uvcal(uv)
 
     delay_object = UVCal()
     delayfile = os.path.join(DATA_PATH, "zen.2457698.40355.xx.delay.calfits")
@@ -785,26 +627,20 @@ def test_from_uvcal_error(uvdata_obj):
 
 
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
-def test_from_uvdata_error():
-    uv = UVCal()
-    uv.read_calfits(test_c_file, use_future_array_shapes=True)
+def test_from_uvdata_error(uvcal_obj):
     uvf = UVFlag()
     with pytest.raises(
         ValueError, match="from_uvdata can only initialize a UVFlag object"
     ):
-        uvf.from_uvdata(uv, use_future_array_shapes=True)
+        uvf.from_uvdata(uvcal_obj)
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.parametrize("read_future_shapes", [True, False])
-@pytest.mark.parametrize("write_future_shapes", [True, False])
-def test_init_list_files_weights(read_future_shapes, write_future_shapes, tmpdir):
+def test_init_list_files_weights(tmpdir):
     # Test that weights are preserved when reading list of files
     tmp_path = tmpdir.strpath
     # Create two files to read
-    uvf = UVFlag(test_f_file, use_future_array_shapes=write_future_shapes)
+    uvf = UVFlag(test_f_file)
     np.random.seed(0)
     wts1 = np.random.rand(*uvf.weights_array.shape)
     uvf.weights_array = wts1.copy()
@@ -813,14 +649,8 @@ def test_init_list_files_weights(read_future_shapes, write_future_shapes, tmpdir
     uvf.weights_array = wts2.copy()
     uvf.write(os.path.join(tmp_path, "test2.h5"))
     uvf2 = UVFlag(
-        [os.path.join(tmp_path, "test1.h5"), os.path.join(tmp_path, "test2.h5")],
-        use_future_array_shapes=read_future_shapes,
+        [os.path.join(tmp_path, "test1.h5"), os.path.join(tmp_path, "test2.h5")]
     )
-    if read_future_shapes != write_future_shapes:
-        if read_future_shapes:
-            uvf2.use_current_array_shapes()
-        else:
-            uvf2.use_future_array_shapes()
 
     assert np.all(uvf2.weights_array == np.concatenate([wts1, wts2], axis=0))
 
@@ -828,8 +658,8 @@ def test_init_list_files_weights(read_future_shapes, write_future_shapes, tmpdir
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_init_posix():
     testfile_posix = pathlib.Path(test_f_file)
-    uvf1 = UVFlag(test_f_file, use_future_array_shapes=True)
-    uvf2 = UVFlag(testfile_posix, use_future_array_shapes=True)
+    uvf1 = UVFlag(test_f_file)
+    uvf2 = UVFlag(testfile_posix)
     assert uvf1 == uvf2
 
 
@@ -898,29 +728,18 @@ def test_hdf5_meta_no_moon(test_outfile, uvf_from_data):
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_data_like_property_mode_tamper(uvdata_obj):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
     uvf.mode = "test"
     with pytest.raises(ValueError, match="Invalid mode. Mode must be one of"):
         list(uvf.data_like_parameters)
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.parametrize("read_future_shapes", [True, False])
-@pytest.mark.parametrize("write_future_shapes", [True, False])
-def test_read_write_loop(
-    uvdata_obj, test_outfile, write_future_shapes, read_future_shapes
-):
+def test_read_write_loop(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=write_future_shapes)
+    uvf = UVFlag(uv, label="test")
 
     uvf.write(test_outfile, clobber=True)
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=read_future_shapes)
-    if read_future_shapes != write_future_shapes:
-        if read_future_shapes:
-            uvf2.use_current_array_shapes()
-        else:
-            uvf2.use_future_array_shapes()
+    uvf2 = UVFlag(test_outfile)
 
     assert uvf.__eq__(uvf2, check_history=True)
     assert uvf2.filename == [os.path.basename(test_outfile)]
@@ -948,7 +767,7 @@ def test_read_write_loop_spw(uvdata_obj, test_outfile, telescope_frame, selenoid
         uv.set_lsts_from_time_array()
         uv.check()
 
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
 
     uvf.Nspws = 2
     uvf.spw_array = np.array([0, 1])
@@ -957,7 +776,7 @@ def test_read_write_loop_spw(uvdata_obj, test_outfile, telescope_frame, selenoid
     uvf.check()
 
     uvf.write(test_outfile, clobber=True)
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+    uvf2 = UVFlag(test_outfile)
     assert uvf.__eq__(uvf2, check_history=True)
     assert uvf2.filename == [os.path.basename(test_outfile)]
 
@@ -969,11 +788,9 @@ def test_read_write_loop_spw(uvdata_obj, test_outfile, telescope_frame, selenoid
     assert np.isclose(loc_obj.z, uvf.telescope.location.z)
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_read_write_loop_missing_shapes(uvdata_obj, test_outfile, future_shapes):
+def test_read_write_loop_missing_shapes(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=future_shapes)
+    uvf = UVFlag(uv, label="test")
     uvf.write(test_outfile, clobber=True)
     with h5py.File(test_outfile, "r+") as h5f:
         del h5f["/Header/Ntimes"]
@@ -982,7 +799,7 @@ def test_read_write_loop_missing_shapes(uvdata_obj, test_outfile, future_shapes)
         del h5f["/Header/Nblts"]
         del h5f["/Header/Nants_data"]
         del h5f["/Header/Nspws"]
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=future_shapes)
+    uvf2 = UVFlag(test_outfile)
     assert uvf.__eq__(uvf2, check_history=True)
     assert uvf2.filename == [os.path.basename(test_outfile)]
 
@@ -1251,7 +1068,7 @@ def test_read_write_loop_missing_telescope_info(
     else:
         run_check = False
 
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
     if uvf_type == "waterfall":
         uvf.to_waterfall()
 
@@ -1264,7 +1081,7 @@ def test_read_write_loop_missing_telescope_info(
         run_check = False
 
     with uvtest.check_warnings(warn_type, match=None if warn_type is None else msg):
-        uvf2 = UVFlag(test_outfile, use_future_array_shapes=True, run_check=run_check)
+        uvf2 = UVFlag(test_outfile, run_check=run_check)
 
     if uv_mod is None:
         if param_list == ["antenna_names"]:
@@ -1286,7 +1103,7 @@ def test_read_write_loop_missing_telescope_info(
         assert uvf2.filename == [os.path.basename(test_outfile)]
 
     if "telescope_name" in param_list and "Nants_telescope" not in param_list:
-        uvf2 = UVFlag(test_outfile, telescope_name="HERA", use_future_array_shapes=True)
+        uvf2 = UVFlag(test_outfile, telescope_name="HERA")
         assert uvf.__eq__(uvf2, check_history=True)
         assert uvf2.filename == [os.path.basename(test_outfile)]
 
@@ -1299,16 +1116,14 @@ def test_read_write_loop_missing_telescope_info(
                 "name in the file (HERA)."
             ],
         ):
-            uvf2 = UVFlag(
-                test_outfile, telescope_name="foo", use_future_array_shapes=True
-            )
+            uvf2 = UVFlag(test_outfile, telescope_name="foo")
 
 
 def test_missing_telescope_info_mwa(test_outfile):
     mwa_uvfits = os.path.join(DATA_PATH, "1133866760.uvfits")
     metafits = os.path.join(DATA_PATH, "mwa_corr_fits_testfiles", "1131733552.metafits")
     uvd = UVData.from_file(mwa_uvfits, use_future_array_shapes=True)
-    uvf = UVFlag(uvd, use_future_array_shapes=True, waterfall=True)
+    uvf = UVFlag(uvd, waterfall=True)
 
     uvf.write(test_outfile, clobber=True)
     param_list = [
@@ -1336,7 +1151,7 @@ def test_missing_telescope_info_mwa(test_outfile):
             "antenna_positions are set using values from known telescopes for mwa.",
         ],
     ):
-        uvf2 = UVFlag(test_outfile, use_future_array_shapes=True, telescope_name="mwa")
+        uvf2 = UVFlag(test_outfile, telescope_name="mwa")
 
     from pyuvdata.uvdata.mwa_corr_fits import read_metafits
 
@@ -1368,16 +1183,14 @@ def test_missing_telescope_info_mwa(test_outfile):
             "location. Consider recomputing with the `set_lsts_from_time_array` method",
         ],
     ):
-        uvf3 = UVFlag(
-            test_outfile, use_future_array_shapes=True, mwa_metafits_file=metafits
-        )
+        uvf3 = UVFlag(test_outfile, mwa_metafits_file=metafits)
 
     assert uvf2.telescope.Nants > uvf3.telescope.Nants
 
 
 def test_read_write_loop_wrong_nants_data(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
     uvf.write(test_outfile, clobber=True)
     with h5py.File(test_outfile, "r+") as h5f:
         nants_data = int(h5f["/Header/Nants_data"][()])
@@ -1389,14 +1202,14 @@ def test_read_write_loop_wrong_nants_data(uvdata_obj, test_outfile):
         match="Nants_data in file does not match number of antennas with data. "
         "Resetting Nants_data.",
     ):
-        uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+        uvf2 = UVFlag(test_outfile)
     assert uvf.__eq__(uvf2, check_history=True)
     assert uvf2.filename == [os.path.basename(test_outfile)]
 
 
 def test_read_write_loop_missing_channel_width(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
     uvf.write(test_outfile, clobber=True)
     with h5py.File(test_outfile, "r+") as h5f:
         del h5f["/Header/channel_width"]
@@ -1405,7 +1218,7 @@ def test_read_write_loop_missing_channel_width(uvdata_obj, test_outfile):
         match="channel_width not available in file, computing it from the freq_array "
         "spacing.",
     ):
-        uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+        uvf2 = UVFlag(test_outfile)
     assert uvf.__eq__(uvf2, check_history=True)
     assert uvf2.filename == [os.path.basename(test_outfile)]
 
@@ -1421,35 +1234,35 @@ def test_read_write_loop_missing_channel_width(uvdata_obj, test_outfile):
         "spacing. The freq_array does not have equal spacing, so the last "
         "channel_width is set equal to the channel width below it.",
     ):
-        uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+        uvf2 = UVFlag(test_outfile)
     assert uvf.__eq__(uvf2, check_history=True)
     assert uvf2.filename == [os.path.basename(test_outfile)]
 
 
 def test_read_write_loop_missing_spw_array(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
     uvf.write(test_outfile, clobber=True)
     with h5py.File(test_outfile, "r+") as h5f:
         del h5f["/Header/spw_array"]
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+    uvf2 = UVFlag(test_outfile)
     assert uvf.__eq__(uvf2, check_history=True)
     assert uvf2.filename == [os.path.basename(test_outfile)]
 
 
 def test_read_write_loop_with_optional_x_orientation(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
     uvf.telescope.x_orientation = "east"
     uvf.write(test_outfile, clobber=True)
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+    uvf2 = UVFlag(test_outfile)
     assert uvf.__eq__(uvf2, check_history=True)
 
 
 @pytest.mark.parametrize("spw_axis", [True, False])
 def test_read_write_loop_waterfall(uvdata_obj, test_outfile, spw_axis):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
     uvf.to_waterfall()
     uvf.write(test_outfile, clobber=True)
 
@@ -1460,23 +1273,23 @@ def test_read_write_loop_waterfall(uvdata_obj, test_outfile, spw_axis):
             del h5f["/Header/freq_array"]
             h5f["/Header/freq_array"] = freq_array[np.newaxis, :]
 
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+    uvf2 = UVFlag(test_outfile)
     assert uvf.__eq__(uvf2, check_history=True)
 
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_read_write_loop_ret_wt_sq(test_outfile):
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.weights_array = 2 * np.ones_like(uvf.weights_array)
     uvf.to_waterfall(return_weights_square=True)
     uvf.write(test_outfile, clobber=True)
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+    uvf2 = UVFlag(test_outfile)
     assert uvf.__eq__(uvf2, check_history=True)
 
 
 def test_bad_mode_savefile(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
 
     # create the file so the clobber gets tested
     with h5py.File(test_outfile, "w") as h5file:
@@ -1489,12 +1302,12 @@ def test_bad_mode_savefile(uvdata_obj, test_outfile):
         mode[...] = np.string_("test")
 
     with pytest.raises(ValueError, match="File cannot be read. Received mode"):
-        uvf = UVFlag(test_outfile, use_future_array_shapes=True)
+        uvf = UVFlag(test_outfile)
 
 
 def test_bad_type_savefile(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
     uvf.write(test_outfile, clobber=True)
     # manually re-read and tamper with parameters
     with h5py.File(test_outfile, "a") as h5:
@@ -1507,7 +1320,7 @@ def test_bad_type_savefile(uvdata_obj, test_outfile):
 
 def test_write_add_version_str(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
     uvf.history = uvf.history.replace(pyuvdata_version_str, "")
 
     assert pyuvdata_version_str not in uvf.history
@@ -1521,7 +1334,7 @@ def test_write_add_version_str(uvdata_obj, test_outfile):
 
 def test_read_add_version_str(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
 
     assert pyuvdata_version_str in uvf.history
     uvf.write(test_outfile, clobber=True)
@@ -1530,54 +1343,36 @@ def test_read_add_version_str(uvdata_obj, test_outfile):
         hist = h5["Header/history"]
         del hist
 
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+    uvf2 = UVFlag(test_outfile)
     assert pyuvdata_version_str in uvf2.history
     assert uvf == uvf2
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.parametrize(
-    ["read_future_shapes", "existing"],
-    [[True, True], [True, False], [False, True], [False, False]],
-)
-@pytest.mark.parametrize("write_future_shapes", [True, False])
-def test_read_write_ant(
-    uvcal_obj, test_outfile, write_future_shapes, read_future_shapes, existing
-):
+@pytest.mark.parametrize("existing", [True, False])
+def test_read_write_ant(uvcal_obj, test_outfile, existing):
     uvc = uvcal_obj
-    uvf = UVFlag(
-        uvc, mode="flag", label="test", use_future_array_shapes=write_future_shapes
-    )
+    uvf = UVFlag(uvc, mode="flag", label="test")
     uvf.write(test_outfile, clobber=True)
 
     if existing:
         uvf2 = uvf.copy()
-        if read_future_shapes:
-            uvf2.use_future_array_shapes()
-        uvf2.read(test_outfile, use_future_array_shapes=read_future_shapes)
+        uvf2.read(test_outfile)
     else:
-        uvf2 = UVFlag(test_outfile, use_future_array_shapes=read_future_shapes)
+        uvf2 = UVFlag(test_outfile)
 
-    if read_future_shapes != write_future_shapes:
-        if read_future_shapes:
-            uvf2.use_current_array_shapes()
-        else:
-            uvf2.use_future_array_shapes()
     assert uvf.__eq__(uvf2, check_history=True)
 
 
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
-def test_read_missing_nants_data(test_outfile):
-    uv = UVCal()
-    uv.read_calfits(test_c_file, use_future_array_shapes=True)
-    uvf = UVFlag(uv, mode="flag", label="test", use_future_array_shapes=True)
+def test_read_missing_nants_data(test_outfile, uvcal_obj):
+    uv = uvcal_obj
+    uvf = UVFlag(uv, mode="flag", label="test")
     uvf.write(test_outfile, clobber=True)
 
     with h5py.File(test_outfile, "a") as h5:
         del h5["Header/Nants_data"]
 
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+    uvf2 = UVFlag(test_outfile)
 
     # make sure this was set to None
     assert uvf2.Nants_data == len(uvf2.ant_array)
@@ -1589,17 +1384,15 @@ def test_read_missing_nants_data(test_outfile):
 
 @pytest.mark.filterwarnings("ignore:The shapes of several attributes will be changing")
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_read_missing_nspws(test_outfile, future_shapes):
-    uv = UVCal()
-    uv.read_calfits(test_c_file, use_future_array_shapes=future_shapes)
-    uvf = UVFlag(uv, mode="flag", label="test", use_future_array_shapes=future_shapes)
+def test_read_missing_nspws(test_outfile, uvcal_obj):
+    uv = uvcal_obj
+    uvf = UVFlag(uv, mode="flag", label="test")
     uvf.write(test_outfile, clobber=True)
 
     with h5py.File(test_outfile, "a") as h5:
         del h5["Header/Nspws"]
 
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=future_shapes)
+    uvf2 = UVFlag(test_outfile)
     # make sure Nspws was calculated
     assert uvf2.Nspws == 1
 
@@ -1609,26 +1402,26 @@ def test_read_missing_nspws(test_outfile, future_shapes):
 
 def test_read_write_nocompress(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
     uvf.write(test_outfile, clobber=True, data_compression=None)
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+    uvf2 = UVFlag(test_outfile)
     assert uvf.__eq__(uvf2, check_history=True)
 
 
 def test_read_write_nocompress_flag(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, mode="flag", label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, mode="flag", label="test")
     uvf.write(test_outfile, clobber=True, data_compression=None)
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+    uvf2 = UVFlag(test_outfile)
     assert uvf.__eq__(uvf2, check_history=True)
 
 
 def test_read_write_extra_keywords(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, label="test", use_future_array_shapes=True)
+    uvf = UVFlag(uv, label="test")
     uvf.extra_keywords = {"keyword1": 1, "keyword2": "string"}
     uvf.write(test_outfile, clobber=True, data_compression=None)
-    uvf2 = UVFlag(test_outfile, use_future_array_shapes=True)
+    uvf2 = UVFlag(test_outfile)
     assert uvf2.extra_keywords["keyword1"] == 1
     assert uvf2.extra_keywords["keyword2"] == "string"
 
@@ -1646,9 +1439,12 @@ def test_init_list(uvdata_obj):
             "UVParameter antenna_diameters does not match. Combining anyway.",
         ],
     ):
-        uvf = UVFlag([uv, test_f_file], use_future_array_shapes=True)
-    uvf1 = UVFlag(uv, use_future_array_shapes=True)
-    uvf2 = UVFlag(test_f_file, use_future_array_shapes=True)
+        uvf = UVFlag([uv, test_f_file])
+    uvf1 = UVFlag(uv)
+    uvf2 = UVFlag(test_f_file)
+
+    uv.telescope.location = uvf2.telescope.location
+    uv.telescope.antenna_names = uvf2.telescope.antenna_names
 
     assert np.array_equal(
         np.concatenate((uvf1.metric_array, uvf2.metric_array), axis=0), uvf.metric_array
@@ -1674,17 +1470,12 @@ def test_init_list(uvdata_obj):
     assert np.all(uvf.polarization_array == uv.polarization_array)
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
-@pytest.mark.parametrize("write_future_shapes", [True, False])
-@pytest.mark.parametrize("read_future_shapes", [True, False])
-def test_read_multiple_files(
-    uvdata_obj, test_outfile, write_future_shapes, read_future_shapes
-):
+def test_read_multiple_files(uvdata_obj, test_outfile):
     uv = uvdata_obj
     uv.time_array -= 1
     uv.set_lsts_from_time_array()
-    uvf = UVFlag(uv, use_future_array_shapes=write_future_shapes)
+    uvf = UVFlag(uv)
     uvf.write(test_outfile, clobber=True)
 
     warn_msg = [
@@ -1692,20 +1483,15 @@ def test_read_multiple_files(
         "UVParameter antenna_diameters does not match. Combining anyway.",
     ]
     warn_type = [UserWarning] * 2
-    if not read_future_shapes:
-        warn_msg += [_future_array_shapes_warning] * 2
-        warn_type += [DeprecationWarning] * 2
 
     with uvtest.check_warnings(warn_type, match=warn_msg):
-        uvf.read(
-            [test_outfile, test_f_file], use_future_array_shapes=read_future_shapes
-        )
+        uvf.read([test_outfile, test_f_file])
     assert uvf.filename == sorted(
         os.path.basename(file) for file in [test_outfile, test_f_file]
     )
 
-    uvf1 = UVFlag(uv, use_future_array_shapes=read_future_shapes)
-    uvf2 = UVFlag(test_f_file, use_future_array_shapes=read_future_shapes)
+    uvf1 = UVFlag(uv)
+    uvf2 = UVFlag(test_f_file)
     assert np.array_equal(
         np.concatenate((uvf1.metric_array, uvf2.metric_array), axis=0), uvf.metric_array
     )
@@ -1738,11 +1524,11 @@ def test_read_error():
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_read_change_type(uvcal_obj, test_outfile):
     uvc = uvcal_obj
-    uvf = UVFlag(uvc, use_future_array_shapes=True)
+    uvf = UVFlag(uvc)
 
     uvf.write(test_outfile, clobber=True)
     assert hasattr(uvf, "ant_array")
-    uvf.read(test_f_file, use_future_array_shapes=True)
+    uvf.read(test_f_file)
 
     # clear sets these to None now
     assert hasattr(uvf, "ant_array")
@@ -1750,7 +1536,7 @@ def test_read_change_type(uvcal_obj, test_outfile):
     assert hasattr(uvf, "baseline_array")
     assert hasattr(uvf, "ant_1_array")
     assert hasattr(uvf, "ant_2_array")
-    uvf.read(test_outfile, use_future_array_shapes=True)
+    uvf.read(test_outfile)
     assert hasattr(uvf, "ant_array")
     assert hasattr(uvf, "baseline_array")
     assert uvf.baseline_array is None
@@ -1763,16 +1549,16 @@ def test_read_change_type(uvcal_obj, test_outfile):
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_read_change_mode(uvdata_obj, test_outfile):
     uv = uvdata_obj
-    uvf = UVFlag(uv, mode="flag", use_future_array_shapes=True)
+    uvf = UVFlag(uv, mode="flag")
     assert hasattr(uvf, "flag_array")
     assert hasattr(uvf, "metric_array")
     assert uvf.metric_array is None
     uvf.write(test_outfile, clobber=True)
-    uvf.read(test_f_file, use_future_array_shapes=True)
+    uvf.read(test_f_file)
     assert hasattr(uvf, "metric_array")
     assert hasattr(uvf, "flag_array")
     assert uvf.flag_array is None
-    uvf.read(test_outfile, use_future_array_shapes=True)
+    uvf.read(test_outfile)
     assert hasattr(uvf, "flag_array")
     assert hasattr(uvf, "metric_array")
     assert uvf.metric_array is None
@@ -1780,7 +1566,7 @@ def test_read_change_mode(uvdata_obj, test_outfile):
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_write_no_clobber():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     with pytest.raises(ValueError, match=re.escape("File " + test_f_file + " exists")):
         uvf.write(test_f_file)
 
@@ -1807,7 +1593,7 @@ def test_set_telescope_params(uvdata_obj):
         keep_all_metadata=False,
         inplace=False,
     )
-    uvf = UVFlag(uvd2, use_future_array_shapes=True)
+    uvf = UVFlag(uvd2)
     # the telescope objects aren't equal because they have different sets of
     # required parameters (UVData's requires instrument while UVFlag's does not)
     # so just test the relevant attributes
@@ -1820,7 +1606,7 @@ def test_set_telescope_params(uvdata_obj):
     assert uvf.telescope._antenna_numbers == uvd.telescope._antenna_numbers
     assert uvf.telescope._antenna_positions == uvd.telescope._antenna_positions
 
-    uvf = UVFlag(uvd2, use_future_array_shapes=True)
+    uvf = UVFlag(uvd2)
     uvf.telescope.antenna_positions = None
     with uvtest.check_warnings(
         UserWarning,
@@ -1829,7 +1615,7 @@ def test_set_telescope_params(uvdata_obj):
     ):
         uvf.set_telescope_params()
 
-    uvf = UVFlag(uvd2, use_future_array_shapes=True)
+    uvf = UVFlag(uvd2)
     uvf.telescope.name = "foo"
     uvf.telescope.location = None
     with pytest.raises(
@@ -1839,11 +1625,9 @@ def test_set_telescope_params(uvdata_obj):
         uvf.set_telescope_params()
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_add(future_shapes):
-    uv1 = UVFlag(test_f_file, use_future_array_shapes=future_shapes)
+def test_add():
+    uv1 = UVFlag(test_f_file)
     uv2 = copy.copy(uv1)
     uv2.time_array += 1  # Add a day
     with uvtest.check_warnings(
@@ -1885,7 +1669,7 @@ def test_add(future_shapes):
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_collapsed_pols():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
     uvf2 = uvf.copy()
     uvf2.polarization_array[0] = -4
@@ -1901,7 +1685,7 @@ def test_add_collapsed_pols():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_add_version_str():
-    uv1 = UVFlag(test_f_file, use_future_array_shapes=True)
+    uv1 = UVFlag(test_f_file)
     uv1.history = uv1.history.replace(pyuvdata_version_str, "")
 
     assert pyuvdata_version_str not in uv1.history
@@ -1915,7 +1699,7 @@ def test_add_add_version_str():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_baseline():
-    uv1 = UVFlag(test_f_file, use_future_array_shapes=True)
+    uv1 = UVFlag(test_f_file)
     uv2 = uv1.copy()
     uv2.baseline_array += 100  # Arbitrary
     uv3 = uv1.__add__(uv2, axis="baseline")
@@ -1949,7 +1733,7 @@ def test_add_baseline():
 @pytest.mark.parametrize("diameters", ["both", "left", "right"])
 def test_add_antenna(uvcal_obj, diameters):
     uvc = uvcal_obj
-    uv1 = UVFlag(uvc, use_future_array_shapes=True)
+    uv1 = UVFlag(uvc)
     uv2 = uv1.copy()
     uv2.ant_array += 100  # Arbitrary
     uv2.telescope.antenna_numbers += 100
@@ -1993,7 +1777,7 @@ def test_add_antenna(uvcal_obj, diameters):
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_frequency():
-    uv1 = UVFlag(test_f_file, use_future_array_shapes=True)
+    uv1 = UVFlag(test_f_file)
     uv2 = uv1.copy()
     uv2.freq_array += 1e4  # Arbitrary
 
@@ -2031,7 +1815,7 @@ def test_add_frequency():
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 @pytest.mark.parametrize("split_spw", [True, False])
 def test_add_frequency_multi_spw(split_spw):
-    uv1 = UVFlag(test_f_file, use_future_array_shapes=True)
+    uv1 = UVFlag(test_f_file)
 
     # add spectral windows to test handling
     uv1.Nspws = 2
@@ -2048,22 +1832,13 @@ def test_add_frequency_multi_spw(split_spw):
         uv2.select(freq_chans=np.arange(uv2.Nfreqs // 3, uv2.Nfreqs))
     else:
         uv1.select(freq_chans=np.arange(uv1.Nfreqs // 2))
-        uv1.flex_spw_id_array = None
         assert uv1.Nspws == 1
         assert uv1.Nfreqs == uv_full.Nfreqs // 2
         uv2.select(freq_chans=np.arange(uv2.Nfreqs // 2, uv2.Nfreqs))
-        uv2.flex_spw_id_array = None
         assert uv2.Nspws == 1
         assert uv2.Nfreqs == uv_full.Nfreqs // 2
 
-        with uvtest.check_warnings(
-            [DeprecationWarning] * 2,
-            match=[
-                "flex_spw_id_array is not set. It will be required starting in "
-                "version 3.0"
-            ]
-            * 2,
-        ):
+        with uvtest.check_warnings(None):
             uv1.check()
             uv2.check()
 
@@ -2077,7 +1852,7 @@ def test_add_frequency_multi_spw(split_spw):
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_frequency_with_weights_square():
     # Same test as above, just checking an optional parameter (also in waterfall mode)
-    uvf1 = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf1 = UVFlag(test_f_file)
     uvf1.weights_array = 2 * np.ones_like(uvf1.weights_array)
     uvf1.to_waterfall(return_weights_square=True)
     uvf2 = uvf1.copy()
@@ -2092,7 +1867,7 @@ def test_add_frequency_with_weights_square():
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_frequency_mix_weights_square():
     # Same test as above, checking some error handling
-    uvf1 = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf1 = UVFlag(test_f_file)
     uvf1.weights_array = 2 * np.ones_like(uvf1.weights_array)
     uvf2 = uvf1.copy()
     uvf1.to_waterfall(return_weights_square=True)
@@ -2107,7 +1882,7 @@ def test_add_frequency_mix_weights_square():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_add_pol():
-    uv1 = UVFlag(test_f_file, use_future_array_shapes=True)
+    uv1 = UVFlag(test_f_file)
     uv2 = uv1.copy()
     uv2.polarization_array += 1  # Arbitrary
     uv3 = uv1.__add__(uv2, axis="polarization")
@@ -2136,7 +1911,7 @@ def test_add_pol():
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_add_flag(uvdata_obj):
     uv = uvdata_obj
-    uv1 = UVFlag(uv, mode="flag", use_future_array_shapes=True)
+    uv1 = UVFlag(uv, mode="flag")
     uv2 = uv1.copy()
     uv2.time_array += 1  # Add a day
     uv2.set_lsts_from_time_array()
@@ -2164,12 +1939,11 @@ def test_add_flag(uvdata_obj):
     assert "Data combined along time axis. " in uv3.history
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_add_errors(uvdata_obj, uvcal_obj):
     uv = uvdata_obj
     uvc = uvcal_obj
-    uv1 = UVFlag(uv, use_future_array_shapes=True)
+    uv1 = UVFlag(uv)
     # Mismatched classes
     with pytest.raises(
         ValueError, match="Only UVFlag objects can be added to a UVFlag object"
@@ -2177,21 +1951,13 @@ def test_add_errors(uvdata_obj, uvcal_obj):
         uv1.__add__(3)
 
     # Mismatched types
-    uv2 = UVFlag(uvc, use_future_array_shapes=True)
+    uv2 = UVFlag(uvc)
     with pytest.raises(ValueError, match="UVFlag object of type "):
         uv1.__add__(uv2)
 
     # Mismatched modes
-    uv3 = UVFlag(uv, mode="flag", use_future_array_shapes=True)
+    uv3 = UVFlag(uv, mode="flag")
     with pytest.raises(ValueError, match="UVFlag object of mode "):
-        uv1.__add__(uv3)
-
-    # Mismatched shapes
-    uv3 = UVFlag(uv)
-    with pytest.raises(
-        ValueError,
-        match="Both objects must have the same `future_array_shapes` parameter",
-    ):
         uv1.__add__(uv3)
 
     uv3 = uv1.copy()
@@ -2215,7 +1981,7 @@ def test_add_errors(uvdata_obj, uvcal_obj):
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_inplace_add():
-    uv1a = UVFlag(test_f_file, use_future_array_shapes=True)
+    uv1a = UVFlag(test_f_file)
     uv1b = uv1a.copy()
     uv2 = uv1a.copy()
     uv2.time_array += 1
@@ -2226,7 +1992,7 @@ def test_inplace_add():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_clear_unused_attributes():
-    uv = UVFlag(test_f_file, use_future_array_shapes=True)
+    uv = UVFlag(test_f_file)
     assert hasattr(uv, "baseline_array")
     assert hasattr(uv, "ant_1_array")
     assert hasattr(uv, "ant_2_array")
@@ -2248,7 +2014,7 @@ def test_clear_unused_attributes():
     assert uv.metric_array is None
 
     # Start over
-    uv = UVFlag(test_f_file, use_future_array_shapes=True)
+    uv = UVFlag(test_f_file)
     uv.ant_array = np.array([4])
     uv.flag_array = np.array([5])
     uv.clear_unused_attributes()
@@ -2260,7 +2026,7 @@ def test_clear_unused_attributes():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_not_equal():
-    uvf1 = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf1 = UVFlag(test_f_file)
     # different class
     assert not uvf1.__eq__(5)
     # different mode
@@ -2283,7 +2049,7 @@ def test_not_equal():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_waterfall_bl():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
     uvf.to_waterfall()
     assert uvf.type == "waterfall"
@@ -2297,7 +2063,7 @@ def test_to_waterfall_bl():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_waterfall_add_version_str():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
 
     uvf.history = uvf.history.replace(pyuvdata_version_str, "")
@@ -2306,11 +2072,9 @@ def test_to_waterfall_add_version_str():
     assert pyuvdata_version_str in uvf.history
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_to_waterfall_bl_multi_pol(future_shapes):
-    uvf = UVFlag(test_f_file, use_future_array_shapes=future_shapes)
+def test_to_waterfall_bl_multi_pol():
+    uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
     uvf2 = uvf.copy()
     uvf2.polarization_array[0] = -4
@@ -2338,7 +2102,7 @@ def test_to_waterfall_bl_multi_pol(future_shapes):
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_waterfall_bl_ret_wt_sq():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     Nbls = uvf.Nbls
     uvf.weights_array = 2 * np.ones_like(uvf.weights_array)
     uvf.to_waterfall(return_weights_square=True)
@@ -2351,7 +2115,7 @@ def test_to_waterfall_bl_ret_wt_sq():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_collapse_pol(test_outfile):
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
     uvf2 = uvf.copy()
     uvf2.polarization_array[0] = -4
@@ -2375,7 +2139,7 @@ def test_collapse_pol(test_outfile):
     uvf2.write(test_outfile, clobber=True)
     with h5py.File(test_outfile, "r") as h5:
         assert h5["Header/polarization_array"].dtype.type is np.string_
-    uvf = UVFlag(test_outfile, use_future_array_shapes=True)
+    uvf = UVFlag(test_outfile)
     assert uvf._polarization_array.expected_type == str
     assert uvf._polarization_array.acceptable_vals is None
     assert uvf == uvf2
@@ -2384,7 +2148,7 @@ def test_collapse_pol(test_outfile):
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_collapse_pol_add_pol_axis():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
     uvf2 = uvf.copy()
     uvf2.polarization_array[0] = -4
@@ -2397,7 +2161,7 @@ def test_collapse_pol_add_pol_axis():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_collapse_pol_or():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
     assert uvf.weights_array is None
     uvf2 = uvf.copy()
@@ -2417,7 +2181,7 @@ def test_collapse_pol_or():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_collapse_pol_add_version_str():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
 
     uvf2 = uvf.copy()
@@ -2435,7 +2199,7 @@ def test_collapse_pol_add_version_str():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_collapse_single_pol():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
     uvf2 = uvf.copy()
     with uvtest.check_warnings(UserWarning, "Cannot collapse polarization"):
@@ -2445,7 +2209,7 @@ def test_collapse_single_pol():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_collapse_pol_flag():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
     assert uvf.weights_array is None
     uvf2 = uvf.copy()
@@ -2465,7 +2229,7 @@ def test_collapse_pol_flag():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_waterfall_bl_flags():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
     uvf.to_waterfall()
     assert uvf.type == "waterfall"
@@ -2481,7 +2245,7 @@ def test_to_waterfall_bl_flags():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_waterfall_bl_flags_or():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
     assert uvf.weights_array is None
     uvf.to_waterfall(method="or")
@@ -2493,7 +2257,7 @@ def test_to_waterfall_bl_flags_or():
         len(uvf.polarization_array),
     )
     assert len(uvf.lst_array) == len(uvf.time_array)
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
     uvf.to_waterfall(method="or")
     assert uvf.type == "waterfall"
@@ -2506,11 +2270,9 @@ def test_to_waterfall_bl_flags_or():
     assert len(uvf.lst_array) == len(uvf.time_array)
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_to_waterfall_ant(uvcal_obj, future_shapes):
+def test_to_waterfall_ant(uvcal_obj):
     uvc = uvcal_obj
-    uvf = UVFlag(uvc, use_future_array_shapes=future_shapes)
+    uvf = UVFlag(uvc)
     uvf.weights_array = np.ones_like(uvf.weights_array)
     uvf.to_waterfall()
     assert uvf.type == "waterfall"
@@ -2525,56 +2287,29 @@ def test_to_waterfall_ant(uvcal_obj, future_shapes):
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_waterfall_waterfall():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.weights_array = np.ones_like(uvf.weights_array)
     uvf.to_waterfall()
     with uvtest.check_warnings(UserWarning, "This object is already a waterfall"):
         uvf.to_waterfall()
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("uvd_future_shapes", [True, False])
-@pytest.mark.parametrize("uvf_future_shapes", [True, False])
 @pytest.mark.parametrize("resort", [True, False])
-def test_to_baseline_flags(uvdata_obj, uvd_future_shapes, uvf_future_shapes, resort):
+def test_to_baseline_flags(uvdata_obj, resort):
     uv = uvdata_obj
-    if not uvd_future_shapes:
-        uv.use_current_array_shapes()
-    uvf = UVFlag(uv, use_future_array_shapes=uvf_future_shapes)
+    uvf = UVFlag(uv)
     uvf.to_waterfall()
     uvf.to_flag()
     uvf.flag_array[0, 10, 0] = True  # Flag time0, chan10
     uvf.flag_array[1, 15, 0] = True  # Flag time1, chan15
 
-    if not uvd_future_shapes and not uvf_future_shapes:
-        # remove spw_array and Nspws to test getting them from uvdata
-        uvf.spw_array = None
-        uvf.Nspws = None
-
-        # make uvdata multi spw
-        uv.spw_array = np.array([0, 1])
-        uv.Nspws = 2
-        uv.flex_spw_id_array = np.zeros(uv.Nfreqs, dtype=int)
-        uv.flex_spw_id_array[uv.Nfreqs // 2 :] = 1
-        uv.check()
-
     if resort:
         rng = np.random.default_rng()
         new_order = rng.permutation(uvf.telescope.Nants)
-        if uvf_future_shapes:
-            uvf.telescope.antenna_numbers = uvf.telescope.antenna_numbers[new_order]
-            uvf.telescope.antenna_names = uvf.telescope.antenna_names[new_order]
-            uvf.telescope.antenna_positions = uvf.telescope.antenna_positions[
-                new_order, :
-            ]
-        else:
-            uv.telescope.antenna_numbers = uvf.telescope.antenna_numbers[new_order]
-            uv.telescope.antenna_names = uvf.telescope.antenna_names[new_order]
-            uv.telescope.antenna_positions = uvf.telescope.antenna_positions[
-                new_order, :
-            ]
+        uvf.telescope.antenna_numbers = uvf.telescope.antenna_numbers[new_order]
+        uvf.telescope.antenna_names = uvf.telescope.antenna_names[new_order]
+        uvf.telescope.antenna_positions = uvf.telescope.antenna_positions[new_order, :]
 
     uvf.to_baseline(uv)
     assert uvf.type == "baseline"
@@ -2584,31 +2319,17 @@ def test_to_baseline_flags(uvdata_obj, uvd_future_shapes, uvf_future_shapes, res
     ntrue = 0.0
     ind = np.where(uvf.time_array == times[0])[0]
     ntrue += len(ind)
-    if uvf_future_shapes:
-        assert np.all(uvf.flag_array[ind, 10, 0])
-    else:
-        assert np.all(uvf.flag_array[ind, 0, 10, 0])
+    assert np.all(uvf.flag_array[ind, 10, 0])
     ind = np.where(uvf.time_array == times[1])[0]
     ntrue += len(ind)
-    if uvf_future_shapes:
-        assert np.all(uvf.flag_array[ind, 15, 0])
-    else:
-        assert np.all(uvf.flag_array[ind, 0, 15, 0])
+    assert np.all(uvf.flag_array[ind, 15, 0])
     assert uvf.flag_array.mean() == ntrue / uvf.flag_array.size
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("uvd_future_shapes", [True, False])
-@pytest.mark.parametrize("uvf_future_shapes", [True, False])
-def test_to_baseline_metric(uvdata_obj, uvd_future_shapes, uvf_future_shapes):
+def test_to_baseline_metric(uvdata_obj):
     uv = uvdata_obj
-
-    if not uvd_future_shapes:
-        uv.use_current_array_shapes()
-
-    uvf = UVFlag(uv, use_future_array_shapes=uvf_future_shapes)
+    uvf = UVFlag(uv)
     uvf.to_waterfall()
     # remove telescope info to check that it's set properly
     uvf.telescope.name = None
@@ -2634,16 +2355,10 @@ def test_to_baseline_metric(uvdata_obj, uvd_future_shapes, uvf_future_shapes):
     times = np.unique(uvf.time_array)
     ind = np.where(uvf.time_array == times[0])[0]
     nt0 = len(ind)
-    if uvf_future_shapes:
-        assert np.all(uvf.metric_array[ind, 10, 0] == 3.2)
-    else:
-        assert np.all(uvf.metric_array[ind, 0, 10, 0] == 3.2)
+    assert np.all(uvf.metric_array[ind, 10, 0] == 3.2)
     ind = np.where(uvf.time_array == times[1])[0]
     nt1 = len(ind)
-    if uvf_future_shapes:
-        assert np.all(uvf.metric_array[ind, 15, 0] == 2.1)
-    else:
-        assert np.all(uvf.metric_array[ind, 0, 15, 0] == 2.1)
+    assert np.all(uvf.metric_array[ind, 15, 0] == 2.1)
     assert np.isclose(
         uvf.metric_array.mean(), (3.2 * nt0 + 2.1 * nt1) / uvf.metric_array.size
     )
@@ -2652,7 +2367,7 @@ def test_to_baseline_metric(uvdata_obj, uvd_future_shapes, uvf_future_shapes):
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_to_baseline_add_version_str(uvdata_obj):
     uv = uvdata_obj
-    uvf = UVFlag(uv, use_future_array_shapes=True)
+    uvf = UVFlag(uv)
     uvf.to_waterfall()
     uvf.metric_array[0, 10, 0] = 3.2  # Fill in time0, chan10
     uvf.metric_array[1, 15, 0] = 2.1  # Fill in time1, chan15
@@ -2667,7 +2382,7 @@ def test_to_baseline_add_version_str(uvdata_obj):
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_baseline_to_baseline(uvdata_obj):
     uv = uvdata_obj
-    uvf = UVFlag(uv, use_future_array_shapes=True)
+    uvf = UVFlag(uv)
     uvf2 = uvf.copy()
     uvf.to_baseline(uv)
     assert uvf == uvf2
@@ -2700,28 +2415,13 @@ def test_to_baseline_metric_error(uvdata_obj, uvf_from_uvcal):
             uvf.to_baseline(uv, force_pol=True)
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("uvf_future_shapes", [True, False])
-@pytest.mark.parametrize("uvd_future_shapes", [True, False])
-def test_to_baseline_from_antenna(
-    uvdata_obj, uvf_from_uvcal, uvf_future_shapes, uvd_future_shapes
-):
+def test_to_baseline_from_antenna(uvdata_obj, uvf_from_uvcal):
     uvf = uvf_from_uvcal
-    if not uvf_future_shapes:
-        uvf.use_current_array_shapes()
-
     uv = uvdata_obj
-    if not uvd_future_shapes:
-        uv.use_current_array_shapes()
 
     uvf.select(polarizations=uvf.polarization_array[0], freq_chans=np.arange(uv.Nfreqs))
-    if uvd_future_shapes == uvf_future_shapes:
-        uv.freq_array = uvf.freq_array
-    elif uvd_future_shapes:
-        uv.freq_array = uvf.freq_array[0, :]
-    else:
-        uv.freq_array = uvf.freq_array[np.newaxis, :]
+    uv.freq_array = uvf.freq_array
 
     with uvtest.check_warnings(
         UserWarning,
@@ -2738,10 +2438,7 @@ def test_to_baseline_from_antenna(
     old_baseline = (uvf.ant_array[0], uvf.ant_array[1])
     old_times = np.unique(uvf.time_array)
     or_flags = np.logical_or(uvf.flag_array[0], uvf.flag_array[1])
-    if uvf_future_shapes:
-        or_flags = np.transpose(or_flags, [1, 0, 2])
-    else:
-        or_flags = np.transpose(or_flags, [2, 0, 1, 3])
+    or_flags = np.transpose(or_flags, [1, 0, 2])
 
     uv2 = uv.copy()
     uvf2 = uvf.copy()
@@ -2788,11 +2485,9 @@ def test_to_baseline_from_antenna(
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
-@pytest.mark.parametrize("uv_future_shapes", [True, False])
 @pytest.mark.parametrize("method", ["to_antenna", "to_baseline"])
-def test_to_baseline_antenna_errors(uvdata_obj, uvcal_obj, method, uv_future_shapes):
+def test_to_baseline_antenna_errors(uvdata_obj, uvcal_obj, method):
     if method == "to_baseline":
         uv = uvdata_obj
         msg = "Must pass in UVData object or UVFlag object"
@@ -2800,20 +2495,17 @@ def test_to_baseline_antenna_errors(uvdata_obj, uvcal_obj, method, uv_future_sha
         uv = uvcal_obj
         msg = "Must pass in UVCal object or UVFlag object"
 
-        uvf = UVFlag(uvdata_obj, use_future_array_shapes=True)
+        uvf = UVFlag(uvdata_obj)
         with pytest.raises(
             ValueError, match='Cannot convert from type "baseline" to "antenna".'
         ):
             uvf.to_antenna(uv)
 
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
 
     uvf.to_waterfall()
     with pytest.raises(ValueError, match=msg):
         getattr(uvf, method)(7.3)  # invalid matching object
-
-    if uv_future_shapes:
-        uv.use_current_array_shapes()
 
     if method == "to_antenna":
         with pytest.raises(
@@ -2867,7 +2559,7 @@ def test_to_baseline_antenna_errors(uvdata_obj, uvcal_obj, method, uv_future_sha
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_to_baseline_force_pol(uvdata_obj):
     uv = uvdata_obj
-    uvf = UVFlag(uv, use_future_array_shapes=True)
+    uvf = UVFlag(uv)
     uvf.to_waterfall()
     uvf.to_flag()
     uvf.flag_array[0, 10, 0] = True  # Flag time0, chan10
@@ -2891,7 +2583,7 @@ def test_to_baseline_force_pol(uvdata_obj):
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_to_baseline_force_pol_npol_gt_1(uvdata_obj):
     uv = uvdata_obj
-    uvf = UVFlag(uv, use_future_array_shapes=True)
+    uvf = UVFlag(uv)
     uvf.to_waterfall()
     uvf.to_flag()
     uvf.flag_array[0, 10, 0] = True  # Flag time0, chan10
@@ -2910,7 +2602,7 @@ def test_to_baseline_force_pol_npol_gt_1(uvdata_obj):
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_to_baseline_metric_force_pol(uvdata_obj):
     uv = uvdata_obj
-    uvf = UVFlag(uv, use_future_array_shapes=True)
+    uvf = UVFlag(uv)
     uvf.to_waterfall()
     uvf.metric_array[0, 10, 0] = 3.2  # Fill in time0, chan10
     uvf.metric_array[1, 15, 0] = 2.1  # Fill in time1, chan15
@@ -2931,78 +2623,36 @@ def test_to_baseline_metric_force_pol(uvdata_obj):
     )
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.parametrize("uvf_future_shapes", [True, False])
-@pytest.mark.parametrize("uvc_future_shapes", [True, False])
 @pytest.mark.parametrize("resort", [True, False])
-def test_to_antenna_flags(uvcal_obj, uvf_future_shapes, uvc_future_shapes, resort):
+def test_to_antenna_flags(uvcal_obj, resort):
     uvc = uvcal_obj
-    if not uvc_future_shapes:
-        uvc.use_current_array_shapes()
-    uvf = UVFlag(uvc, use_future_array_shapes=uvf_future_shapes)
-    if uvf_future_shapes == uvc_future_shapes:
-        uvf.freq_array = uvc.freq_array
-    elif uvf_future_shapes:
-        uvf.freq_array = uvc.freq_array[0, :]
-    else:
-        uvf.freq_array = uvc.freq_array[np.newaxis, :]
+    uvf = UVFlag(uvc)
+    uvf.freq_array = uvc.freq_array
 
     uvf.to_waterfall()
     uvf.to_flag()
     uvf.flag_array[0, 10, 0] = True  # Flag time0, chan10
     uvf.flag_array[1, 15, 0] = True  # Flag time1, chan15
 
-    if not uvc_future_shapes and not uvf_future_shapes:
-        # remove spw_array and Nspws to test getting them from uvcal
-        uvf.spw_array = None
-        uvf.Nspws = None
-
-        # make uvdata multi spw
-        uvc.spw_array = np.array([0, 1])
-        uvc.Nspws = 2
-        uvc.flex_spw_id_array = np.zeros(uvc.Nfreqs, dtype=int)
-        uvc.flex_spw_id_array[uvc.Nfreqs // 2 :] = 1
-        uvc.check()
-
     if resort:
         rng = np.random.default_rng()
         new_order = rng.permutation(uvf.telescope.Nants)
-        if uvf_future_shapes:
-            uvf.telescope.antenna_numbers = uvf.telescope.antenna_numbers[new_order]
-            uvf.telescope.antenna_names = uvf.telescope.antenna_names[new_order]
-            uvf.telescope.antenna_positions = uvf.telescope.antenna_positions[
-                new_order, :
-            ]
-        else:
-            uvc.telescope.antenna_numbers = uvf.telescope.antenna_numbers[new_order]
-            uvc.telescope.antenna_names = uvf.telescope.antenna_names[new_order]
-            uvc.telescope.antenna_positions = uvf.telescope.antenna_positions[
-                new_order, :
-            ]
+        uvf.telescope.antenna_numbers = uvf.telescope.antenna_numbers[new_order]
+        uvf.telescope.antenna_names = uvf.telescope.antenna_names[new_order]
+        uvf.telescope.antenna_positions = uvf.telescope.antenna_positions[new_order, :]
 
     uvf.to_antenna(uvc)
     assert uvf.type == "antenna"
     assert np.all(uvf.ant_array == uvc.ant_array)
     assert np.all(uvf.time_array == uvc.time_array)
-    if uvf_future_shapes:
-        assert np.all(uvf.flag_array[:, 10, 0, 0])
-        assert np.all(uvf.flag_array[:, 15, 1, 0])
-    else:
-        assert np.all(uvf.flag_array[:, 0, 10, 0, 0])
-        assert np.all(uvf.flag_array[:, 0, 15, 1, 0])
+    assert np.all(uvf.flag_array[:, 10, 0, 0])
+    assert np.all(uvf.flag_array[:, 15, 1, 0])
     assert uvf.flag_array.mean() == 2.0 * uvc.Nants_data / uvf.flag_array.size
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.parametrize("uvc_future_shapes", [True, False])
-@pytest.mark.parametrize("uvf_future_shapes", [True, False])
-def test_to_antenna_add_version_str(uvcal_obj, uvc_future_shapes, uvf_future_shapes):
+def test_to_antenna_add_version_str(uvcal_obj):
     uvc = uvcal_obj
-    if not uvc_future_shapes:
-        uvc.use_current_array_shapes()
-    uvf = UVFlag(uvc, use_future_array_shapes=uvf_future_shapes)
+    uvf = UVFlag(uvc)
     uvf.to_waterfall()
     uvf.to_flag()
     uvf.flag_array[0, 10, 0] = True  # Flag time0, chan10
@@ -3022,11 +2672,9 @@ def test_to_antenna_add_version_str(uvcal_obj, uvc_future_shapes, uvf_future_sha
     assert pyuvdata_version_str in uvf.history
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_to_antenna_metric(uvcal_obj, future_shapes):
+def test_to_antenna_metric(uvcal_obj):
     uvc = uvcal_obj
-    uvf = UVFlag(uvc, use_future_array_shapes=future_shapes)
+    uvf = UVFlag(uvc)
     uvf.to_waterfall()
     # remove telescope info to check that it's set properly
     uvf.telescope.name = None
@@ -3048,12 +2696,8 @@ def test_to_antenna_metric(uvcal_obj, future_shapes):
 
     assert np.all(uvf.ant_array == uvc.ant_array)
     assert np.all(uvf.time_array == uvc.time_array)
-    if future_shapes:
-        assert np.all(uvf.metric_array[:, 10, 0, 0] == 3.2)
-        assert np.all(uvf.metric_array[:, 15, 1, 0] == 2.1)
-    else:
-        assert np.all(uvf.metric_array[:, 0, 10, 0, 0] == 3.2)
-        assert np.all(uvf.metric_array[:, 0, 15, 1, 0] == 2.1)
+    assert np.all(uvf.metric_array[:, 10, 0, 0] == 3.2)
+    assert np.all(uvf.metric_array[:, 15, 1, 0] == 2.1)
     assert np.isclose(
         uvf.metric_array.mean(), (3.2 + 2.1) * uvc.Nants_data / uvf.metric_array.size
     )
@@ -3061,7 +2705,7 @@ def test_to_antenna_metric(uvcal_obj, future_shapes):
 
 def test_to_antenna_flags_match_uvflag(uvcal_obj):
     uvc = uvcal_obj
-    uvf = UVFlag(uvc, use_future_array_shapes=True)
+    uvf = UVFlag(uvc)
     uvf2 = uvf.copy()
     uvf.to_waterfall()
     uvf.to_flag()
@@ -3077,7 +2721,7 @@ def test_to_antenna_flags_match_uvflag(uvcal_obj):
 
 def test_antenna_to_antenna(uvcal_obj):
     uvc = uvcal_obj
-    uvf = UVFlag(uvc, use_future_array_shapes=True)
+    uvf = UVFlag(uvc)
     uvf2 = uvf.copy()
     uvf.to_antenna(uvc)
     assert uvf == uvf2
@@ -3086,7 +2730,7 @@ def test_antenna_to_antenna(uvcal_obj):
 def test_to_antenna_force_pol(uvcal_obj):
     uvc = uvcal_obj
     uvc.select(jones=-5)
-    uvf = UVFlag(uvc, use_future_array_shapes=True)
+    uvf = UVFlag(uvc)
     uvf.to_waterfall()
     uvf.to_flag()
     uvf.flag_array[0, 10, 0] = True  # Flag time0, chan10
@@ -3104,7 +2748,7 @@ def test_to_antenna_force_pol(uvcal_obj):
 def test_to_antenna_metric_force_pol(uvcal_obj):
     uvc = uvcal_obj
     uvc.select(jones=-5)
-    uvf = UVFlag(uvc, use_future_array_shapes=True)
+    uvf = UVFlag(uvc)
     uvf.to_waterfall()
     uvf.metric_array[0, 10, 0] = 3.2  # Fill in time0, chan10
     uvf.metric_array[1, 15, 0] = 2.1  # Fill in time1, chan15
@@ -3122,7 +2766,7 @@ def test_to_antenna_metric_force_pol(uvcal_obj):
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_copy():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf2 = uvf.copy()
     assert uvf == uvf2
     # Make sure it's a copy and not just pointing to same object
@@ -3132,7 +2776,7 @@ def test_copy():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_or():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
     uvf2 = uvf.copy()
     uvf2.flag_array = np.ones_like(uvf2.flag_array)
@@ -3147,7 +2791,7 @@ def test_or():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_or_add_version_str():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
     uvf.history = uvf.history.replace(pyuvdata_version_str, "")
 
@@ -3164,7 +2808,7 @@ def test_or_add_version_str():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_or_error():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf2 = uvf.copy()
     uvf.to_flag()
     with pytest.raises(ValueError, match='UVFlag object must be in "flag" mode'):
@@ -3173,7 +2817,7 @@ def test_or_error():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_or_add_history():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
     uvf2 = uvf.copy()
     uvf2.history = "Different history"
@@ -3185,7 +2829,7 @@ def test_or_add_history():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_ior():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
     uvf2 = uvf.copy()
     uvf2.flag_array = np.ones_like(uvf2.flag_array)
@@ -3200,7 +2844,7 @@ def test_ior():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_flag():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
     assert hasattr(uvf, "flag_array")
     assert hasattr(uvf, "metric_array")
@@ -3211,7 +2855,7 @@ def test_to_flag():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_flag_add_version_str():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.history = uvf.history.replace(pyuvdata_version_str, "")
     assert pyuvdata_version_str not in uvf.history
 
@@ -3221,7 +2865,7 @@ def test_to_flag_add_version_str():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_flag_threshold():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.metric_array = np.zeros_like(uvf.metric_array)
     uvf.metric_array[0, 4, 0] = 2.0
     uvf.to_flag(threshold=1.0)
@@ -3236,7 +2880,7 @@ def test_to_flag_threshold():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_flag_to_flag():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
     uvf2 = uvf.copy()
     uvf2.to_flag()
@@ -3245,24 +2889,18 @@ def test_flag_to_flag():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_flag_unknown_mode():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.mode = "foo"
     with pytest.raises(ValueError, match="Unknown UVFlag mode: foo"):
         uvf.to_flag()
 
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_to_metric_baseline(future_shapes):
-    uvf = UVFlag(test_f_file, use_future_array_shapes=future_shapes)
+def test_to_metric_baseline():
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
-    if future_shapes:
-        uvf.flag_array[:, 10] = True
-        uvf.flag_array[1, :] = True
-    else:
-        uvf.flag_array[:, :, 10] = True
-        uvf.flag_array[1, :, :] = True
+    uvf.flag_array[:, 10] = True
+    uvf.flag_array[1, :] = True
     assert hasattr(uvf, "flag_array")
     assert hasattr(uvf, "metric_array")
     assert uvf.metric_array is None
@@ -3274,15 +2912,12 @@ def test_to_metric_baseline(future_shapes):
     assert uvf.mode == "metric"
     assert 'Converted to mode "metric"' in uvf.history
     assert np.isclose(uvf.weights_array[1], 0.0).all()
-    if future_shapes:
-        assert np.isclose(uvf.weights_array[:, 10], 0.0).all()
-    else:
-        assert np.isclose(uvf.weights_array[:, :, 10], 0.0).all()
+    assert np.isclose(uvf.weights_array[:, 10], 0.0).all()
 
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_metric_add_version_str():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_flag()
     uvf.flag_array[:, 10] = True
     uvf.flag_array[1, :] = True
@@ -3300,7 +2935,7 @@ def test_to_metric_add_version_str():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_metric_waterfall():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_waterfall()
     uvf.to_flag()
     uvf.flag_array[:, 10] = True
@@ -3310,29 +2945,19 @@ def test_to_metric_waterfall():
     assert np.isclose(uvf.weights_array[:, 10], 0.0).all()
 
 
-@pytest.mark.filterwarnings("ignore:" + _future_array_shapes_warning)
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_to_metric_antenna(uvcal_obj, future_shapes):
+def test_to_metric_antenna(uvcal_obj):
     uvc = uvcal_obj
-    uvf = UVFlag(uvc, mode="flag", use_future_array_shapes=future_shapes)
-    if future_shapes:
-        uvf.flag_array[10, :, 1, :] = True
-        uvf.flag_array[15, 3, :, :] = True
-    else:
-        uvf.flag_array[10, :, :, 1, :] = True
-        uvf.flag_array[15, :, 3, :, :] = True
+    uvf = UVFlag(uvc, mode="flag")
+    uvf.flag_array[10, :, 1, :] = True
+    uvf.flag_array[15, 3, :, :] = True
     uvf.to_metric(convert_wgts=True)
-    if future_shapes:
-        assert np.isclose(uvf.weights_array[10, :, 1, :], 0.0).all()
-        assert np.isclose(uvf.weights_array[15, 3, :, :], 0.0).all()
-    else:
-        assert np.isclose(uvf.weights_array[10, :, :, 1, :], 0.0).all()
-        assert np.isclose(uvf.weights_array[15, :, 3, :, :], 0.0).all()
+    assert np.isclose(uvf.weights_array[10, :, 1, :], 0.0).all()
+    assert np.isclose(uvf.weights_array[15, 3, :, :], 0.0).all()
 
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_metric_to_metric():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf2 = uvf.copy()
     uvf.to_metric()
     assert uvf == uvf2
@@ -3340,7 +2965,7 @@ def test_metric_to_metric():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_to_metric_unknown_mode():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.mode = "foo"
     with pytest.raises(ValueError, match="Unknown UVFlag mode: foo"):
         uvf.to_metric()
@@ -3348,7 +2973,7 @@ def test_to_metric_unknown_mode():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_antpair2ind():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     ind = uvf.antpair2ind(uvf.ant_1_array[0], uvf.ant_2_array[0])
     assert np.all(uvf.ant_1_array[ind] == uvf.ant_1_array[0])
     assert np.all(uvf.ant_2_array[ind] == uvf.ant_2_array[0])
@@ -3356,7 +2981,7 @@ def test_antpair2ind():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_antpair2ind_nonbaseline():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     uvf.to_waterfall()
     with pytest.raises(
         ValueError,
@@ -3368,7 +2993,7 @@ def test_antpair2ind_nonbaseline():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_baseline_to_antnums():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     a1, a2 = uvf.baseline_to_antnums(uvf.baseline_array[0])
     assert a1 == uvf.ant_1_array[0]
     assert a2 == uvf.ant_2_array[0]
@@ -3376,14 +3001,14 @@ def test_baseline_to_antnums():
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_get_baseline_nums():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     bls = uvf.get_baseline_nums()
     assert np.array_equal(bls, np.unique(uvf.baseline_array))
 
 
 @pytest.mark.filterwarnings("ignore:The lst_array is not self-consistent")
 def test_get_antpairs():
-    uvf = UVFlag(test_f_file, use_future_array_shapes=True)
+    uvf = UVFlag(test_f_file)
     antpairs = uvf.get_antpairs()
     for a1, a2 in antpairs:
         ind = np.where((uvf.ant_1_array == a1) & (uvf.ant_2_array == a2))[0]
@@ -3394,7 +3019,7 @@ def test_get_antpairs():
 
 def test_combine_metrics_inplace(uvcal_obj):
     uvc = uvcal_obj
-    uvf = UVFlag(uvc, use_future_array_shapes=True)
+    uvf = UVFlag(uvc)
     np.random.seed(44)
     uvf.metric_array = np.random.normal(size=uvf.metric_array.shape)
     uvf2 = uvf.copy()
@@ -3408,7 +3033,7 @@ def test_combine_metrics_inplace(uvcal_obj):
 
 def test_combine_metrics_not_inplace(uvcal_obj):
     uvc = uvcal_obj
-    uvf = UVFlag(uvc, use_future_array_shapes=True)
+    uvf = UVFlag(uvc)
     np.random.seed(44)
     uvf.metric_array = np.random.normal(size=uvf.metric_array.shape)
     uvf2 = uvf.copy()
@@ -3422,7 +3047,7 @@ def test_combine_metrics_not_inplace(uvcal_obj):
 
 def test_combine_metrics_not_uvflag(uvcal_obj):
     uvc = uvcal_obj
-    uvf = UVFlag(uvc, use_future_array_shapes=True)
+    uvf = UVFlag(uvc)
     with pytest.raises(
         ValueError, match='"others" must be UVFlag or list of UVFlag objects'
     ):
@@ -3431,7 +3056,7 @@ def test_combine_metrics_not_uvflag(uvcal_obj):
 
 def test_combine_metrics_not_metric(uvcal_obj):
     uvc = uvcal_obj
-    uvf = UVFlag(uvc, use_future_array_shapes=True)
+    uvf = UVFlag(uvc)
     np.random.seed(44)
     uvf.metric_array = np.random.normal(size=uvf.metric_array.shape)
     uvf2 = uvf.copy()
@@ -3444,7 +3069,7 @@ def test_combine_metrics_not_metric(uvcal_obj):
 
 def test_combine_metrics_wrong_shape(uvcal_obj):
     uvc = uvcal_obj
-    uvf = UVFlag(uvc, use_future_array_shapes=True)
+    uvf = UVFlag(uvc)
     np.random.seed(44)
     uvf.metric_array = np.random.normal(size=uvf.metric_array.shape)
     uvf2 = uvf.copy()
@@ -3455,7 +3080,7 @@ def test_combine_metrics_wrong_shape(uvcal_obj):
 
 def test_combine_metrics_add_version_str(uvcal_obj):
     uvc = uvcal_obj
-    uvf = UVFlag(uvc, use_future_array_shapes=True)
+    uvf = UVFlag(uvc)
     uvf.history = uvf.history.replace(pyuvdata_version_str, "")
 
     assert pyuvdata_version_str not in uvf.history
@@ -3482,7 +3107,6 @@ def test_super(uvdata_obj):
             history="",
             label="",
             test_property="prop",
-            use_future_array_shapes=False,
         ):
             super(TestClass, self).__init__(
                 indata,
@@ -3491,14 +3115,13 @@ def test_super(uvdata_obj):
                 waterfall=waterfall,
                 history=history,
                 label=label,
-                use_future_array_shapes=use_future_array_shapes,
             )
 
             self.test_property = test_property
 
     uv = uvdata_obj
 
-    tc = TestClass(uv, test_property="test_property", use_future_array_shapes=True)
+    tc = TestClass(uv, test_property="test_property")
 
     # UVFlag.__init__ is tested, so just see if it has a metric array
     assert hasattr(tc, "metric_array")
@@ -3506,13 +3129,9 @@ def test_super(uvdata_obj):
     assert tc.test_property == "test_property"
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_flags2waterfall_uvdata(uvdata_obj, future_shapes):
+def test_flags2waterfall_uvdata(uvdata_obj):
     uv = uvdata_obj
-    if not future_shapes:
-        uv.use_current_array_shapes()
 
     np.random.seed(0)
     uv.flag_array = np.random.randint(0, 2, size=uv.flag_array.shape, dtype=bool)
@@ -3531,12 +3150,8 @@ def test_flags2waterfall_uvdata(uvdata_obj, future_shapes):
     assert wf.shape == (uv.Ntimes, uv.Nfreqs)
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_flags2waterfall_uvcal(uvcal_obj, future_shapes):
+def test_flags2waterfall_uvcal(uvcal_obj):
     uvc = uvcal_obj
-    if not future_shapes:
-        uvc.use_current_array_shapes()
 
     uvc.flag_array = np.random.randint(0, 2, size=uvc.flag_array.shape, dtype=bool)
     wf = flags2waterfall(uvc)
@@ -3589,16 +3204,12 @@ def test_select_waterfall_errors(uvf_from_waterfall):
         uvf.select(bls=[(0, 1), (0, 2)])
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @cases_decorator
 @pytest.mark.parametrize("uvf_mode", ["to_flag", "to_metric"])
 @pytest.mark.parametrize("dimension", list(range(1, 4)))
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_select_blt_inds(input_uvf, uvf_mode, dimension, future_shapes):
+def test_select_blt_inds(input_uvf, uvf_mode, dimension):
     uvf = input_uvf
-    if not future_shapes:
-        uvf.use_current_array_shapes()
 
     # used to set the mode depending on which input is given to uvf_mode
     getattr(uvf, uvf_mode)()
@@ -3627,10 +3238,7 @@ def test_select_blt_inds(input_uvf, uvf_mode, dimension, future_shapes):
         if uvf.type == "baseline":
             assert np.allclose(old_param[blt_inds_use], new_param)
         if uvf.type == "antenna":
-            if future_shapes:
-                assert np.allclose(old_param[:, :, blt_inds_use], new_param)
-            else:
-                assert np.allclose(old_param[:, :, :, blt_inds_use], new_param)
+            assert np.allclose(old_param[:, :, blt_inds_use], new_param)
         if uvf.type == "waterfall":
             assert np.allclose(old_param[blt_inds_use], new_param)
 
@@ -3672,16 +3280,12 @@ def test_select_blt_inds_errors(input_uvf, uvf_mode, select_kwargs, err_msg):
         uvf.select(**select_kwargs)
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @cases_decorator_no_waterfall
 @pytest.mark.parametrize("uvf_mode", ["to_flag", "to_metric"])
 @pytest.mark.parametrize("dimension", list(range(1, 4)))
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_select_antenna_nums(input_uvf, uvf_mode, dimension, future_shapes):
+def test_select_antenna_nums(input_uvf, uvf_mode, dimension):
     uvf = input_uvf
-    if not future_shapes:
-        uvf.use_current_array_shapes()
 
     # used to set the mode depending on which input is given to uvf_mode
     getattr(uvf, uvf_mode)()
@@ -3909,15 +3513,11 @@ def test_select_bls_errors(input_uvf, uvf_mode, select_kwargs, err_msg):
             uvf.select(**select_kwargs)
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @cases_decorator
 @pytest.mark.parametrize("uvf_mode", ["to_flag", "to_metric"])
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_select_times(input_uvf, uvf_mode, future_shapes):
+def test_select_times(input_uvf, uvf_mode):
     uvf = input_uvf
-    if not future_shapes:
-        uvf.use_current_array_shapes()
 
     # used to set the mode depending on which input is given to uvf_mode
     getattr(uvf, uvf_mode)()
@@ -3969,15 +3569,11 @@ def test_select_times(input_uvf, uvf_mode, future_shapes):
         uvf.select(times=bad_time)
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @cases_decorator
 @pytest.mark.parametrize("uvf_mode", ["to_flag", "to_metric"])
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_select_frequencies(input_uvf, uvf_mode, future_shapes):
+def test_select_frequencies(input_uvf, uvf_mode):
     uvf = input_uvf
-    if not future_shapes:
-        uvf.use_current_array_shapes()
 
     # used to set the mode depending on which input is given to uvf_mode
     getattr(uvf, uvf_mode)()
@@ -4104,16 +3700,12 @@ def test_select_freq_chans(input_uvf, uvf_mode):
         assert f in uvf.freq_array[chans_to_keep]
 
 
-@pytest.mark.filterwarnings("ignore:This method will be removed in version 3.0 when")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @cases_decorator
 @pytest.mark.parametrize("uvf_mode", ["to_flag", "to_metric"])
 @pytest.mark.parametrize("pols_to_keep", ([-5], ["xx"], ["nn"], [[-5]]))
-@pytest.mark.parametrize("future_shapes", [True, False])
-def test_select_polarizations(uvf_mode, pols_to_keep, input_uvf, future_shapes):
+def test_select_polarizations(uvf_mode, pols_to_keep, input_uvf):
     uvf = input_uvf
-    if not future_shapes:
-        uvf.use_current_array_shapes()
     # used to set the mode depending on which input is given to uvf_mode
     getattr(uvf, uvf_mode)()
     np.random.seed(0)

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -2325,6 +2325,23 @@ def test_to_baseline_flags(uvdata_obj, resort):
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_to_baseline_fill_spws(uvdata_obj):
+    uv = uvdata_obj
+    uvf = UVFlag(uv)
+    uvf2 = uvf.copy()
+
+    uvf.to_waterfall()
+    uvf.Nspws = uvf.spw_array = uvf.flex_spw_id_array = None
+    uvf.to_baseline(uv)
+    # Assign the weights, since they're mucked by the collapse in the waterfall call
+    uvf.weights_array = uvf2.weights_array
+    # Also scrub the history, since the two objects are different histories
+    uvf.history = uvf2.history
+
+    assert uvf == uvf2
+
+
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_to_baseline_metric(uvdata_obj):
     uv = uvdata_obj
     uvf = UVFlag(uv)

--- a/pyuvdata/uvflag/tests/test_uvflag.py
+++ b/pyuvdata/uvflag/tests/test_uvflag.py
@@ -1205,7 +1205,7 @@ def test_read_write_loop_wrong_nants_data(uvdata_obj, test_outfile):
     assert uvf2.filename == [os.path.basename(test_outfile)]
 
 
-def test_read_write_loop_missing_channel_width(uvdata_obj, test_outfile):
+def test_read_write_loop_mucked_channel_width(uvdata_obj, test_outfile):
     uv = uvdata_obj
     uvf = UVFlag(uv, label="test")
     uvf.write(test_outfile, clobber=True)
@@ -1219,6 +1219,14 @@ def test_read_write_loop_missing_channel_width(uvdata_obj, test_outfile):
         uvf2 = UVFlag(test_outfile)
     assert uvf.__eq__(uvf2, check_history=True)
     assert uvf2.filename == [os.path.basename(test_outfile)]
+
+    uvf.write(test_outfile, clobber=True)
+    with h5py.File(test_outfile, "r+") as h5f:
+        del h5f["/Header/channel_width"]
+        h5f["/Header/channel_width"] = uvf.channel_width[0]
+
+    uvf2 = UVFlag(test_outfile)
+    assert uvf == uvf2
 
     uvf.freq_array[0] -= uvf.channel_width[0]
     uvf.channel_width[0] *= 2
@@ -1380,7 +1388,6 @@ def test_read_missing_nants_data(test_outfile, uvcal_obj):
     assert uvf.__eq__(uvf2, check_history=True)
 
 
-@pytest.mark.filterwarnings("ignore:The shapes of several attributes will be changing")
 @pytest.mark.filterwarnings("ignore:telescope_location, antenna_positions")
 def test_read_missing_nspws(test_outfile, uvcal_obj):
     uv = uvcal_obj

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -22,15 +22,6 @@ from ..uvdata import UVData
 __all__ = ["UVFlag", "flags2waterfall", "and_rows_cols"]
 
 
-_future_array_shapes_warning = (
-    "The shapes of several attributes will be changing in the future to remove the "
-    "deprecated spectral window axis. You can call the `use_future_array_shapes` "
-    "method to convert to the future array shapes now or set the parameter of the same "
-    "name on this method to both convert to the future array shapes and silence this "
-    "warning."
-)
-
-
 telescope_params = {
     "telescope_name": "name",
     "telescope_location": "location",
@@ -105,13 +96,8 @@ def flags2waterfall(uv, *, flag_array=None, keep_pol=False):
 
     if isinstance(uv, UVCal):
         mean_axis = [0]
-        if not uv.future_array_shapes:
-            mean_axis.append(1)
         if not keep_pol:
-            if uv.future_array_shapes:
-                mean_axis.append(3)
-            else:
-                mean_axis.append(4)
+            mean_axis.append(3)
 
         mean_axis = tuple(mean_axis)
         if keep_pol:
@@ -120,13 +106,8 @@ def flags2waterfall(uv, *, flag_array=None, keep_pol=False):
             waterfall = np.mean(flag_array, axis=mean_axis).T
     else:
         mean_axis = [0]
-        if not uv.future_array_shapes:
-            mean_axis.append(1)
         if not keep_pol:
-            if uv.future_array_shapes:
-                mean_axis.append(2)
-            else:
-                mean_axis.append(3)
+            mean_axis.append(2)
 
         mean_axis = tuple(mean_axis)
         if keep_pol:
@@ -184,8 +165,7 @@ class UVFlag(UVBase):
         files allows for other telescope metadata to be set from the known
         telescopes. Setting this parameter overrides any telescope name in the file.
     use_future_array_shapes : bool
-        Option to convert to the future planned array shapes before the changes go
-        into effect by removing the spectral window axis.
+        Defunct option, will result in an error in version 3.2.
     run_check : bool
         Option to check for the existence and proper shapes of parameters
         after creating UVFlag object.
@@ -216,7 +196,7 @@ class UVFlag(UVBase):
         label="",
         telescope_name=None,
         mwa_metafits_file=None,
-        use_future_array_shapes=False,
+        use_future_array_shapes=None,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -285,54 +265,45 @@ class UVFlag(UVBase):
 
         desc = (
             "Floating point metric information, only available in metric mode. "
-            "The shape depends on the `type` parameter and on the "
-            "`future_array_shapes` parameter. For 'baseline' type objects, "
-            "the shape is (Nblts, 1, Nfreq, Npols) or (Nblts, Nfreqs, Npols) if "
-            "future_array_shapes=True. For 'antenna' type objects, the shape is "
-            "(Nants_data, 1, Nfreqs, Ntimes, Npols) or "
-            "(Nants_data, Nfreqs, Ntimes, Npols) if future_array_shapes=True. "
-            "For 'waterfall' type objects, the shape is (Ntimes, Nfreq, Npols)."
+            "The shape depends on the `type` parameter. For 'baseline' type objects, "
+            "the shape is (Nblts, Nfreq, Npols). For 'antenna' type objects, the shape "
+            "is (Nants_data, Nfreqs, Ntimes, Npols). For 'waterfall' type objects, the "
+            "shape is (Ntimes, Nfreq, Npols)."
         )
         self._metric_array = uvp.UVParameter(
             "metric_array",
             description=desc,
-            form=("Nblts", 1, "Nfreqs", "Npols"),
+            form=("Nblts", "Nfreqs", "Npols"),
             expected_type=float,
             required=False,
         )
 
         desc = (
             "Boolean flag, True is flagged, only available in flag mode. "
-            "The shape depends on the `type` parameter and on the "
-            "`future_array_shapes` parameter. For 'baseline' type objects, "
-            "the shape is (Nblts, 1, Nfreq, Npols) or (Nblts, Nfreqs, Npols) if "
-            "future_array_shapes=True. For 'antenna' type objects, the shape is "
-            "(Nants_data, 1, Nfreqs, Ntimes, Npols) or "
-            "(Nants_data, Nfreqs, Ntimes, Npols) if future_array_shapes=True. "
-            "For 'waterfall' type objects, the shape is (Ntimes, Nfreq, Npols)."
+            "The shape depends on the `type` parameter. For 'baseline' type objects, "
+            "the shape is (Nblts, Nfreq, Npols). For 'antenna' type objects, the shape "
+            "is (Nants_data, Nfreqs, Ntimes, Npols). For 'waterfall' type objects, the "
+            "shape is (Ntimes, Nfreq, Npols)."
         )
         self._flag_array = uvp.UVParameter(
             "flag_array",
             description=desc,
-            form=("Nblts", 1, "Nfreqs", "Npols"),
+            form=("Nblts", "Nfreqs", "Npols"),
             expected_type=bool,
             required=False,
         )
 
         desc = (
             "Floating point weight information, only available in metric mode."
-            "The shape depends on the `type` parameter and on the "
-            "`future_array_shapes` parameter. For 'baseline' type objects, "
-            "the shape is (Nblts, 1, Nfreq, Npols) or (Nblts, Nfreqs, Npols) if "
-            "future_array_shapes=True. For 'antenna' type objects, the shape is "
-            "(Nants_data, 1, Nfreqs, Ntimes, Npols) or "
-            "(Nants_data, Nfreqs, Ntimes, Npols) if future_array_shapes=True. "
-            "For 'waterfall' type objects, the shape is (Ntimes, Nfreq, Npols)."
+            "The shape depends on the `type` parameter. For 'baseline' type objects, "
+            "the shape is (Nblts, Nfreq, Npols). For 'antenna' type objects, the shape "
+            "is (Nants_data, Nfreqs, Ntimes, Npols). For 'waterfall' type objects, the "
+            "shape is (Ntimes, Nfreq, Npols)."
         )
         self._weights_array = uvp.UVParameter(
             "weights_array",
             description=desc,
-            form=("Nblts", 1, "Nfreqs", "Npols"),
+            form=("Nblts", "Nfreqs", "Npols"),
             expected_type=float,
         )
 
@@ -425,14 +396,11 @@ class UVFlag(UVBase):
             required=False,
         )
 
-        desc = (
-            "Array of frequencies in Hz, center of the channel. Shape (1, Nfreqs) or "
-            "(Nfreqs,) if type is 'waterfall' or if future_array_shapes=True."
-        )
+        desc = "Array of frequencies in Hz, center of the channel. Shape (Nfreqs,)."
         self._freq_array = uvp.UVParameter(
             "freq_array",
             description=desc,
-            form=(1, "Nfreqs"),
+            form=("Nfreqs",),
             expected_type=float,
             tols=1e-3,
         )  # mHz
@@ -454,17 +422,11 @@ class UVFlag(UVBase):
         )
 
         desc = (
-            "Required if Nspws > 1 and will always be required starting in "
-            "version 3.0. Maps individual channels along the "
-            "frequency axis to individual spectral windows, as listed in the "
-            "spw_array. Shape (Nfreqs), type = int."
+            "Maps individual channels along the  frequency axis to individual spectral "
+            "windows, as listed in the spw_array. Shape (Nfreqs), type = int."
         )
         self._flex_spw_id_array = uvp.UVParameter(
-            "flex_spw_id_array",
-            description=desc,
-            form=("Nfreqs",),
-            expected_type=int,
-            required=False,
+            "flex_spw_id_array", description=desc, form=("Nfreqs",), expected_type=int
         )
 
         desc = (
@@ -506,9 +468,16 @@ class UVFlag(UVBase):
             expected_type=dict,
         )
 
-        desc = "Flag indicating that this object is using the future array shapes."
+        desc = (
+            "Flag indicating that this object is using the future array shapes. "
+            "Defunct, will be removed in version 3.2."
+        )
         self._future_array_shapes = uvp.UVParameter(
-            "future_array_shapes", description=desc, expected_type=bool, value=False
+            "future_array_shapes",
+            description=desc,
+            expected_type=bool,
+            value=True,
+            acceptable_vals=[True],
         )
 
         desc = (
@@ -550,6 +519,9 @@ class UVFlag(UVBase):
         # set the appropriate telescope attributes as required
         self._set_telescope_requirements()
 
+        # Do one call up front to issue a DeprecationWarning
+        self._set_future_array_shapes(use_future_array_shapes=use_future_array_shapes)
+
         self.history = ""  # Added to at the end
 
         self.label = ""  # Added to at the end
@@ -561,7 +533,6 @@ class UVFlag(UVBase):
                 waterfall=waterfall,
                 history=history,
                 label=label,
-                use_future_array_shapes=use_future_array_shapes,
                 run_check=run_check,
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
@@ -574,7 +545,6 @@ class UVFlag(UVBase):
                         copy_flags=copy_flags,
                         waterfall=waterfall,
                         history=history,
-                        use_future_array_shapes=use_future_array_shapes,
                         run_check=run_check,
                         check_extra=check_extra,
                         run_check_acceptability=run_check_acceptability,
@@ -595,7 +565,6 @@ class UVFlag(UVBase):
                 history=history,
                 telescope_name=telescope_name,
                 mwa_metafits_file=mwa_metafits_file,
-                use_future_array_shapes=use_future_array_shapes,
                 run_check=run_check,
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
@@ -608,7 +577,6 @@ class UVFlag(UVBase):
                 waterfall=waterfall,
                 history=history,
                 label=label,
-                use_future_array_shapes=use_future_array_shapes,
                 run_check=run_check,
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
@@ -622,7 +590,6 @@ class UVFlag(UVBase):
                 waterfall=waterfall,
                 history=history,
                 label=label,
-                use_future_array_shapes=use_future_array_shapes,
                 run_check=run_check,
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
@@ -686,101 +653,39 @@ class UVFlag(UVBase):
                 np.arange(1, 5)
             )
 
-    def _set_future_array_shapes(self):
+    def _set_future_array_shapes(self, use_future_array_shapes=None):
         """
         Set future_array_shapes to True and adjust required parameters.
 
         This method should not be called directly by users; instead it is called
         by file-reading methods and `use_future_array_shapes` to indicate the
         `future_array_shapes` is True and define expected parameter shapes.
-
+        This function has been deprecated, and will result in an error in version 3.2.
         """
-        self.future_array_shapes = True
-        self._freq_array.form = ("Nfreqs",)
-        data_like_params = ["metric_array", "weights_array", "flag_array"]
+        if use_future_array_shapes is None:
+            # This basically wraps no-ops when no argument is passed.
+            return
 
-        if self.type == "baseline":
-            for param_name in data_like_params:
-                getattr(self, "_" + param_name).form = ("Nblts", "Nfreqs", "Npols")
-        elif self.type == "antenna":
-            for param_name in data_like_params:
-                getattr(self, "_" + param_name).form = (
-                    "Nants_data",
-                    "Nfreqs",
-                    "Ntimes",
-                    "Npols",
-                )
+        if not use_future_array_shapes:
+            raise ValueError(
+                'The future is now! So-called "current" array shapes no longer '
+                'supported, must use "future" array shapes (spw-axis dropped).'
+            )
+        warnings.warn(
+            (
+                "Future array shapes are now always used, setting/calling "
+                "use_future_array_shapes will result in an error in version 3.2."
+            ),
+            DeprecationWarning,
+        )
 
     def use_future_array_shapes(self):
         """
         Change the array shapes of this object to match the planned future shapes.
 
-        This method sets allows users to convert to the planned array shapes changes
-        before the changes go into effect. This method sets the `future_array_shapes`
-        parameter on this object to True.
-
+        This function has been deprecated, and will result in an error in version 3.2.
         """
-        if self.future_array_shapes:
-            return
-
-        self._set_future_array_shapes()
-        if not self.type == "waterfall":
-            # remove the length-1 spw axis for all data-like parameters
-            for param_name in self._data_params:
-                if param_name == "weights_square_array":
-                    continue
-                setattr(self, param_name, (getattr(self, param_name))[:, 0])
-
-            # remove the length-1 spw axis for the freq_array
-            self.freq_array = self.freq_array[0, :]
-
-    def use_current_array_shapes(self):
-        """
-        Change the array shapes of this object to match the current future shapes.
-
-        This method sets allows users to convert back to the current array shapes.
-        This method sets the `future_array_shapes` parameter on this object to False.
-        """
-        warnings.warn(
-            "This method will be removed in version 3.0 when the current array shapes "
-            "are no longer supported.",
-            DeprecationWarning,
-        )
-
-        if not self.future_array_shapes:
-            return
-
-        data_like_params = ["metric_array", "weights_array", "flag_array"]
-
-        self.future_array_shapes = False
-        if not self.type == "waterfall":
-            if self.type == "baseline":
-                for param_name in data_like_params:
-                    getattr(self, "_" + param_name).form = (
-                        "Nblts",
-                        1,
-                        "Nfreqs",
-                        "Npols",
-                    )
-            elif self.type == "antenna":
-                for param_name in data_like_params:
-                    getattr(self, "_" + param_name).form = (
-                        "Nants_data",
-                        1,
-                        "Nfreqs",
-                        "Ntimes",
-                        "Npols",
-                    )
-
-            for param_name in self._data_params:
-                if param_name == "weights_square_array":
-                    continue
-                setattr(
-                    self, param_name, (getattr(self, param_name))[:, np.newaxis, :, :]
-                )
-
-            self._freq_array.form = (1, "Nfreqs")
-            self.freq_array = self.freq_array[np.newaxis, :]
+        self._set_future_array_shapes(True)
 
     def _set_mode_flag(self):
         """Set the mode and required parameters consistent with a flag object."""
@@ -816,15 +721,9 @@ class UVFlag(UVBase):
         self._Nbls.required = False
         self._Nblts.required = False
 
-        if self.future_array_shapes:
-            self._metric_array.form = ("Nants_data", "Nfreqs", "Ntimes", "Npols")
-            self._flag_array.form = ("Nants_data", "Nfreqs", "Ntimes", "Npols")
-            self._weights_array.form = ("Nants_data", "Nfreqs", "Ntimes", "Npols")
-        else:
-            self._metric_array.form = ("Nants_data", 1, "Nfreqs", "Ntimes", "Npols")
-            self._flag_array.form = ("Nants_data", 1, "Nfreqs", "Ntimes", "Npols")
-            self._weights_array.form = ("Nants_data", 1, "Nfreqs", "Ntimes", "Npols")
-            self._freq_array.form = (1, "Nfreqs")
+        self._metric_array.form = ("Nants_data", "Nfreqs", "Ntimes", "Npols")
+        self._flag_array.form = ("Nants_data", "Nfreqs", "Ntimes", "Npols")
+        self._weights_array.form = ("Nants_data", "Nfreqs", "Ntimes", "Npols")
 
         self._time_array.form = ("Ntimes",)
         self._lst_array.form = ("Ntimes",)
@@ -843,16 +742,9 @@ class UVFlag(UVBase):
         if self.time_array is not None:
             self.Nblts = len(self.time_array)
 
-        if self.future_array_shapes:
-            self._metric_array.form = ("Nblts", "Nfreqs", "Npols")
-            self._flag_array.form = ("Nblts", "Nfreqs", "Npols")
-            self._weights_array.form = ("Nblts", "Nfreqs", "Npols")
-
-        else:
-            self._metric_array.form = ("Nblts", 1, "Nfreqs", "Npols")
-            self._flag_array.form = ("Nblts", 1, "Nfreqs", "Npols")
-            self._weights_array.form = ("Nblts", 1, "Nfreqs", "Npols")
-            self._freq_array.form = (1, "Nfreqs")
+        self._metric_array.form = ("Nblts", "Nfreqs", "Npols")
+        self._flag_array.form = ("Nblts", "Nfreqs", "Npols")
+        self._weights_array.form = ("Nblts", "Nfreqs", "Npols")
 
         self._time_array.form = ("Nblts",)
         self._lst_array.form = ("Nblts",)
@@ -874,9 +766,6 @@ class UVFlag(UVBase):
 
         self._time_array.form = ("Ntimes",)
         self._lst_array.form = ("Ntimes",)
-
-        if not self.future_array_shapes:
-            self._freq_array.form = ("Nfreqs",)
 
     def check(
         self,
@@ -919,12 +808,6 @@ class UVFlag(UVBase):
             values (if run_check_acceptability is True)
 
         """
-        # set the flex_spw_id_array to required if Nspws > 1
-        if self.Nspws is not None and self.Nspws > 1:
-            self._flex_spw_id_array.required = True
-        else:
-            self._flex_spw_id_array.required = False
-
         self._set_telescope_requirements()
         self._check_pol_state()
 
@@ -981,18 +864,11 @@ class UVFlag(UVBase):
                         f"are: {missing_ants}"
                     )
 
-        if self.flex_spw_id_array is None:
-            warnings.warn(
-                "flex_spw_id_array is not set. It will be required starting in version "
-                "3.0",
-                DeprecationWarning,
+        # Check that all values in flex_spw_id_array are entries in the spw_array
+        if not np.all(np.isin(self.flex_spw_id_array, self.spw_array)):
+            raise ValueError(
+                "All values in the flex_spw_id_array must exist in the spw_array."
             )
-        else:
-            # Check that all values in flex_spw_id_array are entries in the spw_array
-            if not np.all(np.isin(self.flex_spw_id_array, self.spw_array)):
-                raise ValueError(
-                    "All values in the flex_spw_id_array must exist in the spw_array."
-                )
 
         if run_check_acceptability:
             # Check antenna positions
@@ -1023,9 +899,6 @@ class UVFlag(UVBase):
             "telescope_name",
             "telescope_location",
             "channel_width",
-            "spw_array",
-            "Nspws",
-            "flex_spw_id_array",  # TODO remove this from this list in version 3.0
             "antenna_names",
             "antenna_numbers",
             "antenna_positions",
@@ -1435,10 +1308,7 @@ class UVFlag(UVBase):
             darr = self.metric_array
 
         if self.type == "antenna":
-            if self.future_array_shapes:
-                collapse_axes = (0,)
-            else:
-                collapse_axes = (0, 1)
+            collapse_axes = (0,)
             d, w = uvutils.collapse(
                 darr,
                 method,
@@ -1605,15 +1475,7 @@ class UVFlag(UVBase):
                 '"baseline" to match.'
             )
 
-        # write it out this rather than comparing the UVParameters because
-        # future_array_shapes might be different. In the future, when shapes are not
-        # variable, this can be done by comparing the UVParameters.
-        if self.Nfreqs != uv.Nfreqs or not np.allclose(
-            np.squeeze(self.freq_array),
-            np.squeeze(uv.freq_array),
-            rtol=self._freq_array.tols[0],
-            atol=self._freq_array.tols[1],
-        ):
+        if self._freq_array != uv._freq_array:
             raise ValueError(
                 "The freq_array on uv is not the same as the freq_array on this "
                 f"object. The value on this object is {self.freq_array}; the value "
@@ -1628,53 +1490,34 @@ class UVFlag(UVBase):
             "antenna_positions",
             "channel_width",
             "spw_array",
+            "flex_spw_id_array",
         ]
         warning_params = ["instrument", "x_orientation", "antenna_diameters"]
-        if self.Nspws is not None and self.Nspws > 1:
-            # TODO: make this always be in the compatibility list in version 3.0
-            compatibility_params.append("flex_spw_id_array")
 
         # sometimes the antenna sorting for the antenna names/numbers/positions
         # is different. If the sets are the same, re-sort self to match uv
         self.sort_ant_metadata_like(uv)
 
         for param in compatibility_params + warning_params:
-            if (
-                issubclass(uv.__class__, UVData)
-                and param == "channel_width"
-                and not (uv.future_array_shapes or uv.flex_spw)
-            ):
-                if not np.allclose(
-                    self.channel_width,
-                    np.full(uv.Nfreqs, uv.channel_width),
-                    rtol=self._channel_width.tols[0],
-                    atol=self._channel_width.tols[1],
-                ):
-                    raise ValueError(
-                        "channel_width is not the same on this object and on uv. The "
-                        f"value on this object is {self.channel_width}; the value on "
-                        f"uv is {uv.channel_width}."
-                    )
+            # compare the UVParameter objects to properly handle tolerances
+            if param in telescope_params:
+                this_param = getattr(self.telescope, "_" + telescope_params[param])
+                uv_param = getattr(uv.telescope, "_" + telescope_params[param])
             else:
-                # compare the UVParameter objects to properly handle tolerances
-                if param in telescope_params:
-                    this_param = getattr(self.telescope, "_" + telescope_params[param])
-                    uv_param = getattr(uv.telescope, "_" + telescope_params[param])
+                this_param = getattr(self, "_" + param)
+                uv_param = getattr(uv, "_" + param)
+            if this_param.value is not None and this_param != uv_param:
+                if param in warning_params:
+                    warnings.warn(
+                        f"{param} is not the same on this object and on uv. "
+                        "Keeping the value on this object."
+                    )
                 else:
-                    this_param = getattr(self, "_" + param)
-                    uv_param = getattr(uv, "_" + param)
-                if this_param.value is not None and this_param != uv_param:
-                    if param in warning_params:
-                        warnings.warn(
-                            f"{param} is not the same on this object and on uv. "
-                            "Keeping the value on this object."
-                        )
-                    else:
-                        raise ValueError(
-                            f"{param} is not the same on this object and on uv. "
-                            f"The value on this object is {this_param.value}; "
-                            f"the value on uv is {uv_param.value}."
-                        )
+                    raise ValueError(
+                        f"{param} is not the same on this object and on uv. "
+                        f"The value on this object is {this_param.value}; "
+                        f"the value on uv is {uv_param.value}."
+                    )
 
         # Deal with polarization
         if force_pol and self.polarization_array.size == 1:
@@ -1707,37 +1550,11 @@ class UVFlag(UVBase):
         if self.type == "waterfall":
             # Populate arrays
             if self.mode == "flag":
-                if (
-                    issubclass(uv.__class__, UVData)
-                    and uv.future_array_shapes != self.future_array_shapes
-                ):
-                    if uv.future_array_shapes:
-                        arr = np.zeros_like(uv.flag_array[:, np.newaxis, :, :])
-                    else:
-                        arr = np.zeros_like(uv.flag_array[:, 0, :, :])
-                else:
-                    arr = np.zeros_like(uv.flag_array)
+                arr = np.zeros_like(uv.flag_array)
                 sarr = self.flag_array
             elif self.mode == "metric":
-                if (
-                    issubclass(uv.__class__, UVData)
-                    and uv.future_array_shapes != self.future_array_shapes
-                ):
-                    if uv.future_array_shapes:
-                        arr = np.zeros_like(
-                            uv.flag_array[:, np.newaxis, :, :], dtype=np.float64
-                        )
-                        warr = np.zeros_like(
-                            uv.flag_array[:, np.newaxis, :, :], dtype=np.float64
-                        )
-                    else:
-                        arr = np.zeros_like(uv.flag_array[:, 0, :, :], dtype=np.float64)
-                        warr = np.zeros_like(
-                            uv.flag_array[:, 0, :, :], dtype=np.float64
-                        )
-                else:
-                    arr = np.zeros_like(uv.flag_array, dtype=np.float64)
-                    warr = np.zeros_like(uv.flag_array, dtype=np.float64)
+                arr = np.zeros_like(uv.flag_array, dtype=np.float64)
+                warr = np.zeros_like(uv.flag_array, dtype=np.float64)
                 sarr = self.metric_array
             for i, t in enumerate(np.unique(self.time_array)):
                 ti = np.where(
@@ -1748,14 +1565,9 @@ class UVFlag(UVBase):
                         atol=max(self._time_array.tols[1], uv._time_array.tols[1]),
                     )
                 )
-                if self.future_array_shapes:
-                    arr[ti] = sarr[i][np.newaxis, :, :]
-                    if self.mode == "metric":
-                        warr[ti] = self.weights_array[i][np.newaxis, :, :]
-                else:
-                    arr[ti] = sarr[i][np.newaxis, np.newaxis, :, :]
-                    if self.mode == "metric":
-                        warr[ti] = self.weights_array[i][np.newaxis, np.newaxis, :, :]
+                arr[ti] = sarr[i][np.newaxis, :, :]
+                if self.mode == "metric":
+                    warr[ti] = self.weights_array[i][np.newaxis, :, :]
             if self.mode == "flag":
                 self.flag_array = arr
             elif self.mode == "metric":
@@ -1778,15 +1590,9 @@ class UVFlag(UVBase):
                 new_flags = np.full(flag_shape, True, dtype=bool)
                 self.flag_array = np.append(self.flag_array, new_flags, axis=0)
 
-            if self.future_array_shapes:
-                baseline_flags = np.full(
-                    (uv.Nblts, self.Nfreqs, self.Npols), True, dtype=bool
-                )
-            else:
-                baseline_flags = np.full(
-                    (uv.Nblts, 1, self.Nfreqs, self.Npols), True, dtype=bool
-                )
-
+            baseline_flags = np.full(
+                (uv.Nblts, self.Nfreqs, self.Npols), True, dtype=bool
+            )
             for blt_index, bl in enumerate(uv.baseline_array):
                 uvf_t_index = np.nonzero(
                     np.isclose(
@@ -1802,24 +1608,13 @@ class UVFlag(UVBase):
                     ant1, ant2 = uv.baseline_to_antnums(bl)
                     ant1_index = np.nonzero(np.array(self.ant_array) == ant1)
                     ant2_index = np.nonzero(np.array(self.ant_array) == ant2)
-                    if self.future_array_shapes:
-                        or_flag = np.logical_or(
-                            self.flag_array[ant1_index, :, uvf_t_index, :],
-                            self.flag_array[ant2_index, :, uvf_t_index, :],
-                        )
-                    else:
-                        or_flag = np.logical_or(
-                            self.flag_array[ant1_index, :, :, uvf_t_index, :],
-                            self.flag_array[ant2_index, :, :, uvf_t_index, :],
-                        )
-
+                    or_flag = np.logical_or(
+                        self.flag_array[ant1_index, :, uvf_t_index, :],
+                        self.flag_array[ant2_index, :, uvf_t_index, :],
+                    )
                     baseline_flags[blt_index] = or_flag.copy()
 
             self.flag_array = baseline_flags
-
-        # Check the frequency array for shape, broadcast to (1, Nfreqs) if needed
-        if not self.future_array_shapes:
-            self.freq_array = np.atleast_2d(self.freq_array)
 
         if self.Nspws is None:
             self.Nspws = uv.Nspws
@@ -1907,15 +1702,7 @@ class UVFlag(UVBase):
                 'Cannot convert from type "' + self.type + '" to "antenna".'
             )
 
-        # write it out this rather than comparing the UVParameters because
-        # future_array_shapes might be different. In the future, when shapes are not
-        # variable, this can be done by comparing the UVParameters.
-        if self.Nfreqs != uv.Nfreqs or not np.allclose(
-            np.squeeze(self.freq_array),
-            np.squeeze(uv.freq_array),
-            rtol=self._freq_array.tols[0],
-            atol=self._freq_array.tols[1],
-        ):
+        if self._freq_array != uv._freq_array:
             raise ValueError(
                 "The freq_array on uv is not the same as the freq_array on this "
                 f"object. The value on this object is {self.freq_array}; the value "
@@ -1930,52 +1717,32 @@ class UVFlag(UVBase):
             "antenna_positions",
             "channel_width",
             "spw_array",
+            "flex_spw_id_array",
         ]
         warning_params = ["instrument", "x_orientation", "antenna_diameters"]
-        if self.Nspws is not None and self.Nspws > 1:
-            # TODO: make this always be in the compatibility list in version 3.0
-            compatibility_params.append("flex_spw_id_array")
 
         # sometimes the antenna sorting for the antenna names/numbers/positions
         # is different. If the sets are the same, re-sort self to match uv
         self.sort_ant_metadata_like(uv)
 
         for param in compatibility_params + warning_params:
-            if (
-                issubclass(uv.__class__, UVCal)
-                and param == "channel_width"
-                and not (uv.future_array_shapes or uv.flex_spw)
-            ):
-                if not np.allclose(
-                    self.channel_width,
-                    np.full(uv.Nfreqs, uv.channel_width),
-                    rtol=self._channel_width.tols[0],
-                    atol=self._channel_width.tols[1],
-                ):
-                    raise ValueError(
-                        "channel_width is not the same on this object and on uv. The "
-                        f"value on this object is {self.channel_width}; the value on "
-                        f"uv is {uv.channel_width}."
-                    )
+            if param in telescope_params:
+                this_param = getattr(self.telescope, "_" + telescope_params[param])
+                uv_param = getattr(uv.telescope, "_" + telescope_params[param])
             else:
-                # compare the UVParameter objects to properly handle tolerances
-                if param in telescope_params:
-                    this_param = getattr(self.telescope, "_" + telescope_params[param])
-                    uv_param = getattr(uv.telescope, "_" + telescope_params[param])
+                this_param = getattr(self, "_" + param)
+                uv_param = getattr(uv, "_" + param)
+            if this_param.value is not None and this_param != uv_param:
+                if param in warning_params:
+                    warnings.warn(
+                        f"{param} is not the same on this object and on uv. "
+                        "Keeping the value on this object."
+                    )
                 else:
-                    this_param = getattr(self, "_" + param)
-                    uv_param = getattr(uv, "_" + param)
-                if this_param.value is not None and this_param != uv_param:
-                    if param in warning_params:
-                        warnings.warn(
-                            f"{param} is not the same on this object and on uv. "
-                            "Keeping the value on this object."
-                        )
-                    else:
-                        raise ValueError(
-                            f"{param} is not the same on this object and on uv. "
-                            f"The value on this object is {this_param.value}; "
-                            f"the value on uv is {uv_param.value}."
+                    raise ValueError(
+                        f"{param} is not the same on this object and on uv. "
+                        f"The value on this object is {this_param.value}; "
+                        f"the value on uv is {uv_param.value}."
                         )
 
         # Deal with polarization
@@ -2012,37 +1779,19 @@ class UVFlag(UVBase):
                 raise ValueError("Polarizations could not be made to match.")
         # Populate arrays
         if self.mode == "flag":
-            if self.future_array_shapes:
-                self.flag_array = np.swapaxes(self.flag_array, 0, 1)[
-                    np.newaxis, :, :, :
-                ]
-            else:
-                self.flag_array = np.swapaxes(self.flag_array, 0, 1)[
-                    np.newaxis, np.newaxis, :, :, :
-                ]
+            self.flag_array = np.swapaxes(self.flag_array, 0, 1)[np.newaxis, :, :, :]
             self.flag_array = self.flag_array.repeat(len(uv.ant_array), axis=0)
         elif self.mode == "metric":
-            if self.future_array_shapes:
-                self.metric_array = np.swapaxes(self.metric_array, 0, 1)[
-                    np.newaxis, :, :, :
-                ]
-                self.weights_array = np.swapaxes(self.weights_array, 0, 1)[
-                    np.newaxis, :, :, :
-                ]
-            else:
-                self.metric_array = np.swapaxes(self.metric_array, 0, 1)[
-                    np.newaxis, np.newaxis, :, :, :
-                ]
-                self.weights_array = np.swapaxes(self.weights_array, 0, 1)[
-                    np.newaxis, np.newaxis, :, :, :
-                ]
+            self.metric_array = np.swapaxes(self.metric_array, 0, 1)[
+                np.newaxis, :, :, :
+            ]
+            self.weights_array = np.swapaxes(self.weights_array, 0, 1)[
+                np.newaxis, :, :, :
+            ]
             self.metric_array = self.metric_array.repeat(len(uv.ant_array), axis=0)
             self.weights_array = self.weights_array.repeat(len(uv.ant_array), axis=0)
         self.ant_array = uv.ant_array
         self.Nants_data = len(uv.ant_array)
-        # Check the frequency array for Nspws, otherwise broadcast to 1,Nfreqs
-        if not self.future_array_shapes:
-            self.freq_array = np.atleast_2d(self.freq_array)
 
         for param in self.telescope:
             this_param = getattr(self.telescope, param)
@@ -2164,25 +1913,15 @@ class UVFlag(UVBase):
                     for i in range(self.Npols):
                         for ap in self.get_antpairs():
                             inds = self.antpair2ind(*ap)
-                            if self.future_array_shapes:
-                                self.weights_array[inds, :, i] *= ~and_rows_cols(
-                                    self.flag_array[inds, :, i]
-                                )
-                            else:
-                                self.weights_array[inds, 0, :, i] *= ~and_rows_cols(
-                                    self.flag_array[inds, 0, :, i]
-                                )
+                            self.weights_array[inds, :, i] *= ~and_rows_cols(
+                                self.flag_array[inds, :, i]
+                            )
                 elif self.type == "antenna":
                     for i in range(self.Npols):
                         for j in range(self.weights_array.shape[0]):
-                            if self.future_array_shapes:
-                                self.weights_array[j, :, :, i] *= ~and_rows_cols(
-                                    self.flag_array[j, :, :, i]
-                                )
-                            else:
-                                self.weights_array[j, 0, :, :, i] *= ~and_rows_cols(
-                                    self.flag_array[j, 0, :, :, i]
-                                )
+                            self.weights_array[j, :, :, i] *= ~and_rows_cols(
+                                self.flag_array[j, :, :, i]
+                            )
         else:
             raise ValueError(
                 "Unknown UVFlag mode: " + self.mode + ". Cannot convert to metric."
@@ -2254,14 +1993,6 @@ class UVFlag(UVBase):
                 "added to object of mode " + this.type + "."
             )
 
-        # check that both objects have the same array shapes
-        if this.future_array_shapes != other.future_array_shapes:
-            raise ValueError(
-                "Both objects must have the same `future_array_shapes` parameter. "
-                "Use the `use_future_array_shapes` or `use_current_array_shapes` "
-                "methods to convert them."
-            )
-
         this_has_spw_id = this.flex_spw_id_array is not None
         other_has_spw_id = other.flex_spw_id_array is not None
         if this_has_spw_id != other_has_spw_id:
@@ -2278,26 +2009,15 @@ class UVFlag(UVBase):
         # Simplify axis referencing
         axis = axis.lower()
         type_nums = {"waterfall": 0, "baseline": 1, "antenna": 2}
-        if self.future_array_shapes:
-            axis_nums = {
-                "time": [0, 0, 2],
-                "baseline": [None, 0, None],
-                "antenna": [None, None, 0],
-                "frequency": [1, 1, 1],
-                "polarization": [2, 2, 3],
-                "pol": [2, 2, 3],
-                "jones": [2, 2, 3],
-            }
-        else:
-            axis_nums = {
-                "time": [0, 0, 3],
-                "baseline": [None, 0, None],
-                "antenna": [None, None, 0],
-                "frequency": [1, 2, 2],
-                "polarization": [2, 3, 4],
-                "pol": [2, 3, 4],
-                "jones": [2, 3, 4],
-            }
+        axis_nums = {
+            "time": [0, 0, 2],
+            "baseline": [None, 0, None],
+            "antenna": [None, None, 0],
+            "frequency": [1, 1, 1],
+            "polarization": [2, 2, 3],
+            "pol": [2, 2, 3],
+            "jones": [2, 2, 3],
+        }
         if axis not in axis_nums.keys():
             raise ValueError(f"Axis not recognized, must be one of {axis_nums.keys()}")
 
@@ -2307,10 +2027,9 @@ class UVFlag(UVBase):
         warning_params = ["instrument", "x_orientation", "antenna_diameters"]
 
         if axis != "frequency":
-            compatibility_params.extend(["freq_array", "channel_width", "spw_array"])
-            if self.flex_spw_id_array is not None:
-                # TODO: make this always be in the compatibility list in version 3.0
-                compatibility_params.append("flex_spw_id_array")
+            compatibility_params.extend(
+                ["freq_array", "channel_width", "spw_array", "flex_spw_id_array"]
+            )
         if axis not in ["polarization", "pol", "jones"]:
             compatibility_params.extend(["polarization_array"])
         if axis != "time":
@@ -3022,12 +2741,7 @@ class UVFlag(UVBase):
             n_selects += 1
 
             freq_inds = np.zeros(0, dtype=np.int64)
-            # this works because we only allow one SPW. This will have to be
-            # reworked when we support more.
-            if self.type != "waterfall" and not self.future_array_shapes:
-                freq_arr_use = self.freq_array[0, :]
-            else:
-                freq_arr_use = self.freq_array
+            freq_arr_use = self.freq_array
             for f in frequencies:
                 if f in freq_arr_use:
                     freq_inds = np.append(freq_inds, np.where(freq_arr_use == f)[0])
@@ -3117,10 +2831,7 @@ class UVFlag(UVBase):
 
         if freq_inds is not None:
             self.Nfreqs = len(freq_inds)
-            if self.type != "waterfall" and not self.future_array_shapes:
-                self.freq_array = self.freq_array[:, freq_inds]
-            else:
-                self.freq_array = self.freq_array[freq_inds]
+            self.freq_array = self.freq_array[freq_inds]
             if self.channel_width is not None:
                 self.channel_width = self.channel_width[freq_inds]
             if self.flex_spw_id_array is not None:
@@ -3280,16 +2991,10 @@ class UVFlag(UVBase):
                 ):
                     setattr(uv_object, param_name, param[blt_inds])
             if self.type == "antenna":
-                if self.future_array_shapes:
-                    for param_name, param in zip(
-                        self._data_params, uv_object.data_like_parameters
-                    ):
-                        setattr(uv_object, param_name, param[:, :, blt_inds, :])
-                else:
-                    for param_name, param in zip(
-                        self._data_params, uv_object.data_like_parameters
-                    ):
-                        setattr(uv_object, param_name, param[:, :, :, blt_inds, :])
+                for param_name, param in zip(
+                    self._data_params, uv_object.data_like_parameters
+                ):
+                    setattr(uv_object, param_name, param[:, :, blt_inds, :])
 
         if ant_inds is not None and self.type == "antenna":
             for param_name, param in zip(
@@ -3299,61 +3004,37 @@ class UVFlag(UVBase):
 
         if freq_inds is not None:
             if self.type == "baseline":
-                if self.future_array_shapes:
-                    for param_name, param in zip(
-                        self._data_params, uv_object.data_like_parameters
-                    ):
-                        setattr(uv_object, param_name, param[:, freq_inds, :])
-                else:
-                    for param_name, param in zip(
-                        self._data_params, uv_object.data_like_parameters
-                    ):
-                        setattr(uv_object, param_name, param[:, :, freq_inds, :])
+                for param_name, param in zip(
+                    self._data_params, uv_object.data_like_parameters
+                ):
+                    setattr(uv_object, param_name, param[:, freq_inds, :])
             if self.type == "waterfall":
                 for param_name, param in zip(
                     self._data_params, uv_object.data_like_parameters
                 ):
                     setattr(uv_object, param_name, param[:, freq_inds, :])
             if self.type == "antenna":
-                if self.future_array_shapes:
-                    for param_name, param in zip(
-                        self._data_params, uv_object.data_like_parameters
-                    ):
-                        setattr(uv_object, param_name, param[:, freq_inds, :, :])
-                else:
-                    for param_name, param in zip(
-                        self._data_params, uv_object.data_like_parameters
-                    ):
-                        setattr(uv_object, param_name, param[:, :, freq_inds, :, :])
+                for param_name, param in zip(
+                    self._data_params, uv_object.data_like_parameters
+                ):
+                    setattr(uv_object, param_name, param[:, freq_inds, :, :])
 
         if pol_inds is not None:
             if self.type == "baseline":
-                if self.future_array_shapes:
-                    for param_name, param in zip(
-                        self._data_params, uv_object.data_like_parameters
-                    ):
-                        setattr(uv_object, param_name, param[:, :, pol_inds])
-                else:
-                    for param_name, param in zip(
-                        self._data_params, uv_object.data_like_parameters
-                    ):
-                        setattr(uv_object, param_name, param[:, :, :, pol_inds])
+                for param_name, param in zip(
+                    self._data_params, uv_object.data_like_parameters
+                ):
+                    setattr(uv_object, param_name, param[:, :, pol_inds])
             if self.type == "waterfall":
                 for param_name, param in zip(
                     self._data_params, uv_object.data_like_parameters
                 ):
                     setattr(uv_object, param_name, param[:, :, pol_inds])
             if self.type == "antenna":
-                if self.future_array_shapes:
-                    for param_name, param in zip(
-                        self._data_params, uv_object.data_like_parameters
-                    ):
-                        setattr(uv_object, param_name, param[:, :, :, pol_inds])
-                else:
-                    for param_name, param in zip(
-                        self._data_params, uv_object.data_like_parameters
-                    ):
-                        setattr(uv_object, param_name, param[:, :, :, :, pol_inds])
+                for param_name, param in zip(
+                    self._data_params, uv_object.data_like_parameters
+                ):
+                    setattr(uv_object, param_name, param[:, :, :, pol_inds])
 
         # check if object is uv_object-consistent
         if run_check:
@@ -3371,7 +3052,7 @@ class UVFlag(UVBase):
         history="",
         mwa_metafits_file=None,
         telescope_name=None,
-        use_future_array_shapes=False,
+        use_future_array_shapes=None,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -3397,8 +3078,7 @@ class UVFlag(UVBase):
             telescopes. Setting this parameter overrides any telescope name in the file.
             This should not be set if `mwa_metafits_file` is passed.
         use_future_array_shapes : bool
-            Option to convert to the future planned array shapes before the changes go
-            into effect by removing the spectral window axis.
+            Defunct option, will result in an error in version 3.2.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after reading data.
@@ -3409,20 +3089,18 @@ class UVFlag(UVBase):
             reading data.
 
         """
+        # Run this check up front once
+        self._set_future_array_shapes(use_future_array_shapes=use_future_array_shapes)
+
         # make sure we have an empty object.
         self.__init__()
         if isinstance(filename, (tuple, list)):
-            self.read(filename[0], use_future_array_shapes=use_future_array_shapes)
+            self.read(filename[0])
             if len(filename) > 1:
                 for f in filename[1:]:
-                    f2 = UVFlag(
-                        f,
-                        history=history,
-                        use_future_array_shapes=use_future_array_shapes,
-                    )
+                    f2 = UVFlag(f, history=history)
                     self += f2
                 del f2
-
         else:
             if not os.path.exists(filename):
                 raise IOError(filename + " not found.")
@@ -3479,32 +3157,31 @@ class UVFlag(UVBase):
 
                 self.lst_array = header["lst_array"][()]
 
-                # read data arrays to figure out if the file has future shapes or not
-                future_shapes_ndim = {"antenna": 4, "baseline": 3}
+                # read data arrays to figure out if the file has old shapes or not
+                current_shapes_ndim = {"antenna": 4, "baseline": 3}
                 dgrp = f["/Data"]
                 if self.mode == "metric":
                     self.metric_array = dgrp["metric_array"][()]
-                    if self.type != "waterfall":
-                        if self.metric_array.ndim == future_shapes_ndim[self.type]:
-                            self._set_future_array_shapes()
-
                     self.weights_array = dgrp["weights_array"][()]
+
+                    if self.type != "waterfall":
+                        if self.metric_array.ndim != current_shapes_ndim[self.type]:
+                            self.metric_array = self.metric_array[:, 0]
+                        if self.weights_array.ndim != current_shapes_ndim[self.type]:
+                            self.weights_array = self.weights_array[:, 0]
+
                     if "weights_square_array" in dgrp:
                         self.weights_square_array = dgrp["weights_square_array"][()]
 
                 elif self.mode == "flag":
                     self.flag_array = dgrp["flag_array"][()]
                     if self.type != "waterfall":
-                        if self.flag_array.ndim == future_shapes_ndim[self.type]:
-                            self._set_future_array_shapes()
+                        if self.flag_array.ndim != current_shapes_ndim[self.type]:
+                            self.flag_array = self.flag_array[:, 0]
 
                 self.freq_array = header["freq_array"][()]
-                # older save files will not have this spws axis
-                # at least_2d will preserve shape of 2d arrays and
-                # promote 1D to (1, Nfreqs)
-                if self.type != "waterfall" and not self.future_array_shapes:
-                    self.freq_array = np.atleast_2d(self.freq_array)
-                elif self.freq_array.ndim > 1:
+                # older save files may have the old spw-axis, squeeze that now
+                if self.freq_array.ndim > 1:
                     self.freq_array = np.squeeze(self.freq_array)
 
                 if "Nfreqs" in header.keys():
@@ -3514,6 +3191,8 @@ class UVFlag(UVBase):
 
                 if "channel_width" in header.keys():
                     self.channel_width = header["channel_width"][()]
+                    if self.channel_width.ndim == 0:
+                        self.channel_width = np.full(self.Nfreqs, self.channel_width)
                 else:
                     # older files do not have the channel_width parameter. Guess it from
                     # the freq array spacing.
@@ -3783,21 +3462,6 @@ class UVFlag(UVBase):
 
             self.clear_unused_attributes()
 
-            if use_future_array_shapes != self.future_array_shapes:
-                if use_future_array_shapes:
-                    self.use_future_array_shapes()
-                else:
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings(
-                            "ignore",
-                            message="This method will be removed in version 3.0 when "
-                            "the current array shapes are no longer supported.",
-                        )
-                        self.use_current_array_shapes()
-
-            if not use_future_array_shapes:
-                warnings.warn(_future_array_shapes_warning, DeprecationWarning)
-
             if run_check:
                 self.check(
                     check_extra=check_extra,
@@ -3828,12 +3492,7 @@ class UVFlag(UVBase):
             header = f.create_group("Header")
 
             # write out metadata
-            if self.future_array_shapes:
-                # this is Version 1.0
-                header["version"] = np.string_("1.0")
-            else:
-                header["version"] = np.string_("0.1")
-
+            header["version"] = np.string_("1.0")
             header["type"] = np.string_(self.type)
             header["mode"] = np.string_(self.mode)
 
@@ -3850,8 +3509,7 @@ class UVFlag(UVBase):
 
             header["Nspws"] = self.Nspws
             header["spw_array"] = self.spw_array
-            if self.flex_spw_id_array is not None:
-                header["flex_spw_id_array"] = self.flex_spw_id_array
+            header["flex_spw_id_array"] = self.flex_spw_id_array
 
             header["Npols"] = self.Npols
 
@@ -3931,7 +3589,7 @@ class UVFlag(UVBase):
         waterfall=False,
         history="",
         label="",
-        use_future_array_shapes=False,
+        use_future_array_shapes=None,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -3955,8 +3613,7 @@ class UVFlag(UVBase):
         label: str, optional
             String used for labeling the object (e.g. 'FM').
         use_future_array_shapes : bool
-            Option to convert to the future planned array shapes before the changes go
-            into effect by removing the spectral window axis.
+            Defunct option, will result in an error in version 3.2.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after creating UVFlag object.
@@ -3984,26 +3641,19 @@ class UVFlag(UVBase):
                 "{}".format((", ").join(self._mode.acceptable_vals))
             )
 
-        if use_future_array_shapes:
-            self._set_future_array_shapes()
+        self._set_future_array_shapes(use_future_array_shapes=use_future_array_shapes)
 
         self.Nfreqs = indata.Nfreqs
         self.polarization_array = copy.deepcopy(indata.polarization_array)
         self.Npols = indata.Npols
         self.Ntimes = indata.Ntimes
-
-        if indata.future_array_shapes or indata.flex_spw:
-            self.channel_width = copy.deepcopy(indata.channel_width)
-        else:
-            self.channel_width = np.full(self.Nfreqs, indata.channel_width)
-
+        self.channel_width = copy.deepcopy(indata.channel_width)
         self.telescope = indata.telescope.copy()
         self._set_telescope_requirements()
 
         self.Nspws = indata.Nspws
         self.spw_array = copy.deepcopy(indata.spw_array)
-        if indata.flex_spw_id_array is not None:
-            self.flex_spw_id_array = copy.deepcopy(indata.flex_spw_id_array)
+        self.flex_spw_id_array = copy.deepcopy(indata.flex_spw_id_array)
 
         if waterfall:
             self._set_type_waterfall()
@@ -4014,10 +3664,7 @@ class UVFlag(UVBase):
                 self.history += self.pyuvdata_version_str
 
             self.time_array, ri = np.unique(indata.time_array, return_index=True)
-            if indata.future_array_shapes:
-                self.freq_array = copy.deepcopy(indata.freq_array)
-            else:
-                self.freq_array = indata.freq_array[0, :]
+            self.freq_array = copy.deepcopy(indata.freq_array)
             self.lst_array = indata.lst_array[ri]
             if copy_flags:
                 raise NotImplementedError(
@@ -4046,27 +3693,12 @@ class UVFlag(UVBase):
             self.ant_1_array = copy.deepcopy(indata.ant_1_array)
             self.ant_2_array = copy.deepcopy(indata.ant_2_array)
             self.Nants_data = indata.Nants_data
-
             self.time_array = copy.deepcopy(indata.time_array)
             self.lst_array = copy.deepcopy(indata.lst_array)
-
-            if self.future_array_shapes == indata.future_array_shapes:
-                # match on future shape
-                self.freq_array = copy.deepcopy(indata.freq_array)
-            elif indata.future_array_shapes:
-                # input is future shaped, self is not
-                self.freq_array = indata.freq_array[np.newaxis, :]
-            else:
-                # input is not future shaped, self is
-                self.freq_array = indata.freq_array[0, :]
+            self.freq_array = copy.deepcopy(indata.freq_array)
 
             if copy_flags:
-                if self.future_array_shapes == indata.future_array_shapes:
-                    self.flag_array = copy.deepcopy(indata.flag_array)
-                elif indata.future_array_shapes:
-                    self.flag_array = indata.flag_array[:, np.newaxis, :, :]
-                else:
-                    self.flag_array = indata.flag_array[:, 0, :, :]
+                self.flag_array = copy.deepcopy(indata.flag_array)
                 self.history += (
                     " Flags copied from " + str(indata.__class__) + " object."
                 )
@@ -4076,10 +3708,7 @@ class UVFlag(UVBase):
                     )
                     self._set_mode_flag()
             else:
-                if self.future_array_shapes:
-                    array_shape = (self.Nblts, self.Nfreqs, self.Npols)
-                else:
-                    array_shape = (self.Nblts, 1, self.Nfreqs, self.Npols)
+                array_shape = (self.Nblts, self.Nfreqs, self.Npols)
                 if self.mode == "flag":
                     self.flag_array = np.zeros(array_shape, dtype=np.bool_)
                 elif self.mode == "metric":
@@ -4100,9 +3729,6 @@ class UVFlag(UVBase):
 
         self.clear_unused_attributes()
 
-        if not use_future_array_shapes:
-            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
-
         if run_check:
             self.check(
                 check_extra=check_extra, run_check_acceptability=run_check_acceptability
@@ -4118,7 +3744,7 @@ class UVFlag(UVBase):
         waterfall=False,
         history="",
         label="",
-        use_future_array_shapes=False,
+        use_future_array_shapes=None,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -4142,8 +3768,7 @@ class UVFlag(UVBase):
         label: str, optional
             String used for labeling the object (e.g. 'FM').
         use_future_array_shapes : bool
-            Option to convert to the future planned array shapes before the changes go
-            into effect by removing the spectral window axis.
+            Defunct option, will result in an error in version 3.2.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after creating UVFlag object.
@@ -4177,8 +3802,7 @@ class UVFlag(UVBase):
                 "{}".format((", ").join(self._mode.acceptable_vals))
             )
 
-        if use_future_array_shapes:
-            self._set_future_array_shapes()
+        self._set_future_array_shapes(use_future_array_shapes=use_future_array_shapes)
 
         self.Nfreqs = indata.Nfreqs
         self.polarization_array = copy.deepcopy(indata.jones_array)
@@ -4186,19 +3810,13 @@ class UVFlag(UVBase):
         self.Ntimes = indata.Ntimes
         self.time_array = copy.deepcopy(indata.time_array)
         self.lst_array = copy.deepcopy(indata.lst_array)
-
-        if indata.future_array_shapes or indata.flex_spw:
-            self.channel_width = copy.deepcopy(indata.channel_width)
-        else:
-            self.channel_width = np.full(self.Nfreqs, indata.channel_width)
-
+        self.channel_width = copy.deepcopy(indata.channel_width)
         self.telescope = indata.telescope.copy()
         self._set_telescope_requirements()
 
         self.Nspws = indata.Nspws
         self.spw_array = copy.deepcopy(indata.spw_array)
-        if indata.flex_spw_id_array is not None:
-            self.flex_spw_id_array = copy.deepcopy(indata.flex_spw_id_array)
+        self.flex_spw_id_array = copy.deepcopy(indata.flex_spw_id_array)
 
         if waterfall:
             self._set_type_waterfall()
@@ -4208,10 +3826,7 @@ class UVFlag(UVBase):
             ):
                 self.history += self.pyuvdata_version_str
 
-            if indata.future_array_shapes:
-                self.freq_array = copy.deepcopy(indata.freq_array)
-            else:
-                self.freq_array = indata.freq_array[0, :]
+            self.freq_array = copy.deepcopy(indata.freq_array)
             if copy_flags:
                 raise NotImplementedError(
                     "Cannot copy flags when "
@@ -4235,24 +3850,10 @@ class UVFlag(UVBase):
                 self.history += self.pyuvdata_version_str
             self.ant_array = copy.deepcopy(indata.ant_array)
             self.Nants_data = len(self.ant_array)
-
-            if self.future_array_shapes == indata.future_array_shapes:
-                # match on future shape
-                self.freq_array = copy.deepcopy(indata.freq_array)
-            elif indata.future_array_shapes:
-                # input is future shaped, self is not
-                self.freq_array = indata.freq_array[np.newaxis, :]
-            else:
-                # input is not future shaped, self is
-                self.freq_array = indata.freq_array[0, :]
+            self.freq_array = copy.deepcopy(indata.freq_array)
 
             if copy_flags:
-                if self.future_array_shapes == indata.future_array_shapes:
-                    self.flag_array = copy.deepcopy(indata.flag_array)
-                elif indata.future_array_shapes:
-                    self.flag_array = indata.flag_array[:, np.newaxis, :, :]
-                else:
-                    self.flag_array = indata.flag_array[:, 0, :, :]
+                self.flag_array = copy.deepcopy(indata.flag_array)
                 self.history += (
                     " Flags copied from " + str(indata.__class__) + " object."
                 )
@@ -4262,21 +3863,7 @@ class UVFlag(UVBase):
                     )
                     self._set_mode_flag()
             else:
-                if self.future_array_shapes:
-                    array_shape = (
-                        self.Nants_data,
-                        self.Nfreqs,
-                        self.Ntimes,
-                        self.Npols,
-                    )
-                else:
-                    array_shape = (
-                        self.Nants_data,
-                        1,
-                        self.Nfreqs,
-                        self.Ntimes,
-                        self.Npols,
-                    )
+                array_shape = (self.Nants_data, self.Nfreqs, self.Ntimes, self.Npols)
                 if self.mode == "flag":
                     self.flag_array = np.zeros(array_shape, dtype=np.bool_)
                 elif self.mode == "metric":
@@ -4293,9 +3880,6 @@ class UVFlag(UVBase):
         self.label += label
 
         self.clear_unused_attributes()
-
-        if not use_future_array_shapes:
-            warnings.warn(_future_array_shapes_warning, DeprecationWarning)
 
         if run_check:
             self.check(

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -469,18 +469,6 @@ class UVFlag(UVBase):
         )
 
         desc = (
-            "Flag indicating that this object is using the future array shapes. "
-            "Defunct, will be removed in version 3.2."
-        )
-        self._future_array_shapes = uvp.UVParameter(
-            "future_array_shapes",
-            description=desc,
-            expected_type=bool,
-            value=True,
-            acceptable_vals=[True],
-        )
-
-        desc = (
             "Number of antennas with data present. "
             "Only available for 'baseline' or 'antenna' type objects."
             "May be smaller than the number of antennas in the array"

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -200,10 +200,8 @@ class UVFlag(UVBase):
     ----------
     UVParameter objects :
         For full list see the UVFlag Parameters Documentation.
-        (https://pyuvdata.readthedocs.io/en/latest/uvflag_parameters.html)
-        Some are always required, some are required for certain phase_types
-        and others are always optional.
-
+        (https://pyuvdata.readthedocs.io/en/latest/uvflag.html)
+        Some are always required, while others are optional.
 
     """
 

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -3094,26 +3094,21 @@ class UVFlag(UVBase):
                 self.lst_array = header["lst_array"][()]
 
                 # read data arrays to figure out if the file has old shapes or not
-                current_shapes_ndim = {"antenna": 4, "baseline": 3}
+                current_shapes_ndim = {"antenna": 4, "baseline": 3, "waterfall": 3}
                 dgrp = f["/Data"]
                 if self.mode == "metric":
                     self.metric_array = dgrp["metric_array"][()]
                     self.weights_array = dgrp["weights_array"][()]
-
-                    if self.type != "waterfall":
-                        if self.metric_array.ndim != current_shapes_ndim[self.type]:
-                            self.metric_array = self.metric_array[:, 0]
-                        if self.weights_array.ndim != current_shapes_ndim[self.type]:
-                            self.weights_array = self.weights_array[:, 0]
-
                     if "weights_square_array" in dgrp:
                         self.weights_square_array = dgrp["weights_square_array"][()]
 
                 elif self.mode == "flag":
                     self.flag_array = dgrp["flag_array"][()]
-                    if self.type != "waterfall":
-                        if self.flag_array.ndim != current_shapes_ndim[self.type]:
-                            self.flag_array = self.flag_array[:, 0]
+
+                for param in self._data_params:
+                    param_value = getattr(self, param)
+                    if param_value.ndim != current_shapes_ndim[self.type]:
+                        setattr(self, param, np.squeeze(param_value, axis=1))
 
                 self.freq_array = header["freq_array"][()]
                 # older save files may have the old spw-axis, squeeze that now

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -1731,7 +1731,7 @@ class UVFlag(UVBase):
                         f"{param} is not the same on this object and on uv. "
                         f"The value on this object is {this_param.value}; "
                         f"the value on uv is {uv_param.value}."
-                        )
+                    )
 
         # Deal with polarization
         if issubclass(uv.__class__, UVCal):

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -1947,14 +1947,6 @@ class UVFlag(UVBase):
                 "added to object of mode " + this.type + "."
             )
 
-        this_has_spw_id = this.flex_spw_id_array is not None
-        other_has_spw_id = other.flex_spw_id_array is not None
-        if this_has_spw_id != other_has_spw_id:
-            warnings.warn(
-                "One object has the flex_spw_id_array set and one does not. Combined "
-                "object will have it set."
-            )
-
         # Update filename parameter
         this.filename = uvutils._combine_filenames(this.filename, other.filename)
         if this.filename is not None:
@@ -2108,15 +2100,6 @@ class UVFlag(UVBase):
 
             # handle multiple spws
             if this.Nspws > 1 or other.Nspws > 1 or this._spw_array != other._spw_array:
-                if this.flex_spw_id_array is None:
-                    this.flex_spw_id_array = np.full(
-                        this.Nfreqs, this.spw_array[0], dtype=int
-                    )
-                if other.flex_spw_id_array is None:
-                    other.flex_spw_id_array = np.full(
-                        other.Nfreqs, other.spw_array[0], dtype=int
-                    )
-
                 this.flex_spw_id_array = np.concatenate(
                     [this.flex_spw_id_array, other.flex_spw_id_array]
                 )
@@ -2129,10 +2112,9 @@ class UVFlag(UVBase):
                 this.spw_array = this.flex_spw_id_array[unique_index]
                 this.Nspws = len(this.spw_array)
             else:
-                if this_has_spw_id or other_has_spw_id:
-                    this.flex_spw_id_array = np.full(
-                        this.freq_array.size, this.spw_array[0], dtype=int
-                    )
+                this.flex_spw_id_array = np.full(
+                    this.freq_array.size, this.spw_array[0], dtype=int
+                )
 
             this.Nfreqs = np.unique(this.freq_array.flatten()).size
 

--- a/pyuvdata/uvflag/uvflag.py
+++ b/pyuvdata/uvflag/uvflag.py
@@ -641,40 +641,6 @@ class UVFlag(UVBase):
                 np.arange(1, 5)
             )
 
-    def _set_future_array_shapes(self, use_future_array_shapes=None):
-        """
-        Set future_array_shapes to True and adjust required parameters.
-
-        This method should not be called directly by users; instead it is called
-        by file-reading methods and `use_future_array_shapes` to indicate the
-        `future_array_shapes` is True and define expected parameter shapes.
-        This function has been deprecated, and will result in an error in version 3.2.
-        """
-        if use_future_array_shapes is None:
-            # This basically wraps no-ops when no argument is passed.
-            return
-
-        if not use_future_array_shapes:
-            raise ValueError(
-                'The future is now! So-called "current" array shapes no longer '
-                'supported, must use "future" array shapes (spw-axis dropped).'
-            )
-        warnings.warn(
-            (
-                "Future array shapes are now always used, setting/calling "
-                "use_future_array_shapes will result in an error in version 3.2."
-            ),
-            DeprecationWarning,
-        )
-
-    def use_future_array_shapes(self):
-        """
-        Change the array shapes of this object to match the planned future shapes.
-
-        This function has been deprecated, and will result in an error in version 3.2.
-        """
-        self._set_future_array_shapes(True)
-
     def _set_mode_flag(self):
         """Set the mode and required parameters consistent with a flag object."""
         self.mode = "flag"

--- a/scripts/convert_to_uvfits.py
+++ b/scripts/convert_to_uvfits.py
@@ -73,7 +73,7 @@ for filename in args.files:
     UV = pyuvdata.UVData()
     UV.read(filename)
 
-    if UV.phase_type == "drift":
+    if any(UV._check_for_cat_type("unprojected")):
         # phase data
         if args.phase_time is not None:
             UV.phase_to_time(Time(args.phase_time, format="jd", scale="utc"))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
"I am inevitable" -- _V3 of pyuvdata_ 

## Description
<!--- Describe your changes in detail -->
Implements the final set of changes for pyuvdata version 3.0, primarily:

- Dropping support for "current array shapes" (the old spw-axis -- which was forced to always be 1 -- has been removed from attributes that have it)
- Requiring flexible spectral windows be used in `UVData and `UVCal` objects (the latter only when a frequency axis is present, i.e., non-wideband solutions)
- Dropping support for the "old" phasing parameters (which were deprecated when `phase_center_catalog` became a standard parameter).

Relatedly, the `use_future_array_shapes` method has been deprecated, and is planned to be removed in v3.2.

Note that while nearly all the required work on this branch is complete, I haven't updated the CHANGELOG yet, mostly in anticipation of (perhaps unlikely) significant changes that may be requested. Also, this PR will follow #1422, and will be moved to "ready" once that PR is successfully merged into `prep_v3.0`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This PR is meant to be the final PR to close out V3 updates, and as such should be the final one merged into `prep_v3.0` before that branch is ready or merge into `main`. And I for one am ready to overthrow our vestigal spw-axis overlords.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Breaking change checklist:
- [x] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to reflect my changes (if appropriate).
- [x] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
