### PR TITLE
updated uvbeam tutorial urls for wget of aee beam fits files and fixe…

### DIFF
--- a/docs/uvbeam_tutorial.rst
+++ b/docs/uvbeam_tutorial.rst
@@ -86,9 +86,9 @@ output simulation file(s) for the model you want:
 - for the full embedded element (FEE) beam use:
   ``wget http://cerberus.mwa128t.org/mwa_full_embedded_element_pattern.h5``
 - for the average embedded element (AEE) beam use:
-  ``wget https://github.com/MWATelescope/mwa_pb/blob/master/mwa_pb/data/Jmatrix.fits``
+  ``wget https://raw.githubusercontent.com/MWATelescope/mwa_pb/master/mwa_pb/data/Jmatrix.fits``
   and
-  ``wget https://github.com/MWATelescope/mwa_pb/blob/master/mwa_pb/data/Zmatrix.fits``
+  ``wget https://raw.githubusercontent.com/MWATelescope/mwa_pb/master/mwa_pb/data/ZMatrix.fits``
 
 For this tutorial we use the files saved in the test data which only
 contain a few frequencies.

--- a/src/pyuvdata/uvbeam/uvbeam.py
+++ b/src/pyuvdata/uvbeam/uvbeam.py
@@ -3577,7 +3577,7 @@ class UVBeam(UVBase):
             required parameters after reading in the file.
         check_extra : bool
             Option to check optional parameters as well as required ones.
-        run_check_acceptabilit : bool
+        run_check_acceptability : bool
             Option to check acceptable range of the values of
             required parameters after reading in the file.
         check_auto_power : bool


### PR DESCRIPTION
…d typo

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Updates the urls in the `wget` commands to download the aee beam fits files in the uvbeam tutorial as they were not working. A small docstring typo in `uvbeam.py` is also fixed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [ ] Other


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Documentation change checklist:
- [x] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. You can check this via the RTD CI build.