### PR TITLE
Faster-unprojected-new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file.
 - Made it possible to *not* return the `interp_basis_vector` array from beam
 interpolators.
 
+### Added
+- New keyword `check_kw` to `new_uvdata` that lets the user specify options to the
+checking of the created object.
+- New keyword `all_times_unique` to `calc_app_coords` that short-cuts the calculation
+when it is known that all input times are unique.
+
+
+
 ### Fixed
 - Initialization of analytic beams with single feed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- New keyword `check_kw` to `new_uvdata` that lets the user specify options to the
+checking of the created object.
+- New keyword `all_times_unique` to `calc_app_coords` that short-cuts the calculation
+when it is known that all input times are unique.
 - New convenience methods on `BeamInterface` to simplify the handling of analytic vs UVBeam objects.
 - Added support for partial read for MWA correlator FITS files.
 - Added `antenna_names`, `time_range`, `lsts` and `lst_range` parameters to
@@ -12,14 +16,6 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Made it possible to *not* return the `interp_basis_vector` array from beam
 interpolators.
-
-### Added
-- New keyword `check_kw` to `new_uvdata` that lets the user specify options to the
-checking of the created object.
-- New keyword `all_times_unique` to `calc_app_coords` that short-cuts the calculation
-when it is known that all input times are unique.
-
-
 
 ### Fixed
 - Initialization of analytic beams with single feed.

--- a/src/pyuvdata/utils/bltaxis.py
+++ b/src/pyuvdata/utils/bltaxis.py
@@ -194,11 +194,11 @@ def determine_rectangularity(
     vice versa. This does NOT require that the baselines and times are sorted within
     that structure.
 
-    Note that blt_order being (time, baseline) or vice versa does *not* guarantee
+    Note that blt_order being (time, baseline) does *not* guarantee
     rectangularity, even when Nblts == Nbls * Ntimes, since if `autos_first = True` is
     set on `reorder_blts`, then it will still set the blt_order attribute to
     (time, baseline), but they will not strictly be in that order (since it will
-    actually be in autos first order).
+    actually be in autos-first order).
     """
     # check if the data is rectangular
     time_first = True
@@ -210,13 +210,11 @@ def determine_rectangularity(
         return True, True
     elif ntimes == 1:
         return True, False
-    # Note that the opposite isn't true: time/baseline ordering does not always mean
-    # that we have rectangularity, because of the autos_first keyword to reorder_blts.
     elif blt_order == ("baseline", "time"):
+        # Note that the opposite isn't true: time/baseline ordering does not always mean
+        # that we have rectangularity, because of the autos_first keyword to
+        # reorder_blts.
         return True, True
-
-    # elif blt_order == ("time", "baseline"):
-    #     return True, False
 
     # That's all the easiest checks.
     if time_array[1] == time_array[0]:

--- a/src/pyuvdata/utils/bltaxis.py
+++ b/src/pyuvdata/utils/bltaxis.py
@@ -193,6 +193,12 @@ def determine_rectangularity(
     or Nbls will give you either all the same time and all different baselines, or
     vice versa. This does NOT require that the baselines and times are sorted within
     that structure.
+
+    Note that blt_order being (time, baseline) or vice versa does *not* guarantee
+    rectangularity, even when Nblts == Nbls * Ntimes, since if `autos_first = True` is
+    set on `reorder_blts`, then it will still set the blt_order attribute to
+    (time, baseline), but they will not strictly be in that order (since it will
+    actually be in autos first order).
     """
     # check if the data is rectangular
     time_first = True
@@ -204,10 +210,13 @@ def determine_rectangularity(
         return True, True
     elif ntimes == 1:
         return True, False
+    # Note that the opposite isn't true: time/baseline ordering does not always mean
+    # that we have rectangularity, because of the autos_first keyword to reorder_blts.
     elif blt_order == ("baseline", "time"):
         return True, True
-    elif blt_order == ("time", "baseline"):
-        return True, False
+
+    # elif blt_order == ("time", "baseline"):
+    #     return True, False
 
     # That's all the easiest checks.
     if time_array[1] == time_array[0]:

--- a/src/pyuvdata/utils/phasing.py
+++ b/src/pyuvdata/utils/phasing.py
@@ -2052,6 +2052,7 @@ def calc_app_coords(
     pm_dec=None,
     vrad=None,
     dist=None,
+    all_times_unique=None,
 ):
     """
     Calculate apparent coordinates for several different coordinate types.
@@ -2159,7 +2160,11 @@ def calc_app_coords(
     if isinstance(time_array, Time):
         time_array = time_array.utc.jd
 
-    unique_time_array, unique_mask = np.unique(time_array, return_index=True)
+    if not all_times_unique:
+        unique_time_array, unique_mask = np.unique(time_array, return_index=True)
+    else:
+        unique_time_array = time_array
+        unique_mask = slice(None)
 
     if coord_type in ["driftscan", "unprojected"]:
         if lst_array is None:
@@ -2245,7 +2250,10 @@ def calc_app_coords(
     app_dec = np.zeros(np.array(time_array).shape)
 
     for idx, unique_time in enumerate(unique_time_array):
-        select_mask = time_array == unique_time
+        if not all_times_unique:
+            select_mask = time_array == unique_time
+        else:
+            select_mask = idx
         app_ra[select_mask] = unique_app_ra[idx]
         app_dec[select_mask] = unique_app_dec[idx]
 

--- a/src/pyuvdata/utils/phasing.py
+++ b/src/pyuvdata/utils/phasing.py
@@ -2052,7 +2052,7 @@ def calc_app_coords(
     pm_dec=None,
     vrad=None,
     dist=None,
-    all_times_unique=None,
+    all_times_unique: bool | None = None,
 ):
     """
     Calculate apparent coordinates for several different coordinate types.
@@ -2121,6 +2121,10 @@ def calc_app_coords(
         Distance of the source, expressed in milliarcseconds. Can either be a single
         float or array of shape (Ntimes,), although this must be consistent with other
         parameters (namely ra_coord and dec_coord). Not required.
+    all_times_unique
+        Boolean specifying whether all the times that were passed are unique. Default
+        is to determine this within the function, but specifying it here can improve
+        performance.
 
     Returns
     -------

--- a/src/pyuvdata/uvdata/initializers.py
+++ b/src/pyuvdata/uvdata/initializers.py
@@ -309,6 +309,7 @@ def new_uvdata(
     phase_center_id_array: np.ndarray | None = None,
     x_orientation: Literal["east", "north", "e", "n", "ew", "ns"] | None = None,
     astrometry_library: str | None = None,
+    check_kw: dict | None = None,
     **kwargs,
 ):
     """Initialize a new UVData object from keyword arguments.
@@ -667,5 +668,5 @@ def new_uvdata(
         else:
             obj.nsample_array = np.ones(shape, dtype=float)
 
-    obj.check()
+    obj.check(**(check_kw or {}))
     return obj

--- a/src/pyuvdata/uvdata/initializers.py
+++ b/src/pyuvdata/uvdata/initializers.py
@@ -440,6 +440,9 @@ def new_uvdata(
         (which uses the astropy utilities). Default is erfa unless the
         telescope_location frame is MCMF (on the moon), in which case the default
         is astropy.
+    check_kw
+        A dictionary of keyword arguments to pass to the :func:`uvdata.UVData.check`
+        method after object creation.
 
     Other Parameters
     ----------------

--- a/src/pyuvdata/uvdata/initializers.py
+++ b/src/pyuvdata/uvdata/initializers.py
@@ -612,6 +612,8 @@ def new_uvdata(
     obj.flex_spw_id_array = flex_spw_id_array
     obj.integration_time = integration_time
     obj.blt_order = blt_order
+    obj.blts_are_rectangular = blts_are_rectangular
+    obj.time_axis_faster_than_bls = time_axis_faster_than_bls
 
     set_phase_params(
         obj,

--- a/src/pyuvdata/uvdata/initializers.py
+++ b/src/pyuvdata/uvdata/initializers.py
@@ -604,9 +604,9 @@ def new_uvdata(
     obj.vis_units = vis_units
     if blts_are_rectangular:
         if time_axis_faster_than_bls:
-            obj.Nants_data = len(set(antpairs[::ntimes]))
+            obj.Nants_data = len(np.unique(antpairs[::ntimes]))
         else:
-            obj.Nants_data = len(set(antpairs[:nbls]))
+            obj.Nants_data = len(np.unique(antpairs[:nbls].flatten()))
     else:
         obj.Nants_data = len(set(np.concatenate([ant_1_array, ant_2_array])))
     obj.Nbls = nbls

--- a/src/pyuvdata/uvdata/initializers.py
+++ b/src/pyuvdata/uvdata/initializers.py
@@ -602,7 +602,13 @@ def new_uvdata(
     obj.channel_width = channel_width
     obj.history = history
     obj.vis_units = vis_units
-    obj.Nants_data = len(set(np.concatenate([ant_1_array, ant_2_array])))
+    if blts_are_rectangular:
+        if time_axis_faster_than_bls:
+            obj.Nants_data = len(set(antpairs[::ntimes]))
+        else:
+            obj.Nants_data = len(set(antpairs[:nbls]))
+    else:
+        obj.Nants_data = len(set(np.concatenate([ant_1_array, ant_2_array])))
     obj.Nbls = nbls
     obj.Nblts = len(baseline_array)
     obj.Nfreqs = len(freq_array)

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -5009,6 +5009,7 @@ class UVData(UVBase):
                 new_uvw = np.repeat(new_uvw, self.Ntimes, axis=0)
             else:
                 new_uvw = np.tile(new_uvw, (self.Ntimes, 1))
+
         else:
             new_uvw = phs_utils.calc_uvw(
                 app_ra=self.phase_center_app_ra,
@@ -7869,6 +7870,12 @@ class UVData(UVBase):
             inds_to_keep = np.array(inds_to_keep, dtype=np.int64)
         else:
             inds_to_keep = np.array([], dtype=bool)
+
+        # we don't know the order now (because we just messed with it), and in harmonize
+        # it sets rectangularity, which gets the wrong behavior if blt_order is wrong.
+        # So we set it to None, so that it doesn't say the wrong thing (we reorder
+        # properly below).
+        self.blt_order = None
         self._harmonize_resample_arrays(
             inds_to_keep=inds_to_keep,
             temp_baseline=temp_baseline,
@@ -7880,7 +7887,6 @@ class UVData(UVBase):
             temp_nsample=temp_nsample,
             astrometry_library=astrometry_library,
         )
-
         if phased:
             print("Undoing phasing.")
             if initial_unprojected:

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -7204,6 +7204,7 @@ class UVData(UVBase):
         self.Nblts = self.baseline_array.shape[0]
         self.Ntimes = np.unique(self.time_array).size
         self.uvw_array = np.zeros((self.Nblts, 3))
+        self.set_rectangularity(force=True)
 
         # set lst array
         self.set_lsts_from_time_array(astrometry_library=astrometry_library)

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -4083,6 +4083,15 @@ class UVData(UVBase):
 
         self.set_rectangularity(force=True)
 
+        print(
+            "blt_ordEr",
+            self.blt_order,
+            self.time_array,
+            self.Ntimes,
+            self.Nbls,
+            self.Nblts,
+            self.blts_are_rectangular,
+        )
         # check if object is self-consistent
         if run_check:
             self.check(

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -4083,15 +4083,6 @@ class UVData(UVBase):
 
         self.set_rectangularity(force=True)
 
-        print(
-            "blt_ordEr",
-            self.blt_order,
-            self.time_array,
-            self.Ntimes,
-            self.Nbls,
-            self.Nblts,
-            self.blts_are_rectangular,
-        )
         # check if object is self-consistent
         if run_check:
             self.check(

--- a/tests/uvbeam/test_uvbeam.py
+++ b/tests/uvbeam/test_uvbeam.py
@@ -835,6 +835,7 @@ def test_freq_interp_real_and_complex(cst_power_2freq):
             "object will have it set to None."
         )
 
+    exp_warnings.append("The default value for `return_basis_vector` is True")
     with check_warnings(UserWarning, match=exp_warnings):
         pbeam = power_beam.interp(
             freq_array=freqs, freq_interp_kind="linear", new_object=True

--- a/tests/uvbeam/test_uvbeam.py
+++ b/tests/uvbeam/test_uvbeam.py
@@ -835,7 +835,6 @@ def test_freq_interp_real_and_complex(cst_power_2freq):
             "object will have it set to None."
         )
 
-    exp_warnings.append("The default value for `return_basis_vector` is True")
     with check_warnings(UserWarning, match=exp_warnings):
         pbeam = power_beam.interp(
             freq_array=freqs, freq_interp_kind="linear", new_object=True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This makes both the setting of the UVWs and the setting of the app coords faster when you're initializing an empty UVData for which the baseline-times are rectangular. 

Motivated by running HERA simulations: for redundant groups of the full HERA-350 and 17280 times, these operations were taking ~40min. I haven't timed them yet with the updated code, but tests on smaller sizes show at least 2 orders of magnitude speed up.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Performance


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.

Performance enhancement:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

