### PR TITLE
Fix `calc_frame_pos_angle` to work correctly near celestial poles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ the data array are single precision. Default is set to write them as doubles.
 - ATA has been added to the list of known telescopes.
 
 ### Fixed
+- Bug in `calc_frame_pa_angle` which gave rise to an indexing error at positions close
+to the Southern celestial pole. Additionally fixed a bug where these values were
+incorrectly calculated.
 - A sign flip of the MWA beam response to azimuthally aligned polarization. This
 was caused by the difference in coordinates used in UVBeam and the mwa_pb repo,
 the coordinates themselves were properly accounted for but the flip in

--- a/src/pyuvdata/utils/phasing.py
+++ b/src/pyuvdata/utils/phasing.py
@@ -1655,18 +1655,17 @@ def calc_frame_pos_angle(
     # 1 deg arc.
     up_dec = unique_dec + offset_pos
     dn_dec = unique_dec - offset_pos
-    up_ra = dn_ra = unique_ra
+    up_ra = np.array(unique_ra)
+    dn_ra = np.array(unique_ra)
 
     # Wrap the positions if they happen to go over the poles
-    up_ra[up_dec > (np.pi / 2.0)] = np.mod(
-        up_ra[up_dec > (np.pi / 2.0)] + np.pi, 2.0 * np.pi
-    )
-    up_dec[up_dec > (np.pi / 2.0)] = np.pi - up_dec[up_dec > (np.pi / 2.0)]
+    select_mask = up_dec > (np.pi / 2.0)
+    up_ra[select_mask] = np.mod(up_ra[select_mask] + np.pi, 2.0 * np.pi)
+    up_dec[select_mask] = np.pi - up_dec[select_mask]
 
-    dn_ra[-dn_dec > (np.pi / 2.0)] = np.mod(
-        dn_ra[dn_dec > (np.pi / 2.0)] + np.pi, 2.0 * np.pi
-    )
-    dn_dec[-dn_dec > (np.pi / 2.0)] = np.pi - dn_dec[-dn_dec > (np.pi / 2.0)]
+    select_mask = dn_dec < (-np.pi / 2.0)
+    dn_ra[select_mask] = np.mod(dn_ra[select_mask] + np.pi, 2.0 * np.pi)
+    dn_dec[select_mask] = (-np.pi) - dn_dec[select_mask]
 
     # Run the set of offset coordinates through the "reverse" transform. The two offset
     # positions are concat'd together to help reduce overheads

--- a/tests/utils/test_phasing.py
+++ b/tests/utils/test_phasing.py
@@ -2005,3 +2005,20 @@ def test_uvw_track_generator_moon(selenoid):
         np.testing.assert_allclose(
             (gen_results["uvw"] ** 2.0).sum(1), 2.0, rtol=0, atol=1e-3
         )
+
+
+def test_pole_calc_pa():
+    # Check a couple of positions up
+    pos_angle = utils.phasing.calc_frame_pos_angle(
+        time_array=np.array([2456789.0, 2456789.0]),
+        app_ra=np.array([np.pi / 4, np.pi]),
+        app_dec=np.radians(np.array([-89.7, 89.8])),
+        telescope_loc=(0, 30, 0),
+        ref_frame="icrs",
+        offset_pos=(np.pi / 180) / (3600),
+    )
+
+    # Test against directly calculated values
+    np.testing.assert_allclose(
+        pos_angle, [0.2564204225333429, 0.00920308652161622], atol=utils.RADIAN_TOL
+    )

--- a/tests/uvdata/test_uvdata.py
+++ b/tests/uvdata/test_uvdata.py
@@ -10989,7 +10989,7 @@ def test_fix_phase(hera_uvh5, tmp_path, use_ant_pos, phase_frame, file_type):
         pytest.skip("MIRIAD not installed.")
 
     # Make some copies of the data
-    uv_in = hera_uvh5.copy()
+    uv_in = hera_uvh5
 
     # These values could be anything -- we're just picking something that we know should
     # be visible from the telescope at the time of obs (ignoring horizon limits).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves an issue where an IndexError that was raised when looking at positions near the SCP.

## Description
<!--- Describe your changes in detail -->
The `utils.phasing.calc_frame_pos_angle` function has been updated to address a few issues, namely an IndexError that was raised wen calling the function with apparent declinations below -89.5 degrees.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
In addition to resolving the IndexError, there was a separate issue where the frame position angle was being calculated incorrectly. For better or worse, this incorrect value would never be seen due to said IndexError, but now should function as intended (and the code made a little more readible).

Closes #1514

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
