### PR TITLE
Clean up and improve tutorials for Sybil testing, add missing content

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ you will need the following packages:
 * pre-commit
 * matplotlib
 * sphinx
+* sybil
 * pypandoc
 
 We manage our test data using pooch, which will download the file the first time

--- a/ci/pyuvdata_min_deps_tests.yml
+++ b/ci/pyuvdata_min_deps_tests.yml
@@ -19,3 +19,4 @@ dependencies:
   - pyyaml>=5.4.1
   - scipy>=1.9
   - setuptools_scm>=8.1
+  - sybil>=8.0

--- a/ci/pyuvdata_min_versions_tests.yml
+++ b/ci/pyuvdata_min_versions_tests.yml
@@ -24,6 +24,7 @@ dependencies:
   - scipy==1.9.*
   - setuptools==65.*
   - setuptools_scm==8.1
+  - sybil==8.0
   - pip:
     - lunarsky==0.2.5
     - novas

--- a/ci/pyuvdata_tests.yml
+++ b/ci/pyuvdata_tests.yml
@@ -24,6 +24,7 @@ dependencies:
   - pyyaml>=5.4.1
   - scipy>=1.9
   - setuptools_scm>=8.1
+  - sybil>=8.0
   - pip:
     - lunarsky>=0.2.5
     - novas

--- a/ci/pyuvdata_tests_mac_arm.yml
+++ b/ci/pyuvdata_tests_mac_arm.yml
@@ -24,6 +24,7 @@ dependencies:
   - pyyaml>=5.4.1
   - scipy>=1.9
   - setuptools_scm>=8.1
+  - sybil>=8.0
   - pip:
     - lunarsky>=0.2.5
     # novas is not available on mac arm

--- a/ci/pyuvdata_tests_windows.yml
+++ b/ci/pyuvdata_tests_windows.yml
@@ -23,5 +23,6 @@ dependencies:
   - scipy>=1.9
   - cython>=3.0
   - setuptools_scm>=8.1
+  - sybil>=8.0
   - pip:
     - lunarsky>=0.2.5

--- a/docs/analytic_beam_tutorial.rst
+++ b/docs/analytic_beam_tutorial.rst
@@ -25,79 +25,83 @@ are included, the array returned from the ``power_eval`` method will be complex.
 
 .. code-block:: python
 
-  >>> import matplotlib.pyplot as plt
-  >>> import numpy as np
-  >>> from matplotlib.colors import LogNorm
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from matplotlib.colors import LogNorm
 
-  >>> from pyuvdata import AiryBeam
+    from pyuvdata import AiryBeam
 
-  >>> # Create an AiryBeam with a diameter of 14.5 meters
-  >>> airy_beam = AiryBeam(diameter=14.5, include_cross_pols=False)
+    # Create an AiryBeam with a diameter of 14.5 meters
+    airy_beam = AiryBeam(diameter=14.5, include_cross_pols=False)
 
-  >>> # set up zenith angle, azimuth and frequency arrays to evaluate with
-  >>> # make a regular grid in direction cosines for nice plots
-  >>> n_vals = 100
-  >>> zmax = np.radians(90)  # Degrees
-  >>> axis_arr = np.arange(-n_vals/2., n_vals/2.) / float(n_vals/2.)
-  >>> l_arr, m_arr = np.meshgrid(axis_arr, axis_arr)
-  >>> radius = np.sqrt(l_arr**2 + m_arr**2)
-  >>> za_array = radius * zmax
-  >>> az_array = np.arctan2(m_arr, l_arr)
+    # set up zenith angle, azimuth and frequency arrays to evaluate with
+    # make a regular grid in direction cosines for nice plots
+    n_vals = 100
+    zmax = np.radians(90)  # Degrees
+    axis_arr = np.arange(-n_vals/2., n_vals/2.) / float(n_vals/2.)
+    l_arr, m_arr = np.meshgrid(axis_arr, axis_arr)
+    radius = np.sqrt(l_arr**2 + m_arr**2)
+    za_array = radius * zmax
+    az_array = np.arctan2(m_arr, l_arr)
 
-  >>> az_array = az_array.flatten()
-  >>> za_array = za_array.flatten()
+    az_array = az_array.flatten()
+    za_array = za_array.flatten()
 
-  >>> Nfreqs = 11
-  >>> freqs = np.linspace(100, 200, 11) * 1e6
+    Nfreqs = 11
+    freqs = np.linspace(100, 200, 11) * 1e6
 
-  >>> # find the values above the horizon so we don't evaluate beyond the horizon
-  >>> above_hor = np.nonzero(za_array <= np.pi / 2.)[0]
+    # find the values above the horizon so we don't evaluate beyond the horizon
+    above_hor = np.nonzero(za_array <= np.pi / 2.)[0]
 
-  >>> # set up an output array that matches the expected shape, except that it
-  >>> # includes the points beyond the horizon, and fill it with infinity.
-  >>> # Then we will set the points above the horizon to the output of power_eval.
-  >>> beam_vals = np.full((1, airy_beam.Npols, Nfreqs, n_vals * n_vals), np.inf, dtype=float)
+    # set up an output array that matches the expected shape, except that it
+    # includes the points beyond the horizon, and fill it with infinity.
+    # Then we will set the points above the horizon to the output of power_eval.
+    beam_vals = np.full((1, airy_beam.Npols, Nfreqs, n_vals * n_vals), np.inf, dtype=float)
 
-  >>> beam_vals[:, :, :, above_hor] = airy_beam.power_eval(
-  ...     az_array=az_array[above_hor], za_array=za_array[above_hor], freq_array=freqs
-  ... )
+    beam_vals[:, :, :, above_hor] = airy_beam.power_eval(
+        az_array=az_array[above_hor], za_array=za_array[above_hor], freq_array=freqs
+    )
 
-  >>> beam_vals = np.reshape(beam_vals, (1, airy_beam.Npols, Nfreqs, n_vals, n_vals))
+    beam_vals = np.reshape(beam_vals, (1, airy_beam.Npols, Nfreqs, n_vals, n_vals))
 
-  >>> fig, ax = plt.subplots(1, 2)
-  >>> bp_low = ax[0].imshow(
-  ...   beam_vals[0,0,0],
-  ...   norm=LogNorm(vmin = 1e-8, vmax =1),
-  ...   extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
-  ...   origin="lower",
-  ... )
-  >>> _ = ax[0].set_title(f"Airy beam {freqs[0]*1e-6} MHz")
-  >>> _ = fig.colorbar(bp_low, ax=ax[0], fraction=0.046, pad=0.04, location="left")
+    fig, ax = plt.subplots(1, 2)
+    bp_low = ax[0].imshow(
+      beam_vals[0,0,0],
+      norm=LogNorm(vmin = 1e-8, vmax =1),
+      extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
+      origin="lower",
+    )
+    _ = ax[0].set_title(f"Airy beam {freqs[0]*1e-6} MHz")
+    _ = fig.colorbar(bp_low, ax=ax[0], fraction=0.046, pad=0.04, location="left")
 
-  >>> bp_high = ax[1].imshow(
-  ...   beam_vals[0,0,-1],
-  ...   norm=LogNorm(vmin = 1e-8, vmax =1),
-  ...   extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
-  ...   origin="lower",
-  ... )
-  >>> _ = ax[1].set_title(f"Airy beam {freqs[-1]*1e-6} MHz")
-  >>> _ = fig.colorbar(bp_high, ax=ax[1], fraction=0.046, pad=0.04, location="left")
+    bp_high = ax[1].imshow(
+      beam_vals[0,0,-1],
+      norm=LogNorm(vmin = 1e-8, vmax =1),
+      extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
+      origin="lower",
+    )
+    _ = ax[1].set_title(f"Airy beam {freqs[-1]*1e-6} MHz")
+    _ = fig.colorbar(bp_high, ax=ax[1], fraction=0.046, pad=0.04, location="left")
 
-  >>> for ind in range(2):
-  ...   _ = ax[ind].set_xticks([0], labels=["North"])
-  ...   _ = ax[ind].set_yticks([0], labels=["East"])
-  ...   _ = ax[ind].yaxis.set_label_position("right")
-  ...   _ = ax[ind].yaxis.tick_right()
-  ...   _ = ax[ind].xaxis.set_label_position("top")
-  ...   _ = ax[ind].xaxis.tick_top()
+    for ind in range(2):
+        _ = ax[ind].set_xticks([0], labels=["North"])
+        _ = ax[ind].set_yticks([0], labels=["East"])
+        _ = ax[ind].yaxis.set_label_position("right")
+        _ = ax[ind].yaxis.tick_right()
+        _ = ax[ind].xaxis.set_label_position("top")
+        _ = ax[ind].xaxis.tick_top()
 
-  >>> fig.tight_layout()
-  >>> plt.show()  # doctest: +SKIP
-  >>> plt.savefig("Images/airy_beam.png", bbox_inches='tight')
-  >>> plt.clf()
+    fig.tight_layout()
+
+.. skip: next
+
+    plt.show()
+
+    plt.savefig("Images/airy_beam.png", bbox_inches='tight')
+    plt.clf()
 
 .. image:: Images/airy_beam.png
-  :width: 600
+    :width: 600
 
 
 Evaluating a Short Dipole Beam E-Field response
@@ -109,96 +113,108 @@ effective maps because we have the response to each polarization basis vector
 for each feed. In the case of a short dipole, these maps do not have an imaginary
 part, but in general E-Field beams can be complex, so a complex array is returned.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import matplotlib.pyplot as plt
-  >>> import numpy as np
+    import matplotlib.pyplot as plt
+    import numpy as np
 
-  >>> from pyuvdata import ShortDipoleBeam
+    from pyuvdata import ShortDipoleBeam
 
-  >>> # Create an ShortDipoleBeam
-  >>> dipole_beam = ShortDipoleBeam()
+    # Create an ShortDipoleBeam
+    dipole_beam = ShortDipoleBeam()
 
-  >>> # set up zenith angle, azimuth and frequency arrays to evaluate with
-  >>> # make a regular grid in direction cosines for nice plots
-  >>> n_vals = 100
-  >>> zmax = np.radians(90)  # Degrees
-  >>> axis_arr = np.arange(-n_vals/2., n_vals/2.) / float(n_vals/2.)
-  >>> l_arr, m_arr = np.meshgrid(axis_arr, axis_arr)
-  >>> radius = np.sqrt(l_arr**2 + m_arr**2)
-  >>> za_array = radius * zmax
-  >>> az_array = np.arctan2(m_arr, l_arr)
+    # set up zenith angle, azimuth and frequency arrays to evaluate with
+    # make a regular grid in direction cosines for nice plots
+    n_vals = 100
+    zmax = np.radians(90)  # Degrees
+    axis_arr = np.arange(-n_vals/2., n_vals/2.) / float(n_vals/2.)
+    l_arr, m_arr = np.meshgrid(axis_arr, axis_arr)
+    radius = np.sqrt(l_arr**2 + m_arr**2)
+    za_array = radius * zmax
+    az_array = np.arctan2(m_arr, l_arr)
 
-  >>> az_array = az_array.flatten()
-  >>> za_array = za_array.flatten()
+    az_array = az_array.flatten()
+    za_array = za_array.flatten()
 
-  >>> Nfreqs = 11
-  >>> freqs = np.linspace(100, 200, 11) * 1e8
+    Nfreqs = 11
+    freqs = np.linspace(100, 200, 11) * 1e8
 
-  >>> # find the values above the horizon so we don't evaluate beyond the horizon
-  >>> above_hor = np.nonzero(za_array <= np.pi / 2.)[0]
+    # find the values above the horizon so we don't evaluate beyond the horizon
+    above_hor = np.nonzero(za_array <= np.pi / 2.)[0]
 
-  >>> # set up an output array that matches the expected shape except, that it
-  >>> # includes the points beyond the horizon, and fill it with infinity.
-  >>> # Then we will set the points above the horizon to the output of efield_eval.
-  >>> beam_vals = np.full((dipole_beam.Naxes_vec, dipole_beam.Nfeeds, Nfreqs, n_vals * n_vals), np.inf, dtype=complex)
+    # set up an output array that matches the expected shape except, that it
+    # includes the points beyond the horizon, and fill it with infinity.
+    # Then we will set the points above the horizon to the output of efield_eval.
+    beam_vals = np.full(
+        (dipole_beam.Naxes_vec, dipole_beam.Nfeeds, Nfreqs, n_vals * n_vals),
+        np.inf,
+        dtype=complex
+    )
 
-  >>> beam_vals[:, :, :, above_hor] = dipole_beam.efield_eval(
-  ...     az_array=az_array[above_hor], za_array=za_array[above_hor], freq_array=freqs
-  ... )
+    beam_vals[:, :, :, above_hor] = dipole_beam.efield_eval(
+        az_array=az_array[above_hor], za_array=za_array[above_hor], freq_array=freqs
+    )
 
-  >>> beam_vals = np.reshape(beam_vals, (dipole_beam.Naxes_vec, dipole_beam.Nfeeds, Nfreqs, n_vals, n_vals))
+    beam_vals = np.reshape(
+        beam_vals, (dipole_beam.Naxes_vec, dipole_beam.Nfeeds, Nfreqs, n_vals, n_vals)
+    )
 
-  >>> fig, ax = plt.subplots(2, 2)
+    fig, ax = plt.subplots(2, 2)
 
-  >>> be00 = ax[0,0].imshow(
-  ...   beam_vals[0,0,0].real,
-  ...   extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
-  ...   origin="lower",
-  ... )
-  >>> _ = ax[0,0].set_title("E/W dipole azimuth response")
-  >>> _ = fig.colorbar(be00, ax=ax[0,0], location="left")
+    be00 = ax[0,0].imshow(
+        beam_vals[0,0,0].real,
+        extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
+        origin="lower",
+    )
+    _ = ax[0,0].set_title("E/W dipole azimuth response")
+    _ = fig.colorbar(be00, ax=ax[0,0], location="left")
 
-  >>> be10 = ax[1,0].imshow(
-  ...   beam_vals[1,0,0].real,
-  ...   extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
-  ...   origin="lower",
-  ... )
-  >>> _ = ax[1,0].set_title("E/W dipole zenith angle response")
-  >>> _ = fig.colorbar(be10, ax=ax[1,0], location="left")
+    be10 = ax[1,0].imshow(
+        beam_vals[1,0,0].real,
+        extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
+        origin="lower",
+    )
+    _ = ax[1,0].set_title("E/W dipole zenith angle response")
+    _ = fig.colorbar(be00, ax=ax[1,0], location="left")
 
-  >>> be01 = ax[0,1].imshow(
-  ...   beam_vals[0,1,0].real,
-  ...   extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
-  ...   origin="lower",
-  ... )
-  >>> _ = ax[0,1].set_title("N/S dipole azimuth response")
-  >>> _ = fig.colorbar(be01, ax=ax[0,1], location="left")
+    be01 = ax[0,1].imshow(
+        beam_vals[0,1,0].real,
+        extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
+        origin="lower",
+    )
+    _ = ax[0,1].set_title("N/S dipole azimuth response")
+    _ = fig.colorbar(be00, ax=ax[0,1], location="left")
 
-  >>> be11 = ax[1,1].imshow(
-  ...   beam_vals[1,1,0].real,
-  ...   extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
-  ...   origin="lower",
-  ... )
-  >>> _ = ax[1,1].set_title("N/S dipole zenith angle response")
-  >>> _ = fig.colorbar(be11, ax=ax[1,1], location="left")
+    be11 = ax[1,1].imshow(
+        beam_vals[1,1,0].real,
+        extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
+        origin="lower",
+    )
+    _ = ax[1,1].set_title("N/S dipole zenith angle response")
+    _ = fig.colorbar(be00, ax=ax[1,1], location="left")
 
-  >>> for row_ind in range(2):
-  ...   for col_ind in range(2):
-  ...      _ = ax[row_ind,col_ind].set_xticks([0], labels=["North"])
-  ...      _ = ax[row_ind,col_ind].set_yticks([0], labels=["East"])
-  ...      _ = ax[row_ind,col_ind].yaxis.set_label_position("right")
-  ...      _ = ax[row_ind,col_ind].yaxis.tick_right()
-  ...      _ = ax[row_ind,col_ind].xaxis.set_label_position("top")
-  ...      _ = ax[row_ind,col_ind].xaxis.tick_top()
+    for ind in range(2):
+        for ind2 in range(2):
+            _ = ax[ind, ind2].set_xticks([0], labels=["North"])
+            _ = ax[ind, ind2].set_yticks([0], labels=["East"])
+            _ = ax[ind, ind2].yaxis.set_label_position("right")
+            _ = ax[ind, ind2].yaxis.tick_right()
+            _ = ax[ind, ind2].xaxis.set_label_position("top")
+            _ = ax[ind, ind2].xaxis.tick_top()
 
-  >>> fig.tight_layout()
-  >>> plt.show()  # doctest: +SKIP
-  >>> plt.savefig("Images/short_dipole_beam.png", bbox_inches='tight')
-  >>> plt.clf()
+    fig.tight_layout()
+
+.. skip: next
+
+    plt.show()
+
+    plt.savefig("Images/short_dipole_beam.png", bbox_inches='tight')
+    plt.clf()
 
 .. image:: Images/short_dipole_beam.png
-  :width: 600
+    :width: 600
 
 
 Defining new analytic beams
@@ -310,79 +326,18 @@ Example: Defining simple unpolarized beams
 
 Airy beams are unpolarized but frequency dependent and require one parameter,
 the dish diameter in meters. Since the Airy beam E-field response goes negative,
-the ``_efield_eval`` method is specified in this beam.
+the ``_efield_eval`` method is specified in this beam. The definition in pyuvdata
+for the AiryBeam object is:
 
-.. code-block:: python
-  :linenos:
-
-    from dataclasses import dataclass
-
-    import numpy as np
-    from astropy.constants import c as speed_of_light
-    from scipy.special import j1
-    from pyuvdata.analytic_beam import UnpolarizedAnalyticBeam
-    from pyuvdata.utils.types import FloatArray
-
-    @dataclass(kw_only=True)
-    class AiryBeam(UnpolarizedAnalyticBeam):
-        """
-        A zenith pointed Airy beam.
-
-        Airy beams are the diffraction pattern of a circular aperture, so represent
-        an idealized dish. Requires a dish diameter in meters and is inherently
-        chromatic and unpolarized.
-
-        The unpolarized nature leads to some results that may be surprising to radio
-        astronomers: if two feeds are specified they will have identical responses
-        and the cross power beam between the two feeds will be identical to the
-        power beam for a single feed.
-
-        Attributes
-        ----------
-        diameter : float
-            Dish diameter in meters.
-
-        Parameters
-        ----------
-        diameter : float
-            Dish diameter in meters.
-        include_cross_pols : bool
-            Option to include the cross polarized beams (e.g. xy and yx or en and ne) for
-            the power beam.
-
-        """
-
-        diameter: float
-
-        def _efield_eval(
-            self,
-            *,
-            az_grid: FloatArray,
-            za_grid: FloatArray,
-            f_grid: FloatArray,
-        ) -> FloatArray:
-            """Evaluate the efield at the given coordinates."""
-            data_array = self._get_empty_data_array(az_grid.shape)
-
-            kvals = (2.0 * np.pi) * f_grid / speed_of_light.to("m/s").value
-            xvals = (self.diameter / 2.0) * np.sin(za_grid) * kvals
-            values = np.zeros_like(xvals)
-            nz = xvals != 0.0
-            ze = xvals == 0.0
-            values[nz] = 2.0 * j1(xvals[nz]) / xvals[nz]
-            values[ze] = 1.0
-
-            for fn in np.arange(self.Nfeeds):
-                data_array[0, fn, :, :] = values / np.sqrt(2.0)
-                data_array[1, fn, :, :] = values / np.sqrt(2.0)
-
-            return data_array
+.. literalinclude:: ../src/pyuvdata/analytic_beam.py
+   :pyobject: AiryBeam
 
 Below we show how to define a cosine shaped beam with a single width parameter,
 which can be defined with just the ``_power_eval`` method.
 
+.. clear-namespace
+
 .. code-block:: python
-  :linenos:
 
     from dataclasses import dataclass
 
@@ -432,8 +387,9 @@ which can be defined with just the ``_power_eval`` method.
 
 Defining a cosine beam with no free parameters is even simpler:
 
+.. clear-namespace
+
 .. code-block:: python
-  :linenos:
 
     import numpy as np
     from pyuvdata.analytic_beam import UnpolarizedAnalyticBeam
@@ -468,6 +424,23 @@ Defining a cosine beam with no free parameters is even simpler:
             return data_array
 
 
+Example: Defining a beam with post init validation
+**************************************************
+
+The gaussian beam defined in pyuvdata is an unpolarized beam that has several
+optional configurations that require some validation, which we do using the
+``validate`` method.
+
+Here is the definition in pyuvdata for the GaussianBeam object and the
+``diameter_to_sigma`` function it uses:
+
+.. literalinclude:: ../src/pyuvdata/analytic_beam.py
+   :pyobject: diameter_to_sigma
+
+.. literalinclude:: ../src/pyuvdata/analytic_beam.py
+   :pyobject: GaussianBeam
+
+
 Example: Defining a simple polarized beam
 *****************************************
 
@@ -480,380 +453,10 @@ we can use some trig identities to reduce the number of cos/sin evaluations for
 the power calculation, but it would give the same results if the ``_power_eval``
 method was not defined (we have tests verifying this).
 
-.. code-block:: python
-  :linenos:
-
-    import numpy as np
-    from pyuvdata.analytic_beam import AnalyticBeam
-    from pyuvdata.utils.types import FloatArray
-
-    class ShortDipoleBeam(AnalyticBeam):
-        """
-        A zenith pointed analytic short dipole beam with two crossed feeds.
-
-        A classical short (Hertzian) dipole beam with two crossed feeds aligned east
-        and north. Short dipole beams are intrinsically polarized but achromatic.
-        Does not require any parameters, but the orientation of the dipole labelled
-        as "x" can be specified to align "north" or "east" via the x_orientation
-        parameter (matching the parameter of the same name on UVBeam and UVData
-        objects).
-
-        Attributes
-        ----------
-        feed_array : list of str
-            Feeds to define this beam for, e.g. x & y or n & e (for "north" and "east").
-        x_orientation : str
-            The orientation of the dipole labeled 'x'. The default ("east") means
-            that the x dipole is aligned east-west and that the y dipole is aligned
-            north-south.
-
-        Parameters
-        ----------
-        feed_array : list of str
-            Feeds to define this beam for, e.g. x & y or n & e (for "north" and "east").
-        x_orientation : str
-            The orientation of the dipole labeled 'x'. The default ("east") means
-            that the x dipole is aligned east-west and that the y dipole is aligned
-            north-south.
-        include_cross_pols : bool
-            Option to include the cross polarized beams (e.g. xy and yx or en and ne)
-            for the power beam.
-
-        """
-
-        basis_vector_type = "az_za"
-
-        def _efield_eval(
-            self,
-            *,
-            az_grid: FloatArray,
-            za_grid: FloatArray,
-            f_grid: FloatArray,
-        ) -> FloatArray:
-            """Evaluate the efield at the given coordinates."""
-            data_array = self._get_empty_data_array(az_grid.shape)
-
-            # The first dimension is for [azimuth, zenith angle] in that order
-            # the second dimension is for feed [e, n] in that order
-            data_array[0, self.east_ind] = -np.sin(az_grid)
-            data_array[0, self.north_ind] = np.cos(az_grid)
-            data_array[1, self.east_ind] = np.cos(za_grid) * np.cos(az_grid)
-            data_array[1, self.north_ind] = np.cos(za_grid) * np.sin(az_grid)
-
-            return data_array
-
-        def _power_eval(
-            self,
-            *,
-            az_grid: FloatArray,
-            za_grid: FloatArray,
-            f_grid: FloatArray,
-        ) -> FloatArray:
-            """Evaluate the power at the given coordinates."""
-            data_array = self._get_empty_data_array(az_grid.shape, beam_type="power")
-
-            # these are just the sum in quadrature of the efield components.
-            # some trig work is done to reduce the number of cos/sin evaluations
-            data_array[0, 0] = 1 - (np.sin(za_grid) * np.cos(az_grid)) ** 2
-            data_array[0, 1] = 1 - (np.sin(za_grid) * np.sin(az_grid)) ** 2
-
-            if self.Npols > self.Nfeeds:
-                # cross pols are included
-                data_array[0, 2] = -(np.sin(za_grid) ** 2) * np.sin(2.0 * az_grid) / 2.0
-                data_array[0, 3] = data_array[0, 2]
-
-            return data_array
-
-If we wanted to specify the default feed_array to be ``["e", "n"]`` and that the
-default x_orientation was ``"north"`` we would define it as shown below. We
-handle the defaulting of the feed_array in the ``validate`` because dataclass
+We handle the defaulting of the feed_array in the ``validate`` because dataclass
 fields cannot have mutable defaults. We also do some other validation in that method.
 
-.. code-block:: python
-  :linenos:
+The definition in pyuvdata for the ShortDipoleBeam object is:
 
-    from typing import Literal
-    from dataclasses import dataclass
-
-    import numpy as np
-    from pyuvdata.analytic_beam import AnalyticBeam
-    from pyuvdata.utils.types import FloatArray, StrArray
-
-    @dataclass(kw_only=True)
-    class ShortDipoleBeam(AnalyticBeam):
-        """
-        A zenith pointed analytic short dipole beam with two crossed feeds.
-
-        A classical short (Hertzian) dipole beam with two crossed feeds aligned east
-        and north. Short dipole beams are intrinsically polarized but achromatic.
-        Does not require any parameters, but the orientation of the dipole labelled
-        as "x" can be specified to align "north" or "east" via the x_orientation
-        parameter (matching the parameter of the same name on UVBeam and UVData
-        objects).
-
-        Attributes
-        ----------
-        feed_array : list of str
-            Feeds to define this beam for, e.g. x & y or n & e (for "north" and "east").
-        x_orientation : str
-            The orientation of the dipole labeled 'x'. The default ("east") means
-            that the x dipole is aligned east-west and that the y dipole is aligned
-            north-south.
-
-        Parameters
-        ----------
-        feed_array : list of str
-            Feeds to define this beam for, e.g. x & y or n & e (for "north" and "east").
-        x_orientation : str
-            The orientation of the dipole labeled 'x'. The default ("east") means
-            that the x dipole is aligned east-west and that the y dipole is aligned
-            north-south.
-        include_cross_pols : bool
-            Option to include the cross polarized beams (e.g. xy and yx or en and ne)
-            for the power beam.
-
-        """
-
-        feed_array: StrArray | list[str] | None = None
-        x_orientation: Literal["east", "north"] | None = "north"
-
-        basis_vector_type = "az_za"
-
-        def validate(self):
-            """Post-initialization validation and conversions."""
-            if self.feed_array is None:
-                self.feed_array = ["e", "n"]
-
-            allowed_feeds = ["n", "e", "x", "y"]
-            for feed in self.feed_array:
-                if feed not in allowed_feeds:
-                    raise ValueError(
-                        f"Feeds must be one of: {allowed_feeds}, "
-                        f"got feeds: {self.feed_array}"
-                    )
-
-        def _efield_eval(
-            self,
-            *,
-            az_grid: FloatArray,
-            za_grid: FloatArray,
-            f_grid: FloatArray,
-        ) -> FloatArray:
-            """Evaluate the efield at the given coordinates."""
-            data_array = self._get_empty_data_array(az_grid.shape)
-
-            # The first dimension is for [azimuth, zenith angle] in that order
-            # the second dimension is for feed [e, n] in that order
-            data_array[0, self.east_ind] = -np.sin(az_grid)
-            data_array[0, self.north_ind] = np.cos(az_grid)
-            data_array[1, self.east_ind] = np.cos(za_grid) * np.cos(az_grid)
-            data_array[1, self.north_ind] = np.cos(za_grid) * np.sin(az_grid)
-
-            return data_array
-
-        def _power_eval(
-            self,
-            *,
-            az_grid: FloatArray,
-            za_grid: FloatArray,
-            f_grid: FloatArray,
-        ) -> FloatArray:
-            """Evaluate the power at the given coordinates."""
-            data_array = self._get_empty_data_array(az_grid.shape, beam_type="power")
-
-            # these are just the sum in quadrature of the efield components.
-            # some trig work is done to reduce the number of cos/sin evaluations
-            data_array[0, 0] = 1 - (np.sin(za_grid) * np.cos(az_grid)) ** 2
-            data_array[0, 1] = 1 - (np.sin(za_grid) * np.sin(az_grid)) ** 2
-
-            if self.Npols > self.Nfeeds:
-                # cross pols are included
-                data_array[0, 2] = -(np.sin(za_grid) ** 2) * np.sin(2.0 * az_grid) / 2.0
-                data_array[0, 3] = data_array[0, 2]
-
-            return data_array
-
-
-
-Example: Defining a beam with post init validation
-**************************************************
-
-The gaussian beam defined in pyuvdata is an unpolarized beam that has several
-optional configurations that require some validation, which we do using the
-``validate`` method.
-
-.. code-block:: python
-  :linenos:
-
-    from dataclasses import dataclass
-    from typing import Literal
-
-    import numpy as np
-    from astropy.constants import c as speed_of_light
-    from pyuvdata.analytic_beam import UnpolarizedAnalyticBeam
-    from pyuvdata.utils.types import FloatArray
-
-    def diameter_to_sigma(diameter: float, freq_array: FloatArray) -> float:
-        """
-        Find the sigma that gives a beam width similar to an Airy disk.
-
-        Find the stddev of a gaussian with fwhm equal to that of
-        an Airy disk's main lobe for a given diameter.
-
-        Parameters
-        ----------
-        diameter : float
-            Antenna diameter in meters
-        freq_array : array of float
-            Frequencies in Hz
-
-        Returns
-        -------
-        sigma : float
-            The standard deviation in zenith angle radians for a Gaussian beam
-            with FWHM equal to that of an Airy disk's main lobe for an aperture
-            with the given diameter.
-
-        """
-        wavelengths = speed_of_light.to("m/s").value / freq_array
-
-        scalar = 2.2150894  # Found by fitting a Gaussian to an Airy disk function
-
-        sigma = np.arcsin(scalar * wavelengths / (np.pi * diameter)) * 2 / 2.355
-
-        return sigma
-
-
-    @dataclass(kw_only=True)
-    class GaussianBeam(UnpolarizedAnalyticBeam):
-        """
-        A circular, zenith pointed Gaussian beam.
-
-        Requires either a dish diameter in meters or a standard deviation sigma in
-        radians. Gaussian beams specified by a diameter will have their width
-        matched to an Airy beam at each simulated frequency, so are inherently
-        chromatic. For Gaussian beams specified with sigma, the sigma_type defines
-        whether the width specified by sigma specifies the width of the E-Field beam
-        (default) or power beam in zenith angle. If only sigma is specified, the
-        beam is achromatic, optionally both the spectral_index and reference_frequency
-        parameters can be set to generate a chromatic beam with standard deviation
-        defined by a power law:
-
-        stddev(f) = sigma * (f/ref_freq)**(spectral_index)
-
-        Attributes
-        ----------
-        sigma : float
-            Standard deviation in radians for the gaussian beam. Only one of sigma
-            and diameter should be set.
-        sigma_type : str
-            Either "efield" or "power" to indicate whether the sigma specifies the size of
-            the efield or power beam. Ignored if `sigma` is None.
-        diameter : float
-            Dish diameter in meters to use to define the size of the gaussian beam, by
-            matching the FWHM of the gaussian to the FWHM of an Airy disk. This will result
-            in a frequency dependent beam.  Only one of sigma and diameter should be set.
-        spectral_index : float
-            Option to scale the gaussian beam width as a power law with frequency. If set
-            to anything other than zero, the beam will be frequency dependent and the
-            `reference_frequency` must be set. Ignored if `sigma` is None.
-        reference_frequency : float
-            The reference frequency for the beam width power law, required if `sigma` is not
-            None and `spectral_index` is not zero. Ignored if `sigma` is None.
-
-        Parameters
-        ----------
-        sigma : float
-            Standard deviation in radians for the gaussian beam. Only one of sigma
-            and diameter should be set.
-        sigma_type : str
-            Either "efield" or "power" to indicate whether the sigma specifies the size of
-            the efield or power beam. Ignored if `sigma` is None.
-        diameter : float
-            Dish diameter in meters to use to define the size of the gaussian beam, by
-            matching the FWHM of the gaussian to the FWHM of an Airy disk. This will result
-            in a frequency dependent beam.  Only one of sigma and diameter should be set.
-        spectral_index : float
-            Option to scale the gaussian beam width as a power law with frequency. If set
-            to anything other than zero, the beam will be frequency dependent and the
-            `reference_frequency` must be set. Ignored if `sigma` is None.
-        reference_frequency : float
-            The reference frequency for the beam width power law, required if `sigma` is not
-            None and `spectral_index` is not zero. Ignored if `sigma` is None.
-        include_cross_pols : bool
-            Option to include the cross polarized beams (e.g. xy and yx or en and ne) for
-            the power beam.
-
-        """
-
-        sigma: float | None = None
-        sigma_type: Literal["efield", "power"] = "efield"
-        diameter: float | None = None
-        spectral_index: float = 0.0
-        reference_frequency: float = None
-
-        def validate(self):
-            """Post-initialization validation and conversions."""
-            if (self.diameter is None and self.sigma is None) or (
-                self.diameter is not None and self.sigma is not None
-            ):
-                if self.diameter is None:
-                    raise ValueError("Either diameter or sigma must be set.")
-                else:
-                    raise ValueError("Only one of diameter or sigma can be set.")
-
-            if self.sigma is not None:
-                if self.sigma_type not in ["efield", "power"]:
-                    raise ValueError("sigma_type must be 'efield' or 'power'.")
-
-                if self.sigma_type == "power":
-                    self.sigma = np.sqrt(2) * self.sigma
-
-                if self.spectral_index != 0.0 and self.reference_frequency is None:
-                    raise ValueError(
-                        "reference_frequency must be set if `spectral_index` is not zero."
-                    )
-                if self.reference_frequency is None:
-                    self.reference_frequency = 1.0
-
-        def get_sigmas(self, freq_array: FloatArray) -> FloatArray:
-            """
-            Get the sigmas for the gaussian beam using the diameter (if defined).
-
-            Parameters
-            ----------
-            freq_array : array of floats
-                Frequency values to get the sigmas for in Hertz.
-
-            Returns
-            -------
-            sigmas : array_like of float
-                Beam sigma values as a function of frequency. Size will match the
-                freq_array size.
-
-            """
-            if self.diameter is not None:
-                sigmas = diameter_to_sigma(self.diameter, freq_array)
-            elif self.sigma is not None:
-                sigmas = (
-                    self.sigma
-                    * (freq_array / self.reference_frequency) ** self.spectral_index
-                )
-            return sigmas
-
-        def _power_eval(
-            self,
-            *,
-            az_grid: FloatArray,
-            za_grid: FloatArray,
-            f_grid: FloatArray,
-        ) -> FloatArray:
-            """Evaluate the power at the given coordinates."""
-            sigmas = self.get_sigmas(f_grid)
-
-            values = np.exp(-(za_grid ** 2) / (sigmas ** 2))
-            data_array = self._get_empty_data_array(az_grid.shape, beam_type="power")
-            for fn in np.arange(self.Npols):
-                data_array[0, fn, :, :] = values
-
-            return data_array
+.. literalinclude:: ../src/pyuvdata/analytic_beam.py
+   :pyobject: ShortDipoleBeam

--- a/docs/beam_interface_tutorial.rst
+++ b/docs/beam_interface_tutorial.rst
@@ -22,91 +22,94 @@ that is attached to it is an analytic beam or a UVBeam.
 
 .. code-block:: python
 
-  >>> import os
-  >>> import matplotlib.pyplot as plt
-  >>> import numpy as np
-  >>> from matplotlib.colors import LogNorm
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from matplotlib.colors import LogNorm
 
-  >>> from pyuvdata import ShortDipoleBeam, BeamInterface, UVBeam
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import ShortDipoleBeam, BeamInterface, UVBeam
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("mwa_full_EE")
+    filename = fetch_data("mwa_full_EE")
 
-  >>> dipole_beam = BeamInterface(ShortDipoleBeam(), beam_type="power")
-  >>> mwa_beam = BeamInterface(UVBeam.from_file(filename, pixels_per_deg=1), beam_type="power")
+    dipole_beam = BeamInterface(ShortDipoleBeam(), beam_type="power")
+    mwa_beam = BeamInterface(UVBeam.from_file(filename, pixels_per_deg=1), beam_type="power")
 
-  >>> # set up zenith angle, azimuth and frequency arrays to evaluate with
-  >>> # make a regular grid in direction cosines for nice plots
-  >>> n_vals = 100
-  >>> zmax = np.radians(90)  # Degrees
-  >>> axis_arr = np.arange(-n_vals/2., n_vals/2.) / float(n_vals/2.)
-  >>> l_arr, m_arr = np.meshgrid(axis_arr, axis_arr)
-  >>> radius = np.sqrt(l_arr**2 + m_arr**2)
-  >>> za_array = radius * zmax
-  >>> az_array = np.arctan2(m_arr, l_arr)
+    # set up zenith angle, azimuth and frequency arrays to evaluate with
+    # make a regular grid in direction cosines for nice plots
+    n_vals = 100
+    zmax = np.radians(90)  # Degrees
+    axis_arr = np.arange(-n_vals/2., n_vals/2.) / float(n_vals/2.)
+    l_arr, m_arr = np.meshgrid(axis_arr, axis_arr)
+    radius = np.sqrt(l_arr**2 + m_arr**2)
+    za_array = radius * zmax
+    az_array = np.arctan2(m_arr, l_arr)
 
-  >>> # Wrap the azimuth array to [0, 2pi] to match the extent of the UVBeam azimuth
-  >>> where_neg_az = np.nonzero(az_array < 0)
-  >>> az_array[where_neg_az] = az_array[where_neg_az] + np.pi * 2.
-  >>> az_array = az_array.flatten()
-  >>> za_array = za_array.flatten()
+    # Wrap the azimuth array to [0, 2pi] to match the extent of the UVBeam azimuth
+    where_neg_az = np.nonzero(az_array < 0)
+    az_array[where_neg_az] = az_array[where_neg_az] + np.pi * 2.
+    az_array = az_array.flatten()
+    za_array = za_array.flatten()
 
-  >>> # find the values above the horizon so we don't try to interpolate the MWA beam
-  >>> # beyond the horizon
-  >>> above_hor = np.nonzero(za_array <= np.pi / 2.)[0]
+    # find the values above the horizon so we don't try to interpolate the MWA beam
+    # beyond the horizon
+    above_hor = np.nonzero(za_array <= np.pi / 2.)[0]
 
-  >>> # set up output arrays that matches the expected shape, except that they
-  >>> # include the points beyond the horizon, and fill them with infinity.
-  >>> # Then we will set the points above the horizon to the computed responses.
-  >>> dipole_beam_vals = np.full((1, 4, 1, n_vals * n_vals), np.inf, dtype=complex)
-  >>> mwa_beam_vals = np.full((1, 4, 1, n_vals * n_vals), np.inf, dtype=complex)
+    # set up output arrays that matches the expected shape, except that they
+    # include the points beyond the horizon, and fill them with infinity.
+    # Then we will set the points above the horizon to the computed responses.
+    dipole_beam_vals = np.full((1, 4, 1, n_vals * n_vals), np.inf, dtype=complex)
+    mwa_beam_vals = np.full((1, 4, 1, n_vals * n_vals), np.inf, dtype=complex)
 
-  >>> # The MWA beam we have in our test data is small, it only has 3 frequencies,
-  >>> # so we will just get the value at one of those frequencies rather than
-  >>> # trying to interpolate to a new frequency.
-  >>> freqs = np.array([mwa_beam.beam.freq_array[-1]])
+    # The MWA beam we have in our test data is small, it only has 3 frequencies,
+    # so we will just get the value at one of those frequencies rather than
+    # trying to interpolate to a new frequency.
+    freqs = np.array([mwa_beam.beam.freq_array[-1]])
 
-  >>> dipole_beam_vals[:, :, :, above_hor] = dipole_beam.compute_response(
-  ...     az_array=az_array[above_hor], za_array=za_array[above_hor], freq_array=freqs
-  ... )
-  >>> dipole_beam_vals = dipole_beam_vals.reshape(4, n_vals, n_vals)
+    dipole_beam_vals[:, :, :, above_hor] = dipole_beam.compute_response(
+        az_array=az_array[above_hor], za_array=za_array[above_hor], freq_array=freqs
+    )
+    dipole_beam_vals = dipole_beam_vals.reshape(4, n_vals, n_vals)
 
-  >>> mwa_beam_vals[:, :, :, above_hor] = mwa_beam.compute_response(
-  ...     az_array=az_array[above_hor], za_array=za_array[above_hor], freq_array=freqs
-  ... )
-  >>> mwa_beam_vals = mwa_beam_vals.reshape(4, n_vals, n_vals)
+    mwa_beam_vals[:, :, :, above_hor] = mwa_beam.compute_response(
+        az_array=az_array[above_hor], za_array=za_array[above_hor], freq_array=freqs
+    )
+    mwa_beam_vals = mwa_beam_vals.reshape(4, n_vals, n_vals)
 
-  >>> fig, ax = plt.subplots(1, 2)
-  >>> bp_dip = ax[0].imshow(
-  ...   dipole_beam_vals[0].real,
-  ...   norm=LogNorm(vmin = 1e-4, vmax =1),
-  ...   extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
-  ...   origin="lower",
-  ... )
-  >>> _ = ax[0].set_title(f"E/W Dipole power beam")
-  >>> _ = fig.colorbar(bp_dip, ax=ax[0], fraction=0.046, pad=0.04, location="left")
+    fig, ax = plt.subplots(1, 2)
+    bp_dip = ax[0].imshow(
+      dipole_beam_vals[0].real,
+      norm=LogNorm(vmin = 1e-4, vmax =1),
+      extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
+      origin="lower",
+    )
+    _ = ax[0].set_title(f"E/W Dipole power beam")
+    _ = fig.colorbar(bp_dip, ax=ax[0], fraction=0.046, pad=0.04, location="left")
 
-  >>> bp_mwa = ax[1].imshow(
-  ...   mwa_beam_vals[0].real,
-  ...   norm=LogNorm(vmin = 1e-4, vmax =1),
-  ...   extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
-  ...   origin="lower",
-  ... )
-  >>> _ = ax[1].set_title(f"MWA E/W power beam")
-  >>> _ = fig.colorbar(bp_mwa, ax=ax[1], fraction=0.046, pad=0.04, location="left")
+    bp_mwa = ax[1].imshow(
+      mwa_beam_vals[0].real,
+      norm=LogNorm(vmin = 1e-4, vmax =1),
+      extent=[np.min(l_arr), np.max(l_arr), np.min(m_arr), np.max(m_arr)],
+      origin="lower",
+    )
+    _ = ax[1].set_title(f"MWA E/W power beam")
+    _ = fig.colorbar(bp_mwa, ax=ax[1], fraction=0.046, pad=0.04, location="left")
 
-  >>> for ind in range(2):
-  ...   _ = ax[ind].set_xticks([0], labels=["North"])
-  ...   _ = ax[ind].set_yticks([0], labels=["East"])
-  ...   _ = ax[ind].yaxis.set_label_position("right")
-  ...   _ = ax[ind].yaxis.tick_right()
-  ...   _ = ax[ind].xaxis.set_label_position("top")
-  ...   _ = ax[ind].xaxis.tick_top()
+    for ind in range(2):
+      _ = ax[ind].set_xticks([0], labels=["North"])
+      _ = ax[ind].set_yticks([0], labels=["East"])
+      _ = ax[ind].yaxis.set_label_position("right")
+      _ = ax[ind].yaxis.tick_right()
+      _ = ax[ind].xaxis.set_label_position("top")
+      _ = ax[ind].xaxis.tick_top()
 
-  >>> fig.tight_layout()
-  >>> plt.show()  # doctest: +SKIP
-  >>> plt.savefig("Images/dipole_mwa_power.png", bbox_inches='tight')
-  >>> plt.clf()
+    fig.tight_layout()
+
+.. skip: next
+
+    plt.show()
+
+    plt.savefig("Images/dipole_mwa_power.png", bbox_inches='tight')
+    plt.clf()
 
 .. image:: Images/dipole_mwa_power.png
-  :width: 600
+    :width: 600

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -9,6 +9,9 @@ from pathlib import Path
 
 import matplotlib
 import pytest
+from sybil import Sybil
+from sybil.parsers.codeblock import PythonCodeBlockParser
+from sybil.parsers.rest import ClearNamespaceParser, DocTestParser
 
 matplotlib.use("Agg")  # Must be before importing matplotlib.pyplot or pylab!
 
@@ -26,3 +29,14 @@ def setup_and_teardown_package(tmp_path_factory):
     finally:
         os.chdir(cwd)
         shutil.rmtree(tmp_path)
+
+
+pytest_collect_file = Sybil(
+    parsers=[
+        DocTestParser(),
+        PythonCodeBlockParser(future_imports=["print_function"]),
+        ClearNamespaceParser(),
+    ],
+    pattern="*.rst",
+    fixtures=["setup_and_teardown_package", "tmp_path_factory"],
+).pytest()

--- a/docs/uvbeam_tutorial.rst
+++ b/docs/uvbeam_tutorial.rst
@@ -63,231 +63,131 @@ parameters for common beam pixel and E-field coordinate systems include:
 
 .. include:: tutorial_data_note.rst
 
-UVBeam: Reading/writing
------------------------
-Reading and writing beam files using UVBeam.
 
-The text files saved out of CST beam simulations do not have much of the
-critical metadata needed for UVBeam objects. When reading in CST files, you
-can either provide the required metadata using keywords to the :meth:`pyuvdata.UVBeam.read` method
-and pass the raw CST files, or you can pass a settings yaml file which lists
-the raw files and provides the required metadata to the :meth:`pyuvdata.UVBeam.read` method. Both
-options are shown in the examples below. More details on creating a new yaml
-settings files can be found in :doc:`cst_settings_yaml`.
+UVBeam: Instantiating a UVBeam object from a file (i.e. reading data)
+---------------------------------------------------------------------
 
-UVBeam (like UVData) has a generic :meth:`pyuvdata.UVBeam.read` method and a
-:meth:`pyuvdata.UVBeam.from_file` class method in addition to the file-type specific
-methods.
+Use the :meth:`pyuvdata.UVBeam.from_file` to instantiate a UVBeam object from
+data in a file (alternatively you can create an object with no inputs and then
+call the :meth:`pyuvdata.UVBeam.read` method). Most file types require a single
+file or folder to instantiate an object, FHD and raw MWA correlator data sets
+require the user to specify multiple files for each dataset.
 
-a) Reading a CST power beam file
-********************************
-.. code-block:: python
-
-  >>> import os
-  >>> from pyuvdata import UVBeam
-  >>> from pyuvdata.datasets import fetch_data
-
-  # you can pass several filenames and the objects from each file will be
-  # combined across the appropriate axis -- in this case frequency
-  >>> filenames = fetch_data(["hera_fagnoni_dipole_123", "hera_fagnoni_dipole_150"])
-
-  # You have to specify the telescope_name, feed_name, feed_version, model_name
-  # and model_version because they are not included in the raw CST files.
-  # You should also specify the polarization that the file represents and you can
-  # set rotate_pol to generate the other polarization by rotating by 90 degrees.
-  # The feed_pol defaults to "x" and rotate_pol defaults to True.
-  >>> beam = UVBeam.from_file(
-  ...   filenames, beam_type="power", frequency=[150e6, 123e6],
-  ...   feed_pol="x", rotate_pol=True, telescope_name="HERA",
-  ...   feed_name="PAPER_dipole", feed_version="0.1",
-  ...   model_name="E-field pattern - Rigging height 4.9m",
-  ...   model_version="1.0", mount_type="fixed",
-  ... )
-  >>> print(beam.beam_type)
-  power
-  >>> print(beam.pixel_coordinate_system)
-  az_za
-  >>> print(beam.data_normalization)
-  physical
-
-  >>> # You can also use a yaml settings file.
-  >>> settings_file = fetch_data("hera_fagnoni_dipole_yaml")
-  >>> beam = UVBeam.from_file(settings_file, beam_type="power")
-  >>> print(beam.beam_type)
-  power
-  >>> print(beam.pixel_coordinate_system)
-  az_za
-  >>> print(beam.data_normalization)
-  physical
-
-  >>> # number of beam polarizations and polarization type.
-  >>> print((beam.Npols, beam.polarization_array))
-  (2, array([-5, -6]))
-  >>> print(beam.Nfreqs)
-  2
-  >>> print(beam.data_array.shape)
-  (1, 2, 2, 181, 360)
+``pyuvdata`` can also be used to create a UVBeam object from arrays in memory
+(see :ref:`new_uvbeam`) and to read in multiple datasets (files) into a single
+object (see :ref:`multiple_files_uvbeam`).
 
 
-b) Reading a CST E-field beam file
-**********************************
-.. code-block:: python
+a) Instantiate an object from a single file or folder
+*****************************************************
+BeamFITS and MWA beams are stored in a single file.
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVBeam
-  >>> from pyuvdata.datasets import fetch_data
+To get all the frequencies available for the MWA full embedded element beam
+you need to download the output simulation file via
+`wget http://cerberus.mwa128t.org/mwa_full_embedded_element_pattern.h5`
+For this tutorial we use the file saved in the test data which only
+contains a few frequencies.
 
-  >>> # the same interface as for power beams, just specify beam_type = "efield"
-  >>> settings_file = fetch_data("hera_fagnoni_dipole_yaml")
-  >>> beam = UVBeam.from_file(settings_file, beam_type="efield")
-  >>> print(beam.beam_type)
-  efield
+For MWA beams, which are composed of phased arrays of dipoles, you can specify
+delay and amplitude arrays to generate beams pointed any where or with varying
+gains per dipole. Set a delay to 32 to get a beam where that dipole is turned
+off (or set the amplitude to zero). The native format of the beam is spherical
+harmonic modes, so there is also an option `pixels_per_deg` to set the output
+beam resolution (default is 5 pixels per degree).
 
-  >>> # UVBeam also has a `from_file` class method we can call directly.
-  >>> beam3 = UVBeam.from_file(settings_file, beam_type="efield")
-  >>> beam == beam3
-  True
-
-c) Reading a FEKO beam file (Power & E-field)
-*********************************************
-.. code-block:: python
-
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVBeam
-  >>> from pyuvdata.datasets import fetch_data
-
-  >>> feko_filenames = fetch_data(["ovro_lwa_feko_x", "ovro_lwa_feko_y"])
-
-  >>> pbeam_feko = UVBeam.from_file(
-  ...   feko_filenames, beam_type="power", feed_pol=["x", "y"],
-  ...   feed_angle=[np.pi/2, 0.0], telescope_name="LWA",feed_name="LWA", feed_version="1",
-  ...   model_name="FEKO_MROsoil_test", model_version="1.0", mount_type="fixed"
-  ... )
-  >>> print(np.shape(pbeam_feko.data_array))
-  (1, 2, 3, 181, 181)
-
-  >>> ebeam_feko = UVBeam.from_file(
-  ...   feko_filenames, beam_type="efield", feed_pol=["x", "y"],
-  ...   feed_angle=[np.pi/2, 0.0], telescope_name="LWA",feed_name="LWA", feed_version="1",
-  ...   model_name="FEKO_MROsoil_test", model_version="1.0", mount_type="fixed"
-  ... )
-  >>> print(np.shape(ebeam_feko.data_array))
-  (2, 2, 3, 181, 181)
-
-d) Reading in the MWA full embedded element beam
-************************************************
-.. code-block:: python
-
-  >>> # To get all the frequencies available for the MWA full embedded element beam
-  >>> # you need to download the output simulation file via
-  >>> # `wget http://cerberus.mwa128t.org/mwa_full_embedded_element_pattern.h5`
-  >>> # For this tutorial we use the file saved in the test data which only
-  >>> # contains a few frequencies.
-  >>> # The `read_mwa_beam` method takes delay and amplitude arrays to generate beams
-  >>> # pointed any where or with varying gains per dipole. Set a delay to 32
-  >>> # to get a beam where that dipole is turned off (or set the amplitude to zero).
-  >>> # The native format of the beam is spherical harmonic modes, so there is also
-  >>> # an option `pixels_per_deg` to set the output beam resolution
-  >>> # (default is 5 pixels per degree).
-
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVBeam
-  >>> from pyuvdata.datasets import fetch_data
-
-  >>> mwa_beam_file = fetch_data("mwa_full_EE")
-  >>> beam = UVBeam.from_file(mwa_beam_file)
-  >>> print(beam.beam_type)
-  efield
-
-  >>> delays = np.zeros((2, 16), dtype="int")
-  >>> delays[:, 0] = 32
-  >>> beam = UVBeam.from_file(mwa_beam_file, pixels_per_deg=1, delays=delays)
-
-
-d) Writing a regularly gridded beam FITS file
-**********************************************
-When reading a beam FITS file, you also have the option of selecting frequencies and
-az/za values at the read step -- i.e. so that memory is never allocated for data outside
-these ranges. Use the ``freq_range``, ``za_range`` and ``az_range`` parameters to
-achieve this. The ``freq_range`` parameter will be effective for both HEALpix beamfits
-files and az/za grid.
+.. clear-namespace
 
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVBeam
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVBeam
+    from pyuvdata.datasets import fetch_data
 
-  >>> settings_file = fetch_data("hera_fagnoni_dipole_yaml")
-  >>> beam = UVBeam()
-  >>> beam.read(
-  ...    settings_file,
-  ...    beam_type="power",
-  ...    freq_range=(1e8, 1.5e8),
-  ...    za_range=(0, 90.0),
-  ... )
-  >>> write_file = os.path.join(".", "tutorial.fits")
-  >>> beam.write_beamfits(write_file, clobber=True)
+    filename = fetch_data("mwa_full_EE")
+    # for a zenith pointed beam let the delays default to all zeros
+    beam = UVBeam.from_file(filename)
 
-e) Writing a HEALPix beam FITS file
-***********************************
-See :ref:`uvbeam_to_healpix` for more details on the :meth:`pyuvdata.UVBeam.to_healpix` method.
-
-.. code-block:: python
-
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVBeam
-  >>> from pyuvdata.datasets import fetch_data
-
-  >>> settings_file = fetch_data("hera_fagnoni_dipole_yaml")
-  >>> beam = UVBeam.from_file(settings_file, beam_type="power")
-
-  >>> # note that the `to_healpix` method requires astropy_healpix to be installed
-  >>> # this beam file is very large. Let's cut down the size to ease the computation
-  >>> # More on the `select` method is covered in the following section
-  >>> za_max = np.deg2rad(10.0)
-  >>> za_inds_use = np.nonzero(beam.axis2_array <= za_max)[0]
-  >>> beam.select(axis2_inds=za_inds_use)
-
-  >>> beam.to_healpix()
-  >>> write_file = os.path.join(".", "tutorial.fits")
-  >>> beam.write_beamfits(write_file, clobber=True)
+    # to point the beam off zenith apply a delay slope across the tile
+    # use the same pointing for both pols.
+    delays = np.empty((2, 16), dtype=int)
+    for pol in range(2):
+        delays[pol] = np.tile(np.arange(0, 8, 2), 4)
+    beam = UVBeam.from_file(filename, pixels_per_deg=1, delays=delays)
 
 
-UVBeam: Instantiating from arrays in memory
--------------------------------------------
-``pyuvdata`` can also be used to create a UVBeam object from arrays in memory. This
-is useful for mocking up data for testing or for creating a UVBeam object from
-simulated data. Instead of instantiating a blank object and setting each required
-parameter, you can use the ``.new()`` static method, which deals with the task
-of creating a consistent object from a minimal set of inputs
+a) Instantiate an object from CST or FEKO beam files
+****************************************************
+
+The text files saved out of CST and FEKO beam simulations do not have much of the
+critical metadata needed for UVBeam objects. When reading in these beams, you must
+provide the required metadata. For both CST and FEKO beams, the metadata can be
+specified using keywords to the :meth:`pyuvdata.UVBeam.from_file` method along
+with the beam files. For CST beams, which have a file per frequency, another
+option is to create a yaml file which lists the beam files and provides the
+required metadata to the :meth:`pyuvdata.UVBeam.read` method. Both options are
+shown in the examples below. More details on creating a new yaml settings files
+can be found in :doc:`cst_settings_yaml`.
+
+.. clear-namespace
 
 .. code-block:: python
 
-  >>> from astropy.coordinates import EarthLocation
-  >>> import numpy as np
-  >>> from pyuvdata import UVBeam
+    import numpy as np
+    from pyuvdata import UVBeam
+    from pyuvdata.datasets import fetch_data
 
-  >>> uvb = UVBeam.new(
-  ...     telescope_name="test",
-  ...     data_normalization="physical",
-  ...     freq_array=np.linspace(100e6, 200e6, 10),
-  ...     x_orientation = "east",
-  ...     feed_array = ["x", "y"],
-  ...     mount_type = "fixed",
-  ...     axis1_array=np.deg2rad(np.linspace(-180, 179, 360)),
-  ...     axis2_array=np.deg2rad(np.linspace(0, 90, 181)),
-  ... )
+    feko_filenames = fetch_data(["ovro_lwa_feko_x", "ovro_lwa_feko_y"])
 
-Notice that you need only provide the required parameters, and the rest will be
-filled in with sensible defaults.
+    # specify the feko files along with the required metadata. Specify either a
+    # "efield" or "power beam type"
+    feko_beam = UVBeam.from_file(
+        feko_filenames, beam_type="efield", feed_pol=["x", "y"],
+        feed_angle=[np.pi/2, 0.0], telescope_name="LWA",feed_name="LWA", feed_version="1",
+        model_name="FEKO_MROsoil_test", model_version="1.0", mount_type="fixed"
+    )
 
-See the full documentation for the method
-:func:`pyuvdata.uvbeam.UVBeam.new` for more information.
+    # you can pass several filenames and the objects from each file will be
+    # combined across the appropriate axis -- in this case frequency
+    cst_filenames = fetch_data(["hera_fagnoni_dipole_123", "hera_fagnoni_dipole_150"])
+
+    # specify the CST files along with the required metadata. Specify either a
+    # "efield" or "power beam type"
+    # If you only have one polarization, you can set rotate_pol to generate the
+    # other polarization by rotating by 90 degrees.
+    cst_beam = UVBeam.from_file(
+        cst_filenames, beam_type="efield", frequency=[150e6, 123e6],
+        feed_pol="x", rotate_pol=True, telescope_name="HERA",
+        feed_name="PAPER_dipole", feed_version="0.1",
+        model_name="E-field pattern - Rigging height 4.9m",
+        model_version="1.0", mount_type="fixed",
+    )
+
+    # For CST beams you can also use a yaml specification file.
+    cst_yml_file = fetch_data("hera_fagnoni_dipole_yaml")
+    cst_beam = UVBeam.from_file(cst_yml_file, beam_type="power")
+
+
+UVBeam: Writing UVBeam objects to disk
+--------------------------------------
+
+pyuvdata can write UVBeam objects to BeamFITS files using the
+:meth:`pyuvdata.UVBeam.write_beamfits` method, which only requires a filename to
+write the data to.
+
+.. clear-namespace
+
+.. code-block:: python
+
+    import os
+    from pyuvdata import UVBeam
+    from pyuvdata.datasets import fetch_data
+
+    cst_yml_file = fetch_data("hera_fagnoni_dipole_yaml")
+    beam = UVBeam.from_file(cst_yml_file, beam_type="power")
+
+    # Write the data out to a uvfits file
+    write_file = os.path.join(".", "tutorial.beamfits")
+    beam.write_beamfits(write_file, clobber=True)
 
 
 UVBeam: Selecting data
@@ -299,33 +199,43 @@ By default, :meth:`pyuvdata.UVBeam.select` will select data that matches the sup
 criteria, but by setting ``invert=True``, you can instead *deselect* this data and
 preserve only that which does not match the selection.
 
+Note: When reading a beamFITS file, you also have the option of selecting
+frequencies and az/za values at the read step -- i.e. so that memory is never
+allocated for data outside these ranges.
+
+
 a) Selecting a range of Zenith Angles
 *************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import matplotlib.pyplot as plt
-  >>> import numpy as np
-  >>> from pyuvdata import UVBeam
-  >>> from pyuvdata.datasets import fetch_data
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from pyuvdata import UVBeam
+    from pyuvdata.datasets import fetch_data
 
-  >>> settings_file = fetch_data("hera_fagnoni_dipole_yaml")
-  >>> beam = UVBeam.from_file(settings_file, beam_type="power")
-  >>> # Make a new object with a reduced zenith angle range with the select method
-  >>> new_beam = beam.select(axis2_inds=np.arange(0, 20), inplace=False)
+    cst_yml_file = fetch_data("hera_fagnoni_dipole_yaml")
+    beam = UVBeam.from_file(cst_yml_file, beam_type="power")
+    # Make a new object with a reduced zenith angle range with the select method
+    new_beam = beam.select(axis2_inds=np.arange(0, 20), inplace=False)
 
-  >>> # plot zenith angle cut through beams
-  >>> fig, ax = plt.subplots(1, 1)
-  >>> _ = ax.plot(np.rad2deg(beam.axis2_array), beam.data_array[0, 0, 0, :, 0], label="original")
-  >>> _ = ax.plot(np.rad2deg(new_beam.axis2_array), new_beam.data_array[0, 0, 0, :, 0], "r", label="cut down")
-  >>> _ = ax.set_xscale("log")
-  >>> _ = ax.set_yscale("log")
-  >>> _ = ax.set_xlabel("Zenith Angle (degrees)")
-  >>> _ = ax.set_ylabel("Power")
-  >>> _ = fig.legend(loc="upper right", bbox_to_anchor=[0.9,0.88])
-  >>> plt.show()  # doctest: +SKIP
-  >>> plt.savefig("Images/select_beam_cut.png", bbox_inches="tight")
-  >>> plt.clf()
+    # plot zenith angle cut through beams
+    fig, ax = plt.subplots(1, 1)
+    _ = ax.plot(np.rad2deg(beam.axis2_array), beam.data_array[0, 0, 0, :, 0], label="original")
+    _ = ax.plot(np.rad2deg(new_beam.axis2_array), new_beam.data_array[0, 0, 0, :, 0], "r", label="cut down")
+    _ = ax.set_xscale("log")
+    _ = ax.set_yscale("log")
+    _ = ax.set_xlabel("Zenith Angle (degrees)")
+    _ = ax.set_ylabel("Power")
+    _ = fig.legend(loc="upper right", bbox_to_anchor=[0.9,0.88])
+
+.. skip: next
+
+    plt.show()
+    plt.savefig("Images/select_beam_cut.png", bbox_inches="tight")
+    plt.clf()
 
 .. image:: Images/select_beam_cut.png
   :width: 600
@@ -342,91 +252,137 @@ numbers or the polarization strings (e.g. "xx" or "yy" for linear polarizations 
 of the feed (e.g. "nn" or "ee") can also be used if the feeds are oriented toward 0 or
 90 degrees (as denoted by ``feed_angle``).
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import utils, UVBeam
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import utils, UVBeam
+    from pyuvdata.datasets import fetch_data
 
-  >>> settings_file = fetch_data("hera_fagnoni_dipole_yaml")
-  >>> uvb = UVBeam.from_file(settings_file, beam_type="efield")
+    cst_yml_file = fetch_data("hera_fagnoni_dipole_yaml")
+    uvb = UVBeam.from_file(cst_yml_file, beam_type="efield")
 
-  >>> # The feeds names can be found in the feed_array
-  >>> print(uvb.feed_array)
-  ['x' 'y']
+    # make a copy and select a feed
+    uvb2 = uvb.copy()
+    uvb2.select(feeds=["y"])
+    assert uvb2.feed_array == ["y"]
+    assert uvb2.feed_angle == [0.]
 
-  >>> # make a copy and select a feed
-  >>> uvb2 = uvb.copy()
-  >>> uvb2.select(feeds=["y"])
-  >>> print(uvb2.feed_array)
-  ['y']
+    # make a copy and select a feed by phyiscal orientation
+    uvb2 = uvb.copy()
+    uvb2.select(feeds=["n"])
+    assert uvb2.feed_array == ["y"]
+    assert uvb2.feed_angle == [0.]
 
-  >>> # check the feed_angle
-  >>> print(uvb2.feed_angle)
-  [0.]
+    # Finally, try a deselect
+    uvb2 = uvb.copy()
+    uvb2.select(feeds=["y"], invert=True)
+    assert uvb2.feed_array == ["x"]
+    assert np.all(np.isclose(uvb2.feed_angle, 1.57079633))
 
-  >>> # check the x_orientation
-  >>> print(uvb.get_x_orientation_from_feeds())
-  east
+    # convert to a power beam for selecting on polarizations
+    uvb.efield_to_power()
+    uvb.select(polarizations=[-5, -6, -7])
+    assert uvb.polarization_array.tolist() == [-5, -6, -7]
+    assert utils.polnum2str(uvb.polarization_array) == ['xx', 'yy', 'xy']
 
-  >>> # make a copy and select a feed by phyiscal orientation
-  >>> uvb2 = uvb.copy()
-  >>> uvb2.select(feeds=["n"])
-  >>> print(uvb2.feed_array)
-  ['y']
+    # select polarizations using the polarization strings
+    uvb.select(polarizations=["xx", "yy"])
+    assert uvb.polarization_array.tolist() == [-5, -6]
+    assert utils.polnum2str(uvb.polarization_array) == ['xx', 'yy']
 
-  >>> # Finally, try a deselect
-  >>> uvb2 = uvb.copy()
-  >>> uvb2.select(feeds=["x"], invert=True)
-  >>> print(uvb2.feed_array)
-  ['y']
+    # select polarizations using the physical orientation strings
+    uvb.select(polarizations=["ee"])
+    assert uvb.polarization_array.tolist() == [-5]
+    assert utils.polnum2str(uvb.polarization_array) == ['xx']
 
-  >>> # convert to a power beam for selecting on polarizations
-  >>> uvb.efield_to_power()
-  >>> # polarization numbers can be found in the polarization_array
-  >>> print(uvb.polarization_array)
-  [-5 -6 -7 -8]
 
-  >>> # polarization numbers can be converted to strings using a utility function
-  >>> print(utils.polnum2str(uvb.polarization_array))
-  ['xx', 'yy', 'xy', 'yx']
+UVBeam: Combining data
+----------------------
+The :meth:`pyuvdata.UVBeam.__add__` method lets you combine UVBeam objects along
+the frequency, polarization, and/or sky direction axes.
 
-  >>> # select polarizations using the polarization numbers
-  >>> uvb.select(polarizations=[-5, -6, -7])
 
-  >>> # print polarization numbers and strings after select
-  >>> print(uvb.polarization_array)
-  [-5 -6 -7]
-  >>> print(utils.polnum2str(uvb.polarization_array))
-  ['xx', 'yy', 'xy']
+a) Combine frequencies.
+***********************
 
-  >>> # select polarizations using the polarization strings
-  >>> uvb.select(polarizations=["xx", "yy"])
+.. clear-namespace
 
-  >>> # print polarization numbers and strings after select
-  >>> print(uvb.polarization_array)
-  [-5 -6]
-  >>> print(utils.polnum2str(uvb.polarization_array))
-  ['xx', 'yy']
+.. code-block:: python
 
-  >>> # print feed_angle
-  >>> print(uvb.feed_angle)
-  [1.57079633 0.        ]
+    import numpy as np
+    from pyuvdata import UVBeam
+    from pyuvdata.datasets import fetch_data
 
-  >>> # print x_orientation
-  >>> print(uvb.get_x_orientation_from_feeds())
-  east
+    filename = fetch_data("mwa_full_EE")
+    # for a zenith pointed beam let the delays default to all zeros
+    beam1 = UVBeam.from_file(filename)
+    beam2 = beam1.copy()
 
-  >>> # select polarizations using the physical orientation strings
-  >>> uvb.select(polarizations=["ee"])
+    # Downselect frequencies to recombine
+    beam1.select(freq_chans=[0])
+    assert beam1.Nfreqs == 1
+    beam2.select(freq_chans=[1, 2])
+    assert beam2.Nfreqs == 2
+    beam3 = beam1 + beam2
+    assert beam3.Nfreqs == 3
 
-  >>> # print polarization numbers and strings after select
-  >>> print(uvb.polarization_array)
-  [-5]
-  >>> print(utils.polnum2str(uvb.polarization_array))
-  ['xx']
 
+c) Combine in place
+*******************
+The following two commands are equivalent, and act on the beam object
+directly without creating a third beam object.
+
+.. clear-namespace
+
+.. code-block:: python
+
+    import numpy as np
+    from pyuvdata import UVBeam
+    from pyuvdata.datasets import fetch_data
+
+    filename = fetch_data("mwa_full_EE")
+    beam1 = UVBeam.from_file(filename)
+    beam2 = beam1.copy()
+    beam1.select(feeds="x")
+    beam2.select(feeds="y")
+    beam1.__add__(beam2, inplace=True)
+
+    beam1 = UVBeam.from_file(filename)
+    beam2 = beam1.copy()
+    beam1.select(feeds="x")
+    beam2.select(feeds="y")
+    beam1 += beam2
+
+
+.. _multiple_files_uvbeam:
+
+d) Reading multiple files.
+**************************
+If the :meth:`pyuvdata.UVBeam.read` method is given a list of beam files each
+file will be read in succession and combined with the previous file(s).
+
+.. clear-namespace
+
+.. code-block:: python
+
+    import numpy as np
+    from pyuvdata import UVBeam
+    from pyuvdata.datasets import fetch_data
+
+    uvb = UVBeam()
+    uvb.read(fetch_data("mwa_full_EE"), pixels_per_deg=1, freq_range=[100e6, 200e6])
+
+    # Break up beam object into 2 objects, divided in zenith angle and write out
+    # to BeamFITS files so we can demonstrate that they get combined on read.
+    uvb1 = uvb.select(axis2_inds=np.arange(0, uvb.Naxes2 // 2), inplace=False)
+    uvb1.write_beamfits("test_beam0.beamfits")
+    uvb1 = uvb.select(axis2_inds=np.arange(uvb.Naxes2 // 2, uvb.Naxes2), inplace=False)
+    uvb1.write_beamfits("test_beam1.beamfits")
+
+    uvb2 = UVBeam().from_file(["test_beam0.beamfits", "test_beam1.beamfits"])
 
 .. _uvbeam_to_healpix:
 
@@ -437,57 +393,61 @@ errors. If the beam is going to be interpolated (e.g. to source locations) in
 downstream code we urge the user use the beam in the original format to avoid incurring
 extra interpolation errors.
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from astropy_healpix import HEALPix
-  >>> import matplotlib.pyplot as plt
-  >>> from matplotlib.colors import LogNorm
-  >>> import numpy as np
-  >>> from pyuvdata import utils, UVBeam
-  >>> from pyuvdata.datasets import fetch_data
+    from astropy_healpix import HEALPix
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import LogNorm
+    import numpy as np
+    from pyuvdata import utils, UVBeam
+    from pyuvdata.datasets import fetch_data
 
-  >>> settings_file = fetch_data("hera_fagnoni_dipole_yaml")
-  >>> beam = UVBeam.from_file(settings_file, beam_type="power")
+    cst_yml_file = fetch_data("hera_fagnoni_dipole_yaml")
+    beam = UVBeam.from_file(cst_yml_file, beam_type="power")
 
-  >>> # Let's cut down to a small area near zenith so we can see the pixelization
-  >>> za_max = np.deg2rad(20.0)
-  >>> za_inds_use = np.nonzero(beam.axis2_array <= za_max)[0]
-  >>> beam.select(axis2_inds=za_inds_use)
+    # Let's cut down to a small area near zenith so we can see the pixelization
+    za_max = np.deg2rad(20.0)
+    za_inds_use = np.nonzero(beam.axis2_array <= za_max)[0]
+    beam.select(axis2_inds=za_inds_use)
 
-  >>> # Optionally specify which interpolation function to use.
-  >>> hpx_beam = beam.to_healpix(inplace=False, interpolation_function="az_za_simple")
+    # Optionally specify which interpolation function to use.
+    hpx_beam = beam.to_healpix(inplace=False, interpolation_function="az_za_simple")
 
-  >>> # Now plot the pixels on an polar projection with zenith in the center
-  >>> radial_ticks_deg = [5, 10, 20]
+    # Now plot the pixels on an polar projection with zenith in the center
+    radial_ticks_deg = [5, 10, 20]
 
-  >>> az_array, za_array = np.meshgrid(beam.axis1_array, beam.axis2_array)
-  >>> az_za_radial_val = np.sin(za_array)
-  >>> fig, (ax1, ax2) = plt.subplots(1, 2, subplot_kw=dict(projection="polar"), figsize=(15, 15))
-  >>> ax1.grid(True)
-  >>> img1 = ax1.scatter(az_array, az_za_radial_val, c=beam.data_array[0,0,0,:], cmap="plasma", norm=LogNorm())
-  >>> cbar=plt.colorbar(img1, ax=ax1, label="Beam power", orientation="vertical",shrink=.5, format="%4.1e")
-  >>> _ = ax1.set_yticks(np.sin(np.deg2rad(radial_ticks_deg)))
-  >>> _ = ax1.set_yticklabels([f"{rt}" + r"$\degree$" for rt in radial_ticks_deg])
-  >>> _ = ax1.set_title("Az/ZA Beam")
+    az_array, za_array = np.meshgrid(beam.axis1_array, beam.axis2_array)
+    az_za_radial_val = np.sin(za_array)
+    fig, (ax1, ax2) = plt.subplots(1, 2, subplot_kw=dict(projection="polar"), figsize=(15, 15))
+    ax1.grid(True)
+    img1 = ax1.scatter(az_array, az_za_radial_val, c=beam.data_array[0,0,0,:], cmap="plasma", norm=LogNorm())
+    cbar=plt.colorbar(img1, ax=ax1, label="Beam power", orientation="vertical",shrink=.5, format="%4.1e")
+    _ = ax1.set_yticks(np.sin(np.deg2rad(radial_ticks_deg)))
+    _ = ax1.set_yticklabels([f"{rt}" + r"$\degree$" for rt in radial_ticks_deg])
+    _ = ax1.set_title("Az/ZA Beam")
 
-  >>> hpx_obj = HEALPix(nside=hpx_beam.nside, order=hpx_beam.ordering)
-  >>> hpx_lon, hpx_lat = hpx_obj.healpix_to_lonlat(hpx_beam.pixel_array)
-  >>> za, az = utils.coordinates.hpx_latlon_to_zenithangle_azimuth(hpx_lat.rad, hpx_lon.rad)
-  >>> hpx_radial_val = np.sin(za)
+    hpx_obj = HEALPix(nside=hpx_beam.nside, order=hpx_beam.ordering)
+    hpx_lon, hpx_lat = hpx_obj.healpix_to_lonlat(hpx_beam.pixel_array)
+    za, az = utils.coordinates.hpx_latlon_to_zenithangle_azimuth(hpx_lat.rad, hpx_lon.rad)
+    hpx_radial_val = np.sin(za)
 
-  >>> ax2.grid(True)
-  >>> img2 = ax2.scatter(az, hpx_radial_val, c=hpx_beam.data_array[0,0,0,:], cmap="plasma", norm=LogNorm())
-  >>> cbar=plt.colorbar(img2, ax=ax2, label="Beam power", orientation="vertical",shrink=.5, format="%4.1e")
+    ax2.grid(True)
+    img2 = ax2.scatter(az, hpx_radial_val, c=hpx_beam.data_array[0,0,0,:], cmap="plasma", norm=LogNorm())
+    cbar=plt.colorbar(img2, ax=ax2, label="Beam power", orientation="vertical",shrink=.5, format="%4.1e")
 
-  >>> _ = ax2.set_yticks(np.sin(np.deg2rad(radial_ticks_deg)))
-  >>> _ = ax2.set_yticklabels([f"{rt}" + r"$\degree$" for rt in radial_ticks_deg])
-  >>> _ = ax2.set_title("Healpix Beam")
+    _ = ax2.set_yticks(np.sin(np.deg2rad(radial_ticks_deg)))
+    _ = ax2.set_yticklabels([f"{rt}" + r"$\degree$" for rt in radial_ticks_deg])
+    _ = ax2.set_title("Healpix Beam")
 
-  >>> fig.tight_layout()
-  >>> plt.show() # doctest: +SKIP
-  >>> plt.savefig("Images/hera_orig_healpix.png", bbox_inches="tight", dpi=80)
-  >>> plt.clf()
+.. skip: next
+
+    fig.tight_layout()
+    plt.show()
+    plt.savefig("Images/hera_orig_healpix.png", bbox_inches="tight", dpi=80)
+    plt.clf()
 
 .. image:: Images/hera_orig_healpix.png
   :width: 600
@@ -498,84 +458,95 @@ UVBeam: Converting from E-Field beams to Power Beams
 
 a) Convert a regularly gridded efield beam to a power beam (leaving original intact).
 *************************************************************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import matplotlib.pyplot as plt
-  >>> import numpy as np
-  >>> from pyuvdata import UVBeam
-  >>> from pyuvdata.datasets import fetch_data
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from pyuvdata import UVBeam
+    from pyuvdata.datasets import fetch_data
 
-  >>> settings_file = fetch_data("hera_fagnoni_dipole_yaml")
-  >>> beam = UVBeam.from_file(settings_file, beam_type="efield")
-  >>> new_beam = beam.efield_to_power(inplace=False)
+    cst_yml_file = fetch_data("hera_fagnoni_dipole_yaml")
+    beam = UVBeam.from_file(cst_yml_file, beam_type="efield")
+    new_beam = beam.efield_to_power(inplace=False)
 
-  >>> # plot zenith angle cut through the beams
-  >>> _ = plt.plot(beam.axis2_array, beam.data_array[1, 0, 0, :, 0].real, label="E-field real")
-  >>> _ = plt.plot(beam.axis2_array, beam.data_array[1, 0, 0, :, 0].imag, "r", label="E-field imaginary")
-  >>> _ = plt.plot(new_beam.axis2_array, np.sqrt(new_beam.data_array[0, 0, 0, :, 0]), "black", label="sqrt Power")
-  >>> _ = plt.xlabel("Zenith Angle (radians)")
-  >>> _ = plt.ylabel("Magnitude")
-  >>> _ = plt.legend()
-  >>> plt.show() # doctest: +SKIP
-  >>> plt.savefig("Images/efield_power_beam_cut.png", bbox_inches="tight")
-  >>> plt.clf()
+    # plot zenith angle cut through the beams
+    _ = plt.plot(beam.axis2_array, beam.data_array[1, 0, 0, :, 0].real, label="E-field real")
+    _ = plt.plot(beam.axis2_array, beam.data_array[1, 0, 0, :, 0].imag, "r", label="E-field imaginary")
+    _ = plt.plot(new_beam.axis2_array, np.sqrt(new_beam.data_array[0, 0, 0, :, 0]), "black", label="sqrt Power")
+    _ = plt.xlabel("Zenith Angle (radians)")
+    _ = plt.ylabel("Magnitude")
+    _ = plt.legend()
+
+.. skip: next
+
+    plt.show()
+    plt.savefig("Images/efield_power_beam_cut.png", bbox_inches="tight")
+    plt.clf()
 
 .. image:: Images/efield_power_beam_cut.png
   :width: 600
 
 b) Generating pseudo Stokes ("pI", "pQ", "pU", "pV") beams
 **********************************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import matplotlib.pyplot as plt
-  >>> from matplotlib.colors import LogNorm
-  >>> import numpy as np
-  >>> from pyuvdata import utils, UVBeam
-  >>> from pyuvdata.datasets import fetch_data
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import LogNorm
+    import numpy as np
+    from pyuvdata import utils, UVBeam
+    from pyuvdata.datasets import fetch_data
 
-  >>> settings_file = fetch_data("hera_fagnoni_dipole_yaml")
-  >>> beam = UVBeam.from_file(settings_file, beam_type="efield")
+    cst_yml_file = fetch_data("hera_fagnoni_dipole_yaml")
+    beam = UVBeam.from_file(cst_yml_file, beam_type="efield")
 
-  >>> # this beam file is very large. Let's cut down the size to ease the computation
-  >>> za_max = np.deg2rad(90.0)
-  >>> za_inds_use = np.nonzero(beam.axis2_array <= za_max)[0]
-  >>> beam.select(axis2_inds=za_inds_use)
+    # this beam file is very large. Let's cut down the size to ease the computation
+    za_max = np.deg2rad(90.0)
+    za_inds_use = np.nonzero(beam.axis2_array <= za_max)[0]
+    beam.select(axis2_inds=za_inds_use)
 
-  >>> pstokes_beam = beam.efield_to_pstokes(inplace=False)
+    pstokes_beam = beam.efield_to_pstokes(inplace=False)
 
-  >>> # plotting pseudo-stokes
-  >>> pol_array = pstokes_beam.polarization_array
-  >>> pI_ind = np.where(np.isin(pol_array, utils.polstr2num("pI")))[0][0]
-  >>> pQ_ind = np.where(np.isin(pol_array, utils.polstr2num("pQ")))[0][0]
+    # plotting pseudo-stokes
+    pol_array = pstokes_beam.polarization_array
+    pI_ind = np.where(np.isin(pol_array, utils.polstr2num("pI")))[0][0]
+    pQ_ind = np.where(np.isin(pol_array, utils.polstr2num("pQ")))[0][0]
 
-  >>> # Now plot the pixels on an polar projection with zenith in the center
-  >>> radial_ticks_deg = [10, 30, 50, 90]
-  >>> az_array, za_array = np.meshgrid(pstokes_beam.axis1_array, pstokes_beam.axis2_array)
-  >>> az_za_radial_val = np.sin(za_array)
-  >>> fig, (ax1, ax2) = plt.subplots(1, 2, subplot_kw=dict(projection="polar"), figsize=(15, 15))
-  >>> ax1.grid(True)
-  >>> img1 = ax1.scatter(az_array, az_za_radial_val, c=pstokes_beam.data_array[0,  pI_ind, 0], cmap="plasma", norm=LogNorm())
-  >>> cbar=plt.colorbar(img1, ax=ax1, label="Beam power", orientation="vertical",shrink=.5, format="%4.1e")
-  >>> _ = ax1.set_yticks(np.sin(np.deg2rad(radial_ticks_deg)))
-  >>> _ = ax1.set_yticklabels([f"{rt}" + r"$\degree$" for rt in radial_ticks_deg])
-  >>> _ = ax1.set_title("pI")
+    # Now plot the pixels on an polar projection with zenith in the center
+    radial_ticks_deg = [10, 30, 50, 90]
+    az_array, za_array = np.meshgrid(pstokes_beam.axis1_array, pstokes_beam.axis2_array)
+    az_za_radial_val = np.sin(za_array)
+    fig, (ax1, ax2) = plt.subplots(1, 2, subplot_kw=dict(projection="polar"), figsize=(15, 15))
+    ax1.grid(True)
+    img1 = ax1.scatter(az_array, az_za_radial_val, c=pstokes_beam.data_array[0,  pI_ind, 0], cmap="plasma", norm=LogNorm())
+    cbar=plt.colorbar(img1, ax=ax1, label="Beam power", orientation="vertical",shrink=.5, format="%4.1e")
+    _ = ax1.set_yticks(np.sin(np.deg2rad(radial_ticks_deg)))
+    _ = ax1.set_yticklabels([f"{rt}" + r"$\degree$" for rt in radial_ticks_deg])
+    _ = ax1.set_title("pI")
 
-  >>> ax2.grid(True)
-  >>> img2 = ax2.scatter(az_array, az_za_radial_val, c=pstokes_beam.data_array[0,  pQ_ind, 0], cmap="plasma", norm=LogNorm())
-  >>> cbar=plt.colorbar(img2, ax=ax2, label="Beam power", orientation="vertical",shrink=.5, format="%4.1e")
-  >>> _ = ax2.set_yticks(np.sin(np.deg2rad(radial_ticks_deg)))
-  >>> _ = ax2.set_yticklabels([f"{rt}" + r"$\degree$" for rt in radial_ticks_deg])
-  >>> _ = ax2.set_title("pQ")
+    ax2.grid(True)
+    img2 = ax2.scatter(az_array, az_za_radial_val, c=pstokes_beam.data_array[0,  pQ_ind, 0], cmap="plasma", norm=LogNorm())
+    cbar=plt.colorbar(img2, ax=ax2, label="Beam power", orientation="vertical",shrink=.5, format="%4.1e")
+    _ = ax2.set_yticks(np.sin(np.deg2rad(radial_ticks_deg)))
+    _ = ax2.set_yticklabels([f"{rt}" + r"$\degree$" for rt in radial_ticks_deg])
+    _ = ax2.set_title("pQ")
 
-  >>> fig.tight_layout()
-  >>> plt.show() # doctest: +SKIP
-  >>> plt.savefig("Images/hera_pstokes.png", bbox_inches="tight")
-  >>> plt.clf()
+    fig.tight_layout()
+
+.. skip: next
+
+    plt.show()
+    plt.savefig("Images/hera_pstokes.png", bbox_inches="tight")
+    plt.clf()
 
 .. image:: Images/hera_pstokes.png
   :width: 600
+
 
 UVBeam: Calculating beam areas
 ------------------------------
@@ -588,75 +559,96 @@ They can be interpolated to HEALPix using the :meth:`pyuvdata.UVBeam.to_healpix`
 
 a) Calculating pseudo Stokes ("pI", "pQ", "pU", "pV") beam area and beam squared area
 *************************************************************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVBeam
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVBeam
+    from pyuvdata.datasets import fetch_data
 
-  >>> settings_file = fetch_data("hera_fagnoni_dipole_yaml")
-  >>> beam = UVBeam.from_file(settings_file, beam_type="efield")
+    cst_yml_file = fetch_data("hera_fagnoni_dipole_yaml")
+    beam = UVBeam.from_file(cst_yml_file, beam_type="efield")
 
-  >>> # note that the `to_healpix` method requires astropy_healpix to be installed
-  >>> # this beam file is very large. Let's cut down the size to ease the computation
-  >>> za_max = np.deg2rad(10.0)
-  >>> za_inds_use = np.nonzero(beam.axis2_array <= za_max)[0]
-  >>> beam.select(axis2_inds=za_inds_use)
+    # note that the `to_healpix` method requires astropy_healpix to be installed
+    # this beam file is very large. Let's cut down the size to ease the computation
+    za_max = np.deg2rad(10.0)
+    za_inds_use = np.nonzero(beam.axis2_array <= za_max)[0]
+    beam.select(axis2_inds=za_inds_use)
 
-  >>> pstokes_beam = beam.to_healpix(inplace=False)
-  >>> pstokes_beam.efield_to_pstokes()
-  >>> pstokes_beam.peak_normalize()
+    pstokes_beam = beam.to_healpix(inplace=False)
+    pstokes_beam.efield_to_pstokes()
+    pstokes_beam.peak_normalize()
 
-  >>> # calculating beam area
-  >>> freqs = pstokes_beam.freq_array
-  >>> pI_area = pstokes_beam.get_beam_area("pI")
-  >>> pQ_area = pstokes_beam.get_beam_area("pQ")
-  >>> pU_area = pstokes_beam.get_beam_area("pU")
-  >>> pV_area = pstokes_beam.get_beam_area("pV")
-  >>> pI_area1, pI_area2 = round(pI_area[0].real, 5), round(pI_area[1].real, 5)
-  >>> pQ_area1, pQ_area2 = round(pQ_area[0].real, 5), round(pQ_area[1].real, 5)
-  >>> pU_area1, pU_area2 = round(pU_area[0].real, 5), round(pU_area[1].real, 5)
-  >>> pV_area1, pV_area2 = round(pV_area[0].real, 5), round(pV_area[1].real, 5)
+    # calculating beam area
+    freqs = pstokes_beam.freq_array
+    pI_area = pstokes_beam.get_beam_area("pI")
+    pQ_area = pstokes_beam.get_beam_area("pQ")
+    pU_area = pstokes_beam.get_beam_area("pU")
+    pV_area = pstokes_beam.get_beam_area("pV")
 
-  >>> print (f"Beam area at {freqs[0]*1e-6} MHz for pseudo-stokes\nI: {pI_area1}\nQ: {pQ_area1}\nU: {pU_area1}\nV: {pV_area1}")
-  Beam area at 123.0 MHz for pseudo-stokes
-  I: 0.04674
-  Q: 0.02904
-  U: 0.02879
-  V: 0.0464
+    assert np.allclose(
+      [pI_area[0].real, pQ_area[0].real, pU_area[0].real, pV_area[0].real],
+      [0.04674, 0.02904, 0.02879, 0.0464],
+      atol=1e-4
+    )
+    assert np.allclose(
+      [pI_area[1].real, pQ_area[1].real, pU_area[1].real, pV_area[1].real],
+      [0.03237, 0.01995, 0.01956, 0.03186],
+      atol=1e-4
+    )
+
+    # calculating beam squared area
+    freqs = pstokes_beam.freq_array
+    pI_sq_area = pstokes_beam.get_beam_sq_area("pI")
+    pQ_sq_area = pstokes_beam.get_beam_sq_area("pQ")
+    pU_sq_area = pstokes_beam.get_beam_sq_area("pU")
+    pV_sq_area = pstokes_beam.get_beam_sq_area("pV")
+
+    assert np.allclose(
+      [pI_sq_area[0].real, pQ_sq_area[0].real, pU_sq_area[0].real, pV_sq_area[0].real],
+      [0.02474, 0.01186, 0.01179, 0.0246],
+      atol=1e-4
+    )
+    assert np.allclose(
+      [pI_sq_area[1].real, pQ_sq_area[1].real, pU_sq_area[1].real, pV_sq_area[1].real],
+      [0.01696, 0.00798, 0.00792, 0.01686],
+      atol=1e-4
+    )
+
+.. _new_uvbeam:
+
+UVBeam: Instantiating from arrays in memory
+-------------------------------------------
+``pyuvdata`` can also be used to create a UVBeam object from arrays in memory. This
+is useful for mocking up data for testing or for creating a UVBeam object from
+simulated data. Instead of instantiating a blank object and setting each required
+parameter, you can use the ``.new()`` static method, which deals with the task
+of creating a consistent object from a minimal set of inputs
 
 
-  >>> print (f"Beam area at {freqs[1]*1e-6} MHz for pseudo-stokes\nI: {pI_area2}\nQ: {pQ_area2}\nU: {pU_area2}\nV: {pV_area2}")
-  Beam area at 150.0 MHz for pseudo-stokes
-  I: 0.03237
-  Q: 0.01995
-  U: 0.01956
-  V: 0.03186
+.. clear-namespace
 
+.. code-block:: python
 
-  >>> # calculating beam squared area
-  >>> freqs = pstokes_beam.freq_array
-  >>> pI_sq_area = pstokes_beam.get_beam_sq_area("pI")
-  >>> pQ_sq_area = pstokes_beam.get_beam_sq_area("pQ")
-  >>> pU_sq_area = pstokes_beam.get_beam_sq_area("pU")
-  >>> pV_sq_area = pstokes_beam.get_beam_sq_area("pV")
-  >>> pI_sq_area1, pI_sq_area2 = round(pI_sq_area[0].real, 5), round(pI_sq_area[1].real, 5)
-  >>> pQ_sq_area1, pQ_sq_area2 = round(pQ_sq_area[0].real, 5), round(pQ_sq_area[1].real, 5)
-  >>> pU_sq_area1, pU_sq_area2 = round(pU_sq_area[0].real, 5), round(pU_sq_area[1].real, 5)
-  >>> pV_sq_area1, pV_sq_area2 = round(pV_sq_area[0].real, 5), round(pV_sq_area[1].real, 5)
+    from astropy.coordinates import EarthLocation
+    import numpy as np
+    from pyuvdata import UVBeam
 
-  >>> print (f"Beam squared area at {freqs[0]*1e-6} MHz for pseudo-stokes\nI: {pI_sq_area1}\nQ: {pQ_sq_area1}\nU: {pU_sq_area1}\nV: {pV_sq_area1}")
-  Beam squared area at 123.0 MHz for pseudo-stokes
-  I: 0.02474
-  Q: 0.01186
-  U: 0.01179
-  V: 0.0246
+    uvb = UVBeam.new(
+        telescope_name="test",
+        data_normalization="physical",
+        freq_array=np.linspace(100e6, 200e6, 10),
+        x_orientation = "east",
+        feed_array = ["x", "y"],
+        mount_type = "fixed",
+        axis1_array=np.deg2rad(np.linspace(-180, 179, 360)),
+        axis2_array=np.deg2rad(np.linspace(0, 90, 181)),
+    )
 
+Notice that you need only provide the required parameters, and the rest will be
+filled in with sensible defaults.
 
-  >>> print (f"Beam squared area at {freqs[1]*1e-6} MHz for pseudo-stokes\nI: {pI_sq_area2}\nQ: {pQ_sq_area2}\nU: {pU_sq_area2}\nV: {pV_sq_area2}")
-  Beam squared area at 150.0 MHz for pseudo-stokes
-  I: 0.01696
-  Q: 0.00798
-  U: 0.00792
-  V: 0.01686
+See the full documentation for the method
+:func:`pyuvdata.uvbeam.UVBeam.new` for more information.

--- a/docs/uvdata_tutorial.rst
+++ b/docs/uvdata_tutorial.rst
@@ -66,13 +66,13 @@ file or folder to instantiate an object, FHD and raw MWA correlator data sets
 require the user to specify multiple files for each dataset.
 
 ``pyuvdata`` can also be used to create a UVData object from arrays in memory
-(see :ref:`new`) and to read in mulitple datasets (files) into a single object
-(see :ref:`multiple_files`).
+(see :ref:`new_uvdata`) and to read in multiple datasets (files) into a single object
+(see :ref:`multiple_files_uvdata`).
 
 .. note::
-  Reading or writing CASA Measurement sets requires python-casacore to be
-  installed (see the readme for details). Reading or writing Miriad files is not
-  supported on Windows.
+    Reading or writing CASA Measurement sets requires python-casacore to be
+    installed (see the readme for details). Reading or writing Miriad files is not
+    supported on Windows.
 
 a) Instantiate an object from a single file or folder
 *****************************************************
@@ -80,41 +80,44 @@ UVFITS and uvh5 and datasets are stored in a single file. Miriad,
 CASA Measurement Sets and MIR datasets are stored in structured folders, for these
 file types pass in the folder name.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
 b) Instantiate an object from an FHD dataset
 ********************************************
 When reading FHD datasets, we need to pass in several auxilliary files.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import os
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> # Set up the files we need
-  >>> fhd_prefix = "1061316296_"
-  >>> fhd_path = fetch_data("mwa_fhd")
-  >>> fhd_vis_files = [os.path.join(fhd_path, "vis_data", fhd_prefix + f) for f in ["vis_XX.sav", "vis_YY.sav"]]
-  >>> flags_file = os.path.join(fhd_path, "vis_data", fhd_prefix + "flags.sav")
-  >>> layout_file = os.path.join(fhd_path, "metadata", fhd_prefix + "layout.sav")
-  >>> params_file = os.path.join(fhd_path, "metadata", fhd_prefix + "params.sav")
-  >>> settings_file = os.path.join(fhd_path, "metadata", fhd_prefix + "settings.txt")
+    # Set up the files we need
+    fhd_prefix = '1061316296_'
+    fhd_path = fetch_data("mwa_fhd")
+    fhd_vis_files = [os.path.join(fhd_path, "vis_data", fhd_prefix + f) for f in ["vis_XX.sav", "vis_YY.sav"]]
+    flags_file = os.path.join(fhd_path, "vis_data", fhd_prefix + "flags.sav")
+    layout_file = os.path.join(fhd_path, "metadata", fhd_prefix + "layout.sav")
+    params_file = os.path.join(fhd_path, "metadata", fhd_prefix + "params.sav")
+    settings_file = os.path.join(fhd_path, "metadata", fhd_prefix + "settings.txt")
 
-  >>> uvd = UVData.from_file(
-  ...    fhd_vis_files,
-  ...    flags_file=flags_file,
-  ...    layout_file=layout_file,
-  ...    params_file=params_file,
-  ...    settings_file=settings_file,
-  ... )
+    uvd = UVData.from_file(
+      fhd_vis_files,
+      flags_file=flags_file,
+      layout_file=layout_file,
+      params_file=params_file,
+      settings_file=settings_file,
+    )
 
 c) Instantiate an object from a raw MWA correlator dataset
 **********************************************************
@@ -130,18 +133,20 @@ optional to apply a Van Vleck correction for Legacy correlator data. The default
 for this correction is to use a Chebyshev polynomial approximation, and there is
 an option to instead use a slower integral implementation.
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> # Construct the list of files. Separate files for each coarse band, the
-  >>> # associated metafits file is also required.
-  >>> filelist = fetch_data(["mwa_2015_metafits", "mwa_2015_raw_gpubox01"])
+    # Construct the list of files. Separate files for each coarse band, the
+    # associated metafits file is also required.
+    filelist = fetch_data(["mwa_2015_metafits", "mwa_2015_raw_gpubox01"])
 
-  >>> # Apply cable corrections and routine time/frequency flagging, phase data to pointing center
-  >>> uvd = UVData.from_file(filelist, correct_cable_len=True, phase_to_pointing_center=True, flag_init=True)
+    # Apply cable corrections and routine time/frequency flagging, phase data to pointing center
+    uvd = UVData().from_file(filelist, correct_cable_len=True, phase_to_pointing_center=True, flag_init=True)
 
 c) Options for SMA MIR data sets
 ********************************
@@ -155,76 +160,74 @@ selection, and visibility handling.
 
 In addition to the selection keywords supported with UVData objects, there are a few
 extra keywords supported for MIR data sets:
--   ``corrchunk``: Specifies (typically DSB) correlator window(s) to load.
+- ``corrchunk``: Specifies (typically DSB) correlator window(s) to load.
 
--   ``receiver``: Specifies a receiver type (generally some combination of "230", "240",
+- ``receiver``: Specifies a receiver type (generally some combination of "230", "240",
     "345", and/or "400") to load, with different receivers typically used to target
     different bands and/or polarizations.
 
--   ``sideband``: Specifies which sideband to load, with the two options being "l" for
+- ``sideband``: Specifies which sideband to load, with the two options being "l" for
     lower and "u" for upper.
 
--   ``pseudo_cont`` : Specifies whether to load the "pseudo-continuum" data, which is
+- ``pseudo_cont`` : Specifies whether to load the "pseudo-continuum" data, which is
     constructed as the average of all channels across a single spectral window (set to
     ``False`` by default).
 
--   ``select_where`` : An keyword which allows for more advanced selection criterion.
+- ``select_where`` : An keyword which allows for more advanced selection criterion.
     See the documentation in :meth:`pyuvdata.mir_parser.MirParser` for more details.
 
 Some example use cases for the selection keywords:
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> # Create a path to the SMA MIR test data set in pyuvdata
-  >>> data_path = fetch_data("sma_mir")
-  >>> # Let's first try loading just the "230" receivers.
-  >>> uvd = UVData.from_file(data_path, receivers="230")
-  >>> print((uvd.Npols, uvd.Nfreqs))
-  (1, 131072)
+    # Create a path to the SMA MIR test data set in pyuvdata
+    data_path = fetch_data("sma_mir")
+    # Let's first try loading just the "230" receivers.
+    uvd = UVData.from_file(data_path, receivers="230")
+    assert (uvd.Npols, uvd.Nfreqs) == (1, 131072)
 
-  >>> # Now try one sideband, say the lower ("l")
-  >>> uvd.read(data_path, sidebands="l")
-  >>> print((uvd.Npols, uvd.Nfreqs))
-  (2, 65536)
+    # Now try one sideband, say the lower ("l")
+    uvd.read(data_path, sidebands="l")
+    assert (uvd.Npols, uvd.Nfreqs) == (2, 65536)
 
-  >>> # Now try one just one chunk (2)
-  >>> uvd.read(data_path, corrchunk=2)
-  >>> print((uvd.Npols, uvd.Nfreqs))
-  (2, 32768)
+    # Now try one just one chunk (2)
+    uvd.read(data_path, corrchunk=2)
+    assert (uvd.Npols, uvd.Nfreqs) == (2, 32768)
 
-  >>> # Now all together -- "230" receiver, "l" sideband, chunks 1 and 3
-  >>> uvd.read(data_path, receivers="230", sidebands="l", corrchunk=[1, 3])
-  >>> print((uvd.Npols, uvd.Nfreqs))
-  (1, 32768)
+    # Now all together -- "230" receiver, "l" sideband, chunks 1 and 3
+    uvd.read(data_path, receivers="230", sidebands="l", corrchunk=[1, 3])
+    assert (uvd.Npols, uvd.Nfreqs) == (1, 32768)
 
 As for visibility handling keywords:
 
 - ``rechunk``: Number of channels to spectrally average the data over on read. This is
-  generally the most commonly used keyword, as it reduces the memory/disk space needed
-  to complete read/write operations.
+    generally the most commonly used keyword, as it reduces the memory/disk space needed
+    to complete read/write operations.
 
 - ``apply_tsys``: Normalize the data using system temperature measurements to produces
-  values in (uncalibrated) Jy (default is ``True``).
+    values in (uncalibrated) Jy (default is ``True``).
 
 - ``apply_flags``: Apply on-line flags (default is ``True``).
 
 For example, the native resolution of the test MIR dataset is 140 kHz -- to
 average this down by a factor of 64 (8.96 MHz resolution) do the following:
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> # Build a path to the test SMA data set
-  >>> filename = fetch_data("sma_mir")
-  >>> # Set things up to average over 64-channel blocks.
-  >>> uvd = UVData.from_file(data_path, rechunk=64)
+    # Build a path to the test SMA data set
+    data_path = fetch_data("sma_mir")
+    # Set things up to average over 64-channel blocks.
+    uvd = UVData.from_file(data_path, rechunk=64)
 
 .. warning::
     Reading and writing of MIR data will on occasion generate a warning message about
@@ -246,19 +249,22 @@ write the data to.
 pyuvdata can be used to simply convert data from one file type to another by
 reading in one file type and writing out another.
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import os
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> ms_file = fetch_data("vla_casa_tutorial_ms")
-  >>> # Instantiate an object from a measurement set
-  >>> uvd = UVData.from_file(ms_file)
+    ms_file = fetch_data("vla_casa_tutorial_ms")
+    # Instantiate an object from a measurement set
+    uvd = UVData.from_file(ms_file)
 
-  >>> # Write the data out to a uvfits file
-  >>> write_file = os.path.join(".", "tutorial.uvfits")
-  >>> uvd.write_uvfits(write_file)
+    # Write the data out to a uvfits file
+    write_file = os.path.join(".", "tutorial.uvfits")
+    uvd.write_uvfits(write_file)
 
 
 .. _quick_access:
@@ -279,81 +285,77 @@ which will overwrite sections of these datasets with user-provided data.
 
 a) Data for single antenna pair / polarization combination.
 ************************************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
-  >>> data = uvd.get_data(1, 2, "rr")  # data for ant1=1, ant2=2, pol="rr"
-  >>> times = uvd.get_times(1, 2)  # times corresponding to 0th axis in data
-  >>> print(data.shape)
-  (9, 64)
-  >>> print(times.shape)
-  (9,)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
+    data = uvd.get_data(1, 2, "rr")  # data for ant1=1, ant2=2, pol="rr"
+    times = uvd.get_times(1, 2)  # times for ant1=1, ant2=2 (0th axis of "data" above)
+    assert data.shape == (9, 64)
+    assert times.shape == (9,)
 
-  >>> # One can equivalently make any of these calls with the input wrapped in a tuple.
-  >>> data = uvd.get_data((1, 2, "rr"))
-  >>> times = uvd.get_times((1, 2))
+    # One can equivalently make any of these calls with the input wrapped in a tuple.
+    data = uvd.get_data((1, 2, "rr"))
+    times = uvd.get_times((1, 2))
 
 b) Flags and nsamples for above data.
 *************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> flags = uvd.get_flags(1, 2, "rr")
-  >>> nsamples = uvd.get_nsamples(1, 2, "rr")
-  >>> print(flags.shape)
-  (9, 64)
-  >>> print(nsamples.shape)
-  (9, 64)
+    flags = uvd.get_flags(1, 2, "rr")
+    nsamples = uvd.get_nsamples(1, 2, "rr")
+    assert flags.shape == (9, 64)
+    assert nsamples.shape == (9, 64)
 
 c) Data for single antenna pair, all polarizations.
 ***************************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> data = uvd.get_data(1, 2)
-  >>> print(data.shape)
-  (9, 64, 4)
+    data = uvd.get_data(1, 2)
+    assert data.shape == (9, 64, 4)
 
-  >>> # Can also give baseline number
-  >>> data2 = uvd.get_data(uvd.antnums_to_baseline(1, 2))
-  >>> print(np.all(data == data2))
-  True
+    # Can also give baseline number, this gives the same array:
+    data2 = uvd.get_data(uvd.antnums_to_baseline(1, 2))
 
 d) Data for single polarization, all baselines.
 ***********************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> data = uvd.get_data("rr")
-  >>> print(data.shape)
-  (1360, 64)
+    data = uvd.get_data("rr")
+    assert data.shape == (1360, 64)
 
 e) Update data arrays in place for UVData
 *****************************************
@@ -362,77 +364,77 @@ nsamples arrays in place. We show how to use the :meth:`pyuvdata.UVData.set_data
 method below, and note there are analogous :meth:`pyuvdata.UVData.set_flags`
 and :meth:`pyuvdata.UVData.set_nsamples` methods.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> data = uvd.get_data(1, 2, "rr", force_copy=True, squeeze="none")
-  >>> data *= 2
-  >>> uvd.set_data(data, 1, 2, "rr")
+    data = uvd.get_data(1, 2, "rr", force_copy=True, squeeze="none")
+    data *= 2
+    uvd.set_data(data, 1, 2, "rr")
 
 f) Iterate over all antenna pair / polarizations.
 *************************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> for key, data in uvd.antpairpol_iter():
-  ...  flags = uvd.get_flags(key)
-  ...  nsamples = uvd.get_nsamples(key)
+    for key, data in uvd.antpairpol_iter():
+        flags = uvd.get_flags(key)
+        nsamples = uvd.get_nsamples(key)
 
-    >>> # Do something with the data, flags, nsamples
+      # Do something with the data, flags, nsamples
 
 g) Convenience functions to ask what antennas, baselines, and pols are in the data.
 ***********************************************************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> # Get all unique antennas in data
-  >>> print(uvd.get_ants())
-  [ 1  2  3  4  7  8  9 12 15 19 20 21 22 23 24 25 27 28]
+    # Get all unique antennas in data
+    unique_ants = uvd.get_ants()
 
-  >>> # Get all baseline nums in data, print first 10.
-  >>> print(uvd.get_baseline_nums()[0:10])
-  [67586 67587 67588 67591 67592 67593 67596 67599 67603 67604]
+    # Get all baseline nums in data.
+    bl_nums = uvd.get_baseline_nums()
 
-  >>> # Get all (ordered) antenna pairs in data (same info as baseline_nums), print first 10.
-  >>> print(uvd.get_antpairs()[0:10])
-  [(1, 2), (1, 3), (1, 4), (1, 7), (1, 8), (1, 9), (1, 12), (1, 15), (1, 19), (1, 20)]
+    # Get all (ordered) antenna pairs in data (same info as baseline_nums)
+    antpairs = uvd.get_antpairs()
 
-  >>> # Get all antenna pairs and polarizations, i.e. keys produced in UVData.antpairpol_iter(), print first 5.
-  >>> print(uvd.get_antpairpols()[0:5])
-  [(1, 2, 'rr'), (1, 2, 'll'), (1, 2, 'rl'), (1, 2, 'lr'), (1, 3, 'rr')]
+    # Get all antenna pairs and polarizations, i.e. keys produced in UVData.antpairpol_iter()
+    antpair_pols = uvd.get_antpairpols()
 
 h) Quick access to file attributes of a UV* object (UVData, UVCal, UVBeam)
 **************************************************************************
-.. code-block:: python
+
+.. code-block:: bash
 
   ## in bash ##
-  >>> # Print data_array.shape to stdout
+  # Print data_array.shape to stdout
   pyuvdata_inspect.py --attr=data_array.shape <uv*_file>
 
-  >>> # Print Ntimes,Nfreqs,Nbls to stdout
+  # Print Ntimes,Nfreqs,Nbls to stdout
   pyuvdata_inspect.py --attr=Ntimes,Nfreqs,Nbls <uv*_file>
 
-  >>> # Load object to instance name "uv" and will remain in interpreter
+  # Load object to instance name "uv" and will remain in interpreter
   pyuvdata_inspect.py -i <uv*_file>
 
 
@@ -441,44 +443,43 @@ UVData: Plotting
 Making a simple waterfall plot.
 
 Note: there is now support for reading in only part of a file for many file types
-(see :ref:`large_files`), so you need not read in the entire file to plot one
+(see :ref:`large_files_uvdata`), so you need not read in the entire file to plot one
 waterfall.
+
+.. clear-namespace
 
 .. code-block:: python
 
-  >>> import os
-  >>> from astropy.time import Time
-  >>> import numpy as np
-  >>> import matplotlib.pyplot as plt
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from astropy.time import Time
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> print(uvd.data_array.shape)
-  (1360, 64, 4)
-  >>> print(uvd.Ntimes)
-  15
-  >>> print(uvd.Nfreqs)
-  64
-  >>> # get the data for a single baseline and polarization
-  >>> waterfall_data = uvd.get_data((1, 2, uvd.polarization_array[0]))
-  >>> # get the corresponding times for this waterfall
-  >>> waterfall_times = Time(uvd.get_times((1, 2, uvd.polarization_array[0])), format="jd").iso
+    # get the data for a single baseline and polarization
+    waterfall_data = uvd.get_data((1, 2, uvd.polarization_array[0]))
+    # get the corresponding times for this waterfall
+    waterfall_times = Time(uvd.get_times((1, 2, uvd.polarization_array[0])), format="jd").iso
 
-  >>> # Amplitude waterfall for all spectral channels and 0th polarization
-  >>> fig, ax = plt.subplots(1, 1)
-  >>> _ = ax.imshow(np.abs(waterfall_data), interpolation="none", origin="lower")
-  >>> _ = ax.set_yticks([0, waterfall_times.size - 1])
-  >>> _ = ax.set_yticklabels([waterfall_times[0], waterfall_times[1]])
-  >>> freq_tick_inds = np.concatenate((np.arange(0, uvd.Nfreqs, 16), [uvd.Nfreqs-1]))
-  >>> _ = ax.set_xticks(freq_tick_inds)
-  >>> _ = ax.set_xticklabels([f"{val:.3f}" for val in uvd.freq_array[freq_tick_inds]*1e-9])
-  >>> _ = ax.set_xlabel("Frequency (GHz)")
-  >>> fig.show() # doctest: +SKIP
-  >>> plt.savefig("Images/amplitude_waterfall.png", bbox_inches="tight")
-  >>> plt.clf()
+    # Amplitude waterfall for all spectral channels and 0th polarization
+    fig, ax = plt.subplots(1, 1)
+    _ = ax.imshow(np.abs(waterfall_data), interpolation="none", origin="lower")
+    _ = ax.set_yticks([0, waterfall_times.size - 1])
+    _ = ax.set_yticklabels([waterfall_times[0], waterfall_times[1]])
+    freq_tick_inds = np.concatenate((np.arange(0, uvd.Nfreqs, 16), [uvd.Nfreqs-1]))
+    _ = ax.set_xticks(freq_tick_inds)
+    _ = ax.set_xticklabels([f"{val:.3f}" for val in uvd.freq_array[freq_tick_inds]*1e-9])
+    _ = ax.set_xlabel("Frequency (GHz)")
+
+.. skip: next
+
+    fig.show() # code-block: +SKIP
+
+    plt.savefig("Images/amplitude_waterfall.png", bbox_inches="tight")
+    plt.clf()
 
 .. image:: Images/amplitude_waterfall.png
     :width: 600
@@ -494,105 +495,86 @@ can instead *deselect* this data and preserve only that which does not match the
 selection.
 
 Note: The same select interface is now supported on the read for many file types
-(see :ref:`large_files`), so you need not read in the entire file before doing the select.
+(see :ref:`large_files_uvdata`), so you need not read in the entire file before
+doing the select.
 
 a) Select 3 antennas to keep using the antenna number.
 ******************************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
+    assert uvd.Nants_data == 18
 
-  >>> # print all the antennas numbers with data in the original file
-  >>> print(np.unique(uvd.ant_1_array.tolist() + uvd.ant_2_array.tolist()))
-  [ 1  2  3  4  7  8  9 12 15 19 20 21 22 23 24 25 27 28]
-  >>> uvd.select(antenna_nums=[1, 12, 21])
+    uvd.select(antenna_nums=[1, 12, 21])
+    assert uvd.Nants_data == 3
+    assert uvd.get_ants().tolist() == [1, 12, 21]
 
-  >>> # print all the antennas numbers with data after the select
-  >>> print(np.unique(uvd.ant_1_array.tolist() + uvd.ant_2_array.tolist()))
-  [ 1 12 21]
 
 b) Select 3 antennas by name and 4 frequencies to keep
 ******************************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
+    assert uvd.Nants_data == 18
+    assert uvd.Nfreqs == 64
 
-  >>> # print all the antenna names with data in the original file
-  >>> unique_ants = np.unique(uvd.ant_1_array.tolist() + uvd.ant_2_array.tolist())
-  >>> print([uvd.telescope.antenna_names[np.where(uvd.telescope.antenna_numbers==a)[0][0]] for a in unique_ants])
-  ['W09', 'E02', 'E09', 'W01', 'N06', 'N01', 'E06', 'E08', 'W06', 'W04', 'N05', 'E01', 'N04', 'E07', 'W05', 'N02', 'E03', 'N08']
-
-  >>> # print how many frequencies in the original file
-  >>> print(uvd.freq_array.size)
-  64
-  >>> uvd.select(antenna_names=["N02", "E09", "W06"], frequencies=uvd.freq_array[0:4])
-
-  >>> # print all the antenna names with data after the select
-  >>> unique_ants = np.unique(uvd.ant_1_array.tolist() + uvd.ant_2_array.tolist())
-  >>> print([uvd.telescope.antenna_names[np.where(uvd.telescope.antenna_numbers==a)[0][0]] for a in unique_ants])
-  ['E09', 'W06', 'N02']
-
-  >>> # print all the frequencies after the select
-  >>> print(uvd.freq_array)
-  [3.6304542e+10 3.6304667e+10 3.6304792e+10 3.6304917e+10]
+    uvd.select(antenna_names=["N02", "E09", "W06"], frequencies=uvd.freq_array[0:4])
+    assert uvd.Nants_data == 3
+    assert uvd.Nfreqs == 4
 
 c) Select a few antenna pairs to keep
 *************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> # print how many antenna pairs with data in the original file
-  >>> print(len(set(zip(uvd.ant_1_array, uvd.ant_2_array))))
-  153
-  >>> uvd.select(bls=[(1, 2), (7, 1), (1, 21)])
+    # note that order of the values in the pair does not matter
+    uvd.select(bls=[(1, 2), (7, 1), (1, 21)])
 
-  >>> # note that order of the values in the pair does not matter
-  >>> # print all the antenna pairs after the select
-  >>> print(sorted(set(zip(uvd.ant_1_array.tolist(), uvd.ant_2_array.tolist()))))
-  [(1, 2), (1, 7), (1, 21)]
+    # get all the antenna pairs after the select
+    antpairs = uvd.get_antpairs()
+    # note that the antpair is listed as it is in the data, not as it was selected on.
+    assert antpairs == [(1, 2), (1, 7), (1, 21)]
+
 
 d) Select antenna pairs using baseline numbers
 **********************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> # baseline numbers can be found in the baseline_array
-  >>> print(len(uvd.baseline_array))
-  1360
-
-  >>> # select baselines using the baseline numbers
-  >>> uvd.select(bls=[73736, 73753, 81945])
-
-  >>> # print unique baselines and antennas after select
-  >>> print(np.unique(uvd.baseline_array))
-  [73736 73753 81945]
-  >>> print(list(set(zip(uvd.ant_1_array.tolist(), uvd.ant_2_array.tolist()))))
-  [(8, 25), (4, 25), (4, 8)]
+    # select baselines using the baseline numbers
+    uvd.select(bls=[73736, 73753, 81945])
+    print(uvd.get_antpairs())
+    assert uvd.get_antpairs() == [(4, 8), (4, 25), (8, 25)]
 
 e) Select polarizations
 ***********************
@@ -604,74 +586,51 @@ line perpendicular to the horizon (as record in ``telescope.feed_angle``) and/or
 y-polarization are aligned to -90 or 0 degrees, strings representing the cardinal
 orientation of the dipole can also be used (e.g. "nn" or "ee").
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import utils, UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import utils, UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> # polarization numbers can be found in the polarization_array
-  >>> print(uvd.polarization_array)
-  [-1 -2 -3 -4]
+    # polarization numbers can be found in the polarization_array
+    assert uvd.polarization_array.tolist() == [-1, -2, -3, -4]
 
-  >>> # polarization numbers can be converted to strings using a utility function
-  >>> print(utils.polnum2str(uvd.polarization_array))
-  ['rr', 'll', 'rl', 'lr']
+    # polarization numbers can be converted to strings using a utility function
+    assert utils.polnum2str(uvd.polarization_array) == ['rr', 'll', 'rl', 'lr']
 
-  >>> # select polarizations using the polarization numbers
-  >>> uvd.select(polarizations=[-1, -2, -3])
+    # select polarizations using the polarization numbers
+    uvd.select(polarizations=[-1, -2, -3])
+    assert uvd.polarization_array.tolist() == [-1, -2, -3]
+    assert utils.polnum2str(uvd.polarization_array) == ['rr', 'll', 'rl']
 
-  >>> # print polarization numbers and strings after select
-  >>> print(uvd.polarization_array)
-  [-1 -2 -3]
-  >>> print(utils.polnum2str(uvd.polarization_array))
-  ['rr', 'll', 'rl']
+    # select polarizations using the polarization strings
+    uvd.select(polarizations=["rr", "ll"])
+    assert uvd.polarization_array.tolist() == [-1, -2]
+    assert utils.polnum2str(uvd.polarization_array) == ['rr', 'll']
 
-  >>> # select polarizations using the polarization strings
-  >>> uvd.select(polarizations=["rr", "ll"])
+    # Now deselect polarizations
+    uvd.select(polarizations=["ll"], invert=True)
+    assert uvd.polarization_array.tolist() == [-1]
+    assert utils.polnum2str(uvd.polarization_array) == ['rr']
 
-  >>> # print polarization numbers and strings after select
-  >>> print(uvd.polarization_array)
-  [-1 -2]
-  >>> print(utils.polnum2str(uvd.polarization_array))
-  ['rr', 'll']
+    # read in a file with linear polarizations and an x_orientation
+    filename = fetch_data("hera_h3c_uvh5")
+    uvd = UVData.from_file(filename)
+    assert uvd.polarization_array.tolist() == [-5, -6]
+    assert utils.polnum2str(uvd.polarization_array) == ['xx', 'yy']
 
+    # check x_orientation
+    assert uvd.telescope.get_x_orientation_from_feeds() == "north"
 
-  >>> # Now deselect polarizations
-  >>> uvd.select(polarizations=["ll"], invert=True)
-
-  >>> # print polarization numbers and strings after select
-  >>> print(uvd.polarization_array)
-  [-1]
-  >>> print(utils.polnum2str(uvd.polarization_array))
-  ['rr']
-
-  >>> # read in a file with linear polarizations and an x_orientation
-  >>> filename = fetch_data("hera_h3c_uvh5")
-  >>> uvd = UVData.from_file(filename)
-
-  >>> # print polarization numbers and strings
-  >>> print(uvd.polarization_array)
-  [-5 -6]
-  >>> print(utils.polnum2str(uvd.polarization_array))
-  ['xx', 'yy']
-
-  >>> # print x_orientation
-  >>> print(uvd.telescope.get_x_orientation_from_feeds())
-  north
-
-  >>> # select polarizations using the physical orientation strings
-  >>> uvd.select(polarizations=["ee"])
-
-  >>> # print polarization numbers and strings after select
-  >>> print(uvd.polarization_array)
-  [-6]
-  >>> print(utils.polnum2str(uvd.polarization_array))
-  ['yy']
+    # select polarizations using the physical orientation strings
+    uvd.select(polarizations=["ee"])
+    assert uvd.polarization_array.tolist() == [-6]
+    assert utils.polnum2str(uvd.polarization_array) == ['yy']
 
 
 f) Select antenna pairs and polarizations using ant_str argument
@@ -687,25 +646,25 @@ ________________________________
 - 1: returns all antenna pairs containing antenna number 1 (including the auto correlation)
 - 1,2: returns all antenna pairs containing antennas 1 and/or 2
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> # Print the number of antenna pairs in the original file
-  >>> print(len(uvd.get_antpairs()))
-  153
+    # check the number of baselines (antenna pairs) in the original file
+    assert uvd.Nbls == 153
 
-  >>> # Apply select to UVData object
-  >>> uvd.select(ant_str="1,2,3")
+    # Apply select to UVData object
+    uvd.select(ant_str="1,2,3")
 
-  >>> # Print the number of antenna pairs after the select
-  >>> print(len(uvd.get_antpairs()))
-  48
+    # check the number of baselines (antenna pairs) after the select
+    assert uvd.Nbls == 48
 
 2. Individual baseline(s):
 ___________________________
@@ -715,25 +674,25 @@ ___________________________
 - (1,2)_3: returns antenna pairs (1,3),(2,3)
 - 1_(2,3): returns antenna pairs (1,2),(1,3)
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> # Print the number of antenna pairs in the original file
-  >>> print(len(uvd.get_antpairs()))
-  153
+    # check the number of baselines (antenna pairs) in the original file
+    assert uvd.Nbls == 153
 
-  >>> # Apply select to UVData object
-  >>> uvd.select(ant_str="(1,2)_(3,7)")
+    # Apply select to UVData object
+    uvd.select(ant_str="(1,2)_(3,7)")
 
-  >>> # Print the antennas pairs with data after the select
-  >>> print(uvd.get_antpairs())
-  [(1, 3), (1, 7), (2, 3), (2, 7)]
+    # check the antenna pairs after the select
+    assert uvd.get_antpairs() == [(1, 3), (1, 7), (2, 3), (2, 7)]
 
 3. Antenna number(s) and polarization(s):
 __________________________________________
@@ -750,25 +709,27 @@ all antenna pairs kept in the object will retain data for each specified polariz
 - 1l_3,2x_3: returns antenna pairs (1,3), (2,3) and polarizations ll, lr, xx, and xy
 - 1_3l,2_3x: returns antenna pairs (1,3), (2,3) and polarizations ll, rl, xx, and yx
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> # Print the number of antennas and polarizations with data in the original file
-  >>> print((len(uvd.get_antpairs()), uvd.get_pols()))
-  (153, ['rr', 'll', 'rl', 'lr'])
+    # check the number of baselines and polarizations in the original file
+    assert uvd.Nbls == 153
+    assert uvd.get_pols() == ['rr', 'll', 'rl', 'lr']
 
-  >>> # Apply select to UVData object
-  >>> uvd.select(ant_str="1r_2l,1l_3l,1r_7r")
+    # Apply select to UVData object
+    uvd.select(ant_str="1r_2l,1l_3l,1r_7r")
 
-  >>> # Print all the antennas numbers and polarizations with data after the select
-  >>> print((uvd.get_antpairs(), uvd.get_pols()))
-  ([(1, 2), (1, 3), (1, 7)], ['rr', 'll', 'rl'])
+    # check the number of antenna pairs and polarizations after the select
+    assert uvd.get_antpairs() == [(1, 2), (1, 3), (1, 7)]
+    assert uvd.get_pols() == ['rr', 'll', 'rl']
 
 4. Stokes parameter(s):
 ________________________
@@ -787,25 +748,25 @@ If a minus sign is present in front of an antenna number, it will not be kept in
 - 1,-1_3: returns all antenna pairs containing antenna 1, except the antenna pair (1,3)
 - 1x_(-3y,10x): returns antenna pair (1,10) and polarization xx
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> # Print the number of antenna pairs in the original file
-  >>> print(len(uvd.get_antpairs()))
-  153
+    # check the number of baselines (antenna pairs) in the original file
+    assert uvd.Nbls == 153
 
-  >>> # Apply select to UVData object
-  >>> uvd.select(ant_str="1,-1_3")
+    # Apply select to UVData object
+    uvd.select(ant_str="1,-1_3")
 
-  >>> # Print the number of antenna pairs with data after the select
-  >>> print(len(uvd.get_antpairs()))
-  16
+    # check the number of baselines (antenna pairs) after the select
+    assert uvd.Nbls == 16
 
 g) Select based on time or local sidereal time (LST)
 ****************************************************
@@ -815,75 +776,61 @@ be in radians (**not** hours), consistent with how the LSTs are stored on the
 object. When specifying an LST range, if the first number is larger than the
 second, the range is assumed to wrap around LST = 0 = 2*pi.
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
 
-  >>> # Times can be found in the time_array, which is length Nblts.
-  >>> # Use unique to find the unique times
-  >>> print(np.unique(uvd.time_array))
-  [2455312.64023149 2455312.64023727 2455312.64024305 2455312.64024884
-   2455312.64034724 2455312.64046293 2455312.64057797 2455312.64057869
-   2455312.64069444 2455312.64069492 2455312.64081019 2455312.64092547
-   2455312.64092594 2455312.6410417  2455312.64115739]
+    # Times can be found in the time_array, which is length Nblts.
+    # Use unique to find the unique times (number given by Ntimes)
+    unique_times = np.unique(uvd.time_array)
+    assert len(unique_times) == uvd.Ntimes
+    assert uvd.Ntimes == 15
 
-  >>> # make a copy and select some times that are on the object
-  >>> uvd2 = uvd.copy()
-  >>> uvd2.select(times=np.unique(uvd.time_array)[0:5])
+    # make a copy and select some times that are on the object
+    uvd2 = uvd.copy()
+    uvd2.select(times=unique_times[0:5])
+    assert uvd2.Ntimes == 5
 
-  >>> # print the unique times after the select
-  >>> print(np.unique(uvd2.time_array))
-  [2455312.64023149 2455312.64023727 2455312.64024305 2455312.64024884
-   2455312.64034724]
+    # make a copy and select a time range
+    uvd2 = uvd.copy()
+    uvd2.select(time_range=[2455312.64023, 2455312.6406])
+    assert uvd2.Ntimes == 8
 
-  >>> # make a copy and select a time range
-  >>> uvd2 = uvd.copy()
-  >>> uvd2.select(time_range=[2455312.64023, 2455312.6406])
+    # make a copy and select some lsts
+    uvd2 = uvd.copy()
+    # LSTs can be found in the lst_array
+    lsts = np.unique(uvd2.lst_array)
+    assert len(lsts) == uvd2.Ntimes
 
-  >>> # print the unique times after the select
-  >>> print(np.unique(uvd2.time_array))
-  [2455312.64023149 2455312.64023727 2455312.64024305 2455312.64024884
-   2455312.64034724 2455312.64046293 2455312.64057797 2455312.64057869]
+    # select LSTs that are on the object
+    uvd2.select(lsts=lsts[0:len(lsts) // 2])
 
-  >>> # LSTs can be found in the lst_array
-  >>> lsts = np.unique(uvd.lst_array)
-  >>> print(len(lsts))
-  15
-
-  >>> # select LSTs that are on the object
-  >>> uvd.select(lsts=lsts[0:len(lsts) // 2])
-
-  >>> # print length of unique LSTs after select
-  >>> print(len(np.unique(uvd.lst_array)))
-  7
+    # print length of unique LSTs after select
+    assert uvd2.Ntimes == 7
 
 h) Select data and return new object (leaving original intact).
 ***************************************************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
-  >>> uvd2 = uvd.select(antenna_nums=[1, 12, 21], inplace=False)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
+    uvd2 = uvd.select(antenna_nums=[1, 12, 21], inplace=False)
 
-  >>> # print all the antennas numbers with data in the original file
-  >>> print(np.unique(uvd.ant_1_array.tolist() + uvd.ant_2_array.tolist()))
-  [ 1  2  3  4  7  8  9 12 15 19 20 21 22 23 24 25 27 28]
-
-  >>> # print all the antennas numbers with data after the select
-  >>> print(np.unique(uvd2.ant_1_array.tolist() + uvd2.ant_2_array.tolist()))
-  [ 1 12 21]
-
+    assert uvd2.Nants_data < uvd.Nants_data
 
 
 .. _uvdata_sorting_data:
@@ -900,22 +847,22 @@ The :meth:`pyuvdata.UVData.conjugate_bls` method will conjugate baselines to con
 various conventions (``"ant1<ant2"``, ``"ant2<ant1"``, ``"u<0"``, ``"u>0"``, ``"v<0"``,
 ``"v>0"``) or it can just conjugate a set of specific baseline-time indices.
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> uvfits_file = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(uvfits_file)
-  >>> uvd.conjugate_bls("ant1<ant2")
-  >>> print(np.min(uvd.ant_2_array - uvd.ant_1_array) >= 0)
-  True
+    uvfits_file = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(uvfits_file)
+    uvd.conjugate_bls("ant1<ant2")
+    assert np.all(uvd.ant_2_array > uvd.ant_1_array)
 
-  >>> uvd2.conjugate_bls("u<0", use_enu=False)
-  >>> print(np.max(uvd2.uvw_array[:, 0]) <= 0)
-  True
+    uvd.conjugate_bls("u<0", use_enu=False)
+    assert np.all(uvd.uvw_array[:, 0] <= 0)
 
 b) Sorting along the baseline-time axis
 ***************************************
@@ -926,36 +873,32 @@ preferred for data that have baseline dependent averaging ``"bda"``. A user can 
 just specify a desired order by passing an array of baseline-time indices. There is also
 an option to sort the auto visibilities before the cross visibilities (``autos_first``).
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> uvfits_file = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(uvfits_file)
+    uvfits_file = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(uvfits_file)
 
-  >>> # The default is to sort first by time, then by baseline
-  >>> uvd.reorder_blts()
-  >>> print(np.min(np.diff(uvd.time_array)) >= 0)
-  True
+    # The default is to sort first by time, then by baseline
+    uvd.reorder_blts()
+    assert np.all(np.diff(uvd.time_array) >= 0)
 
-  >>> # Explicity sorting by "time" then "baseline" gets the same result
-  >>> uvd2 = uvd.copy()
-  >>> uvd2.reorder_blts("time", minor_order="baseline")
-  >>> print(uvd == uvd2)
-  True
+    # Explicity sorting by "time" then "baseline" gets the same result
+    uvd2 = uvd.copy()
+    uvd2.reorder_blts("time", minor_order="baseline")
+    assert uvd == uvd2
 
-  >>> uvd.reorder_blts("ant1", minor_order="ant2")
-  >>> print(np.min(np.diff(uvd.ant_1_array)) >= 0)
-  True
+    uvd.reorder_blts("ant1", minor_order="ant2")
+    assert np.all(np.diff(uvd.ant_1_array) >= 0)
 
-  >>> # You can also sort and conjugate in a single step for the purposes of comparing two objects
-  >>> uvd.reorder_blts("bda", conj_convention="ant1<ant2")
-  >>> uvd2.reorder_blts("bda", conj_convention="ant1<ant2")
-  >>> print(uvd == uvd2)
-  True
+    # You can also sort and conjugate in a single step
+    uvd.reorder_blts("bda", conj_convention="ant1<ant2")
 
 c) Sorting along the frequency axis
 ***********************************
@@ -966,45 +909,38 @@ spectral windows). Spectral windows or channels can be sorted by ascending or de
 number or in an order specified by passing an index array for spectral window or
 channels.
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> testfile = fetch_data("sma_mir")
-  >>> uvd = UVData.from_file(testfile)
+    testfile = fetch_data("sma_mir")
+    uvd = UVData.from_file(testfile)
 
-  >>> # Sort by spectral window number and by frequency within the spectral window
-  >>> # Now the spectral windows are in ascending order and the frequencies in each window
-  >>> # are in ascending order.
-  >>> uvd.reorder_freqs(spw_order="number", channel_order="freq")
-  >>> print(uvd.spw_array)
-  [-4 -3 -2 -1  1  2  3  4]
+    # Sort by spectral window number and by frequency within the spectral window
+    # Now the spectral windows are in ascending order and the frequencies in each window
+    # are in ascending order.
+    uvd.reorder_freqs(spw_order="number", channel_order="freq")
+    assert np.all(np.diff(uvd.spw_array) > 0)
+    assert np.all(np.diff(uvd.freq_array[np.nonzero(uvd.flex_spw_id_array == 1)]) > 0)
 
-  >>> print(np.min(np.diff(uvd.freq_array[np.nonzero(uvd.flex_spw_id_array == 1)])) >= 0)
-  True
+    # Prepend a ``-`` to the sort string to sort in descending order.
+    # Now the spectral windows are in descending order but the frequencies in each window
+    # are in ascending order.
+    uvd.reorder_freqs(spw_order="-number", channel_order="freq")
+    assert np.all(np.diff(uvd.spw_array) < 0)
+    assert np.all(np.diff(uvd.freq_array[np.nonzero(uvd.flex_spw_id_array == 1)]) > 0)
 
-  >>> # Prepend a ``-`` to the sort string to sort in descending order.
-  >>> # Now the spectral windows are in descending order but the frequencies in each window
-  >>> # are in ascending order.
-  >>> uvd.reorder_freqs(spw_order="-number", channel_order="freq")
-  >>> print(uvd.spw_array)
-  [ 4  3  2  1 -1 -2 -3 -4]
-
-  >>> print(np.min(np.diff(uvd.freq_array[np.nonzero(uvd.flex_spw_id_array == 1)])) >= 0)
-  True
-
-  >>> # Use the ``select_spw`` keyword to sort only one spectral window.
-  >>> # Now the frequencies in spectral window 1 are in descending order but the frequencies
-  >>> # in spectral window 2 are in ascending order
-  >>> uvd.reorder_freqs(select_spw=1, channel_order="-freq")
-  >>> print(np.min(np.diff(uvd.freq_array[np.nonzero(uvd.flex_spw_id_array == 1)])) <= 0)
-  True
-
-  >>> print(np.min(np.diff(uvd.freq_array[np.nonzero(uvd.flex_spw_id_array == 2)])) >= 0)
-  True
+    # Use the ``select_spw`` keyword to sort only one spectral window.
+    # Now the frequencies in spectral window 1 are in descending order but the frequencies
+    # in spectral window 2 are in ascending order
+    uvd.reorder_freqs(select_spw=1, channel_order="-freq")
+    assert np.all(np.diff(uvd.freq_array[np.nonzero(uvd.flex_spw_id_array == 1)]) < 0)
+    assert np.all(np.diff(uvd.freq_array[np.nonzero(uvd.flex_spw_id_array == 2)]) > 0)
 
 c) Sorting along the polarization axis
 **************************************
@@ -1013,20 +949,19 @@ The :meth:`pyuvdata.UVData.reorder_pols` method will reorder the polarization ax
 either following the ``"AIPS"`` or ``"CASA"`` convention, or by an explicit index
 ordering set by the user.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import utils, UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import utils, UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> uvfits_file = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(uvfits_file)
-  >>> print(utils.polnum2str(uvd.polarization_array))
-  ['rr', 'll', 'rl', 'lr']
+    uvfits_file = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(uvfits_file)
+    assert utils.polnum2str(uvd.polarization_array) == ['rr', 'll', 'rl', 'lr']
 
-  >>> uvd.reorder_pols("CASA")
-  >>> print(utils.polnum2str(uvd.polarization_array))
-  ['rr', 'rl', 'lr', 'll']
+    uvd.reorder_pols("CASA")
+    assert utils.polnum2str(uvd.polarization_array) == ['rr', 'rl', 'lr', 'll']
 
 
 UVData: Averaging and Resampling
@@ -1053,88 +988,65 @@ by or ``min_int_time`` to specify a minimum final integration time. Specifying
 ``min_int_time`` is most appropriate when the integration time varies, e.g. if
 the data have had baseline-dependent averaging applied.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> datafile = fetch_data("hera_h3c_uvh5")
-  >>> uvd = UVData.from_file(datafile)
-  >>> uvd2 = uvd.copy()
-  >>> print("Range of integration times: ", np.amin(uvd.integration_time),
-  ...       "-", np.amax(uvd.integration_time))
-  Range of integration times:  1.879048192 - 1.879048192
+    datafile = fetch_data("hera_h3c_uvh5")
+    uvd = UVData.from_file(datafile)
+    uvd2 = uvd.copy()
+    assert np.unique(uvd.integration_time).tolist() == [1.879048192]
 
-  >>> # first use n_times_to_avg to average by a factor of 2 in time.
-  >>> uvd.downsample_in_time(n_times_to_avg=2)
-  Data are unprojected or phased as a driftscan, phasing before resampling.
-  Undoing phasing.
+    # first use n_times_to_avg to average by a factor of 2 in time.
+    uvd.downsample_in_time(n_times_to_avg=2)
+    assert np.unique(uvd.integration_time).tolist() == [3.758096384]
 
-  >>> print("Range of integration times after downsampling: ", np.amin(uvd.integration_time),
-  ...       "-", np.amax(uvd.integration_time))
-  Range of integration times after downsampling:  3.758096384 - 3.758096384
-
-  >>> # Now use min_int_time to average by a factor of 2 in time.
-  >>> min_integration_time = np.amax(uvd2.integration_time) * 2.0
-  >>> uvd2.downsample_in_time(min_int_time=min_integration_time)
-  Data are unprojected or phased as a driftscan, phasing before resampling.
-  Undoing phasing.
-
-  >>> print("Range of integration times after downsampling: ", np.amin(uvd2.integration_time),
-  ...       "-", np.amax(uvd2.integration_time))
-  Range of integration times after downsampling:  3.758096384 - 3.758096384
-
+    # Now use min_int_time to average by a factor of 2 in time.
+    min_integration_time = np.amax(uvd2.integration_time) * 2.0
+    uvd2.downsample_in_time(min_int_time=min_integration_time)
+    assert np.unique(uvd2.integration_time).tolist() == [3.758096384]
 
 b) Upsampling in time
 *********************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> datafile = fetch_data("hera_h3c_uvh5")
-  >>> uvd = UVData.from_file(datafile)
-  >>> print("Range of integration times: ", np.amin(uvd.integration_time),
-  ...       "-", np.amax(uvd.integration_time))
-  Range of integration times:  1.879048192 - 1.879048192
+    datafile = fetch_data("hera_h3c_uvh5")
+    uvd = UVData.from_file(datafile)
+    assert np.unique(uvd.integration_time).tolist() == [1.879048192]
 
-  >>> max_integration_time = np.amin(uvd.integration_time) / 2.0
-  >>> uvd.upsample_in_time(max_integration_time)
-  Data are unprojected or phased as a driftscan, phasing before resampling.
-  Undoing phasing.
-
-  >>> print("Range of integration times after upsampling: ", np.amin(uvd.integration_time),
-  ...       "-", np.amax(uvd.integration_time))
-  Range of integration times after upsampling:  0.939524096 - 0.939524096
+    max_integration_time = np.amin(uvd.integration_time) / 2.0
+    uvd.upsample_in_time(max_integration_time)
+    assert np.unique(uvd.integration_time).tolist() == [0.939524096]
 
 c) Resampling a BDA dataset in time
 ***********************************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> testfile = fetch_data("sim_bda")
-  >>> uvd = UVData.from_file(testfile, default_mount_type="fixed")
-  >>> print(
-  ...    "Range of integration times: ", np.amin(uvd.integration_time), "-", np.amax(uvd.integration_time)
-  ... )
-  Range of integration times:  2.0 - 16.0
+    testfile = fetch_data("sim_bda")
+    uvd = UVData.from_file(testfile, default_mount_type="fixed")
+    assert np.unique(uvd.integration_time).tolist() == [2.0, 4.0, 8.0, 16.0]
 
-  >>> # Resample all baselines to an 8s integration time
-  >>> uvd.resample_in_time(8, allow_drift=True)
-  Data are unprojected or phased as a driftscan and allow_drift is True, so resampling will be done without phasing.
-  Data are unprojected or phased as a driftscan and allow_drift is True, so resampling will be done without phasing.
-
-  >>> print("Range of integration times after resampling: ", np.amin(uvd.integration_time),
-  ...       "-", np.amax(uvd.integration_time))
-  Range of integration times after resampling:  8.0 - 8.0
+    # Resample all baselines to an 8s integration time
+    uvd.resample_in_time(8, allow_drift=True)
+    assert np.unique(uvd.integration_time).tolist() == [8.0]
 
 d) Averaging in frequency
 *************************
@@ -1144,22 +1056,21 @@ number of frequencies in each spectral window does not divide evenly by the numb
 channels to be averaged together. Use the `respect_spws` parameter to control whether
 averaging will be done over spectral window boundaries.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> datafile = fetch_data("hera_h3c_uvh5")
-  >>> uvd = UVData.from_file(datafile)
-  >>> print("Channel width: ", uvd.channel_width)
-  Channel width:  [122070.3125 122070.3125 122070.3125 122070.3125]
+    datafile = fetch_data("hera_h3c_uvh5")
+    uvd = UVData.from_file(datafile)
+    assert np.unique(uvd.channel_width).tolist() == [122070.3125]
 
-  >>> # Average by a factor of 2 in frequency
-  >>> uvd.frequency_average(n_chan_to_avg=2, keep_ragged=True)
-  >>> print("Channel width after frequency averaging: ", uvd.channel_width)
-  Channel width after frequency averaging:  [244140.625 244140.625]
+    # Average by a factor of 2 in frequency
+    uvd.frequency_average(n_chan_to_avg=2, keep_ragged=True)
+    assert np.unique(uvd.channel_width).tolist() == [244140.625]
 
 
 UVData: Combining and concatenating data
@@ -1169,73 +1080,80 @@ the baseline-time, frequency, and/or polarization axis.
 
 a) Combine frequencies.
 ***********************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd1 = UVData.from_file(filename)
-  >>> uvd2 = uvd1.copy()
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd1 = UVData.from_file(filename)
+    uvd2 = uvd1.copy()
 
-  >>> # Downselect frequencies to recombine
-  >>> uvd1.select(freq_chans=np.arange(0, 32))
-  >>> uvd2.select(freq_chans=np.arange(32, 64))
-  >>> uvd3 = uvd1 + uvd2
-  >>> print((uvd1.Nfreqs, uvd2.Nfreqs, uvd3.Nfreqs))
-  (32, 32, 64)
+    # Downselect frequencies to recombine
+    uvd1.select(freq_chans=np.arange(0, 32))
+    assert uvd1.Nfreqs == 32
+    uvd2.select(freq_chans=np.arange(32, 64))
+    assert uvd2.Nfreqs == 32
+    uvd3 = uvd1 + uvd2
+    assert uvd3.Nfreqs == 64
 
 b) Combine times.
 *****************
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd1 = UVData.from_file(filename)
-  >>> uvd2 = uvd1.copy()
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd1 = UVData.from_file(filename)
+    uvd2 = uvd1.copy()
 
-  >>> # Downselect times to recombine
-  >>> times = np.unique(uvd1.time_array)
-  >>> uvd1.select(times=times[0:len(times) // 2])
-  >>> uvd2.select(times=times[len(times) // 2:])
-  >>> uvd3 = uvd1 + uvd2
-  >>> print((uvd1.Ntimes, uvd2.Ntimes, uvd3.Ntimes))
-  (7, 8, 15)
-  >>> print((uvd1.Nblts, uvd2.Nblts, uvd3.Nblts))
-  (459, 901, 1360)
+    # Downselect times to recombine
+    times = np.unique(uvd1.time_array)
+    uvd1.select(times=times[0:len(times) // 2])
+    assert uvd1.Ntimes == 7
+    uvd2.select(times=times[len(times) // 2:])
+    assert uvd2.Ntimes == 8
+    uvd3 = uvd1 + uvd2
+    assert uvd3.Ntimes == 15
 
 c) Combine in place.
 ********************
 The following two commands are equivalent, and act on uvd1
 directly without creating a third uvdata object.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd1 = UVData.from_file(filename)
-  >>> uvd2 = uvd1.copy()
-  >>> uvd1.select(times=times[0:len(times) // 2])
-  >>> uvd2.select(times=times[len(times) // 2:])
-  >>> uvd1.__add__(uvd2, inplace=True)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd1 = UVData.from_file(filename)
+    uvd2 = uvd1.copy()
+    times = np.unique(uvd1.time_array)
+    uvd1.select(times=times[0:len(times) // 2])
+    uvd2.select(times=times[len(times) // 2:])
+    uvd1.__add__(uvd2, inplace=True)
 
-  >>> uvd1 = UVData.from_file(filename)
-  >>> uvd2 = uvd1.copy()
-  >>> uvd1.select(times=times[0:len(times) // 2])
-  >>> uvd2.select(times=times[len(times) // 2:])
-  >>> uvd1 += uvd2
+    uvd1 = UVData.from_file(filename)
+    uvd2 = uvd1.copy()
+    uvd1.select(times=times[0:len(times) // 2])
+    uvd2.select(times=times[len(times) // 2:])
+    uvd1 += uvd2
 
 
-.. _multiple_files:
+.. _multiple_files_uvdata:
 
 d) Reading multiple files.
 **************************
@@ -1243,24 +1161,25 @@ If the :meth:`pyuvdata.UVData.read` method is given a list of dataset files or
 folders (or list of lists for FHD or MWA correlator datasets), each dataset will
 be read in succession and combined with the previous file(s).
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import os
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
-  >>> uvd1 = uvd.select(freq_chans=np.arange(0, 20), inplace=False)
-  >>> uvd2 = uvd.select(freq_chans=np.arange(20, 40), inplace=False)
-  >>> uvd3 = uvd.select(freq_chans=np.arange(40, 64), inplace=False)
-  >>> uvd1.write_uvfits(os.path.join(".", "tutorial1.uvfits"))
-  >>> uvd2.write_uvfits(os.path.join(".", "tutorial2.uvfits"))
-  >>> uvd3.write_uvfits(os.path.join(".", "tutorial3.uvfits"))
-  >>> filenames = [os.path.join(".", f) for f
-  ...             in ["tutorial1.uvfits", "tutorial2.uvfits", "tutorial3.uvfits"]]
-  >>> uvd = UVData.from_file(filenames)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
+    uvd1 = uvd.select(freq_chans=np.arange(0, 20), inplace=False)
+    uvd2 = uvd.select(freq_chans=np.arange(20, 40), inplace=False)
+    uvd3 = uvd.select(freq_chans=np.arange(40, 64), inplace=False)
+    uvd1.write_uvfits(os.path.join('.', 'tutorial1.uvfits'))
+    uvd2.write_uvfits(os.path.join('.', 'tutorial2.uvfits'))
+    uvd3.write_uvfits(os.path.join('.', 'tutorial3.uvfits'))
+    filenames = [os.path.join('.', f) for f in ['tutorial1.uvfits', 'tutorial2.uvfits', 'tutorial3.uvfits']]
+    uvd = UVData.from_file(filenames)
 
 e) Fast concatenation
 *********************
@@ -1274,12 +1193,12 @@ the ``__add__`` method to combine the data contained in the files into a single
 UVData object.
 
 .. warning::
-  There is no guarantee that two objects combined in this fashion
-  will result in a self-consistent object after concatenation. Basic checking is
-  done, but time-consuming robust checks are eschewed for the sake of speed. The
-  data will also *not* be reordered or sorted as part of the concatenation, and so
-  this must be done manually by the user if a reordering is desired
-  (see :ref:`uvdata_sorting_data`).
+    There is no guarantee that two objects combined in this fashion
+    will result in a self-consistent object after concatenation. Basic checking is
+    done, but time-consuming robust checks are eschewed for the sake of speed. The
+    data will also *not* be reordered or sorted as part of the concatenation, and so
+    this must be done manually by the user if a reordering is desired
+    (see :ref:`uvdata_sorting_data`).
 
 The :meth:`pyuvdata.UVData.fast_concat` method is significantly faster than
 :meth:`pyuvdata.UVData.__add__`, especially for large UVData objects.
@@ -1288,24 +1207,25 @@ time-ordered visibilities from disk using the ``axis`` keyword argument can
 improve throughput by nearly an order of magnitude for 100 HERA data files
 stored as uvh5 files.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import os
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename)
-  >>> uvd1 = uvd.select(freq_chans=np.arange(0, 20), inplace=False)
-  >>> uvd2 = uvd.select(freq_chans=np.arange(20, 40), inplace=False)
-  >>> uvd3 = uvd.select(freq_chans=np.arange(40, 64), inplace=False)
-  >>> uvd1.write_uvfits(os.path.join(".", "tutorial1.uvfits"))
-  >>> uvd2.write_uvfits(os.path.join(".", "tutorial2.uvfits"))
-  >>> uvd3.write_uvfits(os.path.join(".", "tutorial3.uvfits"))
-  >>> filenames = [os.path.join(".", f) for f
-  ...             in ["tutorial1.uvfits", "tutorial2.uvfits", "tutorial3.uvfits"]]
-  >>> uvd = UVData.from_file(filenames, axis="freq")
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename)
+    uvd1 = uvd.select(freq_chans=np.arange(0, 20), inplace=False)
+    uvd2 = uvd.select(freq_chans=np.arange(20, 40), inplace=False)
+    uvd3 = uvd.select(freq_chans=np.arange(40, 64), inplace=False)
+    uvd1.write_uvfits(os.path.join('.', 'tutorial1.uvfits'))
+    uvd2.write_uvfits(os.path.join('.', 'tutorial2.uvfits'))
+    uvd3.write_uvfits(os.path.join('.', 'tutorial3.uvfits'))
+    filenames = [os.path.join('.', f) for f in ['tutorial1.uvfits', 'tutorial2.uvfits', 'tutorial3.uvfits']]
+    uvd = UVData.from_file(filenames, axis='freq')
 
 
 UVData: Summing and differencing visibilities
@@ -1313,30 +1233,32 @@ UVData: Summing and differencing visibilities
 Simple summing and differencing of visibilities can be done with the :meth:`pyuvdata.UVData.sum_vis`
 and :meth:`pyuvdata.UVData.diff_vis` methods.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from astropy.time import Time
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from astropy.time import Time
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd1 = UVData.from_file(filename)
-  >>> uvd2 = uvd1.copy()
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd1 = UVData.from_file(filename)
+    uvd2 = uvd1.copy()
 
-  >>> # sum visibilities
-  >>> uvd1 = uvd1.sum_vis(uvd2)
+    # sum visibilities
+    uvd1 = uvd1.sum_vis(uvd2)
 
-  >>> # diff visibilities
-  >>> uvd1 = uvd1.diff_vis(uvd2)
+    # diff visibilities
+    uvd1 = uvd1.diff_vis(uvd2)
 
-  >>> # in place option
-  >>> uvd1.sum_vis(uvd2, inplace=True)
+    # in place option
+    uvd1.sum_vis(uvd2, inplace=True)
 
-  >>> # override a particular parameter
-  >>> rdate_obj = Time(np.floor(uvd1.time_array[0]), format="jd", scale="utc")
-  >>> uvd1.rdate = rdate_obj.strftime("%Y-%m-%d")
-  >>> uvd1.sum_vis(uvd2, inplace=True, override_params=["rdate"])
+    # override a particular parameter
+    rdate_obj = Time(np.floor(uvd1.time_array[0]), format="jd", scale="utc")
+    uvd1.rdate = rdate_obj.strftime("%Y-%m-%d")
+    uvd1.sum_vis(uvd2, inplace=True, override_params=["rdate"])
 
 
 UVData: Phasing
@@ -1347,92 +1269,121 @@ and other analyses is called phasing. See our
 for a detailed description of phasing and the specific implementation details in
 pyuvdata.
 
+We use the :meth:`pyuvdata.UVData.print_phase_center_info` to print a nice description
+of the phasing of the object.
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from astropy.time import Time
-  >>> from numpy import pi
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from astropy.time import Time
+    from numpy import pi
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> uvh5_file = fetch_data("hera_h3c_uvh5")
-  >>> uvd = UVData.from_file(uvh5_file)
+    uvh5_file = fetch_data("hera_h3c_uvh5")
+    uvd = UVData.from_file(uvh5_file)
+    uvd.print_phase_center_info()
 
-  >>> # We can get information on the sources in the data set by using the
-  >>> # `print_phase_center_info` command. This object is initially unprojected (unphased)
-  >>> uvd.print_phase_center_info()
+This object is initially unprojected (unphased) so the print command yields::
+
      ID     Cat Entry          Type      Az/Lon/RA    El/Lat/Dec  Frame
       #          Name                          deg           deg
   ----------------------------------------------------------------------
       0        zenith   unprojected     0:00:00.00  +90:00:00.00  altaz
 
 
-  >>> # When phasing, the user needs to supply a name for each phase
-  >>> # center, though it does not need to be unique. We are specifying that the type
-  >>> # here is "sidereal", which means that the position is represented by a fixed set
-  >>> # of coordinates in a sidereal coordinate frame (e.g., ICRS, FK5, etc).
-  >>> uvd.phase(lon=5.23368, lat=0.710940, epoch="J2000", cat_name="target1", cat_type="sidereal")
-  >>> uvd.print_phase_center_info()
+When phasing, the user needs to supply a name for each phase center, though it
+does not need to be unique. We are specifying that the type here is "sidereal",
+which means that the position is represented by a fixed set of coordinates in a
+sidereal coordinate frame (e.g., ICRS, FK5, etc).
+
+.. code-block:: python
+
+    uvd.phase(lon=5.23368, lat=0.710940, epoch="J2000", cat_name="target1", cat_type="sidereal")
+    uvd.print_phase_center_info()
+
+Now the print command yields::
+
      ID     Cat Entry          Type     Az/Lon/RA    El/Lat/Dec  Frame    Epoch
       #          Name                       hours           deg
   ------------------------------------------------------------------------------
       1       target1      sidereal   19:59:28.27  +40:44:01.90   icrs  J2000.0
 
 
-  >>> # You can use the `phase_to_time` method to phase to zenith at a particular time.
-  >>> # The time can be passed as an astropy Time object or as a float which will be
-  >>> # interpreted as a JD
-  >>> uvd.phase_to_time(Time(uvd.time_array[0], format="jd"))
-  >>> uvd.print_phase_center_info()
+You can use the `phase_to_time` method to phase to zenith at a particular time.
+The time can be passed as an astropy Time object or as a float which will be
+interpreted as a JD
+
+.. code-block:: python
+
+    uvd.phase_to_time(Time(uvd.time_array[0], format="jd"))
+    uvd.print_phase_center_info()
+
+Now the print command yields::
+
      ID     Cat Entry          Type     Az/Lon/RA    El/Lat/Dec  Frame    Epoch
       #          Name                       hours           deg
   ------------------------------------------------------------------------------
       0  zenith_at_jd2458661.234803      sidereal   13:20:57.92  -30:37:09.44   icrs  J2000.0
 
 
-  >>> # You can also now phase to "ephem" objects, which
-  >>> # move with time, e.g. solar system bodies. The phase method has a `lookup_name`
-  >>> # option which, if set to true, will allow you to search JPL-Horizons for coords
-  >>> uvd.phase(lon=0, lat=0, epoch="J2000", cat_name="Sun", lookup_name=True)
-  >>> uvd.print_phase_center_info()
+You can also now phase to "ephem" objects, which move with time, e.g. solar
+system bodies. The phase method has a `lookup_name` option which, if set to true,
+will allow you to search JPL-Horizons for coords
+
+.. code-block:: python
+
+    uvd.phase(lon=0, lat=0, epoch="J2000", cat_name="Sun", lookup_name=True)
+    uvd.print_phase_center_info()
+
+Now the print command yields::
+
      ID     Cat Entry          Type     Az/Lon/RA    El/Lat/Dec  Frame    Epoch        Ephem Range        Dist   V_rad
       #          Name                       hours           deg                  Start-MJD    End-MJD       pc    km/s
   ---------------------------------------------------------------------------------------------------------------------
       1           Sun         ephem    6:19:28.68  +23:21:44.63   icrs  J2000.0   58660.25   58661.00  1.0e+00  0.2157
 
 
-  >>> # Finally, we can use a selection mask to only phase part of the data at a time,
-  >>> # like only the data belonging to the first integration
-  >>> select_mask = uvd.time_array == uvd.time_array[0]
+Finally, we can use a selection mask to only phase part of the data at a time,
+like only the data belonging to the first integration. In this example we'll phase
+the first integration to a "driftscan" target, which is phased to a particular
+azimuth and elevation (note this is different than "unprojected" data -- which
+used to be designated with phase_type="drift" -- in that it is still phased and
+can be to any azimuth and elevation, not just zenith). Note that we need to
+supply `phase_frame` as "altaz", since driftscans are always in that frame.
 
-  >>> # Let's use this to create a "driftscan" target, which is phased to a particular
-  >>> # azimuth and elevation (note this is different than "unprojected" data -- which
-  >>> # used to be designated with phase_type="drift" -- in that it is still phased and
-  >>> # can be to any azimuth and elevation, not just zenith). Note that we need to
-  >>> # supply `phase_frame` as "altaz", since driftscans are always in that frame.
-  >>> uvd.phase(lon=0, lat=pi/2, cat_name="zenith", phase_frame="altaz", cat_type="driftscan", select_mask=select_mask)
+.. code-block:: python
 
-  >>> # Now when using `print_phase_center_info`, we'll see that there are multiple
-  >>> # phase centers present in the data
-  >>> uvd.print_phase_center_info()
+    select_mask = uvd.time_array == uvd.time_array[0]
+    uvd.phase(lon=0, lat=pi/2, cat_name="zenith", phase_frame="altaz", cat_type="driftscan", select_mask=select_mask)
+    uvd.print_phase_center_info()
+
+Now when using `print_phase_center_info`, we see that there are multiple phase
+centers present in the data::
+
      ID     Cat Entry          Type      Az/Lon/RA    El/Lat/Dec  Frame    Epoch        Ephem Range        Dist   V_rad
       #          Name                          deg           deg                  Start-MJD    End-MJD       pc    km/s
   ----------------------------------------------------------------------------------------------------------------------
       0        zenith     driftscan     0:00:00.00  +90:00:00.00  altaz  J2000.0
       1           Sun         ephem    94:52:10.21  +23:21:44.63   icrs  J2000.0   58660.25   58661.00  1.0e+00  0.2157
 
-  >>> # We can unproject (unphase) data using the `unproject_phase` method
-  >>> uvd.unproject_phase()
+We can unproject (unphase) data using the `unproject_phase` method:
 
-  >>> # Now when using `print_phase_center_info`, we'll see that all the data are unprojected
-  >>> uvd.print_phase_center_info()
+.. code-block:: python
+
+    uvd.unproject_phase()
+    uvd.print_phase_center_info()
+
+Now when using `print_phase_center_info`, we'll see that all the data are unprojected::
+
      ID     Cat Entry          Type      Az/Lon/RA    El/Lat/Dec  Frame
       #          Name                          deg           deg
   ----------------------------------------------------------------------
       2   unprojected   unprojected     0:00:00.00  +90:00:00.00  altaz
 
 
-.. _large_files:
+.. _large_files_uvdata:
 
 UVData: Working with large files
 --------------------------------
@@ -1459,25 +1410,21 @@ are available.
 Measurement set (ms) files do not support reading only the metadata
 (the read_data keyword is ignored for ms files).
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
+    filename = fetch_data("vla_casa_tutorial_uvfits")
 
-  >>> # read the metadata but not the data
-  >>> uvd = UVData.from_file(filename, read_data=False)
+    # read the metadata but not the data
+    uvd = UVData.from_file(filename, read_data=False)
+    assert uvd.metadata_only
+    assert uvd.time_array.size == 1360
+    assert uvd.data_array is None
 
-  >>> print(uvd.metadata_only)
-  True
-
-  >>> print(uvd.time_array.size)
-  1360
-
-  >>> print(uvd.data_array)
-  None
 
 b) Reading only parts of files
 ******************************
@@ -1491,40 +1438,36 @@ save memory. Miriad and Mir only supports some of the selections on the read, th
 unsupported ones are done after the read. MWA correlator fits has support for most
 but not all selections, the unsupported ones are done after the read.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("vla_casa_tutorial_uvfits")
-  >>> uvd = UVData.from_file(filename, freq_chans=np.arange(32))
-  >>> print(uvd.data_array.shape)
-  (1360, 32, 4)
+    filename = fetch_data("vla_casa_tutorial_uvfits")
+    uvd = UVData.from_file(filename, freq_chans=np.arange(32))
+    assert uvd.Nfreqs == 32
 
-  >>> # Reading in the metadata can help with specifying what data to read in
-  >>> uvd = UVData.from_file(filename, read_data=False)
-  >>> unique_times = np.unique(uvd.time_array)
-  >>> print(unique_times.shape)
-  (15,)
+    # Reading in the metadata can help with specifying what data to read in
+    uvd = UVData.from_file(filename, read_data=False)
+    assert uvd.Ntimes == 15
 
-  >>> times_to_keep = unique_times[[0, 2, 4]]
-  >>> uvd = UVData.from_file(filename, times=times_to_keep)
-  >>> print(uvd.data_array.shape)
-  (179, 64, 4)
+    unique_times = np.unique(uvd.time_array)
+    times_to_keep = unique_times[[0, 2, 4]]
+    uvd = UVData.from_file(filename, times=times_to_keep)
+    assert uvd.Ntimes == 3
 
-  >>> # Select a few baselines from a miriad file
-  >>> filename = fetch_data("hera_old_miriad")
-  >>> uvd = UVData.from_file(filename, bls=[(9, 10), (9, 20)])
-  >>> print(uvd.get_antpairs())
-  [(9, 10), (9, 20)]
+    # Select a few baselines from a miriad file
+    filename = fetch_data("hera_old_miriad")
+    uvd = UVData.from_file(filename, bls=[(9, 10), (9, 20)])
+    assert uvd.get_antpairs() == [(9, 10), (9, 20)]
 
-  >>> # Select certain frequencies from a uvh5 file
-  >>> filename = fetch_data("hera_h3c_uvh5")
-  >>> uvd = UVData.from_file(filename, freq_chans=np.arange(2))
-  >>> print(uvd.data_array.shape)
-  (200, 2, 2)
+    # Select certain frequencies from a uvh5 file
+    filename = fetch_data("hera_h3c_uvh5")
+    uvd = UVData.from_file(filename, freq_chans=np.arange(2))
+    assert uvd.Nfreqs == 2
 
 c) Writing to a uvh5 file in parts
 **********************************
@@ -1543,46 +1486,49 @@ parts of the data, flags, and nsample arrays should be written to. The user then
 also provides the data, flags, and nsample arrays of the proper size, and they
 are written to the appropriate parts of the file on disk.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import os
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> filename = fetch_data("hera_h3c_uvh5")
-  >>> uvd = UVData.from_file(filename, read_data=False)
-  >>> partfile = os.path.join(".", "tutorial_partial_io.uvh5")
-  >>> uvd.initialize_uvh5_file(partfile, clobber=True)
+    filename = fetch_data("hera_h3c_uvh5")
+    uvd = UVData.from_file(filename, read_data=False)
+    partfile = os.path.join('.', 'tutorial_partial_io.uvh5')
+    uvd.initialize_uvh5_file(partfile, clobber=True)
 
-  >>> # read in the lower and upper halves of the band separately, and apply different scalings
-  >>> Nfreqs = uvd.Nfreqs
-  >>> Hfreqs = Nfreqs // 2
-  >>> freq_inds1 = np.arange(Hfreqs)
-  >>> freq_inds2 = np.arange(Hfreqs, Nfreqs)
-  >>> uvd2 = UVData.from_file(filename, freq_chans=freq_inds1)
-  >>> data_array = 0.5 * uvd2.data_array
-  >>> flag_array = uvd2.flag_array
-  >>> nsample_array = uvd2.nsample_array
-  >>> uvd.write_uvh5_part(
-  ...   partfile,
-  ...   data_array=data_array,
-  ...   flag_array=flag_array,
-  ...   nsample_array=nsample_array,
-  ...   freq_chans=freq_inds1
-  ... )
+    # read in the lower and upper halves of the band separately, and apply different scalings
+    Nfreqs = uvd.Nfreqs
+    Hfreqs = Nfreqs // 2
+    freq_inds1 = np.arange(Hfreqs)
+    freq_inds2 = np.arange(Hfreqs, Nfreqs)
+    uvd2 = UVData()
+    uvd2 = UVData.from_file(filename, freq_chans=freq_inds1)
+    data_array = 0.5 * uvd2.data_array
+    flag_array = uvd2.flag_array
+    nsample_array = uvd2.nsample_array
+    uvd.write_uvh5_part(
+        partfile,
+        data_array=data_array,
+        flag_array=flag_array,
+        nsample_array=nsample_array,
+        freq_chans=freq_inds1
+    )
 
-  >>> uvd2 = UVData.from_file(filename, freq_chans=freq_inds2)
-  >>> data_array = 2.0 * uvd2.data_array
-  >>> flag_array = uvd2.flag_array
-  >>> nsample_array = uvd2.nsample_array
-  >>> uvd.write_uvh5_part(
-  ...   partfile,
-  ...   data_array=data_array,
-  ...   flag_array=flag_array,
-  ...   nsample_array=nsample_array,
-  ...   freq_chans=freq_inds2
-  ... )
+    uvd2 = UVData.from_file(filename, freq_chans=freq_inds2)
+    data_array = 2.0 * uvd2.data_array
+    flag_array = uvd2.flag_array
+    nsample_array = uvd2.nsample_array
+    uvd.write_uvh5_part(
+        partfile,
+        data_array=data_array,
+        flag_array=flag_array,
+        nsample_array=nsample_array,
+        freq_chans=freq_inds2
+    )
 
 
 UVData: Working with Redundant Baselines
@@ -1619,39 +1565,34 @@ functions for the baselines on an object is less memory efficient than using
 :meth:`pyuvdata.UVData.get_redundancies` because the latter only uses the first time in
 the baseline array.
 
+.. clear-namespace
 
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import utils, UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import utils, UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> # This file contains a HERA19 layout.
-  >>> uvd = UVData.from_file(fetch_data("sim_airy_hex"))
-  >>> uvd.unproject_phase(use_ant_pos=True)
-  >>> tol = 0.05  # Tolerance in meters
+    # This file contains a HERA19 layout.
+    uvd = UVData.from_file(fetch_data("sim_airy_hex"))
+    uvd.unproject_phase(use_ant_pos=True)
+    tol = 0.05  # Tolerance in meters
 
-  >>> # Returned values: list of redundant groups, corresponding mean baseline vectors, baseline lengths. No conjugates included, so conjugates is None.
-  >>> baseline_groups, vec_bin_centers, lengths = uvd.get_redundancies(tol=tol, include_conjugates=False)
-  >>> print(len(baseline_groups))
-  19
+    # Returned values: list of redundant groups, corresponding mean baseline vectors, baseline lengths. No conjugates included, so conjugates is None.
+    baseline_groups, vec_bin_centers, lengths = uvd.get_redundancies(tol=tol, include_conjugates=False)
+    assert len(baseline_groups) == 19
 
-  >>> # The include_conjugates option includes baselines that are redundant when reversed.
-  >>> # If used, the conjugates list will contain a list of indices of baselines that must be flipped to be redundant.
-  >>> baseline_groups, vec_bin_centers, lengths, conjugates = uvd.get_redundancies(tol=tol, include_conjugates=True)
-  >>> print(len(baseline_groups))
-  19
+    # The include_conjugates option includes baselines that are redundant when reversed.
+    # If used, the conjugates list will contain a list of indices of baselines that must be flipped to be redundant.
+    baseline_groups, vec_bin_centers, lengths, conjugates = uvd.get_redundancies(tol=tol, include_conjugates=True)
+    assert len(baseline_groups) == 19
 
-  >>> # Using antenna positions instead. This has one more group because it includes the autos.
-  >>> baseline_groups, vec_bin_centers, lengths = uvd.get_redundancies(tol=tol, use_antpos=True)
-  >>> print(len(baseline_groups))
-  20
+    # Using antenna positions instead. This has one more group because it includes the autos.
+    baseline_groups, vec_bin_centers, lengths = uvd.get_redundancies(tol=tol, use_antpos=True)
+    assert len(baseline_groups) == 20
 
-  >>> # get_redundancies has the option to ignore autocorrelations.
-  >>> baseline_groups, vec_bin_centers, lengths = uvd.get_redundancies(tol=tol, use_antpos=True, include_autos=False)
-  >>> print(len(baseline_groups))
-  19
+    # get_redundancies has the option to ignore autocorrelations.
+    baseline_groups, vec_bin_centers, lengths = uvd.get_redundancies(tol=tol, use_antpos=True, include_autos=False)
+    assert len(baseline_groups) == 19
 
 b) Compressing/inflating on Redundant Baselines
 ***********************************************
@@ -1670,30 +1611,31 @@ This action is (almost) inverted by the :meth:`pyuvdata.UVData.inflate_by_redund
 method, which finds all possible baselines from the antenna positions and fills
 in the full data array based on redundancy.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> uv0 = UVData.from_file(fetch_data("sim_airy_hex"))
-  >>> tol = 0.02   # In meters
+    uv0 = UVData.from_file(fetch_data("sim_airy_hex"))
+    tol = 0.02   # In meters
 
-  >>> # Compression can be run in-place or return a separate UVData object.
-  >>> uv_backup = uv0.copy()
-  >>> uvd2 = uv0.compress_by_redundancy(method="select", tol=tol, inplace=False)
-  >>> uv0.compress_by_redundancy(method="select", tol=tol)
-  >>> assert uvd2 == uv0
+    # Compression can be run in-place or return a separate UVData object.
+    uv_backup = uv0.copy()
+    uvd2 = uv0.compress_by_redundancy(method="select", tol=tol, inplace=False)
+    uv0.compress_by_redundancy(method="select", tol=tol)
+    assert uvd2 == uv0
 
-  >>> # Note -- Compressing and inflating changes the baseline order, reorder before comparing.
-  >>> uv0.inflate_by_redundancy(tol=tol)
-  >>> uv_backup.reorder_blts(conj_convention="u>0", uvw_tol=tol)
-  >>> uv0.reorder_blts()
-  >>> assert np.all(uv0.baseline_array == uv_backup.baseline_array)
+    # Note -- Compressing and inflating changes the baseline order, reorder before comparing.
+    uv0.inflate_by_redundancy(tol=tol)
+    uv_backup.reorder_blts(conj_convention="u>0", uvw_tol=tol)
+    uv0.reorder_blts()
+    assert np.all(uv0.baseline_array == uv_backup.baseline_array)
 
-  >>> uvd2.inflate_by_redundancy(tol=tol)
-  >>> assert uvd2 == uv0
+    uvd2.inflate_by_redundancy(tol=tol)
+    assert uvd2 == uv0
 
 
 .. _flex_pol:
@@ -1737,53 +1679,46 @@ We do not currently have an SMA flex_pol file in the repo, so we first generate 
 using some low-level Mir interfaces, then explore some of its properties and convert it
 into a standard UVData object (which doubles its size).
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.uvdata.mir import Mir
-  >>> from pyuvdata.uvdata.mir_parser import MirParser
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.uvdata.mir import Mir
+    from pyuvdata.uvdata.mir_parser import MirParser
+    from pyuvdata.datasets import fetch_data
 
-  >>> mir_file = fetch_data("sma_mir")
-  >>> mir_data = MirParser(mir_file, load_cross=True, load_auto=True, has_auto=True)
+    mir_file = fetch_data("sma_mir")
+    mir_data = MirParser(mir_file, load_cross=True, load_auto=True, has_auto=True)
 
-  >>> # Read in the raw data so that we can manipulate it, and make it look like the
-  >>> # test data set was recorded with split-tuning
-  >>> mir_data.sp_data._data["gunnLO"][np.isin(mir_data.sp_data["blhid"], [1, 3])] += 30.0
-  >>> mir_data.sp_data._data["fsky"][np.isin(mir_data.sp_data["blhid"], [1, 3])] += 30.0
+    # Read in the raw data so that we can manipulate it, and make it look like the
+    # test data set was recorded with split-tuning
+    mir_data.sp_data._data["gunnLO"][np.isin(mir_data.sp_data["blhid"], [1, 3])] += 30.0
+    mir_data.sp_data._data["fsky"][np.isin(mir_data.sp_data["blhid"], [1, 3])] += 30.0
 
-  >>> # Convert MirParser object into a UVData object with flex-pol enabled.
-  >>> mir_uv = UVData()
-  >>> mir_obj = Mir()
-  >>> mir_obj._init_from_mir_parser(mir_data)
-  >>> mir_uv._convert_from_filetype(mir_obj)
+    # Convert MirParser object into a UVData object with flex-pol enabled.
+    mir_uv = UVData()
+    mir_obj = Mir()
+    mir_obj._init_from_mir_parser(mir_data)
+    mir_uv._convert_from_filetype(mir_obj)
 
-  >>> # Start exploring SMA flex_pol object
-  >>> print(mir_uv.spw_array)
-  [-255   -4   -3   -2   -1    1    2    3    4  255  257  508  509  510
-    511  513  514  515  516  767]
-  >>> print(mir_uv.flex_spw_polarization_array)
-  [-5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -6 -6 -6 -6 -6 -6 -6 -6 -6 -6]
-  >>> print(mir_uv.polarization_array)
-  [0]
-  >>> print(mir_uv.data_array.shape)
-  (1, 262160, 1)
+    # Start exploring SMA flex_pol object
+    assert mir_uv.spw_array.tolist() == [-255, -4, -3, -2, -1, 1, 2, 3, 4, 255, 257, 508, 509, 510, 511, 513, 514, 515, 516, 767]
+    print(mir_uv.flex_spw_polarization_array.tolist())
+    assert mir_uv.flex_spw_polarization_array.tolist() == [-5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -6, -6, -6, -6, -6, -6, -6, -6, -6, -6]
+    assert mir_uv.polarization_array == 0
+    assert mir_uv.data_array.shape == (1, 262160, 1)
 
-  >>> # Use the ``remove_flex_pol`` method to get a standard object. Note that it
-  >>> # doubles the data_array size
-  >>> mir_uv.remove_flex_pol(combine_spws=False)
-  >>> print(mir_uv.spw_array)
-  [-255   -4   -3   -2   -1    1    2    3    4  255  257  508  509  510
-    511  513  514  515  516  767]
-  >>> print(mir_uv.flex_spw_polarization_array)
-  None
-  >>> print(mir_uv.polarization_array)
-  [-6 -5]
-  >>> print(mir_uv.data_array.shape)
-  (1, 262160, 2)
-
+    # Use the ``remove_flex_pol`` method to get a standard object. Note that it
+    # doubles the data_array size
+    mir_uv.remove_flex_pol(combine_spws=False)
+    print(mir_uv.spw_array)
+    assert mir_uv.spw_array.tolist() == [-255, -4, -3, -2, -1, 1, 2, 3, 4, 255, 257, 508, 509, 510, 511, 513, 514, 515, 516, 767]
+    assert mir_uv.flex_spw_polarization_array is None
+    assert mir_uv.polarization_array.tolist() == [-6, -5]
+    assert mir_uv.data_array.shape == (1, 262160, 2)
 
 b) Converting between standard and flex_pol objects
 ***************************************************
@@ -1791,47 +1726,35 @@ Here we load a HERA dataset and convert it to a flex-pol object, which reshapes 
 data_array but does not change its total size and then back, recovering the initial
 object.
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> uvd = UVData.from_file(fetch_data("hera_h3c_uvh5"))
-  >>> # make a copy to enable comparisons after converting to and from flex_pol
-  >>> uvd_orig = uvd.copy()
-  >>> print(uvd.polarization_array)
-  [-5 -6]
-  >>> print(uvd.spw_array)
-  [0]
-  >>> print(uvd.flex_spw_polarization_array)
-  None
-  >>> print(uvd.data_array.shape)
-  (200, 4, 2)
+    uvd = UVData.from_file(fetch_data("hera_h3c_uvh5"))
+    # make a copy to enable comparisons after converting to and from flex_pol
+    uvd_orig = uvd.copy()
+    assert uvd.polarization_array.tolist() == [-5, -6]
+    assert uvd.spw_array.tolist() == [0]
+    assert uvd.flex_spw_polarization_array is None
+    assert uvd.data_array.shape == (200, 4, 2)
 
-  >>> uvd.convert_to_flex_pol()
-  >>> print(uvd.polarization_array)
-  [0]
-  >>> print(uvd.spw_array)
-  [0 1]
-  >>> print(uvd.flex_spw_polarization_array)
-  [-5 -6]
-  >>> print(uvd.data_array.shape)
-  (200, 8, 1)
+    uvd.convert_to_flex_pol()
+    assert uvd.polarization_array.tolist() == [0]
+    assert uvd.spw_array.tolist() == [0, 1]
+    assert uvd.flex_spw_polarization_array.tolist() == [-5, -6]
+    assert uvd.data_array.shape == (200, 8, 1)
 
-  >>> uvd.remove_flex_pol()
-  >>> print(uvd.polarization_array)
-  [-5 -6]
-  >>> print(uvd.spw_array)
-  [0]
-  >>> print(uvd.flex_spw_polarization_array)
-  None
-  >>> print(uvd.data_array.shape)
-  (200, 4, 2)
+    uvd.remove_flex_pol()
+    assert uvd.polarization_array.tolist() == [-5, -6]
+    assert uvd.spw_array.tolist() == [0]
+    assert uvd.flex_spw_polarization_array is None
+    assert uvd.data_array.shape == (200, 4, 2)
 
-
-.. _new:
+.. _new_uvdata:
 
 UVData: Instantiating from arrays in memory
 -------------------------------------------
@@ -1841,27 +1764,30 @@ simulated data. Instead of instantiating a blank object and setting each require
 parameter, you can use the  :meth:`pyuvdata.Telescope.new` static method, which
 deals with the task of creating a consistent object from a minimal set of inputs
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> from astropy.coordinates import EarthLocation
-  >>> import numpy as np
-  >>> from pyuvdata import Telescope, UVData
+    from astropy.coordinates import EarthLocation
+    import numpy as np
+    from pyuvdata import Telescope, UVData
 
-  >>> uvd = UVData.new(
-  ...     freq_array = np.linspace(1e8, 2e8, 100),
-  ...     polarization_array = ["xx", "yy"],
-  ...     telescope = Telescope.new(
-  ...         antenna_positions = {
-  ...             0: [0.0, 0.0, 0.0],
-  ...             1: [0.0, 0.0, 1.0],
-  ...             2: [0.0, 0.0, 2.0],
-  ...         },
-  ...         location = EarthLocation.from_geodetic(0, 0, 0),
-  ...         name = "test",
-  ...         instrument = "test",
-  ...     ),
-  ...     times = np.linspace(2459855, 2459856, 20),
-  ... )
+    uvd = UVData.new(
+           freq_array = np.linspace(1e8, 2e8, 100),
+           polarization_array = ["xx", "yy"],
+           telescope = Telescope.new(
+               antenna_positions = {
+                   0: [0.0, 0.0, 0.0],
+                   1: [0.0, 0.0, 1.0],
+                   2: [0.0, 0.0, 2.0],
+               },
+               location = EarthLocation.from_geodetic(0, 0, 0),
+               name = "test",
+               instrument = "test",
+           ),
+           times = np.linspace(2459855, 2459856, 20),
+    )
 
 Notice that you need only provide the required parameters, and the rest will be
 filled in with sensible defaults. The telescope related metadata is passed
@@ -1876,96 +1802,104 @@ to enable this. Let us for example create an unusual object with 4 times and 4 b
 where each baseline observed one time each. This case is ambiguous without the
 ``do_blt_outer`` keyword, so we must set it:
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> from astropy.coordinates import EarthLocation
-  >>> import numpy as np
-  >>> from pyuvdata import Telescope, UVData
+    from astropy.coordinates import EarthLocation
+    import numpy as np
+    from pyuvdata import Telescope, UVData
 
-  >>> times = np.array([2459855.0, 2459855.1, 2459855.2, 2459855.3])
-  >>> antpairs = [(0, 1), (0, 2), (1, 2), (1, 1)]
-  >>> uvd = UVData.new(
-  ...     freq_array = np.linspace(1e8, 2e8, 100),
-  ...     polarization_array = ["xx", "yy"],
-  ...     telescope = Telescope.new(
-  ...         antenna_positions = {
-  ...             0: [0.0, 0.0, 0.0],
-  ...             1: [0.0, 0.0, 1.0],
-  ...             2: [0.0, 0.0, 2.0],
-  ...         },
-  ...         location = EarthLocation.from_geodetic(0, 0, 0),
-  ...         name = "test",
-  ...         instrument = "test",
-  ...     ),
-  ...     times = times,
-  ...     antpairs=antpairs,
-  ...     do_blt_outer=False,
-  ... )
-  >>> uvd.time_array
-  array([2459855. , 2459855.1, 2459855.2, 2459855.3])
+    times = np.array([2459855.0, 2459855.1, 2459855.2, 2459855.3])
+    antpairs = [(0, 1), (0, 2), (1, 2), (1, 1)]
+    uvd = UVData.new(
+           freq_array = np.linspace(1e8, 2e8, 100),
+           polarization_array = ["xx", "yy"],
+           telescope = Telescope.new(
+               antenna_positions = {
+                   0: [0.0, 0.0, 0.0],
+                   1: [0.0, 0.0, 1.0],
+                   2: [0.0, 0.0, 2.0],
+               },
+               location = EarthLocation.from_geodetic(0, 0, 0),
+               name = "test",
+               instrument = "test",
+           ),
+           times = times,
+           antpairs=antpairs,
+           do_blt_outer=False,
+    )
+    assert uvd.Nblts == 4
+    assert np.allclose(uvd.time_array, times)
 
-Notice that the resulting ``time_array`` only has 4 values. If we had set
+Notice that the resulting object only has 4 baseline-times. If we had set
 ``do_blt_outer = True``, we would have gotten the cartesian outer product of the
-provided times and baselines, which would have resulted in 16 times:
+provided times and baselines, which would have resulted in 16 baseline-times:
+
+.. clear-namespace
 
 .. code-block:: python
 
-  >>> from astropy.coordinates import EarthLocation
-  >>> import numpy as np
-  >>> from pyuvdata import Telescope, UVData
+    from astropy.coordinates import EarthLocation
+    import numpy as np
+    from pyuvdata import Telescope, UVData
 
-  >>> uvd_rect = UVData.new(
-  ...     freq_array = np.linspace(1e8, 2e8, 100),
-  ...     polarization_array = ["xx", "yy"],
-  ...     telescope = Telescope.new(
-  ...         antenna_positions = {
-  ...             0: [0.0, 0.0, 0.0],
-  ...             1: [0.0, 0.0, 1.0],
-  ...             2: [0.0, 0.0, 2.0],
-  ...         },
-  ...         location = EarthLocation.from_geodetic(0, 0, 0),
-  ...         name = "test",
-  ...         instrument = "test",
-  ...     ),
-  ...     times = times,
-  ...     antpairs=antpairs,
-  ...     do_blt_outer=True,
-  ... )
-  >>> uvd_rect.time_array
-  array([2459855. , 2459855. , 2459855. , 2459855. , 2459855.1, 2459855.1,
-         2459855.1, 2459855.1, 2459855.2, 2459855.2, 2459855.2, 2459855.2,
-         2459855.3, 2459855.3, 2459855.3, 2459855.3])
+    times = np.array([2459855.0, 2459855.1, 2459855.2, 2459855.3])
+    antpairs = [(0, 1), (0, 2), (1, 2), (1, 1)]
+    uvd_rect = UVData.new(
+           freq_array = np.linspace(1e8, 2e8, 100),
+           polarization_array = ["xx", "yy"],
+           telescope = Telescope.new(
+               antenna_positions = {
+                   0: [0.0, 0.0, 0.0],
+                   1: [0.0, 0.0, 1.0],
+                   2: [0.0, 0.0, 2.0],
+               },
+               location = EarthLocation.from_geodetic(0, 0, 0),
+               name = "test",
+               instrument = "test",
+           ),
+           times = times,
+           antpairs=antpairs,
+           do_blt_outer=True,
+    )
+    assert uvd_rect.Nblts == 16
+    assert np.allclose(uvd_rect.time_array, np.repeat(times, 4))
 
 To change the order of the blt-axis, set the ``time_axis_faster_than_bls`` keyword:
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> from astropy.coordinates import EarthLocation
-  >>> import numpy as np
-  >>> from pyuvdata import Telescope, UVData
+    from astropy.coordinates import EarthLocation
+    import numpy as np
+    from pyuvdata import Telescope, UVData
 
-  >>> uvd_rect = UVData.new(
-  ...   freq_array = np.linspace(1e8, 2e8, 100),
-  ...   polarization_array = ["xx", "yy"],
-  ...   telescope = Telescope.new(
-  ...     antenna_positions = {
-  ...       0: [0.0, 0.0, 0.0],
-  ...       1: [0.0, 0.0, 1.0],
-  ...       2: [0.0, 0.0, 2.0],
-  ...     },
-  ...     location = EarthLocation.from_geodetic(0, 0, 0),
-  ...     name = "test",
-  ...     instrument = "test",
-  ...   ),
-  ...   times = times,
-  ...   antpairs=antpairs,
-  ...   do_blt_outer=True,
-  ...   time_axis_faster_than_bls=True,
-  ... )
-  >>> uvd_rect.time_array
-  array([2459855. , 2459855.1, 2459855.2, 2459855.3, 2459855. , 2459855.1,
-         2459855.2, 2459855.3, 2459855. , 2459855.1, 2459855.2, 2459855.3,
-         2459855. , 2459855.1, 2459855.2, 2459855.3])
+    times = np.array([2459855.0, 2459855.1, 2459855.2, 2459855.3])
+    antpairs = [(0, 1), (0, 2), (1, 2), (1, 1)]
+    uvd_rect = UVData.new(
+         freq_array = np.linspace(1e8, 2e8, 100),
+         polarization_array = ["xx", "yy"],
+         telescope = Telescope.new(
+           antenna_positions = {
+             0: [0.0, 0.0, 0.0],
+             1: [0.0, 0.0, 1.0],
+             2: [0.0, 0.0, 2.0],
+           },
+           location = EarthLocation.from_geodetic(0, 0, 0),
+           name = "test",
+           instrument = "test",
+         ),
+         times = times,
+         antpairs=antpairs,
+         do_blt_outer=True,
+         time_axis_faster_than_bls=True,
+    )
+    assert uvd_rect.Nblts == 16
+    assert np.allclose(
+      uvd_rect.time_array, np.repeat(times[np.newaxis, :], 4, axis=0).flatten()
+    )
 
 See the full documentation for the method
 :func:`pyuvdata.uvdata.UVData.new` for more information.
@@ -1994,26 +1928,28 @@ positions in the ENU frame. Or use the ``telescope.location`` and
 to the ``telescope.location``) with the :meth:`pyuvdata.utils.ENU_from_ECEF`
 utility method.
 
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> # directly from Telescope object
-  >>> import os
-  >>> from astropy.units import Quantity
-  >>> from pyuvdata import utils, UVData
-  >>> from pyuvdata.datasets import fetch_data
+    # directly from Telescope object
+    from astropy.units import Quantity
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> data_file = fetch_data("paper_2012_miriad")
-  >>> uvd = UVData.from_file(data_file)
-  >>> antpos = uvd.telescope.get_enu_antpos()
+    data_file = fetch_data("paper_2012_miriad")
+    uvd = UVData.from_file(data_file)
+    antpos = uvd.telescope.get_enu_antpos()
 
-  >>> # using utils
-  >>> # get antennas positions in ECEF
-  >>> telescope_ecef_xyz = Quantity(uvd.telescope.location.geocentric).to_value("m")
-  >>> antpos = uvd.telescope.antenna_positions + telescope_ecef_xyz
+    # using utils
+    from pyuvdata import utils
 
-  >>> # convert to East, North, Up (ENU) coords.
-  >>> antpos = utils.ENU_from_ECEF(antpos, center_loc=uvd.telescope.location)
+    # get antennas positions in ECEF
+    telescope_ecef_xyz = Quantity(uvd.telescope.location.geocentric).to_value("m")
+    antpos = uvd.telescope.antenna_positions + telescope_ecef_xyz
 
+    # convert to East, North, Up (ENU) coords.
+    antpos = utils.ENU_from_ECEF(antpos, center_loc=uvd.telescope.location)
 
 UVData: Normalizing data
 ------------------------
@@ -2027,41 +1963,38 @@ statistical uncertainty in the amplitude of the autos is under most circumstance
 relatively much less than that for the crosses, performing this step affords one the
 ability to perform some basic flux scaling of the data provided some a priori
 information about the antennas (namely the system temperature and the so-called "forward
-gain" of the antenna, which typically depend on geometric size and aperture efficiency
-).
+gain" of the antenna, which typically depend on geometric size and aperture efficiency).
 
 Note that when normalizing, if the corresponding autocorrelations are not found or are
 otherwise marked as bad in ``flag_array``, then the the cross-correlation will be
 flagged as well (e.g., if all of antenna 1's autos are flagged, then every baseline that
 contains antenna 1 will also be flagged).
 
+
+.. clear-namespace
+
 .. code-block:: python
 
-  >>> import os
-  >>> import numpy as np
-  >>> from pyuvdata import UVData
-  >>> from pyuvdata.datasets import fetch_data
+    import numpy as np
+    from pyuvdata import UVData
+    from pyuvdata.datasets import fetch_data
 
-  >>> uvd = UVData.from_file(fetch_data("hera_h3c_uvh5"))
-  >>> # Build a binary mask where the cross-correlations are stored.
-  >>> cross_mask = uvd.ant_1_array != uvd.ant_2_array
-  >>> # Check to see that all the crosses have amplitudes greater than 1
-  >>> print(np.all(np.abs(uvd.data_array[cross_mask]) > 1))
-  True
+    uvd = UVData.from_file(fetch_data("hera_h3c_uvh5"))
+    # Build a binary mask where the cross-correlations are stored.
+    cross_mask = uvd.ant_1_array != uvd.ant_2_array
+    # Check to see that all the crosses have amplitudes greater than 1
+    assert np.all(np.abs(uvd.data_array[cross_mask]) > 1)
 
-  >>> # On normalization, you can convert arb scaled data to correlation coefficients,
-  >>> # which should always be less than 1 in amplitude.
-  >>> uvd.normalize_by_autos()
-  >>> print(np.all(np.abs(uvd.data_array[cross_mask]) < 1))
-  True
+    # On normalization, you can convert arb scaled data to correlation coefficients,
+    # which should always be less than 1 in amplitude.
+    uvd.normalize_by_autos()
+    assert np.all(np.abs(uvd.data_array[cross_mask]) < 1)
 
-  >>> # An important note for using normalize_by_autos is that it will usually leave the
-  >>> # autos alone unless told otherwise, in order to make reverting normalization
-  >>> # possible. We can see this by checking the values of the autos.
-  >>> print(np.any(uvd.data_array[~cross_mask]) < 1)
-  False
+    # An important note for using normalize_by_autos is that it will usually leave the
+    # autos alone unless told otherwise, in order to make reverting normalization
+    # possible. We can see this by checking the values of the autos.
+    assert not np.any(uvd.data_array[~cross_mask] < 1)
 
-  >>> # Finally, we can undo the above by setting invert=True.
-  >>> uvd.normalize_by_autos(invert=True)
-  >>> print(np.all(np.abs(uvd.data_array[cross_mask]) > 1))
-  True
+    # Finally, we can undo the above by setting invert=True.
+    uvd.normalize_by_autos(invert=True)
+    assert np.all(np.abs(uvd.data_array[cross_mask]) > 1)

--- a/environment.yaml
+++ b/environment.yaml
@@ -27,6 +27,7 @@ dependencies:
   - scipy>=1.9
   - setuptools_scm>=8.1
   - sphinx
+  - sybil>=8.0
   - pip:
       - lunarsky>=0.2.5
       - novas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,14 +63,15 @@ novas = ["novas", "novas_de405"]
 all = ["pyuvdata[astroquery,casa,hdf5_compression,healpix,lunar,novas]"]
 tutorial = ["matplotlib", "pooch>=1.8"]
 test = [
+    "coverage",
+    "cython>=3.0",
     "pooch>=1.8",
+    "pre-commit",
     "pytest>=8.2.0",
     "pytest-xdist",
     "pytest-cases>=3.9.1",
     "pytest-cov",
-    "cython>=3.0",
-    "coverage",
-    "pre-commit",
+    "sybil>=8.0",
 ]
 doc = ["matplotlib", "pypandoc", "sphinx"]
 dev = ["pyuvdata[all,test,doc]"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I changed how we're doing the tutorial testing to use Sybil instead of just Sphinx + pytest. This improves the way the tests are called, making each separate code block be run as a separate test. It also enables testing ``code-block`` blocks, which have much nicer formatting.

It also:
- moves to using ``code_block`` style rather than ``doctest`` style blocks throughout the tutorials. These eliminate the ``>>>`` prefix in every line, making the code easier to read and to copy and paste.
- adds a ``clear-namespace`` directive before each example to ensure no unexpected carry over of imports or variables between examples.
- improves the organization of the UVCal and UVBeam tutorials in a similar way to what was done recently for UVData in #1534
- Adds some missing content, e.g. adding UVBeam objects.

View the compiled docs here: https://pyuvdata--1612.org.readthedocs.build/en/1612/

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [ ] Other


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. You can check this via the RTD CI build.
