### PR TITLE
Dcp uvfits rdate fix

### DIFF
--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4382,9 +4382,10 @@ def test_determine_blt_order_size_1():
 
 
 def test_antnums_to_baseline_miriad_convention():
-    ant1 = np.array([0, 1, 2, 3, 0, 0]) + 1  # Ant1 array should be 1-based
-    ant2 = np.array([0, 1, 2, 3, 255, 256]) + 1  # Ant2 array should be 1-based
-    bl_gold = np.array([257, 514, 771, 1028, 67840, 67841], dtype="uint64")
+    ant1 = np.array([1, 2, 3, 1, 1, 1, 255, 256])  # Ant1 array should be 1-based
+    ant2 = np.array([0, 1, 2, 254, 255, 256, 0, 1])  # Ant2 array should be 1-based
+    bl_gold = np.array([256, 513, 770, 510, 511, 67840, 65280, 65537], dtype="uint64")
+
     n_ant = 256
     bl = uvutils.antnums_to_baseline(ant1, ant2, n_ant, use_miriad_convention=True)
     assert np.allclose(bl, bl_gold)

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -4383,8 +4383,8 @@ def test_determine_blt_order_size_1():
 
 def test_antnums_to_baseline_miriad_convention():
     ant1 = np.array([1, 2, 3, 1, 1, 1, 255, 256])  # Ant1 array should be 1-based
-    ant2 = np.array([0, 1, 2, 254, 255, 256, 0, 1])  # Ant2 array should be 1-based
-    bl_gold = np.array([256, 513, 770, 510, 511, 67840, 65280, 65537], dtype="uint64")
+    ant2 = np.array([1, 2, 3, 254, 255, 256, 1, 2])  # Ant2 array should be 1-based
+    bl_gold = np.array([257, 514, 771, 510, 511, 67840, 65281, 65538], dtype="uint64")
 
     n_ant = 256
     bl = uvutils.antnums_to_baseline(ant1, ant2, n_ant, use_miriad_convention=True)

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -2770,6 +2770,8 @@ def transform_icrs_to_app(
                 v_coord = v_coord.repeat(ra_coord.size)
 
         if isinstance(site_loc, EarthLocation):
+            time_obj_array = Time(time_obj_array, location=site_loc)
+
             sky_coord = SkyCoord(
                 ra=ra_coord,
                 dec=dec_coord,
@@ -2805,9 +2807,8 @@ def transform_icrs_to_app(
                     frame="lunartopo",
                 )
             )
-            time_obj_array = LTime(time_obj_array)
+            time_obj_array = LTime(time_obj_array, location=site_loc)
 
-        time_obj_array.location = site_loc
         app_ha, app_dec = erfa.ae2hd(
             azel_data.az.rad, azel_data.alt.rad, site_loc.lat.rad
         )
@@ -3098,9 +3099,9 @@ def transform_app_to_icrs(
 
     if astrometry_library == "astropy":
         if hasmoon and isinstance(site_loc, MoonLocation):
-            time_obj_array = LTime(time_obj_array)
-
-        time_obj_array.location = site_loc
+            time_obj_array = LTime(time_obj_array, location=site_loc)
+        else:
+            time_obj_array = Time(time_obj_array, location=site_loc)
 
         az_coord, el_coord = erfa.hd2ae(
             np.mod(

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -207,7 +207,7 @@ cdef inline void _antnum_to_bl_2048_miriad(
   cdef Py_ssize_t i
 
   for i in range(nbls):
-    if ant2[i] >= 255:
+    if ant2[i] > 255:      # MIRIAD uses 1-index antenna IDs 
       baselines[i] = 2048 * (ant1[i]) + (ant2[i]) + 2 ** 16
     else:
       baselines[i] = 256 * (ant1[i]) + (ant2[i])

--- a/pyuvdata/utils.pyx
+++ b/pyuvdata/utils.pyx
@@ -207,7 +207,7 @@ cdef inline void _antnum_to_bl_2048_miriad(
   cdef Py_ssize_t i
 
   for i in range(nbls):
-    if ant2[i] > 255:      # MIRIAD uses 1-index antenna IDs 
+    if ant2[i] > 255:      # MIRIAD uses 1-index antenna IDs
       baselines[i] = 2048 * (ant1[i]) + (ant2[i]) + 2 ** 16
     else:
       baselines[i] = 256 * (ant1[i]) + (ant2[i])

--- a/pyuvdata/uvdata/tests/test_ms.py
+++ b/pyuvdata/uvdata/tests/test_ms.py
@@ -42,10 +42,17 @@ def check_members(tar, path):
     return tar.getmembers()
 
 
-def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+def safe_extract(
+    tar, path=".", members=None, *, numeric_owner=False, use_filter="data"
+):
     # this is factored this way (splitting out the `check_members` function)
     # to appease bandit.
-    tar.extractall(path, members=check_members(tar, path), numeric_owner=numeric_owner)
+    tar.extractall(
+        path,
+        members=check_members(tar, path),
+        numeric_owner=numeric_owner,
+        filter=use_filter,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/pyuvdata/uvdata/tests/test_uvdata.py
+++ b/pyuvdata/uvdata/tests/test_uvdata.py
@@ -6941,6 +6941,11 @@ def test_redundancy_missing_groups(method, grid_alg, pyuvsim_redundant, tmp_path
     uv1 = UVData()
     uv1.read_uvfits(fname, use_future_array_shapes=True)
 
+    # The UVFITS writer fills in the rdate parameter automatically if not present on
+    # the main object, so check it and set the two equal to one another.
+    assert uv1.rdate == "2017-12-22"
+    uv0.rdate = uv1.rdate
+
     # check that filenames are what we expect
     assert uv0.filename == ["fewant_randsrc_airybeam_Nsrc100_10MHz.uvfits"]
     assert uv1.filename == ["temp_hera19_missingreds.uvfits"]

--- a/pyuvdata/uvdata/tests/test_uvfits.py
+++ b/pyuvdata/uvdata/tests/test_uvfits.py
@@ -1641,9 +1641,9 @@ def test_uvfits_extra_params(sma_mir, tmp_path):
 
     # Finally, move on to the uvfits extra parameters
     exp_dict = {
-        "dut1": -0.2137079,
+        "dut1": -0.2139843,
         "earth_omega": 360.9856438593,
-        "gst0": 122.6673828188983,
+        "gst0": 302.1745672595617,
         "rdate": "2020-07-24",
         "timesys": "UTC",
     }

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -60,9 +60,11 @@ class UVFITS(UVData):
             # angles in uvfits files are stored in degrees, so convert to radians
             self.lst_array = np.deg2rad(vis_hdu.data.par("lst"))
             if run_check_acceptability:
-                (latitude, longitude, altitude) = (
-                    self.telescope_location_lat_lon_alt_degrees
-                )
+                (
+                    latitude,
+                    longitude,
+                    altitude,
+                ) = self.telescope_location_lat_lon_alt_degrees
             uvutils.check_lsts_against_times(
                 jd_array=self.time_array,
                 lst_array=self.lst_array,
@@ -1161,11 +1163,12 @@ class UVFITS(UVData):
 
         # Create an  astropy.time.Time object from first timestamp.
         # This is used to generate DATE-OBS and RDATE keywords
-        eloc = EarthLocation(self.telescope_location[0],
-                             self.telescope_location[1],
-                             self.telescope_location[2],
-                             unit='m'
-                             )
+        eloc = EarthLocation(
+            self.telescope_location[0],
+            self.telescope_location[1],
+            self.telescope_location[2],
+            unit="m",
+        )
         obs_date0 = Time(self.time_array[0], format="jd", scale="utc", location=eloc)
 
         # Per AIPS memo 117, DATE-OBS is the YYYY-MM-DD string

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -11,6 +11,7 @@ import numpy as np
 from astropy import constants as const
 from astropy.io import fits
 from astropy.time import Time
+from astropy.coordinates import EarthLocation
 from docstring_parser import DocstringStyle
 
 from .. import utils as uvutils
@@ -1160,7 +1161,12 @@ class UVFITS(UVData):
 
         # Create an  astropy.time.Time object from first timestamp.
         # This is used to generate DATE-OBS and RDATE keywords
-        obs_date0 = Time(self.time_array[0], format="jd", scale="utc", location=self.location)
+        eloc = EarthLocation(self.telescope_location[0],
+                             self.telescope_location[1],
+                             self.telescope_location[2],
+                             unit='m'
+                             )
+        obs_date0 = Time(self.time_array[0], format="jd", scale="utc", location=eloc)
 
         # Per AIPS memo 117, DATE-OBS is the YYYY-MM-DD string
         hdu.header["DATE-OBS"] = obs_date0.strftime("%Y-%m-%d")

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -9,7 +9,6 @@ import warnings
 
 import numpy as np
 from astropy import constants as const
-from astropy.coordinates import EarthLocation
 from astropy.io import fits
 from astropy.time import Time
 from docstring_parser import DocstringStyle
@@ -1161,13 +1160,7 @@ class UVFITS(UVData):
 
         # Create an  astropy.time.Time object from first timestamp.
         # This is used to generate DATE-OBS and RDATE keywords
-        eloc = EarthLocation(
-            self.telescope_location[0],
-            self.telescope_location[1],
-            self.telescope_location[2],
-            unit="m",
-        )
-        obs_date0 = Time(self.time_array[0], format="jd", scale="utc", location=eloc)
+        obs_date0 = Time(self.time_array[0], format="jd", scale="utc")
 
         # Per AIPS memo 117, DATE-OBS is the YYYY-MM-DD string
         hdu.header["DATE-OBS"] = obs_date0.strftime("%Y-%m-%d")
@@ -1355,9 +1348,11 @@ class UVFITS(UVData):
         else:
             ant_hdu.header["RDATE"] = self.rdate
 
-        # GSTIA0: Greenwich sidereal time in degrees at zero hours on RDATE
+        # AIPS Memo 117: The value of the GSTIA0 keyword shall be the
+        # Greenwich sidereal time in degrees at zero hours on RDATE
         if self.gst0 is None:
-            ant_hdu.header["GSTIA0"] = obs_date0.sidereal_time("apparent", "tio").deg
+            obs_date0_zerohrs = Time(obs_date0.strftime("%Y-%m-%d"), format="iso", scale="utc")
+            ant_hdu.header["GSTIA0"] = obs_date0_zerohrs.sidereal_time("apparent", "greenwich").deg
         else:
             ant_hdu.header["GSTIA0"] = self.gst0
 

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -9,9 +9,9 @@ import warnings
 
 import numpy as np
 from astropy import constants as const
+from astropy.coordinates import EarthLocation
 from astropy.io import fits
 from astropy.time import Time
-from astropy.coordinates import EarthLocation
 from docstring_parser import DocstringStyle
 
 from .. import utils as uvutils
@@ -60,11 +60,9 @@ class UVFITS(UVData):
             # angles in uvfits files are stored in degrees, so convert to radians
             self.lst_array = np.deg2rad(vis_hdu.data.par("lst"))
             if run_check_acceptability:
-                (
-                    latitude,
-                    longitude,
-                    altitude,
-                ) = self.telescope_location_lat_lon_alt_degrees
+                (latitude, longitude, altitude) = (
+                    self.telescope_location_lat_lon_alt_degrees
+                )
             uvutils.check_lsts_against_times(
                 jd_array=self.time_array,
                 lst_array=self.lst_array,

--- a/pyuvdata/uvdata/uvfits.py
+++ b/pyuvdata/uvdata/uvfits.py
@@ -1356,7 +1356,9 @@ class UVFITS(UVData):
         # AIPS Memo 117: The value of the GSTIA0 keyword shall be the
         # Greenwich sidereal time in degrees at zero hours on RDATE
         if self.gst0 is None:
-            ant_hdu.header["GSTIA0"] = obs_date0_zerohrs.sidereal_time("apparent", "greenwich").deg
+            ant_hdu.header["GSTIA0"] = obs_date0_zerohrs.sidereal_time(
+                "apparent", "greenwich"
+            ).deg
         else:
             ant_hdu.header["GSTIA0"] = self.gst0
 


### PR DESCRIPTION
Fixes to RDATE and DATE-OBS header parameters in UVFITS writer. Supercedes #1436 

## Description
As per #1433, RDATE calculation is odd. I've also updated DATE-OBS to be YYYY-MM-DD, instead of ISOT, as this is what AIPS memo 117 uses.

## Motivation and Context
This fixes incorrect RDATE and DATE-OBS header parameters. These parameters are used by MIRIAD when importing UVFITS files, and MIRIAD was getting confused. I'm not sure if CASA uses these when importing uvfits (if it did, I think this would have been caught sooner?)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass. 
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

### Bugfix notes

One unit test now fails, `test_uvfits_extra_params`, due to DUT1 being slightly different (-0.2136028 vs expected -0.2137079). Not sure if test is incorrect, or astropy's DUT1 calculation is unexpected.