### PR TITLE
fix our branch scheme to handle slashes in branch names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,11 @@ def branch_scheme(version):
         if version.branch == "main":
             return version.format_choice("+{node}", "+{node}.dirty")
         else:
-            return version.format_choice("+{node}.{branch}", "+{node}.{branch}.dirty")
+            version_str = version.format_choice(
+                "+{node}.{branch}", "+{node}.{branch}.dirty"
+            )
+            version_str = version_str.replace("/", ".")
+            return version_str
 
 
 def is_platform_mac():

--- a/src/pyuvdata/__init__.py
+++ b/src/pyuvdata/__init__.py
@@ -25,7 +25,11 @@ def branch_scheme(version):  # pragma: nocover
         if version.branch == "main":
             return version.format_choice("+{node}", "+{node}.dirty")
         else:
-            return version.format_choice("+{node}.{branch}", "+{node}.{branch}.dirty")
+            version_str = version.format_choice(
+                "+{node}.{branch}", "+{node}.{branch}.dirty"
+            )
+            version_str = version_str.replace("/", ".")
+            return version_str
 
 
 try:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This came up as a breaking problem in pyuvsim and pyradiosky when they had dependabot PRs. The problem was that the dependabot branch name had "/"'s in it, which causes errors in the install step. This fixes that issue.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change
- [ ] Other


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme, pyproject.toml, environment.yaml and CI conda yaml files to reflect the changes.
