### PR TITLE
pin pytest<8.4 because pytest-cases is not yet compatible with 8.4

### DIFF
--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -13,7 +13,7 @@ dependencies:
   - scipy>=1.9
   - setuptools_scm>=8.1
   - coverage
-  - pytest>=8.2.0
+  - pytest>=8.2.0,<8.4.0  # 8.4.0 has a bug that breaks our tests see https://github.com/smarie/python-pytest-cases/issues/364
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -16,7 +16,7 @@ dependencies:
   - pyyaml>=5.4.1
   - scipy>=1.9
   - coverage
-  - pytest>=8.2.0
+  - pytest>=8.2.0,<8.4.0  # 8.4.0 has a bug that breaks our tests see https://github.com/smarie/python-pytest-cases/issues/364
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist

--- a/ci/pyuvdata_tests_mac_arm.yml
+++ b/ci/pyuvdata_tests_mac_arm.yml
@@ -16,7 +16,7 @@ dependencies:
   - pyyaml>=5.4.1
   - scipy>=1.9
   - coverage
-  - pytest>=8.2.0
+  - pytest>=8.2.0,<8.4.0  # 8.4.0 has a bug that breaks our tests see https://github.com/smarie/python-pytest-cases/issues/364
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -15,7 +15,7 @@ dependencies:
   - pyyaml>=5.4.1
   - scipy>=1.9
   - coverage
-  - pytest>=8.2.0
+  - pytest>=8.2.0,<8.4.0  # 8.4.0 has a bug that breaks our tests see https://github.com/smarie/python-pytest-cases/issues/364
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist

--- a/ci/test_requirements.txt
+++ b/ci/test_requirements.txt
@@ -1,6 +1,6 @@
 coverage
 packaging
-pytest>=8.2.0
+pytest>=8.2.0,<8.4.0  # 8.4.0 has a bug that breaks our tests see https://github.com/smarie/python-pytest-cases/issues/364
 pytest-cov
 pytest-cases>=3.8.3
 pytest-xdist

--- a/environment.yaml
+++ b/environment.yaml
@@ -17,7 +17,7 @@ dependencies:
   - pre-commit
   - pyerfa>=2.0.1.1
   - pypandoc
-  - pytest>=8.2.0
+  - pytest>=8.2.0,<8.4.0  # 8.4.0 has a bug that breaks our tests see https://github.com/smarie/python-pytest-cases/issues/364
   - pytest-cases>=3.8.3
   - pytest-cov
   - pytest-xdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ lunar = ["lunarsky>=0.2.5"]
 novas = ["novas", "novas_de405"]
 all = ["pyuvdata[astroquery,casa,hdf5_compression,healpix,lunar,novas]"]
 test = [
-    "pytest>=8.2.0",
+    "pytest>=8.2.0,<8.4.0",  # 8.4.0 has a bug that breaks our tests see https://github.com/smarie/python-pytest-cases/issues/364
     "pytest-xdist",
     "pytest-cases>=3.8.3",
     "pytest-cov",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
pytest-cases breaks with pytest 8.4, so pin 8.4 for now until pytest-cases is fixed. See https://github.com/smarie/python-pytest-cases/issues/364

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change
- [x] Other


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme, pyproject.toml, environment.yaml and CI conda yaml files to reflect the changes.

**Note: readme not updated as I view this as temporary**