### PR TITLE
Add option to write uvw_array as double precision in UVFITS when data_array is single precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Option to write the uvw_array as double precision in UVFITS files even when
+the data array are single precision. Default is set to write them as doubles.
 - ATA has been added to the list of known telescopes.
 
 ### Fixed

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -11395,20 +11395,7 @@ class UVData(UVBase):
         )
         del ms_obj
 
-    def write_uvfits(
-        self,
-        filename,
-        *,
-        write_lst=True,
-        force_phase=False,
-        run_check=True,
-        check_extra=True,
-        run_check_acceptability=True,
-        strict_uvw_antpos_check=False,
-        check_autos=True,
-        fix_autos=False,
-        use_miriad_convention=False,
-    ):
+    def write_uvfits(self, filename: str, **kwargs):
         """
         Write the data to a uvfits file.
 
@@ -11424,29 +11411,16 @@ class UVData(UVBase):
             The uvfits file to write to.
         write_lst : bool
             Option to write the LSTs to the metadata (random group parameters).
-        force_phase:  : bool
+            Default is True.
+        force_phase : bool
             Option to automatically phase unprojected data to zenith of the first
-            timestamp.
-        run_check : bool
-            Option to check for the existence and proper shapes of parameters
-            after before writing the file (the default is True,
-            meaning the check will be run).
-        check_extra : bool
-            Option to check optional parameters as well as required ones (the
-            default is True, meaning the optional parameters will be checked).
-        run_check_acceptability : bool
-            Option to check acceptable range of the values of parameters before
-            writing the file (the default is True, meaning the acceptable
-            range check will be done).
-        strict_uvw_antpos_check : bool
-            Option to raise an error rather than a warning if the check that
-            uvws match antenna positions does not pass.
-        check_autos : bool
-            Check whether any auto-correlations have non-zero imaginary values in
-            data_array (which should not mathematically exist). Default is True.
-        fix_autos : bool
-            If auto-correlations with imaginary values are found, fix those values so
-            that they are real-only in data_array. Default is False.
+            timestamp. Default is False.
+        uvw_double : bool
+            Option to write uvws at double precision if data array is single
+            precision (if data array is double precision uvws are always written
+            at double precision). This requires writing the uvws out into two
+            identically named parameters to be added together on read (the same
+            mechanism that is used for times in uvfits). Default is True.
         use_miriad_convention : bool
             Option to use the MIRIAD baseline convention, and write to BASELINE column.
             This mode is required for UVFITS files with >256 antennas to be
@@ -11455,16 +11429,35 @@ class UVData(UVBase):
             `bl = 256 * ant1 + ant2` if `ant2 < 256`, otherwise
             `bl = 2048 * ant1 + ant2 + 2**16`.
             Note MIRIAD uses 1-indexed antenna IDs, but this code accepts 0-based.
+            Default is False.
+        run_check : bool
+            Option to check for the existence and proper shapes of parameters
+            before writing the file. Default is True.
+        check_extra : bool
+            Option to check optional parameters as well as required ones.
+            Default is True.
+        run_check_acceptability : bool
+            Option to check acceptable range of the values of parameters before
+            writing the file. Default is True.
+        strict_uvw_antpos_check : bool
+            Option to raise an error rather than a warning if the check that
+            uvws match antenna positions does not pass. Default is False.
+        check_autos : bool
+            Check whether any auto-correlations have non-zero imaginary values in
+            data_array (which should not mathematically exist). Default is True.
+        fix_autos : bool
+            If auto-correlations with imaginary values are found, fix those values so
+            that they are real-only in data_array. Default is False.
 
         Raises
         ------
         ValueError
-            Any blts are unprojected and `force_phase` keyword is not set.
+            The object contains unprojected data and `force_phase` keyword is not set.
             If the frequencies are not evenly spaced or are separated by more
             than their channel width.
             The polarization values are not evenly spaced.
-            If the `timesys` parameter is not set to "UTC".
             If the UVData object is a metadata only object.
+            If the `timesys` parameter is set to anything other than "UTC" or None.
         TypeError
             If any entry in extra_keywords is not a single string or number.
 
@@ -11484,18 +11477,7 @@ class UVData(UVBase):
             uvfits_obj = uvfits_obj.copy()
             uvfits_obj.remove_flex_pol()
 
-        uvfits_obj.write_uvfits(
-            filename,
-            write_lst=write_lst,
-            force_phase=force_phase,
-            run_check=run_check,
-            check_extra=check_extra,
-            run_check_acceptability=run_check_acceptability,
-            strict_uvw_antpos_check=strict_uvw_antpos_check,
-            check_autos=check_autos,
-            fix_autos=fix_autos,
-            use_miriad_convention=use_miriad_convention,
-        )
+        uvfits_obj.write_uvfits(filename, **kwargs)
         del uvfits_obj
 
     def write_uvh5(

--- a/src/pyuvdata/uvdata/uvfits.py
+++ b/src/pyuvdata/uvdata/uvfits.py
@@ -1009,8 +1009,12 @@ class UVFITS(UVData):
                 self.time_array - jd_midnight - time_array1.astype(np.float64)
             ).astype(np.float32)
 
+            uvw_array1 = np.float32(uvw_array_sec)
+            uvw_array2 = np.float32(uvw_array_sec - np.float64(uvw_array1))
         else:
             time_array1 = self.time_array - jd_midnight
+            uvw_array1 = uvw_array_sec
+
         int_time_array = self.integration_time
 
         # If using MIRIAD convention, we need 1-indexed data
@@ -1104,6 +1108,12 @@ class UVFITS(UVData):
             pscal_dict["DATE2   "] = 1.0
             pzero_dict["DATE2   "] = 0.0
             parnames_use.append("DATE2   ")
+            for ind, name in enumerate(["UU", "VV", "WW"]):
+                keyname = name + "2     "
+                group_parameter_dict[keyname] = uvw_array2[:, ind]
+                pscal_dict[keyname] = 1.0
+                pzero_dict[keyname] = 0.0
+                parnames_use.append(keyname)
 
         if use_miriad_convention or (
             np.max(ant1_array_use) < 255 and np.max(ant2_array_use) < 255
@@ -1134,6 +1144,9 @@ class UVFITS(UVData):
             # add second date part
             parnames_write = copy.deepcopy(parnames_use)
             parnames_write[parnames_write.index("DATE2   ")] = "DATE    "
+            parnames_write[parnames_write.index("UU2     ")] = "UU      "
+            parnames_write[parnames_write.index("VV2     ")] = "VV      "
+            parnames_write[parnames_write.index("WW2     ")] = "WW      "
             if write_lst:
                 # add second LST array part
                 parnames_use.append("LST2    ")

--- a/tests/uvdata/test_uvfits.py
+++ b/tests/uvdata/test_uvfits.py
@@ -170,9 +170,9 @@ def test_group_param_precision(tmp_path, uvw_double):
     )
 
     if uvw_double:
-        np.testing.assert_allclose(uvd.uvw_array, uvd2.uvw_array, rtol=0, atol=1e-13)
+        np.testing.assert_allclose(uvd.uvw_array, uvd2.uvw_array, rtol=1e-13)
     else:
-        assert not np.allclose(uvd.uvw_array, uvd2.uvw_array, rtol=0, atol=1e-13)
+        np.testing.assert_allclose(uvd.uvw_array, uvd2.uvw_array, rtol=1e-7)
 
     # The incoming ra is specified as negative, it gets 2pi added to it in the roundtrip
     uvd2.phase_center_catalog[1]["cat_lon"] -= 2 * np.pi

--- a/tests/uvdata/test_uvfits.py
+++ b/tests/uvdata/test_uvfits.py
@@ -173,6 +173,7 @@ def test_group_param_precision(tmp_path, uvw_double):
         np.testing.assert_allclose(uvd.uvw_array, uvd2.uvw_array, rtol=1e-13)
     else:
         np.testing.assert_allclose(uvd.uvw_array, uvd2.uvw_array, rtol=1e-7)
+        assert not np.allclose(uvd.uvw_array, uvd2.uvw_array, rtol=1e-13)
 
     # The incoming ra is specified as negative, it gets 2pi added to it in the roundtrip
     uvd2.phase_center_catalog[1]["cat_lon"] -= 2 * np.pi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This adds the option write the uvw_array as double precision in UVFITS even when the data_array is single precision (they are always written as double precision when the data array are double precision). This is done using the same mechanism as is used for the time_array in UVFITS files, namely creating two identically named group parameters that are intended to be added together. This happens automatically in astropy's FITS reader, but it is possible this could mess up other UVFITS readers, so I added an option to allow it to be turned on or off and defaulted it to on because I think most users would prefer not to lose precision on their uvws.

This problem was noted as far back as #154 and it has come up occasionally since then.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

