### PR TITLE
Pin version of cython for installation and CI jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ you will need the following packages:
 * pytest >= 6.2
 * pytest-cases >= 3.8.3
 * pytest-cov
-* cython >=3.0
+* cython ==3.0
 * coverage
 * pre-commit
 * matplotlib

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - astropy>=6.0
-  - cython>=3.0
+  - cython==3.0.*
   - docstring_parser>=0.15
   - h5py>=3.1
   - numpy>=1.23

--- a/ci/pyuvdata_min_versions_tests.yml
+++ b/ci/pyuvdata_min_versions_tests.yml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-cases==3.8.3
   - pytest-cov
   - pytest-xdist
-  - cython==3.0.*.0
+  - cython==3.0.0
   - setuptools==64
   - setuptools_scm==8.1
   - pip

--- a/ci/pyuvdata_min_versions_tests.yml
+++ b/ci/pyuvdata_min_versions_tests.yml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-cases==3.8.3
   - pytest-cov
   - pytest-xdist
-  - cython==3.0.0
+  - cython==3.0.*.0
   - setuptools==64
   - setuptools_scm==8.1
   - pip

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -19,7 +19,7 @@ dependencies:
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
-  - cython>=3.0
+  - cython==3.0.*
   - setuptools_scm>=8.1
   - pip
   - pip:

--- a/ci/pyuvdata_tests_mac_arm.yml
+++ b/ci/pyuvdata_tests_mac_arm.yml
@@ -19,7 +19,7 @@ dependencies:
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
-  - cython>=3.0
+  - cython==3.0.*
   - setuptools_scm>=8.1
   - pip
   - pip:

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist
-  - cython>=3.0
+  - cython==3.0.*
   - setuptools_scm>=8.1
   - pip
   - pip:

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,7 +6,7 @@ dependencies:
   - astropy-healpix>=1.0.2
   - astroquery>=0.4.4
   - coverage
-  - cython>=3.0
+  - cython==3.0.*
   - docstring_parser>=0.15
   - h5py>=3.4
   - hdf5plugin>=3.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=64",
             "wheel",
             "setuptools_scm>=8.1",
             "numpy",
-            "cython>=3.0"]
+            "cython==3.0.*"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -65,7 +65,7 @@ test = [
     "pytest-xdist",
     "pytest-cases>=3.8.3",
     "pytest-cov",
-    "cython>=3.0",
+    "cython==3.0.*",
     "coverage",
     "pre-commit",
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pins the version of cython used to `3.0.*`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
A new release of cython appears to be breaking the build for pyuvdata -- this PR is meant to be a "quick-fix", and arguably one would actually go in and update the cython code itself, but given that we are in the process of re-evaluating our use of cython (a la #1543), I think this is a sensible solution for the immediate term. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme, pyproject.toml, environment.yaml and CI conda yaml files to reflect the changes.

