### PR TITLE
feat: ignore_telescope_param_update_warnings_for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- New `ignore_telescope_param_update_warnings_for` function that globally ignores
+warnings for specific telescopes.
 - New `.telescope` cached property on the `FastUVH5Meta` object that auto-creates a
 telescope object from the metadata.
 - `UVData.get_enu_data_ants` method to get east, north, up positions only for

--- a/src/pyuvdata/telescopes.py
+++ b/src/pyuvdata/telescopes.py
@@ -110,9 +110,9 @@ def ignore_telescope_param_update_warnings_for(tel: str):
     up in the stack. This simple convenience method allows all such warnings for a
     given telescope to be ignored.
     """
-    if tel not in _WARN_STATUS:
+    if tel.lower() not in _WARN_STATUS:
         raise ValueError(f"'{tel}' is not a known telescope")
-    _WARN_STATUS[tel] = False
+    _WARN_STATUS[tel.lower()] = False
 
 
 def unignore_telescope_param_update_warnings_for(tel: str):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds two functions -- `ignore_telescope_param_update_warnings_for` and `unignore_telescope_param_update_warnings_for`, which enable warnings for updates from a given telescope to be globally ignored. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
There are many many warnings emanating from `hera_cal` tests because old HERA files used in the tests don't have metadata like `antenna_diameters` (and frankly for the tests we don't care). Lately these have raised warnings. While raising the warnings makes sense in general, often for specific telescopes it doesn't, since we can know ahead of time that the data provided by the pyuvdata KNOWN_TELESCOPES is good.

While we could silence the warnings in our tests by finding every call to `.read()` and using the `pytest.warns()` context manager, this becomes pretty annoying as there are MANY instances, and it adds noise to the code. This solution would allow us to call one function in the `conftest`. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

