### PR TITLE
Select refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- New `strict` keyword added to `UVData.select`, `UVBeam.select`, `UVFlag.select`, and
+`UVFlag.select`, which allows the user to specify whether to warn or error when
+supplied criteria only partially match (default being to warn).
+- New `invert` keyword added to `UVData.select`, `UVBeam.select`, `UVFlag.select`, and
+`UVFlag.select`, which allows the user to specify data to deselect rather than select.
+- New method `UVBase._select_along_param_axis`, which allows for more uniform selection
+behavior across parameters within `UVData`, `UVCal`, `UVBeam`, `UVFlag`, and `Telescope`
+classes.
+- Several new selection helper and check functions have been added to `utils`.
+- New `warn_spacing` keyword added to `select`, `__add__`, `fast_concat` methods of
+`UVData`, `UVCal`, `UVBeam`, and `UVFlag`, which allows the user to specify whether or
+not to warn based on spacing errors that would prevent writing out to e.g., FITS-based
+file formats. Default is typically `False` (with the exception of `UVBeam`, where the
+default is `True`), such that most warnings about frequency/polarization/time spacing
+will not normally be raised.
+
+### Changed
+- `UVData.select`, `UVBeam.select`, `UVFlag.select`, `UVFlag.select` have been
+significantly refactored and made to behave more uniformly.
+- Allowing `UVParameter.__eq__` to use `UVParameter.compare_value` if the item being
+compared and `UVParameter.value` share the same class.
+- Warnings about `extra_keywords` have been removed from `UVData.check`, `UVCal.check`,
+and `UVBeam.check`.
+
+### Fixed
+- Bug in `UVBeam.select` where `polarization_array` could be incorrectly ordered after
+selection (if input to `polarizations` keyword was unordered).
+
 ## [3.1.3] - 2025-01-13
 
 ### Added

--- a/docs/uvbeam_tutorial.rst
+++ b/docs/uvbeam_tutorial.rst
@@ -266,7 +266,7 @@ The :meth:`pyuvdata.UVBeam.select` method lets you select specific image axis in
 (or pixels if pixel_coordinate_system is HEALPix), frequencies and feeds
 (or polarizations if beam_type is power) to keep in the object while removing others.
 By default, :meth:`pyuvdata.UVBeam.select` will select data that matches the supplied
-criteria, but by setting ``invert=False``, you can instead *deselect* this data and
+criteria, but by setting ``invert=True``, you can instead *deselect* this data and
 preserve only that which does not match the selection.
 
 a) Selecting a range of Zenith Angles

--- a/docs/uvbeam_tutorial.rst
+++ b/docs/uvbeam_tutorial.rst
@@ -265,6 +265,9 @@ UVBeam: Selecting data
 The :meth:`pyuvdata.UVBeam.select` method lets you select specific image axis indices
 (or pixels if pixel_coordinate_system is HEALPix), frequencies and feeds
 (or polarizations if beam_type is power) to keep in the object while removing others.
+By default, :meth:`pyuvdata.UVBeam.select` will select data that matches the supplied
+criteria, but by setting ``invert=False``, you can instead *deselect* this data and
+preserve only that which does not match the selection.
 
 a) Selecting a range of Zenith Angles
 *************************************
@@ -335,6 +338,12 @@ or "ee).
   >>> # make a copy and select a feed by phyiscal orientation
   >>> uvb2 = uvb.copy()
   >>> uvb2.select(feeds=["n"])
+  >>> print(uvb2.feed_array)
+  ['y']
+
+  >>> # Finally, try a deselect
+  >>> uvb2 = uvb.copy()
+  >>> uvb2.select(feeds=["x"], invert=True)
   >>> print(uvb2.feed_array)
   ['y']
 

--- a/docs/uvcal_tutorial.rst
+++ b/docs/uvcal_tutorial.rst
@@ -402,7 +402,7 @@ The :meth:`pyuvdata.UVCal.select` method lets you select specific antennas
 (by number or name), frequencies (in Hz or by channel number), times (either exact
 times or times covered by a time range) or jones components (by number or string) to keep
 in the object while removing others. By default, :meth:`pyuvdata.UVCal.select` will
-select data that matches the supplied criteria, but by setting ``invert=False``, you
+select data that matches the supplied criteria, but by setting ``invert=True``, you
 can instead *deselect* this data and preserve only that which does not match the
 selection.
 

--- a/docs/uvcal_tutorial.rst
+++ b/docs/uvcal_tutorial.rst
@@ -424,7 +424,7 @@ a) Select antennas to keep on UVCal object using the antenna number.
 
   >>> # print all the antenna numbers with data after deselection
   >>> print(cal.ant_array)
-  [ 0 13 23 24 25]
+  [ 1 13 23 24 25]
   >>> cal.select(antenna_nums=[1, 13, 25])
 
   >>> # print all the antennas numbers with data after the select

--- a/docs/uvcal_tutorial.rst
+++ b/docs/uvcal_tutorial.rst
@@ -401,7 +401,10 @@ UVCal: Selecting data
 The :meth:`pyuvdata.UVCal.select` method lets you select specific antennas
 (by number or name), frequencies (in Hz or by channel number), times (either exact
 times or times covered by a time range) or jones components (by number or string) to keep
-in the object while removing others.
+in the object while removing others. By default, :meth:`pyuvdata.UVCal.select` will
+select data that matches the supplied criteria, but by setting ``invert=False``, you
+can instead *deselect* this data and preserve only that which does not match the
+selection.
 
 a) Select antennas to keep on UVCal object using the antenna number.
 ********************************************************************
@@ -417,6 +420,11 @@ a) Select antennas to keep on UVCal object using the antenna number.
   >>> # print all the antennas numbers with data in the original file
   >>> print(cal.ant_array)
   [ 0  1 11 12 13 23 24 25]
+  >>> cal.select(antenna_nums=[0, 11, 12], invert=True)
+
+  >>> # print all the antenna numbers with data after deselection
+  >>> print(cal.ant_array)
+  [ 0 13 23 24 25]
   >>> cal.select(antenna_nums=[1, 13, 25])
 
   >>> # print all the antennas numbers with data after the select

--- a/docs/uvdata_tutorial.rst
+++ b/docs/uvdata_tutorial.rst
@@ -984,7 +984,7 @@ The :meth:`pyuvdata.UVData.select` method lets you select specific antennas (by 
 antenna pairs, frequencies (in Hz or by channel number), times (or time range),
 local sidereal time (LST) (or LST range), or polarizations to keep in the object
 while removing others. By default, :meth:`pyuvdata.UVData.select` will
-select data that matches the supplied criteria, but by setting ``invert=False``, you
+select data that matches the supplied criteria, but by setting ``invert=True``, you
 can instead *deselect* this data and preserve only that which does not match the
 selection.
 

--- a/docs/uvdata_tutorial.rst
+++ b/docs/uvdata_tutorial.rst
@@ -983,7 +983,10 @@ UVData: Selecting data
 The :meth:`pyuvdata.UVData.select` method lets you select specific antennas (by number or name),
 antenna pairs, frequencies (in Hz or by channel number), times (or time range),
 local sidereal time (LST) (or LST range), or polarizations to keep in the object
-while removing others.
+while removing others. By default, :meth:`pyuvdata.UVData.select` will
+select data that matches the supplied criteria, but by setting ``invert=False``, you
+can instead *deselect* this data and preserve only that which does not match the
+selection.
 
 Note: The same select interface is now supported on the read for many file types
 (see :ref:`large_files`), so you need not read in the entire file before doing the select.
@@ -1124,6 +1127,16 @@ the physical orientation of the dipole can also be used (e.g. "nn" or "ee).
   [-1 -2]
   >>> print(utils.polnum2str(uvd.polarization_array))
   ['rr', 'll']
+
+
+  >>> # Now deselect polarizations
+  >>> uvd.select(polarizations=["ll"], invert=True)
+
+  >>> # print polarization numbers and strings after select
+  >>> print(uvd.polarization_array)
+  [-1]
+  >>> print(utils.polnum2str(uvd.polarization_array))
+  ['rr']
 
   >>> # read in a file with linear polarizations and an x_orientation
   >>> filename = os.path.join(DATA_PATH, 'zen.2458661.23480.HH.uvh5')

--- a/src/pyuvdata/parameter.py
+++ b/src/pyuvdata/parameter.py
@@ -326,17 +326,6 @@ class UVParameter:
         if not (
             isinstance(other, self.__class__) and isinstance(self, other.__class__)
         ):
-            # If the UVParameter value is of the same type, then compare that instead
-            if isinstance(other, self.value.__class__) and isinstance(
-                self.value, other.__class__
-            ):
-                if not silent:
-                    print(
-                        f"{self.name} and other classes do not match, but "
-                        f"{self.name}.value and other do -- comparing those instead."
-                    )
-                return self.compare_value(other)
-
             if not silent:
                 print(f"{self.name} parameter classes are different")
             return False

--- a/src/pyuvdata/parameter.py
+++ b/src/pyuvdata/parameter.py
@@ -328,7 +328,7 @@ class UVParameter:
         ):
             # If the UVParameter value is of the same type, then compare that instead
             if isinstance(other, self.value.__class__) and isinstance(
-                self, other.__class__
+                self.value, other.__class__
             ):
                 if not silent:
                     print(

--- a/src/pyuvdata/utils/antenna.py
+++ b/src/pyuvdata/utils/antenna.py
@@ -40,11 +40,13 @@ def _select_antenna_helper(
         Normally indices matching given criteria are what are included in the
         subsequent list. However, if set to True, these indices are excluded
         instead. Default is False.
-    strict : bool
-        Normally, select ignores when no records match a one element of a
-        parameter, as long as _at least one_ element matches with what is in the
-        object. However, if set to True, an error is thrown if any element
-        does not match. Default is False.
+    strict : bool or None
+        Normally, select will warn when an element of the selection criteria does not
+        match any element for the parameter, as long as the selection criteria results
+        in _at least one_ element being selected. However, if set to True, an error is
+        thrown if any selection criteria does not match what is given for the object
+        parameters element. If set to None, then neither errors nor warnings are raised,
+        unless no records are selected. Default is False.
 
     Returns
     -------

--- a/src/pyuvdata/utils/bls.py
+++ b/src/pyuvdata/utils/bls.py
@@ -398,6 +398,52 @@ def _extract_bls_pol(
     invert=False,
     strict=True,
 ):
+    """
+    Decompose a list of ant-tuples or baseline numbers into ant-pairs and polarizations.
+
+    This is a helper function that takes the `bls` parameter from the select function
+    of several different classes (which can accept multiple different input types) and
+    generates a consistent output, namely antenna pairs and a list of polarizations to
+    select upon.
+
+    Parameters
+    ----------
+    bls : list of tuple or int
+        List containing the baselines being selected, either based on baseline number
+        (in which case, the list should contain only ints), antenna-pairs (the list
+        should contain 2-tuples), or antenna-polarization pairs (the list should contain
+        3-tules, with the third element being a string denoting the polarization).
+    polarizations : str or array-like of str
+        List of polarizations that are being selected. If provided and bls contains
+        3-tuples, an error is thrown.
+    baseline_array : array-like of int
+        Array of baseline numbers for the object.
+    ant_1_array : array-like of int
+        Array of first antenna numbers for the object.
+    ant_2_array : array-like of int
+        Array of second antenna numbers for the object.
+    nants_telescope : int
+        Number of antennas within a given telescope. Used to translate between baseline
+        number and antenna pairs.
+    invert : bool
+        Option to specify whether a select operation is trying to perform an inverse
+        selection (matching everything but what is listed). If set to True and bls
+        contains 3-tuples, an error is thrown.
+    strict : bool or None
+        Normally, select will warn when an element of the selection criteria does not
+        match any element for the parameter, as long as the selection criteria results
+        in _at least one_ element being selected. However, if set to True, an error is
+        thrown if any selection criteria does not match what is given for the object
+        parameters element. If set to None, then neither errors nor warnings are raised,
+        unless no records are selected. Default is False.
+
+    Returns
+    -------
+    bls : list of tuples
+        List containing all matching antenna-pairs (in the form of 2-tuples).
+    polarizations : list of str
+        List specifying which polarizations are being selected.
+    """
     if isinstance(bls, list) and all(
         isinstance(bl_ind, int | np.integer) for bl_ind in bls
     ):

--- a/src/pyuvdata/utils/bltaxis.py
+++ b/src/pyuvdata/utils/bltaxis.py
@@ -387,7 +387,9 @@ def _select_blt_preprocess(
                 "in the ant_1_array or ant_2_array"
             )
             tools._strict_raise(msg, strict=strict)
-        mask = np.logical_and(
+        # OR the masks if deselecting, otherwise AND the masks
+        eval_func = np.logical_or if invert else np.logical_and
+        mask = eval_func(
             np.isin(ant_1_array, select_antenna_nums),
             np.isin(ant_2_array, select_antenna_nums),
         )

--- a/src/pyuvdata/utils/bltaxis.py
+++ b/src/pyuvdata/utils/bltaxis.py
@@ -327,11 +327,14 @@ def _select_blt_preprocess(
         Normally indices matching given criteria are what are included in the
         subsequent list. However, if set to True, these indices are excluded
         instead. Default is False.
-    strict : bool
-        Normally, select ignores when no records match a one element of a
-        parameter, as long as _at least one_ element matches with what is in the
-        object. However, if set to True, an error is thrown if any element
-        does not match. Default is False.
+    strict : bool or None
+        Normally, select will warn when an element of the selection criteria does not
+        match any element for the parameter, as long as the selection criteria results
+        in _at least one_ element being selected. However, if set to True, an error is
+        thrown if any selection criteria does not match what is given for the object
+        parameters element. If set to None, then neither errors nor warnings are raised,
+        unless no records are selected. Default is False.
+
 
     Returns
     -------

--- a/src/pyuvdata/utils/frequency.py
+++ b/src/pyuvdata/utils/frequency.py
@@ -478,10 +478,11 @@ def _select_freq_helper(
 
     if spw_inds is not None:
         # Caputed selected SPWs, broadcast selection to freqs
-        sel_spw_array = obj_spw_array[spw_inds]
+        sel_spw_array = np.asarray(obj_spw_array)[spw_inds]
         if obj_spw_id_array is not None:
+            # Note - no invert here because that's already ben applied above
             mask = np.isin(obj_spw_id_array, sel_spw_array)
-            freq_inds = tools._where_combine(mask, inds=freq_inds, invert=invert)
+            freq_inds = tools._where_combine(mask, inds=freq_inds)
 
         spw_inds = spw_inds.tolist()
 
@@ -497,11 +498,11 @@ def _select_freq_helper(
 
     if freq_inds is not None:
         if obj_channel_width is not None:
-            sel_chan_width = obj_channel_width[freq_inds]
+            sel_chan_width = np.asarray(obj_channel_width)[freq_inds]
         if obj_spw_id_array is not None:
-            sel_spw_id_array = obj_spw_id_array[freq_inds]
+            sel_spw_id_array = np.asarray(obj_spw_id_array)[freq_inds]
         if obj_freq_array is not None:
-            sel_freq_array = obj_freq_array[freq_inds]
+            sel_freq_array = np.asarray(obj_freq_array)[freq_inds]
 
         spacing_error, chanwidth_error = _check_freq_spacing(
             freq_array=sel_freq_array,

--- a/src/pyuvdata/utils/frequency.py
+++ b/src/pyuvdata/utils/frequency.py
@@ -376,11 +376,13 @@ def _select_freq_helper(
         Normally indices matching given criteria are what are included in the
         subsequent list. However, if set to True, these indices are excluded
         instead. Default is False.
-    strict : bool
-        Normally, select ignores when no records match a one element of a
-        parameter, as long as _at least one_ element matches with what is in the
-        object. However, if set to True, an error is thrown if any element
-        does not match. Default is False.
+    strict : bool or None
+        Normally, select will warn when an element of the selection criteria does not
+        match any element for the parameter, as long as the selection criteria results
+        in _at least one_ element being selected. However, if set to True, an error is
+        thrown if any selection criteria does not match what is given for the object
+        parameters element. If set to None, then neither errors nor warnings are raised,
+        unless no records are selected. Default is False.
 
     Returns
     -------

--- a/src/pyuvdata/utils/frequency.py
+++ b/src/pyuvdata/utils/frequency.py
@@ -10,7 +10,7 @@ from . import tools
 from .pol import jstr2num, polstr2num
 
 
-def _check_flex_spw_contiguous(*, spw_array, flex_spw_id_array):
+def _check_flex_spw_contiguous(*, spw_array, flex_spw_id_array, raise_errors=True):
     """
     Check if the spectral windows are contiguous for multi-spw datasets.
 
@@ -26,6 +26,9 @@ def _check_flex_spw_contiguous(*, spw_array, flex_spw_id_array):
         Array of spectral window numbers, shape (Nspws,).
     flex_spw_id_array : array of integers
         Array of spectral window numbers per frequency channel, shape (Nfreqs,).
+    raise_errors : bool
+        Option to raise errors if the various checks do not pass. Default is True,
+        if set to False, then a warning is raised instead.
 
     """
     if spw_array is None and flex_spw_id_array is None:
@@ -43,12 +46,20 @@ def _check_flex_spw_contiguous(*, spw_array, flex_spw_id_array):
 
     n_breaks = np.sum(flex_spw_id_array[1:] != flex_spw_id_array[:-1])
     if (n_breaks + 1) != spw_array.size:
-        raise ValueError(
-            "Channels from different spectral windows are interspersed with "
-            "one another, rather than being grouped together along the "
-            "frequency axis. Most file formats do not support such "
-            "non-grouping of data."
-        )
+        if raise_errors:
+            raise ValueError(
+                "Channels from different spectral windows are interspersed with "
+                "one another, rather than being grouped together along the "
+                "frequency axis. Most file formats do not support such "
+                "non-grouping of data."
+            )
+        else:
+            warnings.warn(
+                "Channels from different spectral windows are interspersed with "
+                "one another, rather than being grouped together along the "
+                "frequency axis. Most file formats do not support such "
+                "non-grouping of data."
+            )
 
 
 def _check_freq_spacing(
@@ -96,7 +107,11 @@ def _check_freq_spacing(
 
     # Check to make sure that the flexible spectral window has indices set up
     # correctly (grouped together) for this check
-    _check_flex_spw_contiguous(spw_array=spw_array, flex_spw_id_array=flex_spw_id_array)
+    _check_flex_spw_contiguous(
+        spw_array=spw_array,
+        flex_spw_id_array=flex_spw_id_array,
+        raise_errors=raise_errors,
+    )
 
     # If spw_id and and spw_array are None, then assume that we just need to check
     # the full freq_array, and handle things accordingly

--- a/src/pyuvdata/utils/frequency.py
+++ b/src/pyuvdata/utils/frequency.py
@@ -94,7 +94,7 @@ def _check_freq_spacing(
     spacing_error = False
     chanwidth_error = False
 
-    # Check to make sure that the flexible spectral window has indicies set up
+    # Check to make sure that the flexible spectral window has indices set up
     # correctly (grouped together) for this check
     _check_flex_spw_contiguous(spw_array=spw_array, flex_spw_id_array=flex_spw_id_array)
 
@@ -226,7 +226,7 @@ def _sort_freq_helper(
             np.sort(channel_order) == np.arange(Nfreqs)
         ):
             raise ValueError(
-                "Index array for channel_order must contain all indicies for "
+                "Index array for channel_order must contain all indices for "
                 "the frequency axis, without duplicates."
             )
         index_array = channel_order
@@ -262,7 +262,7 @@ def _sort_freq_helper(
                     np.sort(spw_order) == np.arange(Nspws)
                 ):
                     raise ValueError(
-                        "Index array for spw_order must contain all indicies for "
+                        "Index array for spw_order must contain all indices for "
                         "the spw_array, without duplicates."
                     )
             elif spw_order not in ["number", "freq", "-number", "-freq", None]:

--- a/src/pyuvdata/utils/pol.py
+++ b/src/pyuvdata/utils/pol.py
@@ -576,7 +576,7 @@ def _select_pol_helper(
     pol_inds = None
     selections = []
 
-    str_eval = polstr2num if is_jones else jstr2num
+    str_eval = jstr2num if is_jones else polstr2num
     select_name = "jones polarization terms" if is_jones else "polarizations"
     term_name = "Jones term" if is_jones else "Polarization"
     arr_name = "jones_array" if is_jones else "polarization_array"

--- a/src/pyuvdata/utils/pol.py
+++ b/src/pyuvdata/utils/pol.py
@@ -562,11 +562,13 @@ def _select_pol_helper(
         Normally indices matching given criteria are what are included in the
         subsequent list. However, if set to True, these indices are excluded
         instead. Default is False.
-    strict : bool
-        Normally, select ignores when no records match a one element of a
-        parameter, as long as _at least one_ element matches with what is in the
-        object. However, if set to True, an error is thrown if any element
-        does not match. Default is False.
+    strict : bool or None
+        Normally, select will warn when an element of the selection criteria does not
+        match any element for the parameter, as long as the selection criteria results
+        in _at least one_ element being selected. However, if set to True, an error is
+        thrown if any selection criteria does not match what is given for the object
+        parameters element. If set to None, then neither errors nor warnings are raised,
+        unless no records are selected. Default is False.
     is_jones : bool
         Normally this function handles polarizations, but if set to True, Jones terms
         can be input instead. Default is False, it is recommended rather than using this
@@ -656,11 +658,13 @@ def _select_jones_helper(
         Normally indices matching given criteria are what are included in the
         subsequent list. However, if set to True, these indices are excluded
         instead. Default is False.
-    strict : bool
-        Normally, select ignores when no records match a one element of a
-        parameter, as long as _at least one_ element matches with what is in the
-        object. However, if set to True, an error is thrown if any element
-        does not match. Default is False.
+    strict : bool or None
+        Normally, select will warn when an element of the selection criteria does not
+        match any element for the parameter, as long as the selection criteria results
+        in _at least one_ element being selected. However, if set to True, an error is
+        thrown if any selection criteria does not match what is given for the object
+        parameters element. If set to None, then neither errors nor warnings are raised,
+        unless no records are selected. Default is False.
     warn_spacing : bool
         Whether or not to warn about Jones spacing. Default is False.
 
@@ -709,11 +713,13 @@ def _select_feed_helper(
         Normally indices matching given criteria are what are included in the
         subsequent list. However, if set to True, these indices are excluded
         instead. Default is False.
-    strict : bool
-        Normally, select ignores when no records match a one element of a
-        parameter, as long as _at least one_ element matches with what is in the
-        object. However, if set to True, an error is thrown if any element
-        does not match. Default is False.
+    strict : bool or None
+        Normally, select will warn when an element of the selection criteria does not
+        match any element for the parameter, as long as the selection criteria results
+        in _at least one_ element being selected. However, if set to True, an error is
+        thrown if any selection criteria does not match what is given for the object
+        parameters element. If set to None, then neither errors nor warnings are raised,
+        unless no records are selected. Default is False.
 
     Returns
     -------
@@ -754,7 +760,7 @@ def _select_feed_helper(
 
 def _check_pol_spacing(*, polarization_array, strict=True, allow_resort=False):
     """
-    Check if frequencies are evenly spaced and separated by their channel width.
+    Check if polarizations are evenly spaced.
 
     This is a requirement for writing uvfits and beamfits files.
 
@@ -783,7 +789,7 @@ def _check_pol_spacing(*, polarization_array, strict=True, allow_resort=False):
 
 def _check_jones_spacing(*, jones_array, strict=True, allow_resort=False):
     """
-    Check if frequencies are evenly spaced and separated by their channel width.
+    Check if Jones polarization terms are equally spaced.
 
     This is a requirement for writing calfits files.
 

--- a/src/pyuvdata/utils/times.py
+++ b/src/pyuvdata/utils/times.py
@@ -385,11 +385,13 @@ def _select_times_helper(
         Normally indices matching given criteria are what are included in the
         subsequent list. However, if set to True, these indices are excluded
         instead. Default is False.
-    strict : bool
-        Normally, select ignores when no records match a one element of a
-        parameter, as long as _at least one_ element matches with what is in the
-        object. However, if set to True, an error is thrown if any element
-        does not match. Default is False.
+    strict : bool or None
+        Normally, select will warn when an element of the selection criteria does not
+        match any element for the parameter, as long as the selection criteria results
+        in _at least one_ element being selected. However, if set to True, an error is
+        thrown if any selection criteria does not match what is given for the object
+        parameters element. If set to None, then neither errors nor warnings are raised,
+        unless no records are selected. Default is False.
     warn_spacing
         Whether or not to warn about time spacing. Only used if no ranges from the
         object are supplied. Default is False.

--- a/src/pyuvdata/utils/times.py
+++ b/src/pyuvdata/utils/times.py
@@ -373,7 +373,7 @@ def _select_times_helper(
     lst_tols : tuple of float
         Length 2 tuple giving (rtol, atol) to use for lst matching.
     time_inds : array_like of int, optional
-        The btime indices to keep in the object. This is not commonly used.
+        The time indices to keep in the object. This is not commonly used.
     invert : bool
         Normally indices matching given criteria are what are included in the
         subsequent list. However, if set to True, these indices are excluded

--- a/src/pyuvdata/utils/tools.py
+++ b/src/pyuvdata/utils/tools.py
@@ -497,7 +497,7 @@ def _where_combine(mask, inds=None, invert=False, use_and=True):
         If False, then indices where mask == True are returned. But if set to True,
         indices where mask == False are returned instead. Default is False.
     use_and : bool
-        If True, then what is returned is ihe intersection of value derived from both
+        If True, then what is returned is the intersection of value derived from both
         mask and inds. If False, then the union of mask and inds is returned instead.
         Default is True.
 

--- a/src/pyuvdata/utils/tools.py
+++ b/src/pyuvdata/utils/tools.py
@@ -204,11 +204,11 @@ def _test_array_constant(array, *, tols=None):
     from pyuvdata.parameter import UVParameter
 
     if isinstance(array, UVParameter):
-        array_to_test = array.value
+        array_to_test = np.asarray(array.value)
         if tols is None:
             tols = array.tols
     else:
-        array_to_test = array
+        array_to_test = np.asarray(array)
         if tols is None:
             tols = (0, 0)
     assert isinstance(tols, tuple), "tols must be a length-2 tuple"

--- a/src/pyuvdata/uvbase.py
+++ b/src/pyuvdata/uvbase.py
@@ -923,11 +923,11 @@ class UVBase:
                     # If we're working with an ndarray, use take to slice along
                     # the axis that we want to grab from.
                     if isinstance(ind_arr, slice):
-                        slice_list = [slice(None)] * len(attr.form)
-                        for axis in sel_axis:
-                            slice_list[axis] = ind_arr
-
-                        attr.value = attr.value[*slice_list]
+                        full_slice = tuple(
+                            ind_arr if idx in sel_axis else slice(None)
+                            for idx in range(len(attr.form))
+                        )
+                        attr.value = attr.value[full_slice]
                         attr.setter(self)
                     else:
                         for axis in sel_axis:

--- a/src/pyuvdata/uvbase.py
+++ b/src/pyuvdata/uvbase.py
@@ -885,7 +885,7 @@ class UVBase:
         Parameters
         ----------
         param_name : str
-            Name of the parameter, which is used to define the expected shapre of other
+            Name of the parameter, which is used to define the expected shape of other
             parameters within the object.
         ind_arr : array-like of int
             Index positions along the given axis to select. Must be 1D. Can be None,

--- a/src/pyuvdata/uvbase.py
+++ b/src/pyuvdata/uvbase.py
@@ -918,8 +918,7 @@ class UVBase:
                 ]
                 if len(sel_axis) == 0:
                     continue
-
-                if isinstance(attr.value, np.ndarray):
+                if isinstance(attr.value, np.ndarray | np.ma.MaskedArray):
                     # If we're working with an ndarray, use take to slice along
                     # the axis that we want to grab from.
                     if isinstance(ind_arr, slice):

--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -3163,7 +3163,7 @@ class UVBeam(UVBase):
         history_update_string : str
             string to append to the end of the history.
         """
-        # Create a dictionary that we can loop over an update if need be
+        # Create a dictionary to pass to _select_along_param_axis
         ind_dict = {
             "Naxes1": axis1_inds,
             "Naxes2": axis2_inds,
@@ -3178,22 +3178,20 @@ class UVBeam(UVBase):
 
         # During each loop interval, we pop off an element of this dict, so continue
         # until the dict is empty.
-        for key, ind_arr in ind_dict.items():
-            self._select_along_param_axis(key, ind_arr)
-            if (
-                key == "Npols"
-                and pol_inds is not None
-                and (had_cross and not any(np.isin(cross_pol, self.polarization_array)))
-            ):
-                # selecting from object with cross-pols down to non-cross pols so
-                # data_array should become real
-                if np.any(np.iscomplex(self.data_array)):
-                    warnings.warn(
-                        "Polarization select should result in a real array but the "
-                        "imaginary part is not zero."
-                    )
-                else:
-                    self.data_array = np.abs(self.data_array)
+        self._select_along_param_axis(ind_dict)
+
+        if pol_inds is not None and (
+            had_cross and not any(np.isin(cross_pol, self.polarization_array))
+        ):
+            # selecting from object with cross-pols down to non-cross pols so
+            # data_array should become real
+            if np.any(np.iscomplex(self.data_array)):
+                warnings.warn(
+                    "Polarization select should result in a real array but the "
+                    "imaginary part is not zero."
+                )
+            else:
+                self.data_array = np.abs(self.data_array)
 
         # Update the history string
         self.history += history_update_string

--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -2584,6 +2584,7 @@ class UVBeam(UVBase):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
+        warn_spacing=True,
     ):
         """
         Combine two UVBeam objects.
@@ -2614,6 +2615,9 @@ class UVBeam(UVBase):
         run_check_acceptability : bool
             Option to check acceptable range of the values of
             required parameters after combining objects.
+        warn_spacing : bool
+            Option to raise warnings about spacing that would prevent writing to
+            calfits file-format. Default is True.
 
         """
         if inplace:
@@ -3059,8 +3063,8 @@ class UVBeam(UVBase):
         this.Nfreqs = this.freq_array.size
 
         # Check specific requirements
-        if this.Nfreqs > 1 and not utils.tools._test_array_constant_spacing(
-            this.freq_array, tols=this._freq_array.tols
+        if warn_spacing and not utils.tools._test_array_constant_spacing(
+            this._freq_array
         ):
             warnings.warn(
                 "Combined frequencies are not evenly spaced. This will "
@@ -3069,7 +3073,7 @@ class UVBeam(UVBase):
 
         if (
             self.beam_type == "power"
-            and this.Npols > 2
+            and warn_spacing
             and not utils.tools._test_array_constant_spacing(this._polarization_array)
         ):
             warnings.warn(
@@ -3194,6 +3198,7 @@ class UVBeam(UVBase):
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
+        warn_spacing=True,
     ):
         """
         Downselect data to keep on the object along various axes.
@@ -3249,6 +3254,9 @@ class UVBeam(UVBase):
         run_check_acceptability : bool
             Option to check acceptable range of the values of
             required parameters after  downselecting data on this object.
+        warn_spacing : bool
+            Option to raise warnings about spacing that would prevent writing to
+            calfits file-format. Default is True.
 
         """
         if inplace:
@@ -3341,6 +3349,7 @@ class UVBeam(UVBase):
             freq_tols=self._freq_array.tols,
             invert=invert,
             strict=strict,
+            warn_spacing=warn_spacing,
         )
         selections.extend(freq_selections)
 
@@ -3359,6 +3368,7 @@ class UVBeam(UVBase):
             obj_x_orientation=self.x_orientation,
             invert=invert,
             strict=strict,
+            warn_spacing=warn_spacing,
         )
         selections.extend(pol_selections)
 

--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -2617,7 +2617,7 @@ class UVBeam(UVBase):
             required parameters after combining objects.
         warn_spacing : bool
             Option to raise warnings about spacing that would prevent writing to
-            calfits file-format. Default is True.
+            beamfits file-format. Default is True.
 
         """
         if inplace:
@@ -3257,7 +3257,7 @@ class UVBeam(UVBase):
             required parameters after  downselecting data on this object.
         warn_spacing : bool
             Option to raise warnings about spacing that would prevent writing to
-            calfits file-format. Default is True.
+            beamfits file-format. Default is True.
 
         """
         if inplace:

--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -3238,11 +3238,12 @@ class UVBeam(UVBase):
             Normally records matching given criteria are what are included in the
             subsequent object. However, if set to True, these records are excluded
             instead. Default is False.
-        strict : bool
-            Normally, select ignores when no records match a one element of a
+        strict : bool or None
+            Normally, select will warn when no records match a one element of a
             parameter, as long as _at least one_ element matches with what is in the
             object. However, if set to True, an error is thrown if any element
-            does not match. Default is False.
+            does not match. If set to None, then neither errors nor warnings are raised.
+            Default is False.
         inplace : bool
             Option to perform the select directly on self or return
             a new UVBeam object, which is a subselection of self.

--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -847,24 +847,6 @@ class UVBeam(UVBase):
         ) > (1 + 1e-15):
             raise ValueError("basis vectors must have lengths of 1 or less.")
 
-        # issue warning if extra_keywords keys are longer than 8 characters
-        for key in list(self.extra_keywords.keys()):
-            if len(key) > 8:
-                warnings.warn(
-                    f"key {key} in extra_keywords is longer than 8 "
-                    "characters. It will be truncated to 8 if written "
-                    "to a fits file format."
-                )
-
-        # issue warning if extra_keywords values are lists, arrays or dicts
-        for key, value in self.extra_keywords.items():
-            if isinstance(value, list | dict | np.ndarray):
-                warnings.warn(
-                    f"{key} in extra_keywords is a list, array or dict, "
-                    "which will raise an error when writing fits "
-                    "files"
-                )
-
         # Check if the interpolation points are evenly-spaced
         if self.pixel_coordinate_system == "az_za":
             for i, ax_param in enumerate((self._axis1_array, self._axis2_array)):

--- a/src/pyuvdata/uvcal/uvcal.py
+++ b/src/pyuvdata/uvcal/uvcal.py
@@ -4178,7 +4178,7 @@ class UVCal(UVBase):
         history_update_string : str
             string to append to the end of the history.
         """
-        # Create a dictionary that we can loop over an update if need be
+        # Create a dictionary to pass to _select_along_param_axis
         ind_dict = {
             "Nants_data": ant_inds,
             "Ntimes": time_inds,
@@ -4189,16 +4189,14 @@ class UVCal(UVBase):
 
         # During each loop interval, we pop off an element of this dict, so continue
         # until the dict is empty.
-        for key, ind_arr in ind_dict.items():
-            self._select_along_param_axis(key, ind_arr)
-            if key == "Nants_data" and not (
-                ind_arr is None or self.total_quality_array is None
-            ):
-                warnings.warn(
-                    "Changing number of antennas, but preserving the "
-                    "total_quality_array, which may have been defined based "
-                    "in part on antennas which will be removed."
-                )
+        self._select_along_param_axis(ind_dict)
+
+        if ant_inds is not None and self.total_quality_array is not None:
+            warnings.warn(
+                "Changing number of antennas, but preserving the "
+                "total_quality_array, which may have been defined based "
+                "in part on antennas which will be removed."
+            )
 
         # Update the history string
         self.history += history_update_string

--- a/src/pyuvdata/uvcal/uvcal.py
+++ b/src/pyuvdata/uvcal/uvcal.py
@@ -3934,6 +3934,7 @@ class UVCal(UVBase):
         phase_center_ids,
         catalog_names,
         invert=False,
+        strict=False,
     ):
         """
         Downselect data to keep on the object along various axes.
@@ -3996,9 +3997,14 @@ class UVCal(UVBase):
             match exactly in spelling and capitalization. Cannot be used with
             `phase_center_ids`.
         invert : bool
-            Normally records matching given critera are what are included in the
-            subsequent option. However, if set to True, these records are excluded
+            Normally records matching given criteria are what are included in the
+            subsequent object. However, if set to True, these records are excluded
             instead. Default is False.
+        strict : bool
+            Normally, select ignores when no records match a one element of a
+            parameter, as long as _at least one_ element matches with what is in the
+            object. However, if set to True, an error is thrown if any element
+            does not match. Default is False.
 
         Returns
         -------
@@ -4036,6 +4042,7 @@ class UVCal(UVBase):
             tel_ant_nums=self.telescope.antenna_numbers,
             obj_ant_array=self.ant_array,
             invert=invert,
+            strict=strict,
         )
         selections.extend(ant_selections)
 
@@ -4051,6 +4058,7 @@ class UVCal(UVBase):
             time_tols=self._time_array.tols,
             lst_tols=self._lst_array.tols,
             invert=invert,
+            strict=strict,
         )
         selections.extend(time_selections)
 
@@ -4060,7 +4068,9 @@ class UVCal(UVBase):
             )
 
         if phase_center_ids is not None:
-            pc_check = np.isin(self.phase_center_id_array, phase_center_ids)
+            pc_check = np.isin(
+                self.phase_center_id_array, phase_center_ids, invert=invert
+            )
             time_inds = utils.tools._sorted_unique_intersection(
                 np.where(pc_check)[0], time_inds
             )
@@ -4109,6 +4119,8 @@ class UVCal(UVBase):
             jones=jones,
             obj_flex_jones_array=self.flex_jones_array,
             obj_x_orientation=self.telescope.x_orientation,
+            invert=invert,
+            strict=strict,
         )
         selections.extend(freq_selections)
 
@@ -4117,6 +4129,8 @@ class UVCal(UVBase):
             obj_jones_array=self.jones_array,
             obj_x_orientation=self.telescope.x_orientation,
             flex_jones=self.flex_jones_array is not None,
+            invert=invert,
+            strict=strict,
         )
         selections.extend(jones_selections)
 
@@ -4205,6 +4219,7 @@ class UVCal(UVBase):
         phase_center_ids=None,
         catalog_names=None,
         invert=False,
+        strict=False,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -4271,9 +4286,14 @@ class UVCal(UVBase):
             match exactly in spelling and capitalization. Cannot be used with
             `phase_center_ids`.
         invert : bool
-            Normally records matching given critera are what are included in the
+            Normally records matching given criteria are what are included in the
             subsequent object. However, if set to True, these records are excluded
             instead. Default is False.
+        strict : bool
+            Normally, select ignores when no records match a one element of a
+            parameter, as long as _at least one_ element matches with what is in the
+            object. However, if set to True, an error is thrown if any element
+            does not match. Default is False.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after downselecting data on this object (the default is True,
@@ -4317,6 +4337,7 @@ class UVCal(UVBase):
             phase_center_ids=phase_center_ids,
             catalog_names=catalog_names,
             invert=invert,
+            strict=strict,
         )
 
         # Call the low-level selection method.

--- a/src/pyuvdata/uvcal/uvcal.py
+++ b/src/pyuvdata/uvcal/uvcal.py
@@ -4030,11 +4030,12 @@ class UVCal(UVBase):
             Normally records matching given criteria are what are included in the
             subsequent object. However, if set to True, these records are excluded
             instead. Default is False.
-        strict : bool
-            Normally, select ignores when no records match a one element of a
+        strict : bool or None
+            Normally, select will warn when no records match a one element of a
             parameter, as long as _at least one_ element matches with what is in the
             object. However, if set to True, an error is thrown if any element
-            does not match. Default is False.
+            does not match. If set to None, then neither errors nor warnings are raised.
+            Default is False.
         warn_spacing : bool
             Option to raise warnings about spacing that would prevent writing to
             calfits file-format. Default is False.
@@ -4312,11 +4313,12 @@ class UVCal(UVBase):
             Normally records matching given criteria are what are included in the
             subsequent object. However, if set to True, these records are excluded
             instead. Default is False.
-        strict : bool
-            Normally, select ignores when no records match a one element of a
+        strict : bool or None
+            Normally, select will warn when no records match a one element of a
             parameter, as long as _at least one_ element matches with what is in the
             object. However, if set to True, an error is thrown if any element
-            does not match. Default is False.
+            does not match. If set to None, then neither errors nor warnings are raised.
+            Default is False.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after downselecting data on this object (the default is True,

--- a/src/pyuvdata/uvcal/uvcal.py
+++ b/src/pyuvdata/uvcal/uvcal.py
@@ -2097,7 +2097,7 @@ class UVCal(UVBase):
                 np.sort(order) == np.arange(self.Nants_data)
             ):
                 raise ValueError(
-                    "If order is an index array, it must contain all indicies for the"
+                    "If order is an index array, it must contain all indices for the"
                     "ant_array, without duplicates."
                 )
             index_array = order
@@ -2218,7 +2218,7 @@ class UVCal(UVBase):
                     np.sort(spw_order) == np.arange(self.Nspws)
                 ):
                     raise ValueError(
-                        "If spw_order is an array, it must contain all indicies for "
+                        "If spw_order is an array, it must contain all indices for "
                         "the spw_array, without duplicates."
                     )
                 index_array = np.asarray(
@@ -2333,7 +2333,7 @@ class UVCal(UVBase):
                 np.sort(order) == np.arange(self.Ntimes)
             ):
                 raise ValueError(
-                    "If order is an array, it must contain all indicies for "
+                    "If order is an array, it must contain all indices for "
                     "the time axis, without duplicates."
                 )
             index_array = order
@@ -2425,7 +2425,7 @@ class UVCal(UVBase):
                 np.sort(order) == np.arange(self.Njones)
             ):
                 raise ValueError(
-                    "If order is an array, it must contain all indicies for "
+                    "If order is an array, it must contain all indices for "
                     "the jones axis, without duplicates."
                 )
             index_array = order

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -6677,11 +6677,12 @@ class UVData(UVBase):
             Normally records matching given criteria are what are included in the
             subsequent object. However, if set to True, these records are excluded
             instead. Default is False.
-        strict : bool
-            Normally, select ignores when no records match a one element of a
+        strict : bool or None
+            Normally, select will warn when no records match a one element of a
             parameter, as long as _at least one_ element matches with what is in the
             object. However, if set to True, an error is thrown if any element
-            does not match. Default is False.
+            does not match. If set to None, then neither errors nor warnings are raised.
+            Default is False.
         warn_spacing : bool
             Option to raise warnings about spacing that would prevent writing to
             uvfits or miriad file-format. Default is False.
@@ -6981,11 +6982,12 @@ class UVData(UVBase):
             Normally records matching given criteria are what are included in the
             subsequent object. However, if set to True, these records are excluded
             instead. Default is False.
-        strict : bool
-            Normally, select ignores when no records match a one element of a
+        strict : bool or None
+            Normally, select will warn when no records match a one element of a
             parameter, as long as _at least one_ element matches with what is in the
             object. However, if set to True, an error is thrown if any element
-            does not match. Default is False.
+            does not match. If set to None, then neither errors nor warnings are raised.
+            Default is False.
         inplace : bool
             Option to perform the select directly on self or return a new UVData
             object with just the selected data (the default is True, meaning the

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -6590,6 +6590,7 @@ class UVData(UVBase):
         phase_center_ids,
         catalog_names,
         invert=False,
+        strict=False,
     ):
         """
         Build up blt_inds, freq_inds, pol_inds and history_update_string for select.
@@ -6669,9 +6670,14 @@ class UVData(UVBase):
             match exactly in spelling and capitalization. Cannot be used with
             `phase_center_ids`.
         invert : bool
-            Normally records matching given critera are what are included in the
-            subsequent option. However, if set to True, these records are excluded
+            Normally records matching given criteria are what are included in the
+            subsequent object. However, if set to True, these records are excluded
             instead. Default is False.
+        strict : bool
+            Normally, select ignores when no records match a one element of a
+            parameter, as long as _at least one_ element matches with what is in the
+            object. However, if set to True, an error is thrown if any element
+            does not match. Default is False.
 
         Returns
         -------
@@ -6745,6 +6751,7 @@ class UVData(UVBase):
             lst_tols=self._lst_array.tols,
             phase_center_id_array=self.phase_center_id_array,
             invert=invert,
+            strict=strict,
         )
         selections.extend(blt_selections)
 
@@ -6762,6 +6769,7 @@ class UVData(UVBase):
             polarizations=polarizations,
             obj_x_orientation=self.telescope.x_orientation,
             invert=invert,
+            strict=strict,
         )
         selections.extend(freq_selections)
 
@@ -6771,6 +6779,7 @@ class UVData(UVBase):
             obj_x_orientation=self.telescope.x_orientation,
             flex_pol=self.flex_spw_polarization_array is not None,
             invert=invert,
+            strict=strict,
         )
         selections.extend(pol_selections)
 
@@ -6863,6 +6872,7 @@ class UVData(UVBase):
         phase_center_ids=None,
         catalog_names=None,
         invert=False,
+        strict=False,
         inplace=True,
         keep_all_metadata=True,
         run_check=True,
@@ -6957,6 +6967,11 @@ class UVData(UVBase):
             Normally records matching given criteria are what are included in the
             subsequent object. However, if set to True, these records are excluded
             instead. Default is False.
+        strict : bool
+            Normally, select ignores when no records match a one element of a
+            parameter, as long as _at least one_ element matches with what is in the
+            object. However, if set to True, an error is thrown if any element
+            does not match. Default is False.
         inplace : bool
             Option to perform the select directly on self or return a new UVData
             object with just the selected data (the default is True, meaning the
@@ -7015,6 +7030,7 @@ class UVData(UVBase):
                 phase_center_ids=phase_center_ids,
                 catalog_names=catalog_names,
                 invert=invert,
+                strict=strict,
             )
         )
 

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -2350,24 +2350,6 @@ class UVData(UVBase):
             raise ValueError("All antennas in ant_2_array must be in antenna_numbers.")
         logger.debug("... Done Antenna Uniqueness Check")
 
-        # issue warning if extra_keywords keys are longer than 8 characters
-        for key in self.extra_keywords:
-            if len(key) > 8:
-                warnings.warn(
-                    f"key {key} in extra_keywords is longer than 8 "
-                    "characters. It will be truncated to 8 if written "
-                    "to uvfits or miriad file formats."
-                )
-
-        # issue warning if extra_keywords values are lists, arrays or dicts
-        for key, value in self.extra_keywords.items():
-            if isinstance(value, list | dict | np.ndarray):
-                warnings.warn(
-                    f"{key} in extra_keywords is a list, array or dict, "
-                    "which will raise an error when writing uvfits or "
-                    "miriad file types"
-                )
-
         if run_check_acceptability:
             # Check antenna positions
             utils.coordinates.check_surface_based_positions(
@@ -5825,25 +5807,6 @@ class UVData(UVBase):
         if this.filename is not None:
             this._filename.form = (len(this.filename),)
 
-        # Check specific requirements
-        if this.Nfreqs > 1:
-            spacing_error, chanwidth_error = this._check_freq_spacing(
-                raise_errors=False
-            )
-
-            if spacing_error:
-                warnings.warn(
-                    "Combined frequencies are not evenly spaced or have differing "
-                    "values of channel widths. This will make it impossible to write "
-                    "this data out to some file types."
-                )
-            elif chanwidth_error:
-                warnings.warn(
-                    "Combined frequencies are separated by more than their "
-                    "channel width. This will make it impossible to write this data "
-                    "out to some file types."
-                )
-
         if n_axes > 0:
             history_update_string += " axis using pyuvdata."
 
@@ -6158,22 +6121,6 @@ class UVData(UVBase):
 
             this.Nspws = len(this.spw_array)
 
-            spacing_error, chanwidth_error = this._check_freq_spacing(
-                raise_errors=False
-            )
-            if spacing_error:
-                warnings.warn(
-                    "Combined frequencies are not evenly spaced or have differing "
-                    "values of channel widths. This will make it impossible to write "
-                    "this data out to some file types."
-                )
-            elif chanwidth_error:
-                warnings.warn(
-                    "Combined frequencies are separated by more than their "
-                    "channel width. This will make it impossible to write this data "
-                    "out to some file types."
-                )
-
             if not self.metadata_only:
                 this.data_array = np.concatenate(
                     [this.data_array] + [obj.data_array for obj in other], axis=1
@@ -6189,12 +6136,6 @@ class UVData(UVBase):
                 [this.polarization_array] + [obj.polarization_array for obj in other]
             )
             this.Npols = sum([this.Npols] + [obj.Npols for obj in other])
-
-            if not utils.tools._test_array_constant_spacing(this._polarization_array):
-                warnings.warn(
-                    "Combined polarizations are not evenly spaced. This will "
-                    "make it impossible to write this data out to some file types."
-                )
 
             if not self.metadata_only:
                 this.data_array = np.concatenate(

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -6805,7 +6805,7 @@ class UVData(UVBase):
         freq_inds : list of int
             list of frequency indices to keep. Can be None (to keep everything).
         spw_inds : list of int
-            list of spw indicies to keep. Can be None (to keep everything).
+            list of spw indices to keep. Can be None (to keep everything).
         pol_inds : list of int
             list of polarization indices to keep. Can be None (to keep everything).
         history_update_string : str

--- a/src/pyuvdata/uvdata/uvfits.py
+++ b/src/pyuvdata/uvdata/uvfits.py
@@ -206,6 +206,7 @@ class UVFITS(UVData):
         bls,
         frequencies,
         freq_chans,
+        spws,
         times,
         time_range,
         lsts,
@@ -224,21 +225,24 @@ class UVFITS(UVData):
         Separated from full read so header and metadata can be read without data.
         """
         # figure out what data to read in
-        blt_inds, freq_inds, pol_inds, history_update_string = self._select_preprocess(
-            antenna_nums=antenna_nums,
-            antenna_names=antenna_names,
-            ant_str=ant_str,
-            bls=bls,
-            frequencies=frequencies,
-            freq_chans=freq_chans,
-            times=times,
-            time_range=time_range,
-            lsts=lsts,
-            lst_range=lst_range,
-            polarizations=polarizations,
-            blt_inds=blt_inds,
-            phase_center_ids=phase_center_ids,
-            catalog_names=catalog_names,
+        blt_inds, freq_inds, spw_inds, pol_inds, history_update_string = (
+            self._select_preprocess(
+                antenna_nums=antenna_nums,
+                antenna_names=antenna_names,
+                ant_str=ant_str,
+                bls=bls,
+                frequencies=frequencies,
+                freq_chans=freq_chans,
+                spws=spws,
+                times=times,
+                time_range=time_range,
+                lsts=lsts,
+                lst_range=lst_range,
+                polarizations=polarizations,
+                blt_inds=blt_inds,
+                phase_center_ids=phase_center_ids,
+                catalog_names=catalog_names,
+            )
         )
 
         if blt_inds is not None:
@@ -275,6 +279,7 @@ class UVFITS(UVData):
             self._select_by_index(
                 blt_inds=blt_inds,
                 freq_inds=freq_inds,
+                spw_inds=spw_inds,
                 pol_inds=pol_inds,
                 history_update_string=history_update_string,
                 keep_all_metadata=keep_all_metadata,
@@ -358,6 +363,7 @@ class UVFITS(UVData):
         bls=None,
         frequencies=None,
         freq_chans=None,
+        spws=None,
         times=None,
         time_range=None,
         lsts=None,
@@ -778,6 +784,7 @@ class UVFITS(UVData):
                     bls=bls,
                     frequencies=frequencies,
                     freq_chans=freq_chans,
+                    spws=spws,
                     times=times,
                     time_range=time_range,
                     lsts=lsts,

--- a/src/pyuvdata/uvdata/uvfits.py
+++ b/src/pyuvdata/uvdata/uvfits.py
@@ -831,6 +831,7 @@ class UVFITS(UVData):
                 check_extra=check_extra,
                 run_check_acceptability=run_check_acceptability,
                 check_freq_spacing=True,
+                check_pol_spacing=True,
                 strict_uvw_antpos_check=strict_uvw_antpos_check,
                 check_autos=check_autos,
                 fix_autos=fix_autos,
@@ -901,12 +902,6 @@ class UVFITS(UVData):
         if self.Npols > 1:
             pol_indexing = np.argsort(np.abs(self.polarization_array))
             polarization_array = self.polarization_array[pol_indexing]
-            if not utils.tools._test_array_constant_spacing(polarization_array):
-                raise ValueError(
-                    "The polarization values are not evenly spaced (probably "
-                    "because of a select operation). The uvfits format "
-                    "does not support unevenly spaced polarizations."
-                )
             pol_spacing = polarization_array[1] - polarization_array[0]
         else:
             pol_indexing = np.asarray([0])

--- a/src/pyuvdata/uvdata/uvh5.py
+++ b/src/pyuvdata/uvdata/uvh5.py
@@ -698,6 +698,7 @@ class UVH5(UVData):
         bls,
         frequencies,
         freq_chans,
+        spws,
         times,
         time_range,
         lsts,
@@ -746,21 +747,25 @@ class UVH5(UVData):
             ) from hdf5plugin_error
 
         # figure out what data to read in
-        blt_inds, freq_inds, pol_inds, history_update_string = self._select_preprocess(
-            antenna_nums=antenna_nums,
-            antenna_names=antenna_names,
-            ant_str=ant_str,
-            bls=bls,
-            frequencies=frequencies,
-            freq_chans=freq_chans,
-            times=times,
-            time_range=time_range,
-            lsts=lsts,
-            lst_range=lst_range,
-            polarizations=polarizations,
-            blt_inds=blt_inds,
-            phase_center_ids=phase_center_ids,
-            catalog_names=catalog_names,
+        blt_inds, freq_inds, spw_inds, pol_inds, history_update_string = (
+            self._select_preprocess(
+                antenna_nums=antenna_nums,
+                antenna_names=antenna_names,
+                ant_str=ant_str,
+                bls=bls,
+                frequencies=frequencies,
+                freq_chans=freq_chans,
+                spws=spws,
+                times=times,
+                time_range=time_range,
+                lsts=lsts,
+                lst_range=lst_range,
+                polarizations=polarizations,
+                blt_inds=blt_inds,
+                phase_center_ids=phase_center_ids,
+                catalog_names=catalog_names,
+                invert=False,
+            )
         )
 
         # figure out which axis is the most selective
@@ -821,6 +826,7 @@ class UVH5(UVData):
             self._select_by_index(
                 blt_inds=blt_inds,
                 freq_inds=freq_inds,
+                spw_inds=spw_inds,
                 pol_inds=pol_inds,
                 history_update_string=history_update_string,
                 keep_all_metadata=keep_all_metadata,
@@ -1007,6 +1013,7 @@ class UVH5(UVData):
         bls=None,
         frequencies=None,
         freq_chans=None,
+        spws=None,
         times=None,
         time_range=None,
         lsts=None,
@@ -1079,6 +1086,7 @@ class UVH5(UVData):
                 bls=bls,
                 frequencies=frequencies,
                 freq_chans=freq_chans,
+                spws=spws,
                 times=times,
                 time_range=time_range,
                 lsts=lsts,
@@ -1625,6 +1633,7 @@ class UVH5(UVData):
         bls=None,
         frequencies=None,
         freq_chans=None,
+        spws=None,
         times=None,
         time_range=None,
         lsts=None,
@@ -1695,6 +1704,8 @@ class UVH5(UVData):
             The frequencies to include when writing data to the file.
         freq_chans : array_like of int, optional
             The frequency channel numbers to include when writing data to the file.
+        spws : array_like of int, optional
+            The spectral window numbers to keep in the file.
         times : array_like of float, optional
             The times in Julian Day to include when writing data to the file.
         time_range : array_like of float, optional
@@ -1760,13 +1771,14 @@ class UVH5(UVData):
             )
 
         # figure out which "full file" indices to write data to
-        blt_inds, freq_inds, pol_inds, _ = self._select_preprocess(
+        blt_inds, freq_inds, _, pol_inds, _ = self._select_preprocess(
             antenna_nums=antenna_nums,
             antenna_names=antenna_names,
             ant_str=ant_str,
             bls=bls,
             frequencies=frequencies,
             freq_chans=freq_chans,
+            spws=spws,
             times=times,
             time_range=time_range,
             lsts=lsts,

--- a/src/pyuvdata/uvflag/uvflag.py
+++ b/src/pyuvdata/uvflag/uvflag.py
@@ -2381,6 +2381,7 @@ class UVFlag(UVBase):
         blt_inds,
         ant_inds,
         invert=False,
+        strict=False,
     ):
         """Build up blt_inds, freq_inds, pol_inds and history_update_string for select.
 
@@ -2451,6 +2452,15 @@ class UVFlag(UVBase):
         ant_inds : array_like of int, optional
             The antenna indices to keep in the object. This is
             not commonly used.
+        invert : bool
+            Normally records matching given criteria are what are included in the
+            subsequent object. However, if set to True, these records are excluded
+            instead. Default is False.
+        strict : bool
+            Normally, select ignores when no records match a one element of a
+            parameter, as long as _at least one_ element matches with what is in the
+            object. However, if set to True, an error is thrown if any element
+            does not match. Default is False.
 
         Returns
         -------
@@ -2524,6 +2534,7 @@ class UVFlag(UVBase):
                 lst_tols=self._lst_array.tols,
                 phase_center_id_array=None,
                 invert=invert,
+                strict=strict,
             )
             selections.extend(blt_selections)
             time_inds = None
@@ -2545,6 +2556,7 @@ class UVFlag(UVBase):
                 tel_ant_nums=self.telescope.antenna_numbers,
                 obj_ant_array=self.ant_array,
                 invert=invert,
+                strict=strict,
             )
             selections.extend(ant_selections)
 
@@ -2560,6 +2572,7 @@ class UVFlag(UVBase):
                 time_tols=self._time_array.tols,
                 lst_tols=self._lst_array.tols,
                 invert=invert,
+                strict=strict,
             )
             selections.extend(time_selections)
 
@@ -2575,6 +2588,7 @@ class UVFlag(UVBase):
             spws=spws,
             warn_freq_spacing=False,
             invert=invert,
+            strict=strict,
         )
         selections.extend(freq_selections)
 
@@ -2583,6 +2597,7 @@ class UVFlag(UVBase):
             obj_pol_array=self.polarization_array,
             obj_x_orientation=self.telescope.x_orientation,
             invert=invert,
+            strict=strict,
         )
         selections.extend(pol_selections)
 
@@ -2678,6 +2693,8 @@ class UVFlag(UVBase):
         lst_range=None,
         polarizations=None,
         blt_inds=None,
+        invert=False,
+        strict=False,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -2763,6 +2780,15 @@ class UVFlag(UVBase):
         ant_inds : array_like of int, optional
             The antenna indices to keep in the object. This is
             not commonly used.
+        invert : bool
+            Normally records matching given criteria are what are included in the
+            subsequent object. However, if set to True, these records are excluded
+            instead. Default is False.
+        strict : bool
+            Normally, select ignores when no records match a one element of a
+            parameter, as long as _at least one_ element matches with what is in the
+            object. However, if set to True, an error is thrown if any element
+            does not match. Default is False.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after downselecting data on this object.
@@ -2816,6 +2842,8 @@ class UVFlag(UVBase):
             polarizations=polarizations,
             blt_inds=blt_inds,
             ant_inds=ant_inds,
+            invert=invert,
+            strict=strict,
         )
 
         # do select operations on everything except data_array, flag_array

--- a/src/pyuvdata/uvflag/uvflag.py
+++ b/src/pyuvdata/uvflag/uvflag.py
@@ -2456,11 +2456,12 @@ class UVFlag(UVBase):
             Normally records matching given criteria are what are included in the
             subsequent object. However, if set to True, these records are excluded
             instead. Default is False.
-        strict : bool
-            Normally, select ignores when no records match a one element of a
+        strict : bool or None
+            Normally, select will warn when no records match a one element of a
             parameter, as long as _at least one_ element matches with what is in the
             object. However, if set to True, an error is thrown if any element
-            does not match. Default is False.
+            does not match. If set to None, then neither errors nor warnings are raised.
+            Default is False.
 
         Returns
         -------
@@ -2787,11 +2788,12 @@ class UVFlag(UVBase):
             Normally records matching given criteria are what are included in the
             subsequent object. However, if set to True, these records are excluded
             instead. Default is False.
-        strict : bool
-            Normally, select ignores when no records match a one element of a
+        strict : bool or None
+            Normally, select will warn when no records match a one element of a
             parameter, as long as _at least one_ element matches with what is in the
             object. However, if set to True, an error is thrown if any element
-            does not match. Default is False.
+            does not match. If set to None, then neither errors nor warnings are raised.
+            Default is False.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after downselecting data on this object.

--- a/src/pyuvdata/uvflag/uvflag.py
+++ b/src/pyuvdata/uvflag/uvflag.py
@@ -2498,6 +2498,10 @@ class UVFlag(UVBase):
                     raise ValueError(
                         f"There is no data matching ant_str={ant_str} in this object."
                     )
+                if invert and polarizations is not None:
+                    raise ValueError(
+                        "Cannot set invert=True if using ant_str with polarizations."
+                    )
 
         if antenna_nums is not None and np.array(antenna_nums).ndim > 1:
             antenna_nums = np.array(antenna_nums).flatten()
@@ -2512,6 +2516,8 @@ class UVFlag(UVBase):
                     ant_1_array=self.ant_1_array,
                     ant_2_array=self.ant_2_array,
                     nants_telescope=self.telescope.Nants,
+                    strict=strict,
+                    invert=invert,
                 )
             blt_inds, blt_selections = utils.bltaxis._select_blt_preprocess(
                 select_antenna_nums=antenna_nums,
@@ -2586,7 +2592,6 @@ class UVFlag(UVBase):
             obj_spw_id_array=self.flex_spw_id_array,
             obj_spw_array=self.spw_array,
             spws=spws,
-            warn_freq_spacing=False,
             invert=invert,
             strict=strict,
         )

--- a/src/pyuvdata/uvflag/uvflag.py
+++ b/src/pyuvdata/uvflag/uvflag.py
@@ -2653,7 +2653,7 @@ class UVFlag(UVBase):
             Option to keep metadata for antennas that are no longer in the dataset.
 
         """
-        # Create a dictionary that we can loop over an update if need be
+        # Create a dictionary to pass to _select_along_param_axis
         ind_dict = {
             "Ntimes": time_inds,
             "Nants_data": ant_inds,
@@ -2663,16 +2663,14 @@ class UVFlag(UVBase):
             "Npols": pol_inds,
         }
 
-        # During each loop interval, we pop off an element of this dict, so continue
-        # until the dict is empty.
-        for key, ind_arr in ind_dict.items():
-            self._select_along_param_axis(key, ind_arr)
-            if key == "Nblts" and ind_arr is not None:
-                # Process post blt-specific selection actions, including counting
-                # unique antennas in the object.
-                self.Nants_data = self._calc_nants_data()
-                self.Nbls = len(np.unique(self.baseline_array))
-                self.Ntimes = len(np.unique(self.time_array))
+        self._select_along_param_axis(ind_dict)
+
+        if blt_inds is not None:
+            # Process post blt-specific selection actions, including counting
+            # unique antennas in the object.
+            self.Nants_data = self._calc_nants_data()
+            self.Nbls = len(np.unique(self.baseline_array))
+            self.Ntimes = len(np.unique(self.time_array))
 
         self.history = self.history + history_update_string
 

--- a/src/pyuvdata/uvflag/uvflag.py
+++ b/src/pyuvdata/uvflag/uvflag.py
@@ -2629,7 +2629,7 @@ class UVFlag(UVBase):
         freq_inds : list of int
             list of frequency indices to keep. Can be None (to keep everything).
         spw_inds : list of int
-            list of spw indicies to keep. Can be None (to keep everything).
+            list of spw indices to keep. Can be None (to keep everything).
         pol_inds : list of int
             list of polarization indices to keep. Can be None (to keep everything).
         history_update_string : str

--- a/tests/test_beam_interface.py
+++ b/tests/test_beam_interface.py
@@ -351,4 +351,8 @@ def test_with_feeds_ordering_power(gaussian_uv):
     assert np.all(intf_feedx.polarization_array == [-5, -6, -7, -8])
 
     intf_feedyx = intf.with_feeds(["y", "x"], maintain_ordering=False)
-    assert np.all(intf_feedyx.polarization_array == [-6, -8, -7, -5])
+    # N.b. (Karto), this used to check against [-6, -8, -7, -5], but I _think_ this
+    # was actually a bug, in that UVBeam.select was sensitive to the ordering of
+    # pol arguments for polarization_array *only*, and not anything else with a
+    # polarization axis.
+    assert np.all(intf_feedyx.polarization_array == [-5, -6, -7, -8])

--- a/tests/utils/test_bls.py
+++ b/tests/utils/test_bls.py
@@ -41,6 +41,7 @@ def test_antnums_to_baseline_miriad_convention():
     np.testing.assert_allclose(bl, bl_gold)
 
 
+@pytest.mark.filterwarnings("ignore:antnums_to_baseline")
 @pytest.mark.skipif(not hasbench, reason="benchmark utility not installed")
 @pytest.mark.parametrize(
     "nbls", [1, 10, 100, 1000, 10000, 100000, 1000000], ids=lambda x: f"len={x:}"
@@ -69,6 +70,7 @@ def test_bls_to_ant(benchmark, bl_start, nbls):
     assert np.array_equal(bls, bls_out)
 
 
+@pytest.mark.filterwarnings("ignore:antnums_to_baseline")
 @pytest.mark.skipif(not hasbench, reason="benchmark utility not installed")
 @pytest.mark.parametrize(
     "nbls", [1, 10, 100, 1000, 10000, 100000, 1000000], ids=lambda x: f"len={x:}"

--- a/tests/utils/test_times.py
+++ b/tests/utils/test_times.py
@@ -18,7 +18,7 @@ from .test_coordinates import selenoids
 
 def test_astrometry_lst(astrometry_args):
     """
-    Check for consistency beteen astrometry libraries when calculating LAST
+    Check for consistency between astrometry libraries when calculating LAST
 
     This test evaluates consistency in calculating local apparent sidereal time when
     using the different astrometry libraries available in pyuvdata, namely: astropy,

--- a/tests/utils/test_tools.py
+++ b/tests/utils/test_tools.py
@@ -111,3 +111,26 @@ def test_array_constant(inp_arr, is_param, tols, exp_outcome):
             kwargs["tols"] = tols
         inp_arr = UVParameter("test", **kwargs)
     assert exp_outcome == utils.tools._test_array_constant(inp_arr, tols=tols)
+
+
+@pytest.mark.parametrize("is_param", [True, False])
+@pytest.mark.parametrize(
+    "inp_arr,inp2_arr,tols,exp_outcome",
+    [
+        [np.array([0, 0, 0, 0]), [0, 0, 0, 0], (0, 0), True],
+        [[1, 2, 3, 4], np.array([1, 1, 1, 1]), None, True],
+        [[0, 0, 0, 1], [0, 0, 0, 0], (0, 0), False],
+        [[0, 0, 0, 1], [0, 0, 0, 0], None, False],
+        [[1, 2, 3, 4], [0, 0, 0, 0], (0, 1), True],
+    ],
+)
+def test_array_consistent(inp_arr, inp2_arr, is_param, tols, exp_outcome):
+    if is_param:
+        kwargs = {"value": inp_arr}
+        if tols is not None:
+            kwargs["tols"] = tols
+        inp_arr = UVParameter("test", **kwargs)
+        inp2_arr = UVParameter("test2", value=inp2_arr)
+    assert exp_outcome == utils.tools._test_array_consistent(
+        inp_arr, inp2_arr, tols=tols
+    )

--- a/tests/utils/test_tools.py
+++ b/tests/utils/test_tools.py
@@ -2,9 +2,11 @@
 # Licensed under the 2-clause BSD License
 """Tests for helper utility functions."""
 
+import numpy as np
 import pytest
 
 from pyuvdata import utils
+from pyuvdata.parameter import UVParameter
 from pyuvdata.testing import check_warnings
 
 
@@ -89,3 +91,23 @@ def test_eval_inds(inds, nrecs, exp_output, nwarn):
     ):
         output = utils.tools._eval_inds(inds=inds, nrecs=nrecs, strict=False)
     assert all(exp_output == output)
+
+
+@pytest.mark.parametrize("is_param", [True, False])
+@pytest.mark.parametrize(
+    "inp_arr,tols,exp_outcome",
+    [
+        [np.array([0, 0, 0, 0]), (0, 0), True],
+        [[0, 0, 0, 0], None, True],
+        [[0, 0, 0, 1], (0, 0), False],
+        [[0, 0, 0, 1], None, False],
+        [[0, 0, 0, 1], (1, 0), True],
+    ],
+)
+def test_array_constant(inp_arr, is_param, tols, exp_outcome):
+    if is_param:
+        kwargs = {"value": inp_arr}
+        if tols is not None:
+            kwargs["tols"] = tols
+        inp_arr = UVParameter("test", **kwargs)
+    assert exp_outcome == utils.tools._test_array_constant(inp_arr, tols=tols)

--- a/tests/uvbeam/test_beamfits.py
+++ b/tests/uvbeam/test_beamfits.py
@@ -638,10 +638,7 @@ def test_extra_keywords_errors(tmp_path, hera_beam_casa, ex_val, error_msg):
     keyword = list(ex_val.keys())[0]
     val = ex_val[keyword]
     beam_in.extra_keywords[keyword] = val
-    with check_warnings(
-        UserWarning, f"{keyword} in extra_keywords is a list, array or dict"
-    ):
-        beam_in.check()
+    beam_in.check()
 
     with pytest.raises(TypeError, match=error_msg):
         beam_in.write_beamfits(testfile, run_check=False)
@@ -655,10 +652,6 @@ def test_extra_keywords_warnings(tmp_path, hera_beam_casa):
 
     # check for warnings with extra_keywords keys that are too long
     beam_in.extra_keywords["test_long_key"] = True
-    with check_warnings(
-        UserWarning, "key test_long_key in extra_keywords is longer than 8 characters"
-    ):
-        beam_in.check()
     with check_warnings(
         UserWarning, "key test_long_key in extra_keywords is longer than 8 characters"
     ):

--- a/tests/uvbeam/test_uvbeam.py
+++ b/tests/uvbeam/test_uvbeam.py
@@ -2002,9 +2002,6 @@ def test_select_frequencies(
         frequencies=freqs_to_keep, freq_chans=chans_to_keep, inplace=False
     )
 
-    print(len(all_chans_to_keep))
-    print(beam2.Nfreqs)
-
     assert len(all_chans_to_keep) == beam2.Nfreqs
     for chan in all_chans_to_keep:
         assert beam.freq_array[chan] in beam2.freq_array

--- a/tests/uvbeam/test_uvbeam.py
+++ b/tests/uvbeam/test_uvbeam.py
@@ -2120,12 +2120,12 @@ def test_select_polarizations_errors(cst_efield_1freq):
 
     # check for errors associated with polarizations not included in data
     with pytest.raises(
-        ValueError, match=f"polarization {-3} is not present in the polarization_array"
+        ValueError, match=f"Polarization {-3} is not present in the polarization_array"
     ):
         power_beam.select(polarizations=[-3, -4])
 
     # check for warnings and errors associated with unevenly spaced polarizations
-    with check_warnings(UserWarning, "Selected polarizations are not evenly spaced"):
+    with check_warnings(UserWarning, "Selected polarization values are not evenly"):
         power_beam.select(polarizations=power_beam.polarization_array[[0, 1, 3]])
     write_file_beamfits = os.path.join(DATA_PATH, "test/select_beam.fits")
     with pytest.raises(

--- a/tests/uvcal/test_calfits.py
+++ b/tests/uvcal/test_calfits.py
@@ -425,31 +425,9 @@ def test_extra_keywords_errors(gain_data, tmp_path, ex_val, error_msg):
     keyword = list(ex_val.keys())[0]
     val = ex_val[keyword]
     cal_in.extra_keywords[keyword] = val
-    with check_warnings(
-        UserWarning, match=f"{keyword} in extra_keywords is a list, array or dict"
-    ):
-        cal_in.check()
+    cal_in.check()
     with pytest.raises(TypeError, match=error_msg):
         cal_in.write_calfits(testfile, run_check=False)
-
-    return
-
-
-def test_extra_keywords_warnings(gain_data, tmp_path):
-    cal_in = gain_data
-    testfile = str(tmp_path / "outtest_extrakwd_warn.fits")
-
-    # check for warnings with extra_keywords keys that are too long
-    cal_in.extra_keywords["test_long_key"] = True
-    with check_warnings(
-        UserWarning,
-        match="key test_long_key in extra_keywords is longer than 8 characters",
-    ):
-        cal_in.check()
-    with check_warnings(
-        UserWarning, "key test_long_key in extra_keywords is longer than 8 characters"
-    ):
-        cal_in.write_calfits(testfile, run_check=False, clobber=True)
 
     return
 

--- a/tests/uvcal/test_calfits.py
+++ b/tests/uvcal/test_calfits.py
@@ -632,3 +632,18 @@ def test_calfits_partial_read(gain_data, delay_data, tmp_path, caltype, param_di
         calobj3 = UVCal.from_file(write_file, **param_dict)
 
     assert calobj2 == calobj3
+
+
+def test_extra_keywords_warnings(gain_data, tmp_path):
+    cal_in = gain_data
+    testfile = str(tmp_path / "outtest_extrakwd_warn.fits")
+
+    # check for warnings with extra_keywords keys that are too long
+    cal_in.extra_keywords["test_long_key"] = True
+    with check_warnings(None):
+        cal_in.check()
+
+    with check_warnings(
+        UserWarning, "key test_long_key in extra_keywords is longer than 8 characters"
+    ):
+        cal_in.write_calfits(testfile, run_check=False, clobber=True)

--- a/tests/uvcal/test_calh5.py
+++ b/tests/uvcal/test_calh5.py
@@ -378,4 +378,4 @@ def test_calh5_partial_read(
         calobj2 = calobj.copy()
         param_dict["lsts"] = 2
         with pytest.raises(ValueError, match="LST 2 does not fall in any lst_range"):
-            calobj2.select(**param_dict)
+            calobj2.select(**param_dict, strict=True)

--- a/tests/uvcal/test_fhd_cal.py
+++ b/tests/uvcal/test_fhd_cal.py
@@ -394,13 +394,7 @@ def test_read_multi(tmp_path, concat_method, read_method):
             )
 
     calfits_outfile = str(tmp_path / "outtest_FHDcal_1061311664.calfits")
-    with pytest.raises(
-        ValueError,
-        match=(
-            "The calfits file format does not support time_range when there is more "
-            "than one time."
-        ),
-    ):
+    with pytest.raises(ValueError, match="Object contains multiple time ranges."):
         fhd_cal.write_calfits(calfits_outfile, clobber=True)
 
     outfile = str(tmp_path / "outtest_FHDcal_1061311664.calh5")

--- a/tests/uvcal/test_ms_cal.py
+++ b/tests/uvcal/test_ms_cal.py
@@ -28,8 +28,6 @@ pytestmark = pytest.mark.filterwarnings(
 sma_warnings = [
     "Unknown polarization basis for solutions, jones_array values may be spurious.",
     "Unknown x_orientation basis for solutions, assuming",
-    "key CASA_Version in extra_keywords is longer than 8 characters. "
-    "It will be truncated to 8 if written to a calfits file format.",
     "Setting telescope_location to value in known_telescopes for SMA.",
 ]
 

--- a/tests/uvcal/test_uvcal.py
+++ b/tests/uvcal/test_uvcal.py
@@ -1037,6 +1037,10 @@ def test_select_frequencies_multispw(multi_spw_gain, tmp_path):
     calobj2.write_calfits(write_file_calfits, clobber=True)
 
     calobj3 = calobj.select(spws=[1], inplace=False)
+
+    # We've used different selection criteria, so the history _will_ be different
+    calobj3.history = calobj2.history
+
     assert calobj3 == calobj2
     with check_warnings(UserWarning, match="Cannot select on spws if Nspws=1."):
         calobj3.select(spws=1)
@@ -4457,8 +4461,8 @@ def test_flex_jones_select_err(multi_spw_gain):
     multi_spw_gain += uvc_spoof
     multi_spw_gain.convert_to_flex_jones()
 
-    with pytest.raises(ValueError, match="this Jones selection in this flex-Jones"):
-        multi_spw_gain.select(jones=-6, spws=1)
+    with pytest.raises(ValueError, match="No data matching this Jones term"):
+        multi_spw_gain.select(jones=[-6], spws=1)
 
 
 def test_remove_flex_jones_dup_err(multi_spw_gain):
@@ -4483,8 +4487,8 @@ def test_flex_jones_shuffle(multi_spw_gain, multi_spw_delay, mode):
     uvc += uvc_spoof
     uvc.convert_to_flex_jones()
 
-    uvc1 = uvc.select(jones=-5, inplace=False)
-    uvc2 = uvc.select(jones=-6, inplace=False)
+    uvc1 = uvc.select(jones=[-5], inplace=False)
+    uvc2 = uvc.select(jones=[-6], inplace=False)
 
     assert uvc1 != uvc2
 

--- a/tests/uvcal/test_uvcal.py
+++ b/tests/uvcal/test_uvcal.py
@@ -1496,14 +1496,14 @@ def test_reorder_ants_errors(gain_data):
 
     with pytest.raises(
         ValueError,
-        match="If order is an index array, it must contain all indicies for the"
+        match="If order is an index array, it must contain all indices for the"
         "ant_array, without duplicates.",
     ):
         gain_data.reorder_antennas(gain_data.telescope.antenna_numbers.astype(float))
 
     with pytest.raises(
         ValueError,
-        match="If order is an index array, it must contain all indicies for the"
+        match="If order is an index array, it must contain all indices for the"
         "ant_array, without duplicates.",
     ):
         gain_data.reorder_antennas(gain_data.telescope.antenna_numbers[:8])
@@ -1606,7 +1606,7 @@ def test_reorder_freqs_errors(gain_data, multi_spw_delay):
 
     with pytest.raises(
         ValueError,
-        match="If spw_order is an array, it must contain all indicies for "
+        match="If spw_order is an array, it must contain all indices for "
         "the spw_array, without duplicates.",
     ):
         multi_spw_delay.reorder_freqs(spw_order=[0, 1])
@@ -1620,7 +1620,7 @@ def test_reorder_freqs_errors(gain_data, multi_spw_delay):
 
     with pytest.raises(
         ValueError,
-        match="Index array for channel_order must contain all indicies for "
+        match="Index array for channel_order must contain all indices for "
         "the frequency axis, without duplicates.",
     ):
         gain_data.reorder_freqs(
@@ -1629,7 +1629,7 @@ def test_reorder_freqs_errors(gain_data, multi_spw_delay):
 
     with pytest.raises(
         ValueError,
-        match="Index array for channel_order must contain all indicies for "
+        match="Index array for channel_order must contain all indices for "
         "the frequency axis, without duplicates.",
     ):
         gain_data.reorder_freqs(channel_order=np.arange(3))
@@ -1686,14 +1686,14 @@ def test_reorder_times_errors(gain_data):
 
     with pytest.raises(
         ValueError,
-        match="If order is an array, it must contain all indicies for the time axis, "
+        match="If order is an array, it must contain all indices for the time axis, "
         "without duplicates.",
     ):
         gain_data.reorder_times(np.arange(gain_data.Ntimes) * 2)
 
     with pytest.raises(
         ValueError,
-        match="If order is an array, it must contain all indicies for the time axis, "
+        match="If order is an array, it must contain all indices for the time axis, "
         "without duplicates.",
     ):
         gain_data.reorder_times(np.arange(7))
@@ -1774,14 +1774,14 @@ def test_reorder_jones_errors(gain_data):
 
     with pytest.raises(
         ValueError,
-        match="If order is an array, it must contain all indicies for "
+        match="If order is an array, it must contain all indices for "
         "the jones axis, without duplicates.",
     ):
         calobj.reorder_jones(np.arange(gain_data.Njones) * 2)
 
     with pytest.raises(
         ValueError,
-        match="If order is an array, it must contain all indicies for "
+        match="If order is an array, it must contain all indices for "
         "the jones axis, without duplicates.",
     ):
         calobj.reorder_jones(np.arange(2))

--- a/tests/uvdata/test_mir.py
+++ b/tests/uvdata/test_mir.py
@@ -526,7 +526,7 @@ def test_flex_pol_select(sma_mir_filt):
     sma_mir_filt2 += sma_mir_filt3
 
     with check_warnings(
-        UserWarning, match="Selected polarization values are not evenly spaced"
+        UserWarning, match="Selected polarizations are not evenly spaced"
     ):
         sma_mir_filt2.select(polarizations=["xx", "xy", "yx"])
 
@@ -541,9 +541,7 @@ def test_flex_pol_select_warning(sma_mir_filt):
     sma_mir_filt.flex_spw_polarization_array = np.array([-8, -8, -6, -5])
     sma_mir_filt.Nspws = 4
 
-    with check_warnings(
-        UserWarning, "Selected polarization values are not evenly spaced."
-    ):
+    with check_warnings(UserWarning, "Selected polarizations are not evenly spaced."):
         sma_mir_filt.select(polarizations=[-8, -6, -5])
 
 

--- a/tests/uvdata/test_mir.py
+++ b/tests/uvdata/test_mir.py
@@ -528,7 +528,7 @@ def test_flex_pol_select(sma_mir_filt):
     with check_warnings(
         UserWarning, match="Selected polarizations are not evenly spaced"
     ):
-        sma_mir_filt2.select(polarizations=["xx", "xy", "yx"])
+        sma_mir_filt2.select(polarizations=["xx", "xy", "yx"], warn_spacing=True)
 
 
 def test_flex_pol_select_warning(sma_mir_filt):
@@ -542,7 +542,7 @@ def test_flex_pol_select_warning(sma_mir_filt):
     sma_mir_filt.Nspws = 4
 
     with check_warnings(UserWarning, "Selected polarizations are not evenly spaced."):
-        sma_mir_filt.select(polarizations=[-8, -6, -5])
+        sma_mir_filt.select(polarizations=[-8, -6, -5], warn_spacing=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/uvdata/test_miriad.py
+++ b/tests/uvdata/test_miriad.py
@@ -235,11 +235,6 @@ def test_read_write_read_carma(tmp_path):
                 "using known location values for SZA."
             ),
             warn_dict["uvw_mismatch"],
-            "pamatten in extra_keywords is a list, array or dict",
-            "psys in extra_keywords is a list, array or dict",
-            "psysattn in extra_keywords is a list, array or dict",
-            "ambpsys in extra_keywords is a list, array or dict",
-            "bfmask in extra_keywords is a list, array or dict",
         ],
     ):
         uv_in.read(carma_file)
@@ -306,11 +301,6 @@ def test_read_carma_miriad_write_ms(tmp_path):
                 "using known location values for SZA."
             ),
             warn_dict["uvw_mismatch"],
-            "pamatten in extra_keywords is a list, array or dict",
-            "psys in extra_keywords is a list, array or dict",
-            "psysattn in extra_keywords is a list, array or dict",
-            "ambpsys in extra_keywords is a list, array or dict",
-            "bfmask in extra_keywords is a list, array or dict",
         ],
     ):
         uv_in.read(carma_file)
@@ -329,11 +319,6 @@ def test_read_carma_miriad_write_ms(tmp_path):
         UserWarning,
         [
             warn_dict["uvw_mismatch"],
-            "pamatten in extra_keywords is a list, array or dict",
-            "psys in extra_keywords is a list, array or dict",
-            "psysattn in extra_keywords is a list, array or dict",
-            "ambpsys in extra_keywords is a list, array or dict",
-            "bfmask in extra_keywords is a list, array or dict",
             "Writing in the MS file that the units of the data are",
         ],
     ):
@@ -1059,61 +1044,32 @@ def test_poltoind(uv_in_paper):
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
-    "kwd_name,kwd_value,warnstr,errstr",
+    "kwd_name,kwd_value,errstr",
     (
-        [
-            "testdict",
-            {"testkey": 23},
-            "testdict in extra_keywords is a list, array or dict",
-            "Extra keyword testdict is of <class 'dict'>",
-        ],
-        [
-            "testlist",
-            [12, 14, 90],
-            "testlist in extra_keywords is a list, array or dict",
-            "Extra keyword testlist is of <class 'list'>",
-        ],
+        ["testdict", {"testkey": 23}, "Extra keyword testdict is of <class 'dict'>"],
+        ["testlist", [12, 14, 90], "Extra keyword testlist is of <class 'list'>"],
         [
             "testarr",
             np.array([12, 14, 90]),
-            "testarr in extra_keywords is a list, array or dict",
             "Extra keyword testarr is of <class 'numpy.ndarray'>",
         ],
-        [
-            "test_long_key",
-            True,
-            "key test_long_key in extra_keywords is longer than 8 characters",
-            None,
-        ],
+        ["test_long_key", True, None],
         [
             "complex1",
             np.complex64(5.3 + 1.2j),
-            None,
             "Extra keyword complex1 is of <class 'numpy.complex64'>",
         ],
-        [
-            "complex2",
-            6.9 + 4.6j,
-            None,
-            "Extra keyword complex2 is of <class 'complex'>",
-        ],
+        ["complex2", 6.9 + 4.6j, "Extra keyword complex2 is of <class 'complex'>"],
     ),
 )
-def test_miriad_extra_keywords_errors(
-    uv_in_paper, kwd_name, kwd_value, warnstr, errstr
-):
+def test_miriad_extra_keywords_errors(uv_in_paper, kwd_name, kwd_value, errstr):
     uv_in, _, testfile = uv_in_paper
 
     uvw_warn_str = "The uvw_array does not match the expected values"
 
     # check for warnings & errors with extra_keywords that are dicts, lists or arrays
     uv_in.extra_keywords[kwd_name] = kwd_value
-    if warnstr is None:
-        warnstr_list = [uvw_warn_str]
-    else:
-        warnstr_list = [warnstr, uvw_warn_str]
-
-    with check_warnings(UserWarning, warnstr_list):
+    with check_warnings(UserWarning, uvw_warn_str):
         uv_in.check()
 
     if errstr is not None:

--- a/tests/uvdata/test_ms.py
+++ b/tests/uvdata/test_ms.py
@@ -662,11 +662,6 @@ def test_ms_scannumber_multiphasecenter(tmp_path, multi_frame):
                 "The uvw_array does not match the expected values given the antenna "
                 "positions."
             ),
-            "pamatten in extra_keywords is a list, array or dict",
-            "psys in extra_keywords is a list, array or dict",
-            "psysattn in extra_keywords is a list, array or dict",
-            "ambpsys in extra_keywords is a list, array or dict",
-            "bfmask in extra_keywords is a list, array or dict",
         ],
     ):
         miriad_uv.read(carma_file)

--- a/tests/uvdata/test_mwa_corr_fits.py
+++ b/tests/uvdata/test_mwa_corr_fits.py
@@ -1283,6 +1283,7 @@ def test_read_mwax(benchmark, tmp_path):
     assert mwax_uv == uvfits_uv
 
 
+@pytest.mark.filterwarnings("ignore:some coarse channel files were not submitted")
 @pytest.mark.skipif(not hasbench, reason="benchmark utility not installed")
 def test_corr_fits_select_on_read(benchmark):
     mwa_uv = UVData()
@@ -1311,6 +1312,7 @@ def test_corr_fits_select_on_read(benchmark):
     assert mwa_uv == mwa_uv2
 
 
+@pytest.mark.filterwarnings("ignore:some coarse channel files were not submitted")
 @pytest.mark.skipif(not hasbench, reason="benchmark utility not installed")
 @pytest.mark.parametrize("cheby", [True, False], ids=lambda x: f"cheby={x:}")
 def test_van_vleck(benchmark, cheby):

--- a/tests/uvdata/test_mwa_corr_fits.py
+++ b/tests/uvdata/test_mwa_corr_fits.py
@@ -295,7 +295,6 @@ def test_read_mwa_multi():
     messages = [
         "some coarse channel files were not submitted",
         "some coarse channel files were not submitted",
-        "Combined frequencies are separated by more than their channel width",
     ]
     with check_warnings(UserWarning, messages):
         mwa_uv2.read([set1, set2], file_type="mwa_corr_fits")
@@ -321,7 +320,6 @@ def test_read_mwa_multi_concat(tmp_path):
     messages = [
         "some coarse channel files were not submitted",
         "some coarse channel files were not submitted",
-        "Combined frequencies are separated by more than their channel width",
     ]
     with check_warnings(UserWarning, messages):
         mwa_uv2.read([set1, set2], axis="freq", file_type="mwa_corr_fits")

--- a/tests/uvdata/test_uvdata.py
+++ b/tests/uvdata/test_uvdata.py
@@ -11958,18 +11958,12 @@ def test_remove_flex_pol_no_op_multiple_spws(uv_phase_comp):
     uvd2.flex_spw_id_array[: uvd2.Nfreqs // 3] = 1
     uvd2.flex_spw_id_array[uvd2.Nfreqs // 3 : 2 * (uvd2.Nfreqs // 3)] = 4
     uvd2.flex_spw_id_array[2 * (uvd2.Nfreqs // 3) :] = 5
-    print(np.unique(uvd2.flex_spw_id_array))
-    print(uvd2.spw_array)
     uvd2.check()
     uvd3 = uvd2.copy()
 
     uvd2.convert_to_flex_pol()
-    print(np.unique(uvd2.flex_spw_id_array))
-    print(uvd2.spw_array)
     uvd2.select(polarizations=["xx"])
     uvd2.remove_flex_pol()
-    print(np.unique(uvd2.flex_spw_id_array))
-    print(uvd2.spw_array)
 
     uvd3.select(polarizations=["xx"])
     assert uvd2 == uvd3

--- a/tests/uvdata/test_uvdata.py
+++ b/tests/uvdata/test_uvdata.py
@@ -11917,12 +11917,18 @@ def test_remove_flex_pol_no_op_multiple_spws(uv_phase_comp):
     uvd2.flex_spw_id_array[: uvd2.Nfreqs // 3] = 1
     uvd2.flex_spw_id_array[uvd2.Nfreqs // 3 : 2 * (uvd2.Nfreqs // 3)] = 4
     uvd2.flex_spw_id_array[2 * (uvd2.Nfreqs // 3) :] = 5
+    print(np.unique(uvd2.flex_spw_id_array))
+    print(uvd2.spw_array)
     uvd2.check()
     uvd3 = uvd2.copy()
 
     uvd2.convert_to_flex_pol()
+    print(np.unique(uvd2.flex_spw_id_array))
+    print(uvd2.spw_array)
     uvd2.select(polarizations=["xx"])
     uvd2.remove_flex_pol()
+    print(np.unique(uvd2.flex_spw_id_array))
+    print(uvd2.spw_array)
 
     uvd3.select(polarizations=["xx"])
     assert uvd2 == uvd3

--- a/tests/uvdata/test_uvdata.py
+++ b/tests/uvdata/test_uvdata.py
@@ -3071,9 +3071,9 @@ def test_reorder_blts_sort_order(
 @pytest.mark.parametrize(
     "arg_dict,msg",
     [
-        [{"spord": [1]}, "Index array for spw_order must contain all indicies for"],
+        [{"spord": [1]}, "Index array for spw_order must contain all indices for"],
         [{"spord": "karto"}, "spw_order can only be one of 'number', '-number',"],
-        [{"chord": [1]}, "Index array for channel_order must contain all indicies"],
+        [{"chord": [1]}, "Index array for channel_order must contain all indices"],
         [{"chord": "karto"}, "channel_order can only be one of 'freq' or '-freq'"],
     ],
 )

--- a/tests/uvdata/test_uvdata.py
+++ b/tests/uvdata/test_uvdata.py
@@ -1558,9 +1558,8 @@ def test_select_antennas(casa_uvfits, invert, use_names, higher_dim, keep_meta):
         uv_object.telescope.antenna_names = np.array(uv_object.telescope.antenna_names)
         orig_telescope.antenna_names = np.array(orig_telescope.antenna_names)
         for param in ["_antenna_names", "_antenna_positions"]:
-            assert (
-                getattr(uv_object.telescope, param)
-                == (getattr(orig_telescope, param[1:])[mask])
+            assert getattr(uv_object.telescope, param).compare_value(
+                getattr(orig_telescope, param[1:])[mask]
             )
         assert np.asarray(uv_object.telescope)
 

--- a/tests/uvdata/test_uvdata.py
+++ b/tests/uvdata/test_uvdata.py
@@ -12562,3 +12562,29 @@ def test_pol_convention_warnings(hera_uvh5):
         ValueError, match="pol_convention is set but the data is uncalibrated"
     ):
         hera_uvh5.check()
+
+
+def test_select_no_bls_match(sma_mir):
+    # Test a particular corner-case with the bls to make sure that the resultant
+    # error is on baselines and _not_ polarizations
+    with (
+        pytest.raises(ValueError, match="No baseline-times were found that match"),
+        check_warnings(UserWarning, match=re.escape("Antenna pair (10, 20, 'xx')")),
+    ):
+        sma_mir.select(bls=(10, 20, "xx"), strict=False)
+
+
+@pytest.mark.parametrize("invert", [True, False])
+def test_select_partial_spw_match(sma_mir, invert):
+    with check_warnings(UserWarning, match="SPW number 5 is not present"):
+        sma_mir.select(spws=[1, 2, 3, 4, 5], invert=invert)
+
+    assert np.all(np.isin(sma_mir.spw_array, [1, 2, 3, 4], invert=invert))
+
+
+@pytest.mark.parametrize("invert", [True, False])
+def test_select_partial_pol_match(sma_mir, invert):
+    with check_warnings(UserWarning, match="Polarization xy is not present"):
+        sma_mir.select(polarizations=["xx", "xy"], invert=invert)
+
+    assert np.all(np.isin(sma_mir.polarization_array, [-5], invert=invert))

--- a/tests/uvdata/test_uvdata.py
+++ b/tests/uvdata/test_uvdata.py
@@ -1498,8 +1498,7 @@ def test_select_antennas(casa_uvfits, invert, use_names, higher_dim, keep_meta):
     uv_object.telescope.antenna_diameters = np.arange(
         uv_object.telescope.Nants, dtype=np.float64
     )
-    if keep_meta:
-        orig_telescope = uv_object.telescope.copy()
+    orig_telescope = uv_object.telescope.copy()
 
     ants_to_keep = np.array([1, 20, 12, 25, 4, 24, 2, 21, 22])
 
@@ -1555,13 +1554,13 @@ def test_select_antennas(casa_uvfits, invert, use_names, higher_dim, keep_meta):
         assert uv_object.telescope.Nants == len(ants_to_keep)
         assert all(np.isin(uv_object.telescope.antenna_numbers, ants_to_keep))
         # Make an array to make comparison easier w/ mask
-        mask = np.isin(uv_object.telescope.antenna_numbers, ants_to_keep)
+        mask = np.isin(orig_telescope.antenna_numbers, ants_to_keep)
         uv_object.telescope.antenna_names = np.array(uv_object.telescope.antenna_names)
-        uv_object.telescope.antenna_names = np.array(uv_object.telescope.antenna_names)
+        orig_telescope.antenna_names = np.array(orig_telescope.antenna_names)
         for param in ["_antenna_names", "_antenna_positions"]:
             assert (
                 getattr(uv_object.telescope, param)
-                == (getattr(uv_object.telescope, param[1:])[mask])
+                == (getattr(orig_telescope, param[1:])[mask])
             )
         assert np.asarray(uv_object.telescope)
 

--- a/tests/uvdata/test_uvdata.py
+++ b/tests/uvdata/test_uvdata.py
@@ -3637,7 +3637,6 @@ def test_add(casa_uvfits, hera_uvh5_xx):
                 "The uvw_array does not match the expected values given the antenna "
                 "positions."
             ),
-            "Combined frequencies are not evenly spaced",
             (
                 "The uvw_array does not match the expected values given the antenna "
                 "positions."
@@ -3661,7 +3660,6 @@ def test_add(casa_uvfits, hera_uvh5_xx):
                 "The uvw_array does not match the expected values given the antenna "
                 "positions."
             ),
-            "Combined frequencies are separated by more than their channel width.",
             (
                 "The uvw_array does not match the expected values given the antenna "
                 "positions."
@@ -3935,18 +3933,13 @@ def test_add_unprojected(casa_uvfits):
     uv2 = uv_full.copy()
     uv1.select(freq_chans=np.arange(0, 32))
     uv2.select(freq_chans=np.arange(33, 64))
-    with check_warnings(UserWarning, "Combined frequencies are not evenly spaced"):
-        uv1.__add__(uv2)
+    uv1.__add__(uv2)
 
     uv1 = uv_full.copy()
     uv2 = uv_full.copy()
     uv1.select(freq_chans=[0])
     uv2.select(freq_chans=[3])
-    with check_warnings(
-        UserWarning,
-        ["Combined frequencies are separated by more than their channel width"],
-    ):
-        uv1.__iadd__(uv2)
+    uv1.__iadd__(uv2)
 
     uv1 = uv_full.copy()
     uv2 = uv_full.copy()
@@ -4198,8 +4191,7 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx):
             "The uvw_array does not match the expected values given the antenna "
             "positions."
         ]
-        * 4
-        + ["Combined frequencies are not evenly spaced"],
+        * 4,
     ):
         uv2.fast_concat([uv1, uv3], "freq", inplace=True)
 
@@ -4248,8 +4240,7 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx):
             "The uvw_array does not match the expected values given the antenna "
             "positions."
         ]
-        * 4
-        + ["Combined polarizations are not evenly spaced"],
+        * 4,
     ):
         uv2.fast_concat([uv1, uv3], "polarization", inplace=True)
 
@@ -4435,7 +4426,6 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx):
                 "The uvw_array does not match the expected values given the antenna "
                 "positions."
             ),
-            "Combined frequencies are not evenly spaced",
             (
                 "The uvw_array does not match the expected values given the antenna "
                 "positions."
@@ -4459,7 +4449,6 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx):
                 "The uvw_array does not match the expected values given the antenna "
                 "positions."
             ),
-            "Combined frequencies are separated by more than their channel width",
             (
                 "The uvw_array does not match the expected values given the antenna "
                 "positions."
@@ -4495,7 +4484,6 @@ def test_fast_concat(casa_uvfits, hera_uvh5_xx):
                 "The uvw_array does not match the expected values given the antenna "
                 "positions."
             ),
-            "Combined polarizations are not evenly spaced",
             (
                 "The uvw_array does not match the expected values given the antenna "
                 "positions."
@@ -11795,11 +11783,6 @@ def test_set_nsamples_wrong_shape_error(hera_uvh5):
                     "The uvw_array does not match the expected values given the antenna"
                     " positions."
                 ),
-            ]
-            + [
-                f"{extra_key} in extra_keywords is a list, array or dict, which will "
-                "raise an error when writing uvfits or miriad file types"
-                for extra_key in ["pamatten", "psys", "psysattn", "ambpsys", "bfmask"]
             ],
         ],
         [

--- a/tests/uvdata/test_uvdata.py
+++ b/tests/uvdata/test_uvdata.py
@@ -2443,6 +2443,34 @@ def test_select_freq_chans(casa_uvfits):
         assert f in uv_object.freq_array[all_chans_to_keep]
 
 
+def test_select_spws(sma_mir):
+    sma_copy1 = sma_mir.copy()
+    sma_copy2 = sma_mir.copy()
+    sma_copy3 = sma_mir.copy()
+
+    sma_mir.select(spws=[-4, -3, -2, -1], inplace=True)
+    sma_copy1.select(spws=[1, 2, 3, 4], invert=True, inplace=True)
+
+    assert sma_mir == sma_copy1
+
+    sma_copy2.select(freq_chans=np.arange(4 * 16384))
+
+    # Histories should be different, since one was spws, the other was freqs
+    assert sma_mir.history != sma_copy2.history
+    assert "Downselected to specific spectral windows" in sma_mir.history
+    sma_mir.__eq__(sma_copy2, allowed_failures=["history"])
+
+    # Test list handling
+    sma_copy3.spw_array = sma_copy3.spw_array.tolist()
+    sma_copy3.select(freq_chans=np.arange(4 * 16384, 8 * 16384), invert=True)
+    sma_copy3.spw_array = np.asarray(sma_copy3.spw_array)
+
+    assert sma_mir.history != sma_copy3.history
+    assert "Downselected to specific frequencies" in sma_copy3.history
+    sma_mir.__eq__(sma_copy3, allowed_failures=["history"])
+    assert sma_copy3 == sma_copy2
+
+
 @pytest.mark.filterwarnings("ignore:Telescope EVLA is not")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(

--- a/tests/uvdata/test_uvfits.py
+++ b/tests/uvdata/test_uvfits.py
@@ -1024,12 +1024,8 @@ def test_extra_keywords_errors(
     uvw_warn_str = "The uvw_array does not match the expected values"
     # check for warnings & errors with extra_keywords that are dicts, lists or arrays
     uv_in.extra_keywords[kwd_name] = kwd_value
-    if warnstr is None:
-        warnstr_list = [uvw_warn_str]
-    else:
-        warnstr_list = [warnstr, uvw_warn_str]
 
-    with check_warnings(UserWarning, match=warnstr_list):
+    with check_warnings(UserWarning, match=uvw_warn_str):
         uv_in.check()
 
     if errstr is not None:

--- a/tests/uvdata/test_uvh5.py
+++ b/tests/uvdata/test_uvh5.py
@@ -3238,7 +3238,7 @@ def test_write_uvh5_part_fix_autos(uv_uvh5, tmp_path):
     test_uvh5 = UVData()
     testfile = os.path.join(tmp_path, "write_uvh5_part_fix_autos.uvh5")
 
-    # Select out the relevant data (where the 0 and 1 indicies of the pol array
+    # Select out the relevant data (where the 0 and 1 indices of the pol array
     # correspond to xx and yy polarization data), and corrupt it accordingly
     auto_data = uv_uvh5.data_array[uv_uvh5.ant_1_array == uv_uvh5.ant_2_array]
     auto_data[:, :, [0, 1]] *= 1j

--- a/tests/uvdata/test_uvh5.py
+++ b/tests/uvdata/test_uvh5.py
@@ -1389,15 +1389,14 @@ def test_uvh5_partial_write_irregular_multi1(uv_partial_write, tmp_path):
             data[iblt, ifreq, :] = full_uvh5.data_array[blt_idx, freq_idx, :]
             flags[iblt, ifreq, :] = full_uvh5.flag_array[blt_idx, freq_idx, :]
             nsamples[iblt, ifreq, :] = full_uvh5.nsample_array[blt_idx, freq_idx, :]
-    with check_warnings(UserWarning, "Selected frequencies are not evenly spaced"):
-        partial_uvh5.write_uvh5_part(
-            partial_testfile,
-            data_array=data,
-            flag_array=flags,
-            nsample_array=nsamples,
-            blt_inds=blt_inds,
-            freq_chans=freq_inds,
-        )
+    partial_uvh5.write_uvh5_part(
+        partial_testfile,
+        data_array=data,
+        flag_array=flags,
+        nsample_array=nsamples,
+        blt_inds=blt_inds,
+        freq_chans=freq_inds,
+    )
 
     # also write the arrays to the partial object
     for iblt, blt_idx in enumerate(blt_inds):
@@ -1460,21 +1459,14 @@ def test_uvh5_partial_write_irregular_multi2(uv_partial_write, tmp_path):
             data[:, ifreq, ipol] = full_uvh5.data_array[:, freq_idx, pol_idx]
             flags[:, ifreq, ipol] = full_uvh5.flag_array[:, freq_idx, pol_idx]
             nsamples[:, ifreq, ipol] = full_uvh5.nsample_array[:, freq_idx, pol_idx]
-    with check_warnings(
-        UserWarning,
-        [
-            "Selected frequencies are not evenly spaced",
-            "Selected polarization values are not evenly spaced",
-        ],
-    ):
-        partial_uvh5.write_uvh5_part(
-            partial_testfile,
-            data_array=data,
-            flag_array=flags,
-            nsample_array=nsamples,
-            freq_chans=freq_inds,
-            polarizations=full_uvh5.polarization_array[pol_inds],
-        )
+    partial_uvh5.write_uvh5_part(
+        partial_testfile,
+        data_array=data,
+        flag_array=flags,
+        nsample_array=nsamples,
+        freq_chans=freq_inds,
+        polarizations=full_uvh5.polarization_array[pol_inds],
+    )
 
     # also write the arrays to the partial object
     for ifreq, freq_idx in enumerate(freq_inds):
@@ -1537,17 +1529,14 @@ def test_uvh5_partial_write_irregular_multi3(uv_partial_write, tmp_path):
             data[iblt, :, ipol] = full_uvh5.data_array[blt_idx, :, pol_idx]
             flags[iblt, :, ipol] = full_uvh5.flag_array[blt_idx, :, pol_idx]
             nsamples[iblt, :, ipol] = full_uvh5.nsample_array[blt_idx, :, pol_idx]
-    with check_warnings(
-        UserWarning, "Selected polarization values are not evenly spaced"
-    ):
-        partial_uvh5.write_uvh5_part(
-            partial_testfile,
-            data_array=data,
-            flag_array=flags,
-            nsample_array=nsamples,
-            blt_inds=blt_inds,
-            polarizations=full_uvh5.polarization_array[pol_inds],
-        )
+    partial_uvh5.write_uvh5_part(
+        partial_testfile,
+        data_array=data,
+        flag_array=flags,
+        nsample_array=nsamples,
+        blt_inds=blt_inds,
+        polarizations=full_uvh5.polarization_array[pol_inds],
+    )
 
     # also write the arrays to the partial object
     for iblt, blt_idx in enumerate(blt_inds):
@@ -1615,22 +1604,15 @@ def test_uvh5_partial_write_irregular_multi4(uv_partial_write, tmp_path):
                 nsamples[iblt, ifreq, ipol] = full_uvh5.nsample_array[
                     blt_idx, freq_idx, pol_idx
                 ]
-    with check_warnings(
-        UserWarning,
-        [
-            "Selected frequencies are not evenly spaced",
-            "Selected polarization values are not evenly spaced",
-        ],
-    ):
-        partial_uvh5.write_uvh5_part(
-            partial_testfile,
-            data_array=data,
-            flag_array=flags,
-            nsample_array=nsamples,
-            blt_inds=blt_inds,
-            freq_chans=freq_inds,
-            polarizations=full_uvh5.polarization_array[pol_inds],
-        )
+    partial_uvh5.write_uvh5_part(
+        partial_testfile,
+        data_array=data,
+        flag_array=flags,
+        nsample_array=nsamples,
+        blt_inds=blt_inds,
+        freq_chans=freq_inds,
+        polarizations=full_uvh5.polarization_array[pol_inds],
+    )
 
     # also write the arrays to the partial object
     for iblt, blt_idx in enumerate(blt_inds):
@@ -2752,15 +2734,14 @@ def test_uvh5_partial_write_ints_irregular_multi1(uv_uvh5, tmp_path):
             data[iblt, ifreq, :] = full_uvh5.data_array[blt_idx, freq_idx, :]
             flags[iblt, ifreq, :] = full_uvh5.flag_array[blt_idx, freq_idx, :]
             nsamples[iblt, ifreq, :] = full_uvh5.nsample_array[blt_idx, freq_idx, :]
-    with check_warnings(UserWarning, "Selected frequencies are not evenly spaced"):
-        partial_uvh5.write_uvh5_part(
-            partial_testfile,
-            data_array=data,
-            flag_array=flags,
-            nsample_array=nsamples,
-            blt_inds=blt_inds,
-            freq_chans=freq_inds,
-        )
+    partial_uvh5.write_uvh5_part(
+        partial_testfile,
+        data_array=data,
+        flag_array=flags,
+        nsample_array=nsamples,
+        blt_inds=blt_inds,
+        freq_chans=freq_inds,
+    )
 
     # also write the arrays to the partial object
     for iblt, blt_idx in enumerate(blt_inds):
@@ -2822,21 +2803,14 @@ def test_uvh5_partial_write_ints_irregular_multi2(uv_uvh5, tmp_path):
             data[:, ifreq, ipol] = full_uvh5.data_array[:, freq_idx, pol_idx]
             flags[:, ifreq, ipol] = full_uvh5.flag_array[:, freq_idx, pol_idx]
             nsamples[:, ifreq, ipol] = full_uvh5.nsample_array[:, freq_idx, pol_idx]
-    with check_warnings(
-        UserWarning,
-        [
-            "Selected frequencies are not evenly spaced",
-            "Selected polarization values are not evenly spaced",
-        ],
-    ):
-        partial_uvh5.write_uvh5_part(
-            partial_testfile,
-            data_array=data,
-            flag_array=flags,
-            nsample_array=nsamples,
-            freq_chans=freq_inds,
-            polarizations=full_uvh5.polarization_array[pol_inds],
-        )
+    partial_uvh5.write_uvh5_part(
+        partial_testfile,
+        data_array=data,
+        flag_array=flags,
+        nsample_array=nsamples,
+        freq_chans=freq_inds,
+        polarizations=full_uvh5.polarization_array[pol_inds],
+    )
 
     # also write the arrays to the partial object
     for ifreq, freq_idx in enumerate(freq_inds):
@@ -2897,17 +2871,14 @@ def test_uvh5_partial_write_ints_irregular_multi3(uv_uvh5, tmp_path):
             data[iblt, :, ipol] = full_uvh5.data_array[blt_idx, :, pol_idx]
             flags[iblt, :, ipol] = full_uvh5.flag_array[blt_idx, :, pol_idx]
             nsamples[iblt, :, ipol] = full_uvh5.nsample_array[blt_idx, :, pol_idx]
-    with check_warnings(
-        UserWarning, "Selected polarization values are not evenly spaced"
-    ):
-        partial_uvh5.write_uvh5_part(
-            partial_testfile,
-            data_array=data,
-            flag_array=flags,
-            nsample_array=nsamples,
-            blt_inds=blt_inds,
-            polarizations=full_uvh5.polarization_array[pol_inds],
-        )
+    partial_uvh5.write_uvh5_part(
+        partial_testfile,
+        data_array=data,
+        flag_array=flags,
+        nsample_array=nsamples,
+        blt_inds=blt_inds,
+        polarizations=full_uvh5.polarization_array[pol_inds],
+    )
 
     # also write the arrays to the partial object
     for iblt, blt_idx in enumerate(blt_inds):
@@ -2976,22 +2947,15 @@ def test_uvh5_partial_write_ints_irregular_multi4(uv_uvh5, tmp_path):
                 nsamples[iblt, ifreq, ipol] = full_uvh5.nsample_array[
                     blt_idx, freq_idx, pol_idx
                 ]
-    with check_warnings(
-        UserWarning,
-        [
-            "Selected frequencies are not evenly spaced",
-            "Selected polarization values are not evenly spaced",
-        ],
-    ):
-        partial_uvh5.write_uvh5_part(
-            partial_testfile,
-            data_array=data,
-            flag_array=flags,
-            nsample_array=nsamples,
-            blt_inds=blt_inds,
-            freq_chans=freq_inds,
-            polarizations=full_uvh5.polarization_array[pol_inds],
-        )
+    partial_uvh5.write_uvh5_part(
+        partial_testfile,
+        data_array=data,
+        flag_array=flags,
+        nsample_array=nsamples,
+        blt_inds=blt_inds,
+        freq_chans=freq_inds,
+        polarizations=full_uvh5.polarization_array[pol_inds],
+    )
 
     # also write the arrays to the partial object
     for iblt, blt_idx in enumerate(blt_inds):

--- a/tests/uvflag/test_uvflag.py
+++ b/tests/uvflag/test_uvflag.py
@@ -3354,7 +3354,7 @@ def test_select_blt_inds_errors(input_uvf, uvf_mode, select_kwargs, err_msg):
         err_msg = 'Only "baseline" mode UVFlag objects may select along the blt axis'
 
     with pytest.raises(ValueError, match=err_msg):
-        uvf.select(**select_kwargs)
+        uvf.select(strict=True, **select_kwargs)
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
@@ -3426,7 +3426,15 @@ def test_select_antenna_nums_error(input_uvf, uvf_mode):
     with pytest.raises(
         ValueError, match=re.escape("Antenna number [708] is not present")
     ):
-        uvf.select(antenna_nums=[708, 9, 10])
+        uvf.select(antenna_nums=[708, 9, 10], strict=True)
+
+    if uvf.type == "antenna":
+        msg = "No data matching this antenna selection exists."
+    else:
+        msg = "No baseline-times were found that match criteria"
+
+    with pytest.raises(ValueError, match=msg):
+        uvf.select(antenna_nums=708, strict=None)
 
 
 def sort_bl(p):
@@ -3605,7 +3613,12 @@ def test_select_times(input_uvf, uvf_mode):
     with pytest.raises(
         ValueError, match=f"Time {bad_time[0]} is not present in the time_array"
     ):
-        uvf.select(times=bad_time)
+        uvf.select(times=bad_time, strict=True)
+
+    with pytest.raises(
+        ValueError, match="No data matching this time selection present in object."
+    ):
+        uvf.select(times=bad_time, strict=None)
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
@@ -3670,7 +3683,12 @@ def test_select_frequencies(input_uvf, uvf_mode):
     with pytest.raises(
         ValueError, match=f"Frequency {bad_freq[0]} is not present in the freq_array"
     ):
-        uvf.select(frequencies=bad_freq)
+        uvf.select(frequencies=bad_freq, strict=True)
+
+    with pytest.raises(
+        ValueError, match="No data matching this frequency selection exists."
+    ):
+        uvf.select(frequencies=bad_freq, strict=None)
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
@@ -3783,7 +3801,12 @@ def test_select_polarizations(uvf_mode, pols_to_keep, input_uvf):
     with pytest.raises(
         ValueError, match="Polarization -3 is not present in the polarization_array"
     ):
-        uvf2.select(polarizations=[-3])
+        uvf2.select(polarizations=[-3], strict=True)
+
+    with pytest.raises(
+        ValueError, match="No data matching this polarization selection exists."
+    ):
+        uvf2.select(polarizations=-3, strict=None)
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")

--- a/tests/uvflag/test_uvflag.py
+++ b/tests/uvflag/test_uvflag.py
@@ -1101,7 +1101,7 @@ def test_read_write_loop_missing_telescope_info(
     if uv_mod is None:
         if param_list == ["antenna_names"]:
             assert not np.array_equal(
-                uvf2.telescope.antenna_names, uvf.telescope.antenna_numbers
+                uvf2.telescope.antenna_names, uvf.telescope.antenna_names
             )
             uvf2.telescope.antenna_names = uvf.telescope.antenna_names
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `select` method of `UVData`, `UVCal`, `UVFlag`, and `UVBeam` have been refactored, and two new additional keywords added:
- `invert`: Allows you to specify which pieces of the object to _discard_ rather than preserve.
- `strict`: Allows you to adjust the error level [Exception / Warning / None] when supplying arguments that don't completely match object parameters (e.g., you give 3 times but only 2 match in `time_array`).

As part of this, several of the selection helper functions inside of utils have been refactored (and in some cases, new helper functions added), with several common pieces of code moved to `utils.tools`.

Additionally, a new method has been added to `UVBase` called `_select_along_param_axis`, which migrated code that used to be found in e.g., `UVData._select_by_index`, which allows users to perform a selection on UVParamters based on their expected form and a provided index array.

Finally, several warnings related to compatibility to FITS-formatted file type have been removed, specifically those related to length of elements in `extra_keywords`, as well as frequency and time spacing.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Well, this was definitely a case of learning to be wary of pulling particular threads...

The original motivation for this was aimed at providing an easy way to deselect entries (i.e., invert selection, a la #988), since this would be desirable for at least some SMA use cases. Attempting to add that was a little difficult with several of the select-helper functions, so I decide to take a heavy pass through them and try to clean them up. To add that, it made sense to modify the default behavior of select to _not_ throw an error if some-but-not-all selection criteria matched supplied parameters (I was originally only going to enable this for the invert selection case, but upon rediscovering #1401 I made it work for the general select case). While I was working on this, I also discovered a lot of common code in `UVData._select_by_index` and `UVCal._select_by_index`, and so I moved that over to a new function called `UVBase._select_along_param_axis`, which should also be accessible to `UVFlag` and `UVBeam` (and be reasonably well-optimized).

Additionally, since i was already tinkering in the code, I have removed several warnings that were popping up when `select` was called related to time/frequency spacing and incompatibility with FITS-formatted file types. These warnings have caused a fair amount of confusion with SMA users, who are not writing to any of these types. Moreover, some of these warnings have been spurious, in that no user actions have caused this incompatibility, but rather the underlying data set itself is intrinsically incompatible with these file types. As it falls in the same vein, I've also taken the opportunity to address #1519, to additionally remove lots of extra noisy warnings. 

Two notes:
- ~I'm marking this as draft for now until I can touch base on the change of behavior here with `select`. The amount of additional work needed is _relatively_ small (particularly as some test coverage is already provided, though how many additional test cases are needed could use some discussion).~ (all work is complete, tests added)

- I'm marking this as a "breaking change", in that it is a change in behavior, although the new behaviors were things that would previously error or otherwise require a keyword to be set. ~Note that hera_cal is currently failing because it's trying to catch a particular error and a different one is being thrown (right type, wrong text).~ (this is now fixed)

Closes #988 
Closes #1401 
Closes #1519 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Breaking change checklist:
- [x] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to reflect my changes (if appropriate).
- [x] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
