### PR TITLE
Fix to x-orientation determination feed wrapped values of `Telescope.feed_array`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- A bug where the `Telescope.get_x_orientation` would not return `"east"` or `"north"`
+if the feed angles if outside of the range of 0 to 90 degrees (e.g. 180 and 270 degrees
+for x- and y-polarization should return "north".).
 - A bug in reading in uvfits files with baseline coordinates that have the '--' suffix,
 which is allowed in uvfits files.
 - A bug in reading in uvfits files where the antenna frame is given by an arbitrary

--- a/src/pyuvdata/utils/pol.py
+++ b/src/pyuvdata/utils/pol.py
@@ -922,6 +922,10 @@ def get_x_orientation_from_feeds(feed_array, feed_angle, tols=None):
 
     x_mask = np.isin(feed_array, ["x", "X"])
 
+    # Wrap the feed angle so that everything lands between -45 deg and +135 deg. This
+    # is done to prevent either 0 or 90 deg to be right on the "boundary" of the wrap.
+    feed_angle = np.mod(np.asarray(feed_angle) + (np.pi / 4), np.pi) - (np.pi / 4)
+
     # Anything that's not 'x' should be oriented straight up (0 deg) for "east"
     # orientation, otherwise at -90 deg for "north".
     if np.allclose(feed_angle, np.where(x_mask, np.pi / 2, 0), rtol=rtol, atol=atol):

--- a/tests/test_telescopes.py
+++ b/tests/test_telescopes.py
@@ -455,6 +455,20 @@ def test_passing_xorient(simplest_working_params, xorient):
         assert tel.get_x_orientation_from_feeds() == name
 
 
+@pytest.mark.parametrize("xorient", ["e", "n", "east", "NORTH"])
+@pytest.mark.parametrize("feed_angle_offset", [-np.pi, 0, np.pi])
+def test_x_orient_wrap(simplest_working_params, xorient, feed_angle_offset):
+    with check_warnings(UserWarning, "Unknown polarization basis"):
+        tel = Telescope.new(
+            x_orientation=xorient, mount_type=["fixed"] * 3, **simplest_working_params
+        )
+
+    tel.feed_angle += feed_angle_offset
+
+    name = "east" if xorient.lower().startswith("e") else "north"
+    assert tel.get_x_orientation_from_feeds() == name
+
+
 def test_xorient_dep_warning(simplest_working_params):
     tel = Telescope.new(
         feeds=["x", "y"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes `utils.pol.get_x_orientation` (used by `Telescope.get_x_orientation` to permit "wrapped" values of feed angles to be "east" or "north" x-oriented. E.g., if a telescope with linear feeds had x- and y-polarized feeds with angles of pi and 3 pi / 2, respectively, the old method returned `None` whereas the new method returns `"east"`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes an issue seen in testing w/ pyuvsim.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

