### PR TITLE
Fix a bug in the MWA beams where the polarization responses were swapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ telescope object from the metadata.
 antennas with data.
 
 ### Fixed
+- A bug in the MWA beam reader that resulted in the wrong polarization response
+(the azimuthal-aligned response was swapped with the zenith angle-aligned response).
 - A bug in reading UVH5 files with antenna names saved as variable length strings
 that was introduced in v3.0.0.
 

--- a/src/pyuvdata/uvbeam/mwa_beam.py
+++ b/src/pyuvdata/uvbeam/mwa_beam.py
@@ -475,8 +475,8 @@ class MWABeam(UVBeam):
                 Sigma_P = np.inner(phi_comp, emn_P_sum)
                 Sigma_T = np.inner(phi_comp, emn_T_sum)
 
-                jones[pol_i, 0, freq_i] = Sigma_T
-                jones[pol_i, 1, freq_i] = -Sigma_P
+                jones[pol_i, 0, freq_i] = -Sigma_P
+                jones[pol_i, 1, freq_i] = Sigma_T
 
         return jones
 

--- a/tests/uvbeam/test_mwa_beam.py
+++ b/tests/uvbeam/test_mwa_beam.py
@@ -59,6 +59,7 @@ def test_read_write_mwa(mwa_beam_1ppd, tmp_path):
     assert beam1 == beam2
 
 
+@pytest.mark.filterwarnings("ignore:There are some terminated dipoles")
 def test_mwa_orientation(mwa_beam_1ppd):
     power_beam = mwa_beam_1ppd.efield_to_power(inplace=False)
 

--- a/tests/uvbeam/test_mwa_beam.py
+++ b/tests/uvbeam/test_mwa_beam.py
@@ -82,7 +82,7 @@ def test_mwa_orientation(mwa_beam_1ppd):
         < power_beam.data_array[0, east_ind, 0, za_val, north_az]
     )
 
-    # check that the e/w dipole is more sensitive n/s
+    # check that the n/s dipole is more sensitive e/w
     assert (
         power_beam.data_array[0, north_ind, 0, za_val, north_az]
         < power_beam.data_array[0, north_ind, 0, za_val, east_az]
@@ -90,6 +90,7 @@ def test_mwa_orientation(mwa_beam_1ppd):
 
     # check that for a single dipole (all others turned off) there is higher
     # azimuth-aligned response near the horizon than zenith angle-aligned response
+    # for both feed orientations
     # this is true with all dipoles on too, but the difference is bigger for a
     # single dipole
     delays = np.full((2, 16), 32, dtype=int)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The azimuthal-aligned response was accidentally assigned to the zenith angle basis vector index and vice versa. Thanks to @nicelmh for pointing out the problem.

I also added tests that would have caught this error if they had been in place.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

