### PR TITLE
Fix uvh5 ant names bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ telescope object from the metadata.
 - `UVData.get_enu_data_ants` method to get east, north, up positions only for
 antennas with data.
 
+### Fixed
+- A bug in reading UVH5 files with antenna names saved as variable length strings
+that was introduced in v3.0.0.
+
 ## [3.0.0] - 2024-7-1
 
 ### Added

--- a/src/pyuvdata/utils/io/hdf5.py
+++ b/src/pyuvdata/utils/io/hdf5.py
@@ -674,7 +674,9 @@ class HDF5Meta:
     @cached_property
     def antenna_names(self) -> list[str]:
         """The antenna names in the file."""
-        return np.char.decode(self.header["antenna_names"][:], encoding="utf8")
+        return np.char.decode(
+            self.header["antenna_names"][:].astype("|S"), encoding="utf8"
+        )
 
     @cached_property
     def extra_keywords(self) -> dict:

--- a/tests/uvdata/test_uvh5.py
+++ b/tests/uvdata/test_uvh5.py
@@ -3043,6 +3043,23 @@ def test_antenna_names_not_list(casa_uvfits, tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_antenna_names_variable_length(casa_uvfits, tmp_path):
+    uv_in = casa_uvfits
+    testfile = str(tmp_path / "outtest_ant_names_object.uvh5")
+    uv_in.write_uvh5(testfile, clobber=True)
+
+    with h5py.File(testfile, "r+") as h5f:
+        antenna_names = h5f["Header/antenna_names"][()]
+        var_dt = h5py.string_dtype(encoding="utf-8")
+        del h5f["Header/antenna_names"]
+        h5f.create_dataset("Header/antenna_names", data=antenna_names, dtype=var_dt)
+
+    uv_out = UVData.from_file(testfile)
+
+    assert uv_in == uv_out
+
+
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_eq_coeffs_roundtrip(casa_uvfits, tmp_path):
     """Test reading and writing objects with eq_coeffs defined"""
     uv_in = casa_uvfits


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a bug in reading UVH5 files with antenna names saved as variable length strings. This was a bug introduced in v3.0 as part of a computational efficiency improvement that accidentally introduced a bug in variable length strings because we didn't have a test on that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes #1467

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).