### PR TITLE
Fix bug in constructing off-zenith MWA beams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ compared and `UVParameter.value` share the same class.
 and `UVBeam.check`.
 
 ### Fixed
+- Bug in MWA beams that caused beams pointed away from zenith to be wrong because
+the delays were not assigned to the right dipoles.
 - Bug in `UVData.sum_vis` where it errored if there were different filenames on
 the input objects. Now the filename lists are combined on the output object.
 - Bug in `UVBeam.select` where `polarization_array` could be incorrectly ordered after

--- a/src/pyuvdata/uvbeam/mwa_beam.py
+++ b/src/pyuvdata/uvbeam/mwa_beam.py
@@ -265,7 +265,7 @@ class MWABeam(UVBeam):
 
         pol_names = sorted(pol_names)
 
-        dipole_names = np.array(sorted(dipole_names))
+        dipole_names = np.sort(np.asarray(list(dipole_names), dtype=int)).astype(str)
 
         freqs_hz = np.array(sorted(freqs_hz))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Off zenith beams made no sense. This was initially reported to me by Jack Line, and he suggested it might be a dipole sorting issue. Turns out he was exactly correct. I was sorting the dipoles as strings rather than integers, so dipoles 10-15 were sorting before dipole 2. This fixes that problem and adds tests to prevent this kind of thing from happening again.

Here are plots for delays of [0 2 4 6 0 2 4 6 0 2 4 6 0 2 4 6] (eastward pointing).

Prior to fix:

<img width="622" alt="Screenshot 2025-04-02 at 2 19 14 PM" src="https://github.com/user-attachments/assets/0fac4a74-566c-4622-8502-577b235a5af2" />
<img width="654" alt="Screenshot 2025-04-02 at 2 19 19 PM" src="https://github.com/user-attachments/assets/16db248a-63c8-4b4e-aa03-3931bfbc3169" />

After fix:

<img width="611" alt="Screenshot 2025-04-02 at 2 17 50 PM" src="https://github.com/user-attachments/assets/343bb715-09b6-4172-9bdb-973d8cd1fc43" />
<img width="624" alt="Screenshot 2025-04-02 at 2 18 00 PM" src="https://github.com/user-attachments/assets/24842fe4-6e13-4850-872e-7757f59e3303" />

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
