### PR TITLE
Fix typo found in #1514

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ adding two uvh5 objects that were of type "sidereal" which did not have "cat_tim
 entries in their phase-center catalogs.
 - Bug in selecting baselines on a UVData object using `bls` keyword with 3-tuples and
 more than one polarization (introduced in 3.1.2).
+- Bug/typo in angle wrapping in calc_frame_pos_angle() function.
 
 ## [3.1.2] - 2024-11-21
 

--- a/src/pyuvdata/utils/phasing.py
+++ b/src/pyuvdata/utils/phasing.py
@@ -1664,7 +1664,7 @@ def calc_frame_pos_angle(
     up_dec[up_dec > (np.pi / 2.0)] = np.pi - up_dec[up_dec > (np.pi / 2.0)]
 
     dn_ra[-dn_dec > (np.pi / 2.0)] = np.mod(
-        dn_ra[dn_dec > (np.pi / 2.0)] + np.pi, 2.0 * np.pi
+        dn_ra[-dn_dec > (np.pi / 2.0)] + np.pi, 2.0 * np.pi
     )
     dn_dec[-dn_dec > (np.pi / 2.0)] = np.pi - dn_dec[-dn_dec > (np.pi / 2.0)]
 


### PR DESCRIPTION
Typo fix to address #1514: a missing minus sign meant that array indexing was broken in `calc_frame_pos_angle()`.

## Description
Changed 

```python
    dn_ra[-dn_dec > (np.pi / 2.0)] = np.mod(
        dn_ra[dn_dec > (np.pi / 2.0)] + np.pi, 2.0 * np.pi
    )
```
to
```python
    dn_ra[-dn_dec > (np.pi / 2.0)] = np.mod(
        dn_ra[-dn_dec > (np.pi / 2.0)] + np.pi, 2.0 * np.pi
    )
```

## Motivation and Context
Fixes #1514. 

Looking at the indexing, you might expect this code to have failed earlier, however this bug only arises when there are values where `abs(dn_dec)` > 90 degrees. To meet this requires inputs `app_dec - offset_pos` to exceed - 90 degrees (meaning an observation close to -90 deg, and/or a large offset position).

The code passed previously because both correct and incorrect index masks returned zero-length arrays. For example, this code runs without an error:

```python
a = np.arange(1024)
a[a<0] = a[a>1024]
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

