### PR TITLE
Bug fix for reading ms caltables with multiple times

### DIFF
--- a/src/pyuvdata/uvcal/ms_cal.py
+++ b/src/pyuvdata/uvcal/ms_cal.py
@@ -281,7 +281,9 @@ class MSCal(UVCal):
                 )
                 if any(close_check):
                     # Fill in the first closest entry matched
-                    time_dict[time] = np.where(close_check)[0][0]
+                    time_dict[time] = time_dict[
+                        list(time_dict)[np.where(close_check)[0][0]]
+                    ]
                 else:
                     # Otherwise, plug in a new entry
                     time_dict[time] = time_count

--- a/tests/uvcal/test_ms_cal.py
+++ b/tests/uvcal/test_ms_cal.py
@@ -398,3 +398,41 @@ def test_ms_dterm_warning(sma_pcal, tmp_path):
         match="CASA MSCal tables store cross-handed Jones terms as leakages ",
     ):
         sma_pcal.write_ms_cal(testfile, clobber=True)
+
+
+def test_ms_close_spaced_times(tmp_path):
+
+    uvobj = UVCal()
+    testfile = fetch_data("sma_pha_gcal")
+    with check_warnings(UserWarning, match=sma_warnings):
+        uvobj.read(testfile)
+
+    use_times = np.array(
+        [
+            np.float64(5274914431.899564),
+            np.float64(5274914431.880366),
+            np.float64(5274914431.878805),
+            np.float64(5274914431.883291),
+            np.float64(5274914431.885088),
+            np.float64(5274914431.883654),
+            np.float64(5274914431.882857),
+            np.float64(5274914431.880334),
+            np.float64(5274914431.880322),
+            np.float64(5274914431.883885),
+            np.float64(5274914431.8886795),
+            np.float64(5274914431.876619),
+            np.float64(5274914431.883705),
+            np.float64(5274914431.886172),
+            np.float64(5274914431.880832),
+            np.float64(5274914431.881411),
+        ]
+    )
+    use_times = (use_times / 86400.0) + 2400000.5  # Convert to jd
+    uvobj.time_array[: len(use_times)] = use_times
+    uvobj.set_lsts_from_time_array()
+    uvobj.select(times=use_times, inplace=True)
+
+    testfile_newtimes = os.path.join(tmp_path, "close_spaced_times.ms")
+    uvobj.write_ms_cal(testfile_newtimes, clobber=True)
+    uvobj_new = UVCal()
+    uvobj_new.read(testfile_newtimes)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changes the way times are indexed when reading ms caltables, fixing a bug.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

The bug affects reading of ms caltables with multiple closely-spaced times. A dictionary is constructed mapping the times in the caltable to those in the UVCal object. Distinct but closely-spaced times can map to the same output time. The mapping used the index of the distinct input times, not the output times, and could therefore produced an indexing error.

Closes #1648

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [ ] Other


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
