### PR TITLE
Fixed sum_vis handling of different filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ compared and `UVParameter.value` share the same class.
 and `UVBeam.check`.
 
 ### Fixed
+- Bug in `UVData.sum_vis` where it errored if there were different filenames on
+the input objects. Now the filename lists are combined on the output object.
 - Bug in `UVBeam.select` where `polarization_array` could be incorrectly ordered after
 selection (if input to `polarizations` keyword was unordered).
 

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -6297,7 +6297,7 @@ class UVData(UVBase):
         Sum visibilities between two UVData objects.
 
         By default requires that all UVParameters are the same on the two objects
-        except for `history`, `data_array`, and `extra_keywords`.
+        except for `history`, `data_array`, `extra_keywords` and `filename`.
         If keys in `extra_keywords` have different values the values from the first
         object are taken.
 
@@ -6372,7 +6372,7 @@ class UVData(UVBase):
         )
 
         compatibility_params = list(this.__iter__())
-        remove_params = ["_history", "_data_array", "_extra_keywords"]
+        remove_params = ["_history", "_data_array", "_extra_keywords", "_filename"]
 
         # Add underscores to override_params to match list from __iter__()
         # Add to parameters to be removed
@@ -6445,6 +6445,7 @@ class UVData(UVBase):
 
         # merge file names
         this.filename = utils.tools._combine_filenames(this.filename, other.filename)
+        this._filename.form = (len(this.filename),)
 
         # Check final object is self-consistent
         if run_check:

--- a/tests/uvdata/test_uvdata.py
+++ b/tests/uvdata/test_uvdata.py
@@ -3289,6 +3289,7 @@ def test_sum_vis(casa_uvfits):
     uv_half.data_array = uv_full.data_array / 2
     uv_half_mod = uv_half.copy()
     uv_half_mod.history += " testing the history. "
+    uv_half_mod.filename = ["foo.uvfits"]
     uv_summed = uv_half.sum_vis(uv_half_mod)
 
     assert np.array_equal(uv_summed.data_array, uv_full.data_array)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Properly handle different filenames on input objects in `UVData.sum_vis`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes #1360

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
