### PR TITLE
Implement a check of pyuvsim cache for fallback file inside _uvbeam_constructor

### DIFF
--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -14,6 +14,7 @@ from typing import Literal
 import numpy as np
 import yaml
 from astropy import units
+from astropy.utils.data import cache_contents, is_url_in_cache
 from docstring_parser import DocstringStyle
 from scipy import interpolate, ndimage
 
@@ -4745,7 +4746,8 @@ def _uvbeam_constructor(loader, node):
     Define a yaml constructor for UVBeam objects.
 
     The yaml must specify a "filename" field pointing to the UVBeam readable file
-    and any desired arguments to the UVBeam.from_file method.
+    and any desired arguments to the UVBeam.from_file method. If the file does not
+    exist, checks pyuvsim cache for file treating the "filename" as the cache url.
 
     Parameters
     ----------
@@ -4783,6 +4785,12 @@ def _uvbeam_constructor(loader, node):
         path_var = getattr(module, var_name)
         for f_i in range(len(files_use)):
             files_use[f_i] = os.path.join(path_var, files_use[f_i])
+
+    for i, file in enumerate(files_use):
+        # if file does not exist, check pyuvsim cache defined from astropy prescription
+        # treat file as download url to check astropy cache for file
+        if not os.path.exists(file) and is_url_in_cache(file, pkgname="pyuvsim"):
+            files_use[i] = cache_contents("pyuvsim")[file]
 
     if len(files_use) == 1:
         files_use = files_use[0]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Implemented check of pyuvsim cache for uvbeam file inside _uvbeam_constructor as a fallback if the file isn't existent otherwise. Updated docstring of _construct_uvbeam to reflect this change.

This change is to support the downloading and handling of large data files -- gleam, uvbeam, etc... (currently just beams and catalogs) -- using astropy. The intention is to allow the passing of the cache url corresponding to a file downloaded or added to the astropy cache into a simulation configuration yaml file directly without having to specify any special path information. Individuals can then simply download the relevant data files to the cache -- in this case UVBeam files -- and they will be recognized and read appropriately while running a simulation.

Where this functionality is immediately important is in the reference simulations of pyuvsim. The current approach to running the new reference simulations is to install the larger data files to the pyuvsim cache specified by astropy using download_file. There is currently no method to appropriately target cached UVBeam files besides manually editing the yaml file to insert the absolute path to the file, a problem that this pr solves.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [ ] Other


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added/updated tests to cover my new feature.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).