### PR TITLE
Correctly pass spline_opts to new uvbeam interpolator

### DIFF
--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -2156,7 +2156,7 @@ class UVBeam(UVBase):
             az_array_use = hpx_lon.radian
 
         extra_keyword_dict = {}
-        if interp_func == "_interp_az_za_rect_spline":
+        if interp_func in ["_interp_az_za_rect_spline", "_interp_az_za_map_coordinates"]:
             extra_keyword_dict["reuse_spline"] = reuse_spline
             extra_keyword_dict["spline_opts"] = spline_opts
             extra_keyword_dict["check_azza_domain"] = check_azza_domain

--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -2156,7 +2156,10 @@ class UVBeam(UVBase):
             az_array_use = hpx_lon.radian
 
         extra_keyword_dict = {}
-        if interp_func in ["_interp_az_za_rect_spline", "_interp_az_za_map_coordinates"]:
+        if interp_func in [
+            "_interp_az_za_rect_spline",
+            "_interp_az_za_map_coordinates",
+        ]:
             extra_keyword_dict["reuse_spline"] = reuse_spline
             extra_keyword_dict["spline_opts"] = spline_opts
             extra_keyword_dict["check_azza_domain"] = check_azza_domain


### PR DESCRIPTION
This PR fixes a small bug introduced by a previous PR, where a new interpolation method was added to `pyuvdata`. In the previous PR, I did not correctly pass the `spline_opts` parameter to `_interp_az_za_map_coordinates`.

## Description
This PR modifies an `if` statement to correctly pass the interpolation keyword arguments.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
