### PR TITLE
Fix to MS History table reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ their feed angles. The feed angles that are stored on the object have their
 feed angles normalized to be between 0 and pi/2.
 
 ### Fixed
+- A bug in `utils.io.ms.read_ms_history` where reading the table caused an IndexError
+due to the "APP_PARAMS" and "CLI_COMMAND" columns being populated in a non-standard
+fashion.
 - A bug in UVBeam's CST reader that caused the bandpass array to be incorrectly
 set to 0 except for the first frequency.
 - A bug in `UVParameter.get_from_form` and `UVParameter.set_from_form` that caused


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changes `utils.io.ms.read_ms_history` to handle when the "APP_PARAMS" and "CLI_COMMAND" are populated in a non-standard way (either unpopulated or populated with an empty array).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

The original motivation for this was fixing a bug when reading in LOFAR1 files, although I realized that actually the way that we were handling weirdness in the "APP_PARAMS" and "CLI_COMMAND" columns was actually making it so that the history wasn't being round-tripped correctly, so I've modified things to resolve both issues.

Closes #1587

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
