### PR TITLE
perf: don't always return basis-vector array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Made it possible to *not* return the `interp_basis_vector` array from beam
+interpolators.
+
 ## [3.1.1] - 2024-10-28
 
 ### Fixed
@@ -37,10 +41,6 @@ antennas with data.
 (the azimuthal-aligned response was swapped with the zenith angle-aligned response).
 - A bug in reading UVH5 files with antenna names saved as variable length strings
 that was introduced in v3.0.0.
-
-### Changed
-- Made it possible to *not* return the `interp_basis_vector` array from beam
-interpolators.
 
 ## [3.0.0] - 2024-7-1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ antennas with data.
 - A bug in reading UVH5 files with antenna names saved as variable length strings
 that was introduced in v3.0.0.
 
+### Changed
+- Made it possible to *not* return the `interp_basis_vector` array from beam
+interpolators.
+
 ## [3.0.0] - 2024-7-1
 
 ### Added

--- a/src/pyuvdata/beam_interface.py
+++ b/src/pyuvdata/beam_interface.py
@@ -171,6 +171,7 @@ class BeamInterface:
                 reuse_spline=reuse_spline,
                 spline_opts=spline_opts,
                 check_azza_domain=check_azza_domain,
+                return_basis_vector=False,
             )
         else:
             if not isinstance(freq_array, np.ndarray) or freq_array.ndim != 1:

--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -1501,7 +1501,7 @@ class UVBeam(UVBase):
         reuse_spline=False,
         spline_opts=None,
         check_azza_domain: bool = True,
-        return_basis_vector: bool = True,
+        return_basis_vector: bool = False,
     ):
         """
         Interpolate in az_za coordinate system using RectBivariateSpline.
@@ -1532,6 +1532,9 @@ class UVBeam(UVBase):
         check_azza_domain : bool
             Whether to check the domain of az/za to ensure that they are covered by the
             intrinsic data array. Checking them can be quite computationally expensive.
+        return_basis_vector : bool
+            Whether to return the interpolated basis vectors. Prior to v3.1.1 these
+            were always returned. Now they are not by default.
 
         Returns
         -------
@@ -1684,7 +1687,7 @@ class UVBeam(UVBase):
         spline_opts=None,
         check_azza_domain: bool = True,
         reuse_spline: bool = False,
-        return_basis_vector: bool = True,
+        return_basis_vector: bool = False,
     ):
         """
         Interpolate in az_za coordinate system using map_coordinates.
@@ -1715,6 +1718,9 @@ class UVBeam(UVBase):
         check_azza_domain : bool
             Whether to check the domain of az/za to ensure that they are covered by the
             intrinsic data array. Checking them can be quite computationally expensive.
+        return_basis_vector : bool
+            Whether to return the interpolated basis vector. Default is False as of
+            v3.1.1, but was previously True.
 
         Returns
         -------
@@ -1826,7 +1832,7 @@ class UVBeam(UVBase):
         freq_interp_tol=1.0,
         polarizations=None,
         reuse_spline=False,
-        return_basis_vector: bool = True,
+        return_basis_vector: bool = False,
     ):
         """
         Interpolate in Healpix coordinate system with a simple bilinear function.
@@ -1847,6 +1853,9 @@ class UVBeam(UVBase):
         polarizations : list of str
             polarizations to interpolate if beam_type is 'power'.
             Default is all polarizations in self.polarization_array.
+        return_basis_vector : bool
+            Whether to return the interpolated basis vectors. Prior to v3.1.1 these
+            were always returned. Now they are not by default.
 
         Returns
         -------
@@ -1980,7 +1989,7 @@ class UVBeam(UVBase):
         polarizations=None,
         return_bandpass=False,
         return_coupling=False,
-        return_basis_vector: bool = True,
+        return_basis_vector: bool | None = None,
         reuse_spline=False,
         spline_opts=None,
         new_object=False,
@@ -2075,6 +2084,9 @@ class UVBeam(UVBase):
             Conversely, if the passed az/za are outside of the domain, they will be
             silently extrapolated and the behavior is not well-defined. Only
             applies for `az_za_simple` interpolation.
+        return_basis_vector : bool
+            Whether to return the interpolated basis vectors. Prior to v3.1.1 these
+            were always returned. Now they are not by default.
 
         Returns
         -------
@@ -2099,6 +2111,13 @@ class UVBeam(UVBase):
             Shape: (Nelements, Nelements, Nfeeds, Nfeeds, freq_array.size)
 
         """
+        if return_basis_vector is None:
+            return_basis_vector = False
+            warnings.warn(
+                "No longer returning basis vectors by default. "
+                "Set return_basis_vector to True if you require them."
+            )
+
         if interpolation_function is None:
             if self.pixel_coordinate_system == "az_za":
                 interpolation_function = "az_za_simple"

--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -2111,11 +2111,16 @@ class UVBeam(UVBase):
             Shape: (Nelements, Nelements, Nfeeds, Nfeeds, freq_array.size)
 
         """
+        if new_object:
+            # To create a new object, we always need the interpolated basis vectors.
+            return_basis_vector = True
+
         if return_basis_vector is None:
-            return_basis_vector = False
+            return_basis_vector = True
             warnings.warn(
-                "No longer returning basis vectors by default. "
-                "Set return_basis_vector to True if you require them."
+                "The default value for `return_basis_vector` is True, but in v3.3 it "
+                "will be set to False. Silence this warning by explicitly setting it "
+                " to either True or False."
             )
 
         if interpolation_function is None:
@@ -2246,11 +2251,6 @@ class UVBeam(UVBase):
 
         # return a new UVBeam object with interpolated data
         else:
-            if not return_basis_vector:
-                raise ValueError(
-                    "if returning a new object, you must compute the basis vector"
-                )
-
             # make a new object
             new_uvb = self.copy()
 

--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -2086,7 +2086,8 @@ class UVBeam(UVBase):
             applies for `az_za_simple` interpolation.
         return_basis_vector : bool
             Whether to return the interpolated basis vectors. Prior to v3.1.1 these
-            were always returned. Now they are not by default.
+            were always returned. In v3.3+ they will _not_ be returned by default
+            (and not computed by default, unless new_object=True).
 
         Returns
         -------
@@ -2120,7 +2121,8 @@ class UVBeam(UVBase):
             warnings.warn(
                 "The default value for `return_basis_vector` is True, but in v3.3 it "
                 "will be set to False. Silence this warning by explicitly setting it "
-                " to either True or False."
+                " to either True or False.",
+                category=DeprecationWarning,
             )
 
         if interpolation_function is None:

--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -1802,10 +1802,10 @@ class UVBeam(UVBase):
             spline_opts = {}
 
         az_array -= phi_use.min()
-        az_array /= (phi_use.max() - phi_use.min()) / (phi_use.size - 1)
+        az_array *= (phi_use.size - 1) / (phi_use.max() - phi_use.min())
 
         za_array -= theta_use.min()
-        za_array /= (theta_use.max() - theta_use.min()) / (theta_use.size - 1)
+        za_array *= (theta_use.size - 1) / (theta_use.max() - theta_use.min())
 
         for index3 in range(input_nfreqs):
             for index0 in range(self.Naxes_vec):

--- a/tests/uvbeam/test_uvbeam.py
+++ b/tests/uvbeam/test_uvbeam.py
@@ -830,7 +830,6 @@ def test_freq_interp_real_and_complex(cst_power_2freq):
             "object will have it set to None."
         )
 
-    exp_warnings.append("The default value for `return_basis_vector` is True")
     with check_warnings(UserWarning, match=exp_warnings):
         pbeam = power_beam.interp(
             freq_array=freqs, freq_interp_kind="linear", new_object=True
@@ -1331,18 +1330,6 @@ def test_interp_no_basis_vector(cst_efield_2freq, interp_func):
         interpolation_function=interp_func,
     )
     assert bv is None
-
-    with pytest.raises(
-        ValueError, match="if returning a new object, you must compute the basis vector"
-    ):
-        beam.interp(
-            az_array=az,
-            za_array=za,
-            return_basis_vector=False,
-            interpolation_function=interp_func,
-            new_object=True,
-            az_za_grid=True,
-        )
 
 
 def test_interp_healpix_nside(cst_efield_2freq, cst_efield_2freq_cut_healpix):

--- a/tests/uvbeam/test_uvbeam.py
+++ b/tests/uvbeam/test_uvbeam.py
@@ -1312,6 +1312,7 @@ def test_interp_no_basis_vector(cst_efield_2freq, interp_func):
     beam = cst_efield_2freq
 
     if interp_func == "healpix_simple":
+        pytest.importorskip("astropy_healpix")
         beam.to_healpix()
 
     az = np.linspace(0, 2 * np.pi, 100)

--- a/tests/uvbeam/test_uvbeam.py
+++ b/tests/uvbeam/test_uvbeam.py
@@ -3261,3 +3261,16 @@ def test_yaml_constructor_errors():
         ValueError, match="yaml entries for UVBeam must specify a filename."
     ):
         yaml.safe_load(input_yaml)["beam"]
+
+
+def test_return_basis_vector_notset(cst_efield_2freq_cut: UVBeam):
+    """Test that a deprecation warning is raised if interp is called with defaults."""
+
+    with pytest.warns(
+        DeprecationWarning, match="The default value for `return_basis_vector` is True"
+    ):
+        _, basis_vector = cst_efield_2freq_cut.interp(
+            freq_array=cst_efield_2freq_cut.freq_array
+        )
+
+    assert basis_vector is not None

--- a/tests/uvbeam/test_uvbeam.py
+++ b/tests/uvbeam/test_uvbeam.py
@@ -1305,6 +1305,38 @@ def test_interp_longitude_branch_cut(beam_type, cst_efield_2freq, cst_power_2fre
     )
 
 
+@pytest.mark.parametrize(
+    "interp_func", ["az_za_simple", "az_za_map_coordinates", "healpix_simple"]
+)
+def test_interp_no_basis_vector(cst_efield_2freq, interp_func):
+    beam = cst_efield_2freq
+
+    if interp_func == "healpix_simple":
+        beam.to_healpix()
+
+    az = np.linspace(0, 2 * np.pi, 100)
+    za = np.linspace(0, np.pi / 2, 100)
+    _, bv = beam.interp(
+        az_array=az,
+        za_array=za,
+        return_basis_vector=False,
+        interpolation_function=interp_func,
+    )
+    assert bv is None
+
+    with pytest.raises(
+        ValueError, match="if returning a new object, you must compute the basis vector"
+    ):
+        beam.interp(
+            az_array=az,
+            za_array=za,
+            return_basis_vector=False,
+            interpolation_function=interp_func,
+            new_object=True,
+            az_za_grid=True,
+        )
+
+
 def test_interp_healpix_nside(cst_efield_2freq, cst_efield_2freq_cut_healpix):
     efield_beam = cst_efield_2freq
 

--- a/tests/uvbeam/test_uvbeam.py
+++ b/tests/uvbeam/test_uvbeam.py
@@ -650,6 +650,7 @@ def test_freq_interpolation(
         return_bandpass=True,
         return_coupling=need_coupling,
         interpolation_function=interpolation_function,
+        return_basis_vector=True,
     )
     if antenna_type == "simple":
         interp_data, interp_basis_vector, interp_bandpass = interp_arrays
@@ -721,6 +722,7 @@ def test_freq_interpolation(
             new_object=True,
             freq_interp_kind="linear",
             interpolation_function=interpolation_function,
+            return_basis_vector=True,
         )
     np.testing.assert_array_almost_equal(new_beam_obj.freq_array, freq_orig_vals)
     assert not hasattr(new_beam_obj, "saved_interp_functions")
@@ -739,6 +741,7 @@ def test_freq_interpolation(
             freq_interp_kind="cubic",
             new_object=True,
             interpolation_function=interpolation_function,
+            return_basis_vector=True,
         )
     assert isinstance(new_beam_obj, UVBeam)
     np.testing.assert_array_almost_equal(new_beam_obj.freq_array, freq_orig_vals)
@@ -826,6 +829,8 @@ def test_freq_interp_real_and_complex(cst_power_2freq):
             "currently support interpolating it in frequency. Returned "
             "object will have it set to None."
         )
+
+    exp_warnings.append("The default value for `return_basis_vector` is True")
     with check_warnings(UserWarning, match=exp_warnings):
         pbeam = power_beam.interp(
             freq_array=freqs, freq_interp_kind="linear", new_object=True
@@ -876,6 +881,7 @@ def test_spatial_interpolation_samepoints(
         za_array=za_orig_vals,
         freq_array=freq_orig_vals,
         interpolation_function=interpolation_function,
+        return_basis_vector=True,
     )
 
     interp_data_array = interp_data_array.reshape(uvbeam.data_array.shape, order="F")
@@ -945,6 +951,7 @@ def test_spatial_interpolation_samepoints(
             freq_array=freq_orig_vals,
             new_object=True,
             interpolation_function=interpolation_function,
+            return_basis_vector=True,
         )
     interp_fn_str = interpolation_function
     if interpolation_function is None:
@@ -1477,6 +1484,7 @@ def test_healpix_interpolation(antenna_type, cst_efield_2freq, phased_array_beam
             freq_array=np.array([np.mean(freq_orig_vals)]),
             freq_interp_kind="linear",
             new_object=True,
+            return_basis_vector=True,
         )
     assert "Interpolated in frequency and to a new healpix grid" in interp_beam.history
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This makes it possible to _not_ return the basis vector array, which is often not needed in simulation contexts, and takes a reasonably significant amount of memory.

It also computes the modified az/za arrays in the `map_coordinates` interpolator in-place to reduce memory (this is fine since these arrays are previously copied outside this function).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
In profiling `fftvis`, I found that the memory usage was higher than naively expected (this was multiprocessing over 128 threads, so everything was magnified). One of the unnecessary memory allocations was this basis-vector array.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [x] Performance enhancement

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Performance checklist:
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

