### PR TITLE
Fix UVBase._select_along_param_axis for SkyCood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- A bug in `UVParameter.get_from_form` and `UVParameter.set_from_form` that caused
+errors when using astropy SkyCoord, Quantity or Time objects in UVParameters,
+arose when using `UVBase._select_along_param_axis`.
+
 ## [3.2.2] - 2025-06-12
 
 ### Added

--- a/src/pyuvdata/parameter.py
+++ b/src/pyuvdata/parameter.py
@@ -836,8 +836,6 @@ class UVParameter:
                 extra_axes[axis] = val_slice[axis]
                 val_slice[axis] = slice(None)
 
-        # use issubclass ShapedLikeNDArray to handle Time and SkyCoord objects
-        # Quantities are instances of np.ndarray.
         if isinstance(
             self.value, np.ndarray | np.ma.MaskedArray | SkyCoord | Time | Quantity
         ):
@@ -917,8 +915,6 @@ class UVParameter:
                 extra_axes[axis] = val_slice[axis]
                 val_slice[axis] = slice(None)
 
-        # use issubclass ShapedLikeNDArray to handle Time and SkyCoord objects
-        # Quantities are instances of np.ndarray.
         if isinstance(self.value, Quantity | SkyCoord | Time):
             if extra_axes:
                 # Quantity, SkyCoord, and TIme have some extra caching that causes

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1188,7 +1188,7 @@ def test_set_from_form(form_dict, exp_arr, partype):
     val = val[:, form_dict.get("b", slice(None))]
     if partype == "array":
         np.testing.assert_array_equal(val, exp_val)
-    elif partype == "quantity1" or partype == "quantity2":
+    elif partype in ["quantity1", "quantity2"]:
         np.testing.assert_array_equal(val.value, exp_val.value)
     elif partype == "time":
         np.testing.assert_array_equal(val.jd, exp_val.jd)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When I tried to use the new `UVBase._select_along_param_axis` in pyradiosky it errored because `UVBase.get_from_form` doesn't handle `SkyCoordParameter` objects properly. SkyModel also has Quantity parameters which should be tested against too. This updates both `UVBase.get_from_form` and `UVBase.set_from_form` to work for `SkyCoordParameter`, `Quantity` and `Time` objects. We don't currently have any code using Time objects, so we could drop that testing if we want.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [ ] Other

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
