### PR TITLE
Fix version for editable (developer) installs

### DIFF
--- a/.github/workflows/macosx_windows_ci.yaml
+++ b/.github/workflows/macosx_windows_ci.yaml
@@ -66,8 +66,8 @@ jobs:
         run: |
           python -m pytest -n auto --dist=loadfile --cov=pyuvdata --cov-config=.coveragerc --cov-report xml:./coverage.xml
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
-          file: ./coverage.xml #optional
+          files: ./coverage.xml #optional

--- a/.github/workflows/warning_test.yaml
+++ b/.github/workflows/warning_test.yaml
@@ -45,8 +45,8 @@ jobs:
         run: |
           pytest -W error -n auto --cov=pyuvdata --cov-config=.coveragerc --cov-report xml:coverage.xml
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
-          file: ./coverage.xml #optional
+          files: ./coverage.xml #optional

--- a/src/pyuvdata/__init__.py
+++ b/src/pyuvdata/__init__.py
@@ -28,9 +28,12 @@ def branch_scheme(version):  # pragma: nocover
             return version.format_choice("+{node}.{branch}", "+{node}.{branch}.dirty")
 
 
-try:  # pragma: nocover
+try:
     # get accurate version for developer installs
-    version_str = get_version(Path(__file__).parent.parent, local_scheme=branch_scheme)
+    # must point to folder that contains the .git file!
+    version_str = get_version(
+        Path(__file__).parent.parent.parent, local_scheme=branch_scheme
+    )
 
     __version__ = version_str
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I recently discovered that versions were not being properly set for editable installs. This was caused by not updating the code handling this in `__init__.py` when we moved to the `src` layout. This also explains why these lines weren't being covered by tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
