### PR TITLE
Fix IndexError in `utils.io.ms.read_ms_history`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 - A bug in `UVParameter.get_from_form` and `UVParameter.set_from_form` that caused
 errors when using astropy SkyCoord, Quantity or Time objects in UVParameters,
 arose when using `UVBase._select_along_param_axis`.
+- A bug in `utils.io.ms.read_ms_history` where an IndexError could be raised in
+the case that a column did not have (any or) enough rows of data to combine into
+the output history string.
 
 ## [3.2.2] - 2025-06-12
 

--- a/src/pyuvdata/utils/io/ms.py
+++ b/src/pyuvdata/utils/io/ms.py
@@ -924,7 +924,10 @@ def read_ms_history(filepath, pyuvdata_version_str, check_origin=False, raise_er
                 if row_idx in pyuvdata_line_idx:
                     continue
 
-                newline = ";".join([str(col[row_idx]) for col in cols]) + "\n"
+                newline = (
+                    ";".join([str(col[row_idx]) for col in cols if len(col) > row_idx])
+                    + "\n"
+                )
                 history_str += newline
 
             history_str += "End measurement set history.\n"


### PR DESCRIPTION
Some LOFAR1 MeasurementSets appear to have empty columns in the HISTORY table. This patch works around that by only combining values for rows in which the column is long enough to contains data for that row.

## Description
This was a first-order workaround, by simply checking if the column is long enough to index into we work-around the potential index error, though given I'm not very familiar with the file format, I'm not sure of any downstream effects of this, or if a similar fix should be applied to other tables being read

Initial discussion was opened in #1587, I was suggested to send along this fix as a MR. Unfortunately at this time I cannot share the HISTORY table itself, so I'm not sure of the best way to add a test to the CI to validate this fix for the future.

## Motivation and Context
Fixes an IndexError raised whenever the history table is read for some LOFAR1 MeasurementSets. Fixes #1587.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [ ] Other


## Checklist:
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).

