### PR TITLE
Improve memory usage in uvfits reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Added improved handling of a few warning messages from h5py and numpy.
 
+### Fixed
+- Significant reduction in memory when reading UVFITS files, particularly when
+reading the entire file (no selection on read).
+
 ## [3.2.5] - 2025-12-11
 
 ### Changed

--- a/src/pyuvdata/parameter.py
+++ b/src/pyuvdata/parameter.py
@@ -1183,7 +1183,7 @@ class LocationParameter(UVParameter):
         """Detect if this location is on the moon."""
         # figure out if this is on the moon. Doing it this way limits
         # attempted imports of lunarsky
-        if isinstance(self.value, EarthLocation):
+        if self.value is None or isinstance(self.value, EarthLocation):
             return False
         else:
             try:

--- a/src/pyuvdata/uvdata/uvfits.py
+++ b/src/pyuvdata/uvdata/uvfits.py
@@ -4,6 +4,7 @@
 """Class for reading and writing uvfits files."""
 
 import copy
+import gc
 import os
 import warnings
 
@@ -197,7 +198,7 @@ class UVFITS(UVData):
 
     def _get_data(
         self,
-        vis_hdu,
+        filename,
         *,
         antenna_nums,
         antenna_names,
@@ -269,17 +270,19 @@ class UVFITS(UVData):
         )
 
         if min_frac == 1:
-            # no select, read in all the data
-            if vis_hdu.header["NAXIS"] == 7:
-                raw_data_array = vis_hdu.data.data[:, 0, 0, :, :, :, :]
-                if self.Nspws != raw_data_array.shape[1]:  # pragma: no cover
-                    raise RuntimeError(bad_data_shape_msg)
+            # no select, read in all the data. Don't need memmap
+            with fits.open(filename, memmap=False) as hdu_list:
+                vis_hdu = hdu_list[0]  # assumes the visibilities are in the primary hdu
+                if vis_hdu.header["NAXIS"] == 7:
+                    raw_data_array = vis_hdu.data.data[:, 0, 0, :, :, :, :]
+                    if self.Nspws != raw_data_array.shape[1]:  # pragma: no cover
+                        raise RuntimeError(bad_data_shape_msg)
 
-            else:
-                # in many uvfits files the spw axis is left out,
-                # here we put it back in so the dimensionality stays the same
-                raw_data_array = vis_hdu.data.data[:, 0, 0, :, :, :]
-                raw_data_array = raw_data_array[:, np.newaxis, :, :]
+                else:
+                    # in many uvfits files the spw axis is left out,
+                    # here we put it back in so the dimensionality stays the same
+                    raw_data_array = vis_hdu.data.data[:, 0, 0, :, :, :]
+                    raw_data_array = raw_data_array[:, np.newaxis, :, :]
         else:
             # do select operations on everything except data_array, flag_array
             # and nsample_array
@@ -293,56 +296,59 @@ class UVFITS(UVData):
             )
 
             # just read in the right portions of the data and flag arrays
-            if blt_frac == min_frac:
-                if vis_hdu.header["NAXIS"] == 7:
-                    raw_data_array = vis_hdu.data.data[blt_inds, :, :, :, :, :, :]
-                    raw_data_array = raw_data_array[:, 0, 0, :, :, :, :]
-                    if self.Nspws != raw_data_array.shape[1]:  # pragma: no cover
-                        raise RuntimeError(bad_data_shape_msg)
-                else:
-                    # in many uvfits files the spw axis is left out,
-                    # here we put it back in so the dimensionality stays the same
-                    raw_data_array = vis_hdu.data.data[blt_inds, :, :, :, :, :]
-                    raw_data_array = raw_data_array[:, 0, 0, :, :, :]
-                    raw_data_array = raw_data_array[:, np.newaxis, :, :, :]
-                if freq_frac < 1:
-                    raw_data_array = raw_data_array[:, :, freq_inds, :, :]
-                if pol_frac < 1:
-                    raw_data_array = raw_data_array[:, :, :, pol_inds, :]
-            elif freq_frac == min_frac:
-                if vis_hdu.header["NAXIS"] == 7:
-                    raw_data_array = vis_hdu.data.data[:, :, :, :, freq_inds, :, :]
-                    raw_data_array = raw_data_array[:, 0, 0, :, :, :, :]
-                    if self.Nspws != raw_data_array.shape[1]:  # pragma: no cover
-                        raise RuntimeError(bad_data_shape_msg)
-                else:
-                    # in many uvfits files the spw axis is left out,
-                    # here we put it back in so the dimensionality stays the same
-                    raw_data_array = vis_hdu.data.data[:, :, :, freq_inds, :, :]
-                    raw_data_array = raw_data_array[:, 0, 0, :, :, :]
-                    raw_data_array = raw_data_array[:, np.newaxis, :, :, :]
+            # need memmap for this, accept the memory hit
+            with fits.open(filename, memmap=False) as hdu_list:
+                vis_hdu = hdu_list[0]  # assumes the visibilities are in the primary hdu
+                if blt_frac == min_frac:
+                    if vis_hdu.header["NAXIS"] == 7:
+                        raw_data_array = vis_hdu.data.data[blt_inds, :, :, :, :, :, :]
+                        raw_data_array = raw_data_array[:, 0, 0, :, :, :, :]
+                        if self.Nspws != raw_data_array.shape[1]:  # pragma: no cover
+                            raise RuntimeError(bad_data_shape_msg)
+                    else:
+                        # in many uvfits files the spw axis is left out,
+                        # here we put it back in so the dimensionality stays the same
+                        raw_data_array = vis_hdu.data.data[blt_inds, :, :, :, :, :]
+                        raw_data_array = raw_data_array[:, 0, 0, :, :, :]
+                        raw_data_array = raw_data_array[:, np.newaxis, :, :, :]
+                    if freq_frac < 1:
+                        raw_data_array = raw_data_array[:, :, freq_inds, :, :]
+                    if pol_frac < 1:
+                        raw_data_array = raw_data_array[:, :, :, pol_inds, :]
+                elif freq_frac == min_frac:
+                    if vis_hdu.header["NAXIS"] == 7:
+                        raw_data_array = vis_hdu.data.data[:, :, :, :, freq_inds, :, :]
+                        raw_data_array = raw_data_array[:, 0, 0, :, :, :, :]
+                        if self.Nspws != raw_data_array.shape[1]:  # pragma: no cover
+                            raise RuntimeError(bad_data_shape_msg)
+                    else:
+                        # in many uvfits files the spw axis is left out,
+                        # here we put it back in so the dimensionality stays the same
+                        raw_data_array = vis_hdu.data.data[:, :, :, freq_inds, :, :]
+                        raw_data_array = raw_data_array[:, 0, 0, :, :, :]
+                        raw_data_array = raw_data_array[:, np.newaxis, :, :, :]
 
-                if blt_frac < 1:
-                    raw_data_array = raw_data_array[blt_inds, :, :, :, :]
-                if pol_frac < 1:
-                    raw_data_array = raw_data_array[:, :, :, pol_inds, :]
-            else:
-                if vis_hdu.header["NAXIS"] == 7:
-                    raw_data_array = vis_hdu.data.data[:, :, :, :, :, pol_inds, :]
-                    raw_data_array = raw_data_array[:, 0, 0, :, :, :, :]
-                    if self.Nspws != raw_data_array.shape[1]:  # pragma: no cover
-                        raise RuntimeError(bad_data_shape_msg)
+                    if blt_frac < 1:
+                        raw_data_array = raw_data_array[blt_inds, :, :, :, :]
+                    if pol_frac < 1:
+                        raw_data_array = raw_data_array[:, :, :, pol_inds, :]
                 else:
-                    # in many uvfits files the spw axis is left out,
-                    # here we put it back in so the dimensionality stays the same
-                    raw_data_array = vis_hdu.data.data[:, :, :, :, pol_inds, :]
-                    raw_data_array = raw_data_array[:, 0, 0, :, :, :]
-                    raw_data_array = raw_data_array[:, np.newaxis, :, :, :]
+                    if vis_hdu.header["NAXIS"] == 7:
+                        raw_data_array = vis_hdu.data.data[:, :, :, :, :, pol_inds, :]
+                        raw_data_array = raw_data_array[:, 0, 0, :, :, :, :]
+                        if self.Nspws != raw_data_array.shape[1]:  # pragma: no cover
+                            raise RuntimeError(bad_data_shape_msg)
+                    else:
+                        # in many uvfits files the spw axis is left out,
+                        # here we put it back in so the dimensionality stays the same
+                        raw_data_array = vis_hdu.data.data[:, :, :, :, pol_inds, :]
+                        raw_data_array = raw_data_array[:, 0, 0, :, :, :]
+                        raw_data_array = raw_data_array[:, np.newaxis, :, :, :]
 
-                if blt_frac < 1:
-                    raw_data_array = raw_data_array[blt_inds, :, :, :, :]
-                if freq_frac < 1:
-                    raw_data_array = raw_data_array[:, :, freq_inds, :, :]
+                    if blt_frac < 1:
+                        raw_data_array = raw_data_array[blt_inds, :, :, :, :]
+                    if freq_frac < 1:
+                        raw_data_array = raw_data_array[:, :, freq_inds, :, :]
 
         if len(raw_data_array.shape) != 5:  # pragma: no cover
             raise RuntimeError(bad_data_shape_msg)
@@ -359,6 +365,9 @@ class UVFITS(UVData):
         self.data_array = raw_data_array[:, :, :, 0] - 1j * raw_data_array[:, :, :, 1]
         self.flag_array = raw_data_array[:, :, :, 2] <= 0
         self.nsample_array = np.abs(raw_data_array[:, :, :, 2])
+
+        del raw_data_array
+        gc.collect()
 
         if fix_old_proj:
             self.fix_phase(use_ant_pos=fix_use_ant_pos)
@@ -403,7 +412,9 @@ class UVFITS(UVData):
         self.filename = [basename]
         self._filename.form = (1,)
 
-        with fits.open(filename, memmap=True) as hdu_list:
+        # memmap=True uses a lot of memory that doesn't get deallocated quickly
+        # not needed for reading the headers, which is what we're doing here
+        with fits.open(filename, memmap=False) as hdu_list:
             vis_hdu = hdu_list[0]  # assumes the visibilities are in the primary hdu
             vis_hdr = vis_hdu.header.copy()
             hdunames = fits_utils._indexhdus(hdu_list)  # find the rest of the tables
@@ -825,29 +836,29 @@ class UVFITS(UVData):
                     rot_axis=0,
                 )[:, :, 0]
 
-            if read_data:
-                # Now read in the data
-                self._get_data(
-                    vis_hdu,
-                    antenna_nums=antenna_nums,
-                    antenna_names=antenna_names,
-                    ant_str=ant_str,
-                    bls=bls,
-                    frequencies=frequencies,
-                    freq_chans=freq_chans,
-                    spws=spws,
-                    times=times,
-                    time_range=time_range,
-                    lsts=lsts,
-                    lst_range=lst_range,
-                    polarizations=polarizations,
-                    blt_inds=blt_inds,
-                    phase_center_ids=phase_center_ids,
-                    catalog_names=catalog_names,
-                    keep_all_metadata=keep_all_metadata,
-                    fix_old_proj=fix_old_proj,
-                    fix_use_ant_pos=fix_use_ant_pos,
-                )
+        if read_data:
+            # Now read in the data
+            self._get_data(
+                filename,
+                antenna_nums=antenna_nums,
+                antenna_names=antenna_names,
+                ant_str=ant_str,
+                bls=bls,
+                frequencies=frequencies,
+                freq_chans=freq_chans,
+                spws=spws,
+                times=times,
+                time_range=time_range,
+                lsts=lsts,
+                lst_range=lst_range,
+                polarizations=polarizations,
+                blt_inds=blt_inds,
+                phase_center_ids=phase_center_ids,
+                catalog_names=catalog_names,
+                keep_all_metadata=keep_all_metadata,
+                fix_old_proj=fix_old_proj,
+                fix_use_ant_pos=fix_use_ant_pos,
+            )
 
         # check if object has all required UVParameters set
         if run_check:

--- a/src/pyuvdata/uvdata/uvfits.py
+++ b/src/pyuvdata/uvdata/uvfits.py
@@ -674,7 +674,7 @@ class UVFITS(UVData):
                 # the array center, but in a rotated ECEF frame so that the x-axis
                 # goes through the local meridian.
                 rot_ecef_positions = ant_hdu.data.field("STABXYZ")
-                _, longitude, altitude = utils.LatLonAlt_from_XYZ(
+                _, longitude, _ = utils.LatLonAlt_from_XYZ(
                     np.array([x_telescope, y_telescope, z_telescope]),
                     frame=telescope_frame,
                     ellipsoid=ellipsoid,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This makes a few memory handling improvements to the uvfits reader (and maybe the MWA correlator FITS reader).

It turns out that when using `astropy.io.fits.open` with `memmap=True`, the python garbage collector does not release the memory promptly upon exiting the context manager. We were always using `memmap=True`, but it's really only needed when doing partial reads. This PR changes the calls to the `astropy.io.fits.open` to only use `memmap=True` when doing partial reads. This leads to significant memory improvements for the uvfits reader when reading the whole file. It's not clear if there are any improvements to the MWA correlator FITS reader in terms of memory usage, but it seemed better to be consistent.

I also refactored the uvfits reader to remove a temporary array that was being used to store and manipulate the data stored in the primary uvfits HDU before assigning parts of it to the data_array, nsample_array and flag_array. I now have it just assign the full data from the HDU to the data_array and do all the manipulations in place in that array. It feels a bit yucky but leads to much better memory usage.

Below are plots of the memory usage as measured by `memray` for a small script that just reads in an MWA uvfits file (the blue resident size is most important). There is some run-to-run variability to these plots that I don't fully understand, so I'm including 2 plots for each codebase, from different days but all three codebase runs were run back to back on the 2 different days (all on my laptop):

main branch:
<img width="1106" height="450" alt="uvfits_read_main" src="https://github.com/user-attachments/assets/d46f4bdc-5bd2-4085-91a5-14baddb70eb9" />
<img width="1106" height="450" alt="uvfits_read_main_2" src="https://github.com/user-attachments/assets/32c1596c-9e92-40f8-9948-1f4d08f1b022" />

After using `memmap=False`:
<img width="1106" height="450" alt="uvfits_read_fix1" src="https://github.com/user-attachments/assets/ee3ed03a-6204-4581-b296-0d9be9a12f91" />
<img width="1106" height="450" alt="uvfits_read_fix1_2" src="https://github.com/user-attachments/assets/3cf05f28-7256-4f0a-930f-bfdd125f6f70" />

After refactoring out the temporary array:
<img width="1106" height="450" alt="uvfits_read_fix2" src="https://github.com/user-attachments/assets/c748a71b-a76a-440c-9239-8344780dabc7" />
<img width="1106" height="450" alt="uvfits_read_fix2_2" src="https://github.com/user-attachments/assets/03b7c5b8-c826-4d2d-995e-0fa744f0d9ed" />

Note that the peak memory use doesn't change much (and is seems quite variable in the last set of plots), but there's a consistent big change in the final memory usage at the end of the script. If you are doing anything with the object after reading it, that becomes your baseline memory usage for the next step. I actually stumbled on this when trying to profile something else (frequency averaging) and discovered that the memory usage was much higher when I used a script that started by reading in a uvfits file vs when I started by reading in the same data saved as a uvh5 file.

Similar plots for the MWA Correlator FITS reader seem to be dominated by run-to-run variability -- I don't see a consistent improvement with these changes, but I don't see it getting materially worse either.

We could certainly make similar changes in the calfits and beamfits readers, but I wasn't sure I should cram them into this PR.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [x] Other

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Other:
- [ ] I have updated any docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the readme and/or tutorial to reflect my changes (if appropriate).
- [ ] I have added/updated tests to cover my changes (if appropriate).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
