### PR TITLE
fix: set include_cross_pols to False if feed_array has length 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 - Made it possible to *not* return the `interp_basis_vector` array from beam
 interpolators.
 
+### Fixed
+- Initialization of analytic beams with single feed.
+
 ## [3.1.1] - 2024-10-28
 
 ### Fixed

--- a/src/pyuvdata/analytic_beam.py
+++ b/src/pyuvdata/analytic_beam.py
@@ -161,6 +161,9 @@ class AnalyticBeam:
                 "x_orientation must be specified for linear polarization feeds"
             )
 
+        if len(self.feed_array) == 1:
+            include_cross_pols = False
+
         self.polarization_array, _ = _convert_feeds_to_pols(
             self.feed_array, include_cross_pols, x_orientation=self.x_orientation
         )

--- a/tests/test_analytic_beam.py
+++ b/tests/test_analytic_beam.py
@@ -562,3 +562,9 @@ def test_yaml_constructor_errors():
         ),
     ):
         yaml.safe_load(input_yaml)["beam"]
+
+
+def test_single_feed():
+    beam = GaussianBeam(diameter=14.0, feed_array=["x"], include_cross_pols=True)
+    assert beam.feed_array == ["x"]
+    assert beam.polarization_array == [-5]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This simply fixes behavior when setting only a single feed in an AnalyticBeam. You can manually get around this on initialization by setting `include_cross_pols=False`, but you _can't_ do this when updating an existing object, i.e.

```python
from pyuvdata.analytic_beam import GaussianBeam
from dataclasses import replace

beam = GaussianBeam(diameter=14.0)
new_beam = replace(beam, feed_array=['x'])
```

This would fail due to the issue resolved here, and you _can't_ specify `include_cross_pols` in the `replace()` call, because it's an init-only parameter.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
