### PR TITLE
Initial editorial tweaks for JOSS paper

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -1,6 +1,6 @@
 @TECHREPORT{aipy,
   author = {Aaron Parsons},
-  title = {Astronomical Interferometry in PYthon},
+  title = {Astronomical Interferometry in {Python}},
   year = {2007},
   file = {http://astro.berkeley.edu/~aparsons/aipy.pdf},
   url = {https://casper.berkeley.edu/astrobaki/index.php/AIPY}}
@@ -27,7 +27,7 @@
 
 @INPROCEEDINGS{miriad,
   author = {{Sault}, R.~J. and {Teuben}, P.~J. and {Wright}, M.~C.~H.},
-  title = "{A Retrospective View of MIRIAD}",
+  title = {A Retrospective View of {MIRIAD}},
   booktitle = {Astronomical Data Analysis Software and Systems IV},
   abstract = {Miriad is a radio interferometry data-reduction package, designed
               for taking raw data through to the image analysis stage. The
@@ -62,8 +62,8 @@
 	          {Tingay}, S.~J. and {Wayth}, R.~B. and {Waterson}, M. and {Webster}, R.~L. and
 	          {Whitney}, A.~R. and {Williams}, A. and {Williams}, C.~L. and
 	          {Wyithe}, J.~S.~B.},
-  title = "{Fast Holographic Deconvolution: A New Technique for Precision Radio Interferometry}",
-  journal = {\apj},
+  title = {Fast Holographic Deconvolution: A New Technique for Precision Radio Interferometry},
+  journal = {The Astrophysical Journal},
   archivePrefix = "arXiv",
   eprint = {1209.1653},
   primaryClass = "astro-ph.IM",
@@ -98,7 +98,7 @@
 }
 
 @TECHREPORT{calfits,
-  author = {{Ali}, Z. and  {Hazelton}, B. and {Beardsley}, A. and {La Plante}, P. and {Kunicki}, T. and {the pyuvdata team}},
+  author = {{Ali}, Z. and  {Hazelton}, B. J. and {Beardsley}, A. and {La Plante}, P. and {Kunicki}, T. and {the pyuvdata team}},
   title = "{Memo: UVCal FITS Format}",
   year = 2017,
   month = jul,
@@ -106,7 +106,7 @@
 }
 
 @TECHREPORT{beamfits,
-  author = {{Hazelton}, B. and {the pyuvdata team}},
+  author = {{Hazelton}, B. J. and {the pyuvdata team}},
   title = "{Memo: UVBeam FITS Format}",
   year = 2018,
   month = jan,
@@ -122,7 +122,7 @@
 }
 
 @TECHREPORT{calh5,
-  author = {{Hazelton}, B. and {the pyuvdata team}},
+  author = {{Hazelton}, B. J. and {the pyuvdata team}},
   title = "{Memo: CalH5 file format}",
   year = 2024,
   month = aug,
@@ -132,7 +132,7 @@
 @ARTICLE{casa,
        author = {{CASA Team} and {Bean}, Ben and {Bhatnagar}, Sanjay and {Castro}, Sandra and {Donovan Meyer}, Jennifer and {Emonts}, Bjorn and {Garcia}, Enrique and {Garwood}, Robert and {Golap}, Kumar and {Gonzalez Villalba}, Justo and {Harris}, Pamela and {Hayashi}, Yohei and {Hoskins}, Josh and {Hsieh}, Mingyu and {Jagannathan}, Preshanth and {Kawasaki}, Wataru and {Keimpema}, Aard and {Kettenis}, Mark and {Lopez}, Jorge and {Marvil}, Joshua and {Masters}, Joseph and {McNichols}, Andrew and {Mehringer}, David and {Miel}, Renaud and {Moellenbrock}, George and {Montesino}, Federico and {Nakazato}, Takeshi and {Ott}, Juergen and {Petry}, Dirk and {Pokorny}, Martin and {Raba}, Ryan and {Rau}, Urvashi and {Schiebel}, Darrell and {Schweighart}, Neal and {Sekhar}, Srikrishna and {Shimada}, Kazuhiko and {Small}, Des and {Steeb}, Jan-Willem and {Sugimoto}, Kanako and {Suoranta}, Ville and {Tsutsumi}, Takahiro and {van Bemmel}, Ilse M. and {Verkouter}, Marjolein and {Wells}, Akeem and {Xiong}, Wei and {Szomoru}, Arpad and {Griffith}, Morgan and {Glendenning}, Brian and {Kern}, Jeff},
         title = "{CASA, the Common Astronomy Software Applications for Radio Astronomy}",
-      journal = {\pasp},
+      journal = {Publications of the Astronomical Society of the Pacific},
      keywords = {Single-dish antennas, Aperture synthesis, Radio astronomy, Radio interferometry, Long baseline interferometry, Astronomy software, Open source software, Software documentation, Astronomy data reduction, Astronomy data analysis, 1460, 53, 1338, 1346, 932, 1855, 1866, 1869, 1861, 1858, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - High Energy Astrophysical Phenomena, Astrophysics - Solar and Stellar Astrophysics},
          year = 2022,
         month = nov,
@@ -149,8 +149,8 @@ archivePrefix = {arXiv},
 }
 
 @ARTICLE{pyuvdata_v1,
-       author = {{Hazelton}, Bryna J. and {Jacobs}, Daniel C. and {Pober}, Jonathan C. and {Beardsley}, Adam P.},
-        title = "{pyuvdata: an interface for astronomical interferometeric datasets in python}",
+       author = {{Hazelton}, B. J. and {Jacobs}, Daniel C. and {Pober}, Jonathan C. and {Beardsley}, Adam P.},
+        title = {pyuvdata: an interface for astronomical interferometeric datasets in Python},
       journal = {The Journal of Open Source Software},
          year = 2017,
         month = feb,

--- a/paper.md
+++ b/paper.md
@@ -1,9 +1,9 @@
 ---
-title: 'pyuvdata v3: an interface for astronomical interferometeric datasets in python'
+title: 'pyuvdata v3: an interface for astronomical interferometeric data sets in Python'
 tags:
  - radio astronomy
- - uvfits
- - miriad
+ - UVFITS
+ - MIRIAD
 authors:
  - name: Garrett K. Keating
    orcid: 0000-0002-3490-146X
@@ -29,7 +29,8 @@ authors:
  - name: Adam Lanman
    affiliation: 7
    orcid: 0000-0003-2116-3573
- - name: Paul La Plante
+ - given-names: Paul
+   surname: La Plante
    affiliation: 8
    orcid: 0000-0002-4693-0102
  - name: Jonathan C. Pober
@@ -38,23 +39,23 @@ authors:
  - name: Pyxie Star
    affiliation: 3
 affiliations:
- - name: Center for Astrophysics | Harvard & Smithsonian
+ - name: Center for Astrophysics | Harvard & Smithsonian, USA
    index: 1
- - name: University of Washington, eScience Institute
+ - name: eScience Institute, University of Washington, USA
    index: 2
- - name: University of Washington, Physics Department
+ - name: Physics Department, University of Washington, USA
    index: 3
  - name: Scuola Normale Superiore, Italy
    index: 4
- - name: Winona State University, Physics Department
+ - name: Physics Department, Winona State University, USA
    index: 5
- - name: Massachusetts Institute of Technology, Physics Department
+ - name: Physics Department, Massachusetts Institute of Technology, USA
    index: 6
- - name: Kavli Institute of Astrophysics and Space Research
+ - name:  Kavli Institute for Astrophysics and Space Research, Massachusetts Institute of Technology, USA
    index: 7
- - name: University of Nevada, Las Vegas, Department of Computer Science
+ - name: Department of Computer Science, University of Nevada, Las Vegas, USA
    index: 8
- - name: Brown University, Physics Department
+ - name: Physics Department, Brown University, USA
    index: 9
 date: 2 July 2024
 bibliography: paper.bib
@@ -65,11 +66,11 @@ pyuvdata is an open-source software package that seeks to provide a well-documen
 feature-rich interface for many of the different data formats that exist within radio
 interferometry, including support for reading and writing the following formats:
 UVH5 [@uvh5], UVFITS [@uvfits], MIRIAD [@miriad], and measurement set [@ms] visibility
-files. It offers read-only support for FHD [@fhd] and MIR [@mir] visibility save files.
+files. It offers read-only support for fast holographic deconvolution [FHD, @fhd] and MIR [@mir] visibility save files.
 Additionally, pyuvdata supports reading/writing measurement set, CalFITS [@calfits], and
 CalH5 [@calh5] calibration solutions; and reading of FHD calibration solutions. pyuvdata
 also provides interfaces for and handling of models of antenna primary beams, including
-BeamFITS [@beamfits] (read and write), CST (read-only), MWA beam formats (read-only).
+BeamFITS [read and write, @beamfits], CST (read-only) and MWA beam formats (read-only).
 It also provides interfaces for handling of data flags.
 
 # Statement of Need
@@ -77,8 +78,8 @@ There are several standard formats for astronomical interferometric data, but
 translating between them in a robust and well-understood way has historically been
 challenging.  This is partially due to conflicting assumptions and standards, giving
 rise to significant (though sometimes subtle) differences between formats.
-Interfacing with different data formats -- like one does when they convert from one
-format to another -- thus requires careful accounting for the complex mathematical
+Interfacing with different data formats---like one does when they convert from one
+format to another---thus requires careful accounting for the complex mathematical
 relationships between both data and metadata to ensure proper data fidelity. This is
 required both for leveraging existing community-favored tools that are typically built
 to interface with a specific data format, as well as analyses requiring bespoke tools
@@ -86,13 +87,13 @@ for specialized types of analyses and simulations leveraging data in a variety o
 formats.
 
 pyuvdata has been designed to facilitate interoperability between different instruments
-and codes by providing high quality, well documented conversion routines as well as an
+and codes by providing high-quality, well-documented conversion routines as well as an
 interface to interact with interferometric data and simulations directly in Python.
-Originally motivated to support new low frequency instruments (e.g. MWA:
-http://www.mwatelescope.org/, PAPER: http://eor.berkeley.edu/, HERA:
-http://reionization.org/), the capabilities of pyuvdata have been steadily expanded
+Originally motivated to support new low frequency instruments
+(e.g.~[MWA](http://www.mwatelescope.org/), [PAPER](http://eor.berkeley.edu/), [HERA](http://reionization.org/)),
+the capabilities of pyuvdata have been steadily expanded
 to support handling of data from several telescopes, ranging from meter to submillimeter
-wavelengths (including SMA: https://cfa.harvard.edu/sma, ALMA, SMA, VLA, ATCA, CARMA,
+wavelengths (including [SMA](https://cfa.harvard.edu/sma), ALMA, VLA, ATCA, CARMA,
 LWA, among others).
 
 # Major updates in this version
@@ -111,7 +112,7 @@ include BeamFITS, MWA, and CST.
 of bad data for visibility data.
 - Drastically improved handling of astrometry.
 - Increased speed and accuracy of algorithms used to ``phase-up'' data (i.e., change
-the sky position where the interferometer is centered up on).
+the sky position upon which the interferometer is centered).
 - Support for several new visibility data formats, including MIR, MS, and MWA/MWAX.
 - Support for data sets containing multiple spectral windows.
 - Support for data sets containing observations of multiple sources/phase centers.


### PR DESCRIPTION
This is an initial set of editorial changes to the JOSS paper for v3 following the [successful review](https://github.com/openjournals/joss-reviews/issues/7482). These are mostly minor and many in the bibliography, rather than text, but you should double check that everything looks acceptable.

Note that I changed "dataset" to "data set" in the title for consistency with the text but you may prefer to go the other way and keep "dataset" in the title and change "data set" to "dataset" in the text (under "Major updates in this version").

Either way, note that the title has changed slightly ("python" → "Python"), so you'll need to update the Zenodo archive title to match.

Once these changes are all in I'll launch another test run of the publication pipeline.