### PR TITLE
+^ look_in_catalog avoid unrelated keys for cat_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Bug in selecting baselines on a UVData object using `bls` keyword with 3-tuples and
 more than one polarization (introduced in 3.1.2).
+- Bug in the `look_in_catalog` utility function that expected keys which could be
+optional for some phase-center catalog-entry types. This was noticed as an issue when
+adding two uvh5 objects that were of type "sidereal" which did not have "cat_times"
+entries in their phase-center catalogs.
 
 ## [3.1.2] - 2024-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ All notable changes to this project will be documented in this file.
 - ATA has been added to the list of known telescopes.
 
 ### Fixed
-- Bug in selecting baselines on a UVData object using `bls` keyword with 3-tuples and
-more than one polarization (introduced in 3.1.2).
 - Bug in the `look_in_catalog` utility function that expected keys which could be
 optional for some phase-center catalog-entry types. This was noticed as an issue when
 adding two uvh5 objects that were of type "sidereal" which did not have "cat_times"
 entries in their phase-center catalogs.
+- Bug in selecting baselines on a UVData object using `bls` keyword with 3-tuples and
+more than one polarization (introduced in 3.1.2).
 
 ## [3.1.2] - 2024-11-21
 

--- a/src/pyuvdata/utils/phase_center_catalog.py
+++ b/src/pyuvdata/utils/phase_center_catalog.py
@@ -161,6 +161,25 @@ def look_in_catalog(
         "cat_vrad": default_tols,
     }
 
+    typenonfields_dict = {
+        "sidereal": [
+            "cat_times",
+        ],
+        "ephem": [
+            "cat_pm_ra",
+            "cat_pm_dec",
+        ],
+        "unprojected": [
+            "cat_frame",
+            "cat_pm_ra",
+            "cat_pm_dec",
+            "cat_times",
+            "cat_dist",
+            "cat_vrad",
+        ],
+    }
+    typenonfields_dict["driftscan"] = typenonfields_dict["unprojected"]
+
     if target_cat_id is not None:
         if target_cat_id not in phase_center_catalog:
             raise ValueError(f"No phase center with ID number {target_cat_id}.")
@@ -196,7 +215,13 @@ def look_in_catalog(
                             tol_dict[key][1],
                         )
             else:
-                cat_diffs += check_dict[key] is not None
+                check_type = check_dict.get("cat_type")
+                check_value = None
+                # if type is known, avoid unrelated fields
+                if (check_type is None) or (key not in typenonfields_dict[check_type]):
+                    check_value = check_dict[key]
+                cat_diffs += check_value is not None
+
         if (cat_diffs == 0) or (cat_name == name):
             if cat_diffs < match_diffs:
                 # If our current match is an improvement on any previous matches,

--- a/src/pyuvdata/utils/phase_center_catalog.py
+++ b/src/pyuvdata/utils/phase_center_catalog.py
@@ -161,25 +161,6 @@ def look_in_catalog(
         "cat_vrad": default_tols,
     }
 
-    typenonfields_dict = {
-        "sidereal": [
-            "cat_times",
-        ],
-        "ephem": [
-            "cat_pm_ra",
-            "cat_pm_dec",
-        ],
-        "unprojected": [
-            "cat_frame",
-            "cat_pm_ra",
-            "cat_pm_dec",
-            "cat_times",
-            "cat_dist",
-            "cat_vrad",
-        ],
-    }
-    typenonfields_dict["driftscan"] = typenonfields_dict["unprojected"]
-
     if target_cat_id is not None:
         if target_cat_id not in phase_center_catalog:
             raise ValueError(f"No phase center with ID number {target_cat_id}.")
@@ -215,12 +196,7 @@ def look_in_catalog(
                             tol_dict[key][1],
                         )
             else:
-                check_type = check_dict.get("cat_type")
-                check_value = None
-                # if type is known, avoid unrelated fields
-                if (check_type is None) or (key not in typenonfields_dict[check_type]):
-                    check_value = check_dict[key]
-                cat_diffs += check_value is not None
+                cat_diffs += check_dict.get(key) is not None
 
         if (cat_diffs == 0) or (cat_name == name):
             if cat_diffs < match_diffs:

--- a/tests/utils/test_phase_center_catalog.py
+++ b/tests/utils/test_phase_center_catalog.py
@@ -2,9 +2,17 @@
 # Licensed under the 2-clause BSD License
 """Tests for phase center catalog utility functions."""
 
+import os
+
 import pytest
 
 import pyuvdata.utils.phase_center_catalog as ps_cat_utils
+from pyuvdata import UVData
+from pyuvdata.data import DATA_PATH
+
+casa_tutorial_uvfits = os.path.join(
+    DATA_PATH, "day2_TDEM0003_10s_norx_1src_1spw.uvfits"
+)
 
 
 def test_generate_new_phase_center_id_errs():
@@ -13,3 +21,23 @@ def test_generate_new_phase_center_id_errs():
 
     with pytest.raises(ValueError, match="Provided cat_id was found in reserved_ids"):
         ps_cat_utils.generate_new_phase_center_id(cat_id=1, reserved_ids=[1, 2, 3])
+
+
+def test_look_in_catalog_missing_entries():
+    casa_uvfits = UVData()
+    casa_uvfits.read(casa_tutorial_uvfits)
+    phase_cat = casa_uvfits.phase_center_catalog
+
+    # Try that this works normally if we do nothing
+    assert ps_cat_utils.look_in_catalog(
+        phase_cat, cat_name=phase_cat[0]["cat_name"]
+    ) == (0, 5)
+
+    # Now delete some keys
+    for value in phase_cat.values():
+        if "cat_times" in value:
+            del value["cat_times"]
+    # Now re-run the above and verify things work as expected
+    assert ps_cat_utils.look_in_catalog(
+        phase_cat, cat_name=phase_cat[0]["cat_name"]
+    ) == (0, 5)

--- a/tests/uvdata/test_uvh5.py
+++ b/tests/uvdata/test_uvh5.py
@@ -415,6 +415,27 @@ def test_uvh5_compression_options(casa_uvfits, tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_uvh5_addition(casa_uvfits, tmp_path):
+    testfile = os.path.join(tmp_path, "uv_test_addition.uvh5")
+
+    casa_uvfits.phase(
+        lon=casa_uvfits.phase_center_catalog[0]["cat_lon"],
+        lat=casa_uvfits.phase_center_catalog[0]["cat_lat"],
+        phase_frame="icrs",
+        cat_type="sidereal",
+        cat_name=casa_uvfits.phase_center_catalog[0]["cat_name"],
+    )
+    casa_uvfits.write_uvh5(testfile, clobber=True)
+    uv = UVData()
+    uv.read(testfile)
+    uv + uv.copy()
+
+    os.remove(testfile)
+
+    return
+
+
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_read_multiple_files(casa_uvfits, tmp_path):
     """
     Test reading multiple uvh5 files.

--- a/tests/uvdata/test_uvh5.py
+++ b/tests/uvdata/test_uvh5.py
@@ -415,27 +415,6 @@ def test_uvh5_compression_options(casa_uvfits, tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
-def test_uvh5_addition(casa_uvfits, tmp_path):
-    testfile = os.path.join(tmp_path, "uv_test_addition.uvh5")
-
-    casa_uvfits.phase(
-        lon=casa_uvfits.phase_center_catalog[0]["cat_lon"],
-        lat=casa_uvfits.phase_center_catalog[0]["cat_lat"],
-        phase_frame="icrs",
-        cat_type="sidereal",
-        cat_name=casa_uvfits.phase_center_catalog[0]["cat_name"],
-    )
-    casa_uvfits.write_uvh5(testfile, clobber=True)
-    uv = UVData()
-    uv.read(testfile)
-    uv + uv.copy()
-
-    os.remove(testfile)
-
-    return
-
-
-@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_uvh5_read_multiple_files(casa_uvfits, tmp_path):
     """
     Test reading multiple uvh5 files.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `look_in_catalog` function never considered the cat_type when accessing keys, leading to keys unrelated to the cat_type being hard-accessed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
When adding multiple UV objects, the `look_in_catalog` hit an error trying to access the "cat_times" key within the phase_catalog dict-entry. The entries are all of "sidereal" type though, which isn't expected to have a "cat_times" key. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Breaking change checklist:
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have noted any dependency changes since the last version and will update the conda package build accordingly.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
