### PR TITLE
Error when attempting to read fringe stopped data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- A NotImplementedError to `mwa_corr_fits.py` that is thrown when trying to read 
+- A NotImplementedError to `mwa_corr_fits.py` that is thrown when trying to read
 fringe-stopped data.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- A NotImplementedError to `mwa_corr_fits.py` that is thrown when trying to read 
+fringe-stopped data.
+
 ### Fixed
 - Compatiblity with numpy>=2.3
 

--- a/src/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/src/pyuvdata/uvdata/mwa_corr_fits.py
@@ -144,7 +144,12 @@ def read_metafits(
 
         # error if fringe stopping is turned on
         if mwax and meta_hdr["DELAYMOD"] == "FULLTRACK":
-            raise ValueError("Fringe stopped data is not supported")
+            raise NotImplementedError("This data has had fringe stopping applied. We do "
+            "not yet have support for fringe stopped data, partly because we have not seen "
+            "files like this yet. Please file an issue in our GitHub issue log so that we "
+            "can help: https://github.com/RadioAstronomySoftwareGroup/pyuvdata/issues. "
+            "Please include a link to the data you're trying to read in your issue."
+            )
         else:
             pass
 

--- a/src/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/src/pyuvdata/uvdata/mwa_corr_fits.py
@@ -142,6 +142,14 @@ def read_metafits(
         else:
             obs_freq_center = meta_hdr["FREQCENT"] * 1e6
 
+        # error if fringe stopping is turned on
+        if mwax and meta_hdr["DELAYMOD"] == 'FULLTRACK':
+            raise ValueError(
+                "Fringe stopped data is not supported"
+            )
+        else:
+            pass
+
         # frequency averaging factor
         avg_factor = meta_hdr["NAV_FREQ"]
 

--- a/src/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/src/pyuvdata/uvdata/mwa_corr_fits.py
@@ -144,11 +144,12 @@ def read_metafits(
 
         # error if fringe stopping is turned on
         if mwax and meta_hdr["DELAYMOD"] == "FULLTRACK":
-            raise NotImplementedError("This data has had fringe stopping applied. We do "
-            "not yet have support for fringe stopped data, partly because we have not seen "
-            "files like this yet. Please file an issue in our GitHub issue log so that we "
-            "can help: https://github.com/RadioAstronomySoftwareGroup/pyuvdata/issues. "
-            "Please include a link to the data you're trying to read in your issue."
+            raise NotImplementedError(
+                "This data has had fringe stopping applied. We do "
+                "not yet have support for fringe stopped data, partly because we have not seen "
+                "files like this yet. Please file an issue in our GitHub issue log so that we "
+                "can help: https://github.com/RadioAstronomySoftwareGroup/pyuvdata/issues. "
+                "Please include a link to the data you're trying to read in your issue."
             )
         else:
             pass

--- a/src/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/src/pyuvdata/uvdata/mwa_corr_fits.py
@@ -143,10 +143,8 @@ def read_metafits(
             obs_freq_center = meta_hdr["FREQCENT"] * 1e6
 
         # error if fringe stopping is turned on
-        if mwax and meta_hdr["DELAYMOD"] == 'FULLTRACK':
-            raise ValueError(
-                "Fringe stopped data is not supported"
-            )
+        if mwax and meta_hdr["DELAYMOD"] == "FULLTRACK":
+            raise ValueError("Fringe stopped data is not supported")
         else:
             pass
 

--- a/src/pyuvdata/uvdata/mwa_corr_fits.py
+++ b/src/pyuvdata/uvdata/mwa_corr_fits.py
@@ -145,10 +145,10 @@ def read_metafits(
         # error if fringe stopping is turned on
         if mwax and meta_hdr["DELAYMOD"] == "FULLTRACK":
             raise NotImplementedError(
-                "This data has had fringe stopping applied. We do "
-                "not yet have support for fringe stopped data, partly because we have not seen "
-                "files like this yet. Please file an issue in our GitHub issue log so that we "
-                "can help: https://github.com/RadioAstronomySoftwareGroup/pyuvdata/issues. "
+                "This data has had fringe stopping applied. We do not yet have support "
+                "for fringe stopped data, partly because we have not seen files like "
+                "this yet. Please file an issue in our GitHub issue log so that we can "
+                "help: https://github.com/RadioAstronomySoftwareGroup/pyuvdata/issues. "
                 "Please include a link to the data you're trying to read in your issue."
             )
         else:

--- a/tests/uvdata/test_mwa_corr_fits.py
+++ b/tests/uvdata/test_mwa_corr_fits.py
@@ -1705,7 +1705,7 @@ def test_partial_read_errors(tmp_path):
 def test_fringe_stopping_error(tmp_path):
     test_metafits = str(tmp_path / "1131733552_fs.metafits")
     with fits.open(fetch_data("mwax_2021_metafits")) as meta:
-        meta[0].header["DELAYMOD"] = 'FULLTRACK'
+        meta[0].header["DELAYMOD"] = "FULLTRACK"
         meta.writeto(test_metafits)
     with pytest.raises(
         NotImplementedError, match="This data has had fringe stopping applied. "

--- a/tests/uvdata/test_mwa_corr_fits.py
+++ b/tests/uvdata/test_mwa_corr_fits.py
@@ -1700,3 +1700,14 @@ def test_partial_read_errors(tmp_path):
         ValueError, match="bls must be a list of 2-tuples giving antenna number pairs"
     ):
         uvd.read_mwa_corr_fits(files_use, bls=[(18, 31, "xx")])
+
+
+def test_fringe_stopping_error(tmp_path):
+    test_metafits = str(tmp_path / "1131733552_fs.metafits")
+    with fits.open(fetch_data("mwax_2021_metafits")) as meta:
+        meta[0].header["DELAYMOD"] = 'FULLTRACK'
+        meta.writeto(test_metafits)
+    with pytest.raises(
+        NotImplementedError, match="This data has had fringe stopping applied. "
+    ):
+        UVData.from_file([test_metafits, fetch_data("mwax_2021_raw_gpubox")])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've added an error in `mwa_corr_fits.py` that is raised when `DELAYMOD = 'FULLTRACK'` is set in a metafits file. This setting indicates that fringe stopping is turned on.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [ ] Other


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
