### PR TITLE
Fix test now that ATCA is in astropy sites

### DIFF
--- a/tests/uvdata/test_miriad.py
+++ b/tests/uvdata/test_miriad.py
@@ -158,7 +158,6 @@ def uv_in_uvfits(paper_miriad, tmp_path):
     del uv_in, uv_out
 
 
-@pytest.mark.filterwarnings("ignore:Telescope ATCA is not")
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 def test_read_write_read_atca(tmp_path):
     uv_in = UVData()
@@ -168,12 +167,9 @@ def test_read_write_read_atca(tmp_path):
     with check_warnings(
         UserWarning,
         [
-            (
-                "Altitude is not present in Miriad file, and "
-                "telescope ATCA is not in known_telescopes. "
-            ),
-            "Altitude is not present",
-            warn_dict["telescope_at_sealevel"],
+            "Altitude is not present in file and latitude and longitude values "
+            "do not match values for ATCA in known telescopes. Using values "
+            "from known telescopes.",
             warn_dict["uvw_mismatch"],
             warn_dict["unclear_projection"],
         ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Our test reading in an ATCA miriad file broke because ATCA was recently added to astropy sites, which changed the set of warnings we got on reading in the file. This PR fixes that test.

Note: if you want to get the new astropy sites info into an existing astropy installation, you need to use `astropy.utils.data.clear_download_cache()` to clear the old info. There's a `refresh_cache` option in `EarthLocation. of_site` and `EarthLocation.get_site_names` but those do not work (see https://github.com/astropy/astropy/issues/18572).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [x] Other


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Other:
- [ ] I have updated any docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the readme and/or tutorial to reflect my changes (if appropriate).
- [ ] I have added/updated tests to cover my changes (if appropriate).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
