### PR TITLE
Time-based interpolation of UVCal calibration tables

### DIFF
--- a/.github/workflows/numba_test.yaml
+++ b/.github/workflows/numba_test.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          NUMBA_DISABLE_JIT=1 pytest tests/utils/test_bls_numba.py -n auto --cov=pyuvdata --cov-config=.coveragerc --cov-report xml:coverage.xml
+          NUMBA_DISABLE_JIT=1 pytest tests/utils/test_bls_numba.py tests/utils/test_gain_interpolate.py -n auto --cov=pyuvdata --cov-config=.coveragerc --cov-report xml:coverage.xml
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: success()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,30 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- `uvcalibrate` now records more detail in `UVData.history`, including which records
+were calibrated when a selection was used, whether the rest were flagged, and how the
+solutions were interpolated if `interpolate` was set.
 - Updating code to no longer set shapes directly on ndarrays (deprecated in NumPy 2.5)
 - Require lunarsky>1.0 to drop spiceypy requirement
 
 ### Added
 - A new method `UVCal.interpolate_in_time`, which allows for UVCal calibration tables
 to be "upsampled" in time.
-- A new module (`gains_interpolate.py`) for performing time-based interpolation of
+- A new module (`gain_interpolate.py`) for performing time-based interpolation of
 calibration solutions.
 - A new option for `uvcalibrate`, called `apply_to_weights`, which allows for the values
 in `UVData.nsample_array` to be adjusted in a manner consistent with the expected
 inverse variance (e.g., if the visibilities are scaled up by a factor of 2 in amplitude,
 `nsample_array` is scaled down by a factor of 4).
+- The options `interpolate` and `interp_kwargs` were added to `uvcalibrate`, which allow
+the solutions to be interpolated onto the times of the data being calibrated (via
+`UVCal.interpolate_in_time`), rather than requiring the two to already match.
+- The options `uvd_select_kwargs` and `uvc_select_kwargs` were added to `uvcalibrate`,
+which allow the calibration to be applied to a subset of the data, and with a subset of
+the solutions, respectively. An additional option, `flag_unselected`, allows users to
+specify whether to flag unselected records in the `UVData` object.
+- A new function `utils.tools.mask_slicify`, which converts a boolean mask into a slice
+if possible, otherwise into an array of index positions.
 - Support for two new types of beams in UVBeam and AnalyticBeam: feed_aligned_response
 and feed_aligned_projection beams which result from an E-field beam decomposition
 used in some analysis codes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 - Require lunarsky>1.0 to drop spiceypy requirement
 
 ### Added
+- A new method `UVCal.interpolate_in_time`, which allows for UVCal calibration tables
+to be "upsampled" in time.
+- A new module (`gains_interpolate.py`) for performing time-based interpolation of
+calibration solutions.
+- A new option for `uvcalibrate`, called `apply_to_weights`, which allows for the values
+in `UVData.nsample_array` to be adjusted in a manner consistent with the expected
+inverse variance (e.g., if the visibilities are scaled up by a factor of 2 in amplitude,
+`nsample_array` is scaled down by a factor of 4).
 - Support for two new types of beams in UVBeam and AnalyticBeam: feed_aligned_response
 and feed_aligned_projection beams which result from an E-field beam decomposition
 used in some analysis codes.

--- a/src/pyuvdata/data/test_analytic_beam.py
+++ b/src/pyuvdata/data/test_analytic_beam.py
@@ -17,11 +17,7 @@ class CosPowerTest(UnpolarizedAnalyticBeam):
     width: float
 
     def _power_eval(
-        self,
-        *,
-        az_grid: FloatArray,
-        za_grid: FloatArray,
-        f_grid: FloatArray,
+        self, *, az_grid: FloatArray, za_grid: FloatArray, f_grid: FloatArray
     ) -> FloatArray:
         """Evaluate the power at the given coordinates."""
         data_array = self._get_empty_data_array(az_grid.shape, beam_type="power")
@@ -41,11 +37,7 @@ class CosEfieldTest(UnpolarizedAnalyticBeam):
     width: float
 
     def _efield_eval(
-        self,
-        *,
-        az_grid: FloatArray,
-        za_grid: FloatArray,
-        f_grid: FloatArray,
+        self, *, az_grid: FloatArray, za_grid: FloatArray, f_grid: FloatArray
     ) -> FloatArray:
         """Evaluate the efield at the given coordinates."""
         data_array = self._get_empty_data_array(az_grid.shape)

--- a/src/pyuvdata/utils/__init__.py
+++ b/src/pyuvdata/utils/__init__.py
@@ -23,6 +23,7 @@ from . import bls  # noqa
 from . import bltaxis  # noqa
 from . import coordinates  # noqa
 from . import frequency  # noqa
+from . import gain_interpolate  # noqa
 from . import history  # noqa
 from . import io  # noqa
 from . import phase_center_catalog  # noqa

--- a/src/pyuvdata/utils/gain_interpolate.py
+++ b/src/pyuvdata/utils/gain_interpolate.py
@@ -1,0 +1,1292 @@
+# Copyright (c) 2026 Radio Astronomy Software Group
+# Licensed under the 2-clause BSD License
+"""Gain interpolation related utilities."""
+
+from typing import Literal
+
+import numba as nb
+import numpy as np
+
+from .types import BoolArray, ComplexArray, FloatArray, IntArray
+
+_MIN_CUBIC_SAMPLES = 4
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _flag_outlier_cal(cal_array, tol_lim, is_gain_amp=False, is_gain_pha=False):
+    """
+    Flag individual outliers in a set of calibration solutions.
+
+    Marks a sample as bad where the deltas to both of its neighbors exceed the
+    tolerance but the delta that skips it does not, which is the signature of an
+    isolated outlier rather than a genuine excursion.
+
+    Parameters
+    ----------
+    cal_array : ndarray of float or complexfloat
+        Calibration solutions to check, shape (Nants, Nfreqs, Ntimes, Njones), dtype
+        is either float or complex (assumed complex if `is_gain_phase` or `is_gain_amp`
+        is set to True).
+    tol_lim : float
+        Largest delta between samples that is considered acceptable. Units match
+        those of the deltas being tested, which depend on `is_gain_amp` and
+        `is_gain_pha`.
+    is_gain_amp : bool
+        If True, treat `cal_array` as complex gains and test fractional changes in
+        amplitude. Default is False.
+    is_gain_pha : bool
+        If True, treat `cal_array` as complex gains and test changes in phase, in
+        radians. Default is False.
+
+    Returns
+    -------
+    new_flags : ndarray of bool
+        Flags for `cal_array`, same shape as `cal_array`. True where the sample is
+        NaN (or zero and `is_gain_amp` or `is_gain_pha` is set), or looks like an
+        isolated outlier.
+    """
+    # Set the initial flags based on nans (and zeros if the solns are complex).
+    new_flags = np.isnan(cal_array)
+    if is_gain_amp or is_gain_pha:
+        if not np.issubdtype(cal_array.dtype, np.complexfloating):
+            raise ValueError(
+                "cal_array must be complex if is_gain_amp or is_gain_pha is True."
+            )
+        mask = cal_array == 0.0
+        if np.any(mask):
+            cal_array = np.where(mask, np.nan, cal_array)
+            new_flags |= mask
+
+    # Dividing through the NaNs when flagged is deliberate, so suppress the warnings.
+    with np.errstate(invalid="ignore"):
+        if is_gain_amp:
+            delta_12 = np.abs(cal_array[:, :, 1:, :] / cal_array[:, :, :-1, :]) - 1
+            delta_13 = np.abs(cal_array[:, :, 2:, :] / cal_array[:, :, :-2, :]) - 1
+        elif is_gain_pha:
+            delta_12 = np.angle(cal_array[:, :, 1:, :] / cal_array[:, :, :-1, :])
+            delta_13 = np.angle(cal_array[:, :, 2:, :] / cal_array[:, :, :-2, :])
+        else:
+            delta_12 = np.real(cal_array[:, :, 1:, :] - cal_array[:, :, :-1, :])
+            delta_13 = np.real(cal_array[:, :, 2:, :] - cal_array[:, :, :-2, :])
+
+    # Where a delta between adjacent points exceeds the threshold, mark it as "bad"
+    bad_12 = (delta_12 > tol_lim) | (delta_12 < -tol_lim)
+    # Where a delta that skips a point is within the threshold, mark it as "good"
+    good_13 = (delta_13 <= tol_lim) & (delta_13 >= -tol_lim)
+    # Separately capture where the delta is NaN
+    nan_12 = np.isnan(delta_12)
+
+    # Where two bad deltas are adjacent, and the larger delta that skips the midpoint
+    # is good, assume the midpoint is bad and flag it.
+    new_flags[:, :, 1:-1, :] |= (bad_12[:, :, 1:, :] & bad_12[:, :, :-1, :]) & good_13
+
+    # If an outlier delta is next to a NaN, assume its bad and flag it too.
+    new_flags[:, :, 1:-1, :] |= bad_12[:, :, 1:, :] & nan_12[:, :, :-1, :]
+    new_flags[:, :, 1:-1, :] |= nan_12[:, :, 1:, :] & bad_12[:, :, :-1, :]
+
+    # Use the "goodness" of the second and second-to-last points to determine the
+    # flags for the first and last points (if the deltas exceed the threshold).
+    new_flags[:, :, 0, :] |= bad_12[:, :, 0, :] & (
+        np.abs(delta_12[:, :, 1, :]) <= tol_lim
+    )
+    new_flags[:, :, -1, :] |= bad_12[:, :, -1, :] & (
+        np.abs(delta_12[:, :, -2, :]) <= tol_lim
+    )
+
+    return new_flags
+
+
+def build_interp_flags(
+    cal_array,
+    flag_array,
+    old_times,
+    new_times,
+    tol_lim=0.0,
+    is_gain_amp=False,
+    is_gain_pha=False,
+    flag_adjacent=True,
+    max_time_delta=0.0,
+    allow_extrapolation=True,
+):
+    """
+    Build the flags that apply to a set of interpolated calibration solutions.
+
+    Parameters
+    ----------
+    cal_array : ndarray
+        Calibration solutions being interpolated, shape (Nants, Nfreqs, Ntimes, Njones),
+        dtype is either float or complex (assumed complex if `is_gain_phase` or
+        `is_gain_amp` is set to True).
+    flag_array : ndarray of bool
+        Flags for `cal_array`, shape (Nants, Nfreqs, Ntimes, Njones), dtype bool.
+    old_times : ndarray of float
+        Times corresponding to the time-axis of `cal_array`, shape (Ntimes,), dtype is
+        float, units are Julian days.
+    new_times : ndarray of float
+        Times at which to evaluate the interpolation, shape (Nnew,), dtype is float,
+        units are Julian days.
+    tol_lim : float
+        Largest delta between adjacent samples that is considered acceptable. If
+        greater than zero, intervals whose delta exceeds this are flagged. Default
+        is 0.0, which disables the check.
+    is_gain_amp : bool
+        If True, treat `cal_array` as complex gains and test fractional changes in
+        amplitude. Default is False.
+    is_gain_pha : bool
+        If True, treat `cal_array` as complex gains and test changes in phase, in
+        radians. Default is False.
+    flag_adjacent : bool
+        If True, propagate flags from `flag_array` to the adjacent intervals in
+        `cal_array`. Default is True.
+    max_time_delta : float
+        Largest gap allowed between a new time and each of the old times that
+        bracket it, in units of Julian days. A new time is flagged unless it lies
+        within this distance of both of its neighbors, so that a solution sitting
+        on top of one old time is still flagged if the other side of the interval
+        is too far away. New times beyond the range of `old_times` are instead
+        tested against the single nearest old time. Default is 0.0, which disables
+        the check.
+    allow_extrapolation : bool
+        If True, allow new times that fall outside the range of `old_times`. If
+        False, those times are flagged. Default is True.
+
+    Returns
+    -------
+    new_flags : ndarray of bool
+        Flags for the interpolated solutions, shape (Nants, Nfreqs, Nnew, Njones), dtype
+        bool.
+    """
+    # Capture any NaN values in cal_array and flag them.
+    flag_array = flag_array | np.isnan(cal_array)
+
+    # If this is a gain amplitude array, also flag any zero values (which are invalid).
+    if is_gain_amp or is_gain_pha:
+        if not np.issubdtype(cal_array.dtype, np.complexfloating):
+            raise ValueError(
+                "cal_array must be complex if is_gain_amp or is_gain_pha is True."
+            )
+        flag_array |= cal_array == 0.0
+
+    if len(old_times) < 2:
+        # Cannot compute a delta with fewer than 2 points, so mark everything as
+        # flagged and then, if there is a single time to work from, let its flags
+        # stand in for every new time.
+        new_flags = np.ones(
+            (
+                flag_array.shape[0],
+                flag_array.shape[1],
+                len(new_times),
+                flag_array.shape[3],
+            ),
+            dtype=np.bool_,
+        )
+        if len(old_times) == 1:
+            new_flags[:, :, :, :] = flag_array[:, :, 0:1, :]
+
+        return new_flags
+
+    if not np.all(np.diff(old_times) >= 0):
+        sort_idx = np.argsort(old_times)
+        old_times = old_times[sort_idx]
+        cal_array = cal_array[:, :, sort_idx, :]
+        flag_array = flag_array[:, :, sort_idx, :]
+
+    # Create a blank set of flags for each time range
+    window_flags = np.zeros(
+        (
+            flag_array.shape[0],
+            flag_array.shape[1],
+            flag_array.shape[2] + 1,
+            flag_array.shape[3],
+        ),
+        dtype=np.bool_,
+    )
+
+    if tol_lim > 0.0:
+        # Dividing through the NaNs when flagged is deliberate, so suppress warnings.
+        with np.errstate(invalid="ignore"):
+            if is_gain_amp:
+                delta_12 = np.abs(cal_array[:, :, 1:, :] / cal_array[:, :, :-1, :]) - 1
+            elif is_gain_pha:
+                delta_12 = np.angle(cal_array[:, :, 1:, :] / cal_array[:, :, :-1, :])
+            else:
+                delta_12 = np.real(cal_array[:, :, 1:, :] - cal_array[:, :, :-1, :])
+
+        window_flags[:, :, 1:-1, :] = (delta_12 > tol_lim) | (delta_12 < -tol_lim)
+        window_flags[:, :, 0, :] = window_flags[:, :, 1, :]
+        window_flags[:, :, -1, :] = window_flags[:, :, -2, :]
+
+    if flag_adjacent:
+        window_flags[:, :, 1:, :] |= flag_array
+        window_flags[:, :, :-1, :] |= flag_array
+
+    insert_idx = np.searchsorted(old_times, new_times, side="left")
+    new_flags = window_flags[:, :, insert_idx, :]
+
+    if max_time_delta > 0.0:
+        time_deltas = np.maximum(
+            new_times - old_times[np.clip(insert_idx - 1, 0, len(old_times) - 1)],
+            old_times[np.clip(insert_idx, 0, len(old_times) - 1)] - new_times,
+        )
+        new_flags[:, :, (time_deltas > max_time_delta), :] = True
+
+    if not allow_extrapolation:
+        # Test the times themselves rather than the insertion indices, since a new
+        # time that lands exactly on the first old time gets an index of zero without
+        # actually being extrapolated.
+        new_flags[:, :, (new_times < old_times[0]), :] = True
+        new_flags[:, :, (new_times > old_times[-1]), :] = True
+
+    return new_flags
+
+
+@nb.njit(cache=True)
+def _interp_linear_cal(old_times, old_cal, old_flags, new_times, ignore_flags=False):
+    """
+    Interpolate calibration solutions in time using linear interpolation.
+
+    Parameters
+    ----------
+    old_times : ndarray of float
+        Times corresponding to the third axis of `old_cal`, shape (Ntimes,), dtype is
+        float. Units must be the same as `new_times`. Must be in ascending order.
+    old_cal : ndarray
+        Calibration solutions to interpolate, shape (Nants, Nfreqs, Ntimes, Njones),
+        dtype is float.
+    old_flags : ndarray of bool
+        Flags for `old_cal`, where flagged entries are excluded from the
+        interpolation if `ignore_flags=False`. Shape is (Nants, Nfreqs, Ntimes, Njones),
+        dtype is bool.
+    new_times : ndarray of float
+        Times at which to evaluate the interpolation, shape (Nnew,), dtype is float,
+        Units must be the same as `old_times`.
+    ignore_flags : bool
+        If True, interpolate against every sample and disregard `old_flags`. Default
+        is False.
+
+    Returns
+    -------
+    new_cal : ndarray
+        Interpolated solutions, shape (Nants, Nfreqs, Nnew, Njones), dtype is float.
+        Entries where too few unflagged samples were available are set to NaN.
+    """
+    new_cal = np.full(
+        (old_cal.shape[0], old_cal.shape[1], len(new_times), old_cal.shape[3]),
+        np.nan,
+        dtype=old_cal.dtype,
+    )
+
+    for ant_idx in range(old_cal.shape[0]):
+        for freq_idx in range(old_cal.shape[1]):
+            for jones_idx in range(old_cal.shape[3]):
+                flag_slice = old_flags[ant_idx, freq_idx, :, jones_idx]
+                if ignore_flags or not np.any(flag_slice):
+                    time_slice = old_times
+                    cal_slice = old_cal[ant_idx, freq_idx, :, jones_idx]
+                else:
+                    if np.all(flag_slice):
+                        continue
+                    good_mask = ~flag_slice
+                    time_slice = old_times[good_mask]
+                    cal_slice = old_cal[ant_idx, freq_idx, good_mask, jones_idx]
+
+                new_cal[ant_idx, freq_idx, :, jones_idx] = np.interp(
+                    new_times, time_slice, cal_slice
+                )
+
+    return new_cal
+
+
+@nb.njit(cache=True)
+def _interp_nearest_cal(old_times, old_cal, old_flags, new_times, ignore_flags=False):
+    """
+    Interpolate calibration solutions in time by taking the nearest sample.
+
+    Parameters
+    ----------
+    old_times : ndarray of float
+        Times corresponding to the third axis of `old_cal`, shape (Ntimes,), dtype is
+        float. Units must be the same as `new_times`. Must be in ascending order.
+    old_cal : ndarray
+        Calibration solutions to interpolate, shape (Nants, Nfreqs, Ntimes, Njones),
+        dtype is float.
+    old_flags : ndarray of bool
+        Flags for `old_cal`, where flagged entries are excluded from the
+        interpolation if `ignore_flags=False`. Shape is (Nants, Nfreqs, Ntimes, Njones),
+        dtype is bool.
+    new_times : ndarray of float
+        Times at which to evaluate the interpolation, shape (Nnew,), dtype is float.
+        Units must be the same as `old_times`.
+    ignore_flags : bool
+        If True, interpolate against every sample and disregard `old_flags`. Default
+        is False.
+
+    Returns
+    -------
+    new_cal : ndarray
+        Interpolated solutions, shape (Nants, Nfreqs, Nnew, Njones), dtype is float.
+        Entries where too few unflagged samples were available are set to NaN.
+    """
+    mid_times = 0.5 * (old_times[1:] + old_times[:-1])
+    new_cal = old_cal[:, :, np.searchsorted(mid_times, new_times), :]
+
+    if ignore_flags or not np.any(old_flags):
+        return new_cal
+
+    for ant_idx in range(old_cal.shape[0]):
+        for freq_idx in range(old_cal.shape[1]):
+            for jones_idx in range(old_cal.shape[3]):
+                flag_slice = old_flags[ant_idx, freq_idx, :, jones_idx]
+                if not np.any(flag_slice):
+                    continue
+
+                good_mask = ~flag_slice
+                if not np.any(good_mask):
+                    # Nothing left to select from, so mark the whole slice as bad.
+                    new_cal[ant_idx, freq_idx, :, jones_idx] = np.nan
+                    continue
+
+                time_slice = old_times[good_mask]
+                cal_slice = old_cal[ant_idx, freq_idx, good_mask, jones_idx]
+                mid_times_slice = 0.5 * (time_slice[1:] + time_slice[:-1])
+                new_cal[ant_idx, freq_idx, :, jones_idx] = cal_slice[
+                    np.searchsorted(mid_times_slice, new_times)
+                ]
+
+    return new_cal
+
+
+@nb.njit(cache=True)
+def _pchip_slopes(h, delta):
+    """
+    Calculate the knot derivatives for a shape-preserving cubic interpolation.
+
+    Derivatives are chosen such that the interpolant is monotonic on any interval
+    where the data are (Fritsch & Carlson 1980). See Moler, "Numerical Computing with
+    MATLAB", Chap 3.6 (pchiptx.m) for further details.
+
+    Parameters
+    ----------
+    h : ndarray of float
+        Spacing between adjacent knots, shape (Nvals).
+    delta : ndarray of float
+        Secant slope across each interval, shape (Nvals,).
+
+    Returns
+    -------
+    d : ndarray of float
+        Derivative at each knot, shape (Nvals + 1,).
+    """
+    # Note that this code has been largely adapted from the MATLAB version of the PCHIP
+    # algorithm. I (Karto) have kept the variable names mostly the same to allow for
+    # easier point-to-point comparison against that code.
+    n = len(h) + 1
+    d = np.zeros(n, dtype=np.float64)
+
+    if n == 2:
+        # With only two points the interpolant is just a straight line.
+        d[0] = delta[0]
+        d[1] = delta[0]
+        return d
+
+    # Check if the derivative goes through a zero-crossing between or at adjacent knots.
+    is_nonflat = (np.sign(delta[:-1]) * np.sign(delta[1:])) > 0
+
+    # Use a weighted mean based on distance (in time) from each point.
+    w1 = (2 * h[1:]) + h[:-1]
+    w2 = h[1:] + (2 * h[:-1])
+    whmean = (w1 / np.where(is_nonflat, delta[:-1], 1.0)) + (
+        w2 / np.where(is_nonflat, delta[1:], 1.0)
+    )
+    d[1:-1] = np.where(is_nonflat, (w1 + w2) / whmean, 0.0)
+
+    # The two end knots have only one neighbor apiece, so they instead use the formula
+    # from pchipend.
+    for knot_idx, next_idx in ((0, 1), (-1, -2)):
+        h1 = h[knot_idx]
+        h2 = h[next_idx]
+        del1 = delta[knot_idx]
+        del2 = delta[next_idx]
+
+        d_end = (((2 * h1) + h2) * del1 - (h1 * del2)) / (h1 + h2)
+
+        if np.sign(d_end) != np.sign(del1):
+            # The estimate points the "wrong way", so flatten it out.
+            d_end = 0.0
+        elif (np.sign(del1) != np.sign(del2)) and (np.abs(d_end) > (3 * np.abs(del1))):
+            # Near a local extremum, limit the slope to preserve monotonic nature.
+            d_end = 3 * del1
+
+        d[knot_idx] = d_end
+
+    return d
+
+
+@nb.njit(cache=True)
+def _interp_pchip(x, y, xq):
+    """
+    Interpolate a calibration solution in time using cubic interpolation.
+
+    See Moler, "Numerical Computing with MATLAB", Chap 3.6 (pchiptx.m) for further
+    details.
+
+    Parameters
+    ----------
+    x : ndarray of float
+        Sample points at which `y` has been evaluated.  Must be in ascending order.
+        Shape (Nold), dtype is float.
+    y : ndarray of float
+        Values at the sample points. Shape (Nold), dtype is float.
+    xq : ndarray of float
+        Points at which to evaluate the interpolation, shape (Nnew,), dtype is float.
+
+    Returns
+    -------
+    new_cal : ndarray of float
+        Interpolated solutions, shape (Nnew,).
+    """
+    # Note that this code has been largely adapted from the MATLAB version of the PCHIP
+    # algorithm. I (Karto) have kept the variable names mostly the same to allow for
+    # easier point-to-point comparison against that code.
+    n = len(x)
+    h = x[1:] - x[:-1]
+    delta = (y[1:] - y[:-1]) / h
+    d = _pchip_slopes(h, delta)
+
+    c = ((3 * delta) - (2 * d[:-1]) - d[1:]) / h
+    b = (d[:-1] - (2 * delta) + d[1:]) / (h * h)
+
+    k = np.clip(np.searchsorted(x, xq) - 1, 0, n - 2)
+    s = xq - x[k]
+
+    return y[k] + s * (d[k] + s * (c[k] + (s * b[k])))
+
+
+@nb.njit(cache=True)
+def _interp_cubic_slices(
+    old_times: FloatArray,
+    old_cal: FloatArray,
+    old_flags: BoolArray,
+    new_times: FloatArray,
+    new_cal: FloatArray,
+    n_good_times: IntArray,
+):
+    """
+    Refit the individual solutions that a batched cubic interpolation could not.
+
+    Operates in place on `new_cal`, overwriting the solutions that had samples
+    dropped and blanking those that cannot be fit at all. Solutions with nothing
+    flagged are left as the batched pass produced them.
+
+    Parameters
+    ----------
+    old_times : ndarray of float
+        Times corresponding to the third axis of `old_cal`, shape (Ntimes,), dtype is
+        float. Units must be the same as `new_times`. Must be in ascending order.
+    old_cal : ndarray
+        Calibration solutions to interpolate, shape (Nants, Nfreqs, Ntimes, Njones),
+        dtype is float.
+    old_flags : ndarray of bool
+        Flags for `old_cal`, where flagged entries are excluded from the
+        interpolation. Shape is (Nants, Nfreqs, Ntimes, Njones), dtype is bool.
+    new_times : ndarray of float
+        Times at which to evaluate the interpolation, shape (Nnew,), dtype is float.
+        Units must be the same as `old_times`.
+    new_cal : ndarray of float
+        Interpolated solutions to update in place, shape
+        (Nants, Nfreqs, Nnew, Njones).
+    n_good_times : ndarray of int
+        Count of unflagged samples for each solution, shape
+        (Nants, Nfreqs, Njones).
+
+    Returns
+    -------
+    None
+        `new_cal` is modified in place.
+    """
+    n_old_times = len(old_times)
+
+    for ant_idx in range(old_cal.shape[0]):
+        for freq_idx in range(old_cal.shape[1]):
+            for jones_idx in range(old_cal.shape[3]):
+                n_good = n_good_times[ant_idx, freq_idx, jones_idx]
+
+                if n_good == n_old_times:
+                    # Assume the batched pass already filled this slice in, so skip it.
+                    continue
+                elif n_good < _MIN_CUBIC_SAMPLES:
+                    # Too few samples left to fit, which covers solutions flagged for
+                    # the whole track as well as ones only sparsely sampled. Note that
+                    # these have to be blanked explicitly -- the batched pass fills
+                    # every solution, flags and all, so whatever it produced here is
+                    # a fit to data that should not have been used.
+                    new_cal[ant_idx, freq_idx, :, jones_idx] = np.nan
+                    continue
+
+                good_mask = ~old_flags[ant_idx, freq_idx, :, jones_idx]
+                new_cal[ant_idx, freq_idx, :, jones_idx] = _interp_pchip(
+                    old_times[good_mask],
+                    old_cal[ant_idx, freq_idx, good_mask, jones_idx],
+                    new_times,
+                )
+
+
+def _interp_pchip_4d(old_times, old_cal, new_times):
+    """
+    Interpolate a UVCal-like array of solutions in time using cubic interpolation.
+
+    Similar to `_interp_pchip`, but fitting every antenna/freq/jones in a single pass,
+    which is typically one to two orders of magnitude faster than going solution by
+    solution.
+
+    Parameters
+    ----------
+    old_times : ndarray of float
+        Times corresponding to the third axis of `old_cal`, shape (Ntimes,), dtype is
+        float. Units must be the same as `new_times`. Must be in ascending order.
+    old_cal : ndarray
+        Calibration solutions to interpolate, shape (Nants, Nfreqs, Ntimes, Njones),
+        dtype is float.
+    new_times : ndarray of float
+        Times at which to evaluate the interpolation, shape (Nnew,), dtype is float.
+        Units must be the same as `old_times`.
+
+    Returns
+    -------
+    new_cal : ndarray of float
+        Interpolated solutions, shape (Nants, Nfreqs, Nnew, Njones). Flags are not
+        consulted, so solutions with any flagged samples must be refit afterwards.
+    """
+    # Note that this code has been largely adapted from the MATLAB version of the PCHIP
+    # algorithm. I (Karto) have kept the variable names mostly the same to allow for
+    # easier point-to-point comparison against that code.
+    n = len(old_times)
+    h = np.diff(old_times)[None, None, :, None]
+    delta = (old_cal[:, :, 1:, :] - old_cal[:, :, :-1, :]) / h
+
+    d = np.zeros(old_cal.shape, dtype=np.float64)
+    delta_lo = delta[:, :, :-1, :]
+    delta_hi = delta[:, :, 1:, :]
+
+    # Check if the derivative goes through a zero-crossing between or at adjacent knots.
+    is_nonflat = (np.sign(delta_lo) * np.sign(delta_hi)) > 0
+
+    w1 = (2 * h[:, :, 1:, :]) + h[:, :, :-1, :]
+    w2 = h[:, :, 1:, :] + (2 * h[:, :, :-1, :])
+    whmean = (w1 / np.where(is_nonflat, delta_lo, 1.0)) + (
+        w2 / np.where(is_nonflat, delta_hi, 1.0)
+    )
+    d[:, :, 1:-1, :] = np.where(is_nonflat, (w1 + w2) / whmean, 0.0)
+
+    # The two end knots use the noncentered three-point formula from pchipend.
+    for knot_idx, next_idx in ((0, 1), (-1, -2)):
+        h1 = h[:, :, knot_idx, :]
+        h2 = h[:, :, next_idx, :]
+        del1 = delta[:, :, knot_idx, :]
+        del2 = delta[:, :, next_idx, :]
+
+        d_end = (((2 * h1) + h2) * del1 - (h1 * del2)) / (h1 + h2)
+
+        # Where the estimate points the "wrong way", make it flat.
+        d_end = np.where(np.sign(d_end) != np.sign(del1), 0.0, d_end)
+
+        # Near a local extremum, limit the slope to preserve monotonic nature.
+        limit_slope = (
+            (np.sign(del1) != np.sign(del2)) & (np.abs(d_end) > (3 * np.abs(del1)))
+        ) & (np.sign(d_end) == np.sign(del1))
+
+        d[:, :, knot_idx, :] = np.where(limit_slope, 3 * del1, d_end)
+
+    # As in _interp_pchip, recast each interval's cubic into plain polynomial
+    # coefficients and evaluate in Horner form.
+    d_lo = d[:, :, :-1, :]
+    d_hi = d[:, :, 1:, :]
+    c = ((3 * delta) - (2 * d_lo) - d_hi) / h
+    b = (d_lo - (2 * delta) + d_hi) / (h * h)
+
+    k = np.clip(np.searchsorted(old_times, new_times) - 1, 0, n - 2)
+    s = (new_times - old_times[k])[None, None, :, None]
+
+    return old_cal[:, :, k, :] + s * (
+        d[:, :, k, :] + s * (c[:, :, k, :] + (s * b[:, :, k, :]))
+    )
+
+
+def _interp_cubic_cal(
+    old_times: FloatArray,
+    old_cal: FloatArray,
+    old_flags: BoolArray,
+    new_times: FloatArray,
+):
+    """
+    Interpolate calibration solutions in time using cubic interpolation.
+
+    Parameters
+    ----------
+    old_times : ndarray of float
+        Times corresponding to the third axis of `old_cal`, shape (Ntimes,), dtype is
+        float. Units must be the same as `new_times`. Must be in ascending order.
+    old_cal : ndarray
+        Calibration solutions to interpolate, shape (Nants, Nfreqs, Ntimes, Njones),
+        dtype is float.
+    old_flags : ndarray of bool
+        Flags for `old_cal`, where flagged entries are excluded from the interpolation.
+        Shape is (Nants, Nfreqs, Ntimes, Njones), dtype is bool.
+    new_times : ndarray of float
+        Times at which to evaluate the interpolation, shape (Nnew,), dtype is float.
+        Units must be the same as `old_times`.
+
+    Returns
+    -------
+    new_cal : ndarray
+        Interpolated solutions, shape (Nants, Nfreqs, Nnew, Njones), dtype is float.
+        Entries where too few unflagged samples were available are set to NaN.
+    """
+    n_old_times = len(old_times)
+
+    if n_old_times < _MIN_CUBIC_SAMPLES:
+        # Too few times for anything here to be fit.
+        return np.full(
+            (old_cal.shape[0], old_cal.shape[1], len(new_times), old_cal.shape[3]),
+            np.nan,
+            dtype=old_cal.dtype,
+        )
+
+    # Number of usable samples for each antenna/freq/jones solution.
+    n_good_times = n_old_times - np.sum(old_flags, axis=2)
+
+    # Every unflagged solution shares the same time grid, so the whole array can be
+    # fit in one pass, which is typically 1-2 orders of magnitude faster than going
+    # slice by slice. Worst case, this adds a ~10% overhead of all solutions are flagged
+    # (though the logic check below traps this worst case scenario).
+    if np.any(n_good_times == n_old_times):
+        new_cal = np.asarray(
+            _interp_pchip_4d(old_times, old_cal, new_times), dtype=old_cal.dtype
+        )
+    else:
+        # Nothing is fully unflagged, so the batched pass would be thrown away in
+        # its entirety -- skip it and fit every solution individually instead.
+        new_cal = np.full(
+            (old_cal.shape[0], old_cal.shape[1], len(new_times), old_cal.shape[3]),
+            np.nan,
+            dtype=old_cal.dtype,
+        )
+
+    if np.any(n_good_times != n_old_times):
+        # If anything is flagged, we need to step through the solutions individually to
+        # refit them.
+        _interp_cubic_slices(
+            old_times, old_cal, old_flags, new_times, new_cal, n_good_times
+        )
+
+    return new_cal
+
+
+@nb.njit(cache=True)
+def _prep_matrix_poly_lsqfit_cal(
+    old_var: FloatArray, new_var: FloatArray, var_order: IntArray
+):
+    """
+    Build the fit and evaluation matrices for a polynomial least-squares fit.
+
+    Each variable is normalized onto [-1, 1] and expanded into Chebyshev
+    polynomials, which span the same space as the raw powers but keep the normal
+    equations far better conditioned at higher order.
+
+    Parameters
+    ----------
+    old_var : ndarray of float
+        Variables to fit against, shape (Nvar, Ntimes).
+    new_var : ndarray of float
+        Values of those variables at the new times, shape (Nvar, Nnew).
+    var_order : ndarray of int
+        Polynomial order for each variable, shape (Nvar,). An order of zero causes the
+        variable to be dropped from the fit.
+
+    Returns
+    -------
+    xval_matrix : ndarray of float
+        Fit matrix evaluated at the old times, shape (Ntimes, Nterms), where Nterms
+        is `sum(var_order) + 1`.
+    eval_matrix : ndarray of float
+        Fit matrix evaluated at the new times, shape (Nnew, Nterms).
+    """
+    n_var = old_var.shape[0]
+    n_terms = sum(var_order) + 1
+    n_old = old_var.shape[1]
+    n_new = new_var.shape[1]
+
+    xval_matrix = np.zeros((n_old, n_terms))
+    eval_matrix = np.zeros((n_new, n_terms))
+    xval_matrix[:, 0] = 1
+    eval_matrix[:, 0] = 1
+
+    marker = 1
+    for idx in range(n_var):
+        if var_order[idx] == 0:
+            # This variable contributes nothing beyond the constant term, so skip
+            # it (which also avoids normalizing a potentially constant variable).
+            continue
+        min_var = np.min(old_var[idx])
+        max_var = np.max(old_var[idx])
+        old_norm_var = (2 * (old_var[idx] - min_var) / (max_var - min_var)) - 1
+        new_norm_var = (2 * (new_var[idx] - min_var) / (max_var - min_var)) - 1
+
+        # Chebyshev polynomials of the first kind, built up via the following eqn:
+        # T_0 = 1, T_1 = x, T_(k+1) = (2 * x * T_k) - T_(k-1).
+        old_prev = np.ones(n_old)
+        new_prev = np.ones(n_new)
+        old_cheb = old_norm_var
+        new_cheb = new_norm_var
+
+        for _ in range(var_order[idx]):
+            xval_matrix[:, marker] = old_cheb
+            eval_matrix[:, marker] = new_cheb
+            marker += 1
+
+            old_next = (2 * old_norm_var * old_cheb) - old_prev
+            old_prev = old_cheb
+            old_cheb = old_next
+
+            new_next = (2 * new_norm_var * new_cheb) - new_prev
+            new_prev = new_cheb
+            new_cheb = new_next
+
+    return xval_matrix, eval_matrix
+
+
+@nb.njit(cache=True)
+def _interp_lsqfit_cal(
+    old_cal: FloatArray,
+    old_flags: BoolArray,
+    xval_matrix: FloatArray,
+    eval_matrix: FloatArray,
+):
+    """
+    Fit and evaluate calibration solutions using a least-squares fit.
+
+    Solves the system of equations for each antenna/freq/jones solution independently,
+    using only the unflagged samples, and then interpolate/extrapolate the fits.
+
+    Parameters
+    ----------
+    old_cal : ndarray
+        Calibration solutions to interpolate, shape (Nants, Nfreqs, Ntimes, Njones),
+        dtype is float.
+    old_flags : ndarray of bool
+        Flags for `old_cal`, where flagged entries are excluded from the
+        interpolation. Shape is (Nants, Nfreqs, Ntimes, Njones), dtype is bool.
+    xval_matrix : ndarray of float
+        Fit matrix evaluated at the "old" (solved for) times, shape (Ntimes, Nterms).
+    eval_matrix : ndarray of float
+        Fit matrix evaluated at the "new" (interpolated) times, shape (Nnew, Nterms).
+
+    Returns
+    -------
+    new_cal : ndarray
+        Interpolated solutions, shape (Nants, Nfreqs, Nnew, Njones), dtype is float.
+        Entries where too few unflagged samples were available are set to NaN.
+    """
+    new_cal = np.full(
+        (old_cal.shape[0], old_cal.shape[1], eval_matrix.shape[0], old_cal.shape[3]),
+        np.nan,
+        dtype=old_cal.dtype,
+    )
+    n_terms = xval_matrix.shape[1]
+    n_flags = np.sum(old_flags, axis=2)
+    n_times = old_cal.shape[2]
+
+    # The fit matrix is the same for every fully unflagged solution, so form its
+    # normal-equation matrix once up front rather than per solution.
+    full_xx_matrix = xval_matrix.T @ xval_matrix
+
+    for ant_idx in range(old_cal.shape[0]):
+        for freq_idx in range(old_cal.shape[1]):
+            for jones_idx in range(old_cal.shape[3]):
+                if n_times - n_flags[ant_idx, freq_idx, jones_idx] < n_terms:
+                    # Too few unflagged samples to constrain the fit.
+                    continue
+
+                mask = ~old_flags[ant_idx, freq_idx, :, jones_idx]
+                if n_flags[ant_idx, freq_idx, jones_idx]:
+                    good_matrix = xval_matrix[mask, :]
+                    xx_matrix = good_matrix.T @ good_matrix
+                else:
+                    good_matrix, xx_matrix = xval_matrix, full_xx_matrix
+
+                # The astype is needed because numba requires both sides of a matmul
+                # to share a dtype, and single-precision solutions are common enough
+                # (calfits gains are typically complex64) to hit that otherwise.
+                cal_vals = old_cal[ant_idx, freq_idx, mask, jones_idx].astype(
+                    xval_matrix.dtype
+                )
+                xy_matrix = good_matrix.T @ cal_vals
+
+                try:
+                    fit_vals = np.linalg.solve(xx_matrix, xy_matrix)
+                except Exception:
+                    # Thrown w/ a singular matrix, leave this solution flagged.
+                    # Note that the nosec here allows getting around an issue w/ bandit,
+                    # since numba only handles the exception in this fashion.
+                    continue  # nosec B112
+
+                new_cal[ant_idx, freq_idx, :, jones_idx] = eval_matrix @ fit_vals
+
+    return new_cal
+
+
+@nb.njit(cache=True)
+def _interp_poly_cal(
+    old_cal: FloatArray,
+    old_flags: BoolArray,
+    old_var: FloatArray,
+    new_var: FloatArray,
+    order: IntArray,
+):
+    """
+    Interpolate calibration solutions using a least-squares polynomial fit.
+
+    Fits a Chebyshev polynomial sequence to calibration solutions against a set of
+    independent variables such as time (provided in `old_var`) to each antenna,
+    frequency, and jones index/solution independently, with the interpolation then
+    performed using the fitted polynomial (provided in `new_var`).
+
+    Parameters
+    ----------
+    old_cal : ndarray
+        Calibration solutions to fit, shape (Nants, Nfreqs, Ntimes, Njones), dtype is
+        float.
+    old_flags : ndarray of bool
+        Flags for `old_cal`, where flagged entries are excluded from the fit. Shape is
+        (Nants, Nfreqs, Ntimes, Njones), dtype is bool.
+    old_var : ndarray of float
+        Variables to fit against, shape (Nvar, Ntimes), dtype float. Typically the first
+        set of entries correspond to time (though not strictly required).
+    new_var : ndarray of float
+        Values of the variables to evaluate the fit at, shape (Nvar, Nnew), dtype float.
+    order : ndarray of int
+        Polynomial order to use, shape (Nvar,), dtype int.
+
+    Returns
+    -------
+    new_cal : ndarray
+        Fit solutions evaluated at `new_times`, shape (Nants, Nfreqs, Nnew, Njones).
+        Entries where too few unflagged samples were available to constrain the fit
+        are set to NaN.
+    """
+    n_var = old_var.shape[0]
+
+    if np.any(order < 0):
+        raise ValueError("order cannot be negative.")
+
+    if n_var != order.size:
+        raise ValueError(
+            "Length of order must match the first dimension of old_var and new_var."
+        )
+
+    if old_var.shape[0] != new_var.shape[0]:
+        raise ValueError(
+            "old_var and new_var must contain the same number of variables."
+        )
+
+    for idx in range(n_var):
+        if order[idx] > 0 and np.min(old_var[idx]) == np.max(old_var[idx]):
+            raise ValueError(
+                f"Variable {idx} is constant, and so cannot be fit with an order "
+                f"{order[idx]} polynomial."
+            )
+
+    xval_matrix, eval_matrix = _prep_matrix_poly_lsqfit_cal(old_var, new_var, order)
+
+    return _interp_lsqfit_cal(old_cal, old_flags, xval_matrix, eval_matrix)
+
+
+def _interp_dispatcher(
+    *,
+    mode: Literal["real", "imag", "amp", "phase"],
+    old_times: FloatArray,
+    old_cal: FloatArray,
+    old_flags: BoolArray,
+    new_times: FloatArray,
+    new_cal: FloatArray | ComplexArray | None = None,
+    new_flags: BoolArray | None = None,
+    kind: Literal["nearest", "linear", "cubic", "poly"],
+    amp_kind: Literal["nearest", "linear", "cubic", "poly"] | None = None,
+    pha_kind: Literal["nearest", "linear", "cubic", "poly"] | None = None,
+    poly_order: int | None = None,
+    amp_poly_order: int | None = None,
+    pha_poly_order: int | None = None,
+    old_var: FloatArray | None = None,
+    new_var: FloatArray | None = None,
+    flag_nearest: bool = True,
+    allow_extrapolation: bool = False,
+    max_time_delta: float = 1.0,
+    amp_max_time_delta: float | None = None,
+    pha_max_time_delta: float | None = None,
+    flag_delta: float = 0.5,
+    amp_flag_delta: float | None = None,
+    pha_flag_delta: float | None = None,
+):
+    """
+    Call various interpolation functions based on the specified kind.
+
+    Note that this is a helper function, not intended to be called directly by users.
+    Use `time_interp_cal` instead. See the docstring there for details on the parameters
+    and return values.
+    """
+    # Making this explicit here that the two items are linked
+    ignore_flags = flag_nearest
+
+    build_flags = build_interp_flags(
+        old_cal,
+        old_flags,
+        old_times,
+        new_times,
+        tol_lim=flag_delta,
+        is_gain_amp=(mode == "amp"),
+        is_gain_pha=(mode == "phase"),
+        flag_adjacent=flag_nearest,
+        max_time_delta=max_time_delta,
+        allow_extrapolation=allow_extrapolation,
+    )
+
+    orig_dtype = old_cal.dtype
+    if mode == "real":
+        old_cal = old_cal.real
+    elif mode == "imag":
+        old_cal = old_cal.imag
+    elif mode == "phase":
+        old_cal = np.unwrap(np.angle(old_cal))
+        if pha_kind is not None:
+            kind = pha_kind
+        if pha_poly_order is not None:
+            poly_order = pha_poly_order
+        if pha_flag_delta is not None:
+            flag_delta = pha_flag_delta
+        if pha_max_time_delta is not None:
+            max_time_delta = pha_max_time_delta
+    elif mode == "amp":
+        old_cal = np.abs(old_cal)
+        if amp_kind is not None:
+            kind = amp_kind
+        if amp_poly_order is not None:
+            poly_order = amp_poly_order
+        if amp_flag_delta is not None:
+            flag_delta = amp_flag_delta
+        if amp_max_time_delta is not None:
+            max_time_delta = amp_max_time_delta
+    else:
+        raise ValueError(f"Unrecognised mode '{mode}'.")
+
+    new_flags = build_flags if new_flags is None else (new_flags | build_flags)
+
+    if kind == "nearest":
+        interp_cal = _interp_nearest_cal(
+            old_times, old_cal, old_flags, new_times, ignore_flags
+        )
+    elif kind == "linear":
+        interp_cal = _interp_linear_cal(old_times, old_cal, old_flags, new_times)
+    elif kind == "cubic":
+        interp_cal = _interp_cubic_cal(old_times, old_cal, old_flags, new_times)
+    elif kind == "poly":
+        interp_cal = _interp_poly_cal(old_cal, old_flags, old_var, new_var, poly_order)
+    else:
+        raise ValueError(f"Unrecognised interpolation kind '{kind}'.")
+
+    if new_cal is None:
+        new_cal = interp_cal
+        if np.issubdtype(orig_dtype, np.complexfloating):
+            if (mode == "real") or (mode == "amp"):
+                new_cal = new_cal.astype(orig_dtype)
+            elif mode == "imag":
+                new_cal = np.multiply(new_cal, 1j, dtype=orig_dtype)
+            elif mode == "phase":
+                new_cal = np.exp(1j * new_cal, dtype=orig_dtype)
+    elif mode == "real":
+        new_cal.real = interp_cal
+    elif mode == "imag":
+        new_cal.imag = interp_cal
+    elif mode == "amp":
+        new_cal *= interp_cal
+    elif mode == "phase":
+        new_cal *= np.exp(1j * interp_cal)
+
+    return new_cal, new_flags
+
+
+# ---------------------------------------------------------------------------
+# Main method
+# ---------------------------------------------------------------------------
+
+
+def time_interp_cal(
+    old_times: FloatArray,
+    old_cal: FloatArray,
+    old_flags: BoolArray,
+    new_times: FloatArray,
+    *,
+    interp_mode: Literal[
+        "real", "imag", "amp", "phase", "ampphase", "complex"
+    ] = "ampphase",
+    kind: Literal["nearest", "linear", "cubic", "poly"] = "linear",
+    amp_kind: Literal["nearest", "linear", "cubic", "poly"] | None = None,
+    pha_kind: Literal["nearest", "linear", "cubic", "poly"] | None = None,
+    poly_order: int = 3,
+    amp_poly_order: int | None = None,
+    pha_poly_order: int | None = None,
+    flag_nearest: bool = True,
+    allow_extrapolation: bool = False,
+    flag_delta: float = 0.0,
+    amp_flag_delta: float | None = None,
+    pha_flag_delta: float | None = None,
+    max_time_delta: float = 1.0,
+    amp_max_time_delta: float | None = None,
+    pha_max_time_delta: float | None = None,
+    old_var: FloatArray | None = None,
+    new_var: FloatArray | None = None,
+):
+    """
+    Interpolate calibration solutions to a new set of times.
+
+    Interpolate a set of calibration solutions (gains or delays) based on the provided
+    inputs. Note that complex gains are split into pairs of real-valued quantities
+    before being interpolated, since multiple interpolation methods will not work on
+    complex quantities. Complex gains can either be split into their real and imaginary
+    components, or into phase and amplitude, which can be more useful when phase and
+    amplitude vary on different timescales. To facilitate interpolation in this context,
+    several keywords have "amp" and "phase" counterparts, which are used when
+    interpolating in amplitude and phase, respectively.
+
+    Parameters
+    ----------
+    old_times : ndarray of float
+        Times corresponding to the third axis of `old_cal`, shape (Ntimes,), dtype is
+        float, units are Julian days. Must be in ascending order.
+    old_cal : ndarray
+        Calibration solutions to interpolate, shape (Nants, Nfreqs, Ntimes, Njones).
+        Must be complex unless `interp_mode` is "real".
+    old_flags : ndarray of bool
+        Flags for `old_cal`, where flagged entries are excluded from the
+        interpolation. Shape is (Nants, Nfreqs, Ntimes, Njones), dtype is bool.
+    new_times : ndarray of float
+        Times at which to evaluate the interpolation, shape (Nnew,), dtype is float,
+        units are Julian days.
+    interp_mode : str
+        Quantity to interpolate. Options are "ampphase" (amplitude and phase,
+        interpolated separately), "complex" (real and imaginary parts, interpolated
+        separately), "real" (real-values only), "imag" (imaginary values only), "amp"
+        (amplitude only), and "phase" (phase only). Default is "ampphase".
+    kind : str
+        The type of interpolation to use. Options are "nearest", "linear", "cubic",
+        and "poly" (polynomial fit using Chebyshev polynomials). Default is "linear".
+    amp_kind : str or None
+        If set, allows the interpolation kind to be set for amplitude separately.
+        Default is None, which uses the value set for `kind` for interpolating
+        amplitude.
+    pha_kind : str or None
+        If set, allows the interpolation kind to be set for phase separately. Default is
+        None, which uses the value set for `kind` for interpolating phase.
+    poly_order : int or sequence of int
+        Polynomial order to use when `kind` is "poly". May be provided as a single int,
+        or sequence of length Nvar + 1, which allows a different order polynomial to be
+        fit against variables provided via `old_var` and `new_var` (with the first entry
+        corresponding to the polynomial used for time). Note that basis set used for
+        fitting are Chebyshev polynomials. Default is 3 for all variables (including
+        time).
+    amp_poly_order : int or None
+        If set, allows the polynomial order to be set for amplitude separately. Default
+        is None, which uses the value set for `poly_order` for interpolating amplitude.
+        Only used when `interp_mode` is either "amp" or "ampphase".
+    pha_poly_order : int or None
+        If set, allows the polynomial order to be set for phase separately. Default is
+        None, which uses the value set for `poly_order` for interpolating phase.
+        Only used when `interp_mode` is either "phase" or "ampphase".
+    flag_nearest : bool
+        If True, interpolated points that lie adjacent to a flagged data point in
+        `old_cal` (as recorded in `old_flags`) are also flagged. If False, then flagged
+        entries are simply excluded during the interpolation processes. Default is True.
+    allow_extrapolation : bool
+        If True, allow new times that fall outside the range of `old_times`. Default is
+        False, which flags times outside of this range.
+    flag_delta : float
+        Largest change between adjacent samples that is considered acceptable, used
+        to flag intervals that appear to have discontinuities. Units are fractional for
+        amplitude, radians for phase, otherwise they are whatever units are native to
+        `old_cal`. Default is 0.0, which disables this flagging.
+    amp_flag_delta : float or None
+        If set, allows the flagging threshold to be set for amplitude separately. Units
+        are in fractional amplitude. Default is None, which uses `flag_delta` for
+        flagging amplitude interpolation.  Only used when `interp_mode` is either "amp"
+        or "ampphase".
+    pha_flag_delta : float or None
+        If set, allows the flagging threshold to be set for phase separately. Units
+        are in radians. Default is None, which uses `flag_delta` for flagging phase
+        interpolation. Only used when `interp_mode` is either "phase" or "ampphase".
+    max_time_delta : float
+        Largest gap allowed between a new time and each of the old times that bracket
+        it, units are days. A new time is flagged unless it lies within this distance
+        of both of its neighbors, so that a solution sitting on top of one old time is
+        still flagged if the other side of the interval is too far away. New times
+        beyond the range of `old_times` are instead tested against the single nearest
+        old time. Default is 1.0.
+    amp_max_time_delta : float or None
+        As `max_time_delta`, but applied when interpolating amplitude. Units are days.
+        Only used when `interp_mode` is either "amp" or "ampphase". Default is None,
+        which uses the value set for `max_time_delta`.
+    pha_max_time_delta : float or None
+        As `max_time_delta`, but applied when interpolating phase. Units are days.
+        Only used when `interp_mode` is either "phase" or "ampphase". Default is None,
+        which uses the value set for `max_time_delta`.
+    old_var : ndarray of float or None
+        Additional variables to fit against when `kind="poly"`, shape (Nvar, Ntimes),
+        dtype is float. Note that time is always included as a fit variable, and do not
+        need to also be supplied here (and will in fact result in a degenerate fit).
+        Default is None, which causes to fit to be against time alone.
+    new_var : ndarray of float
+        Values of those variables at `new_times`, shape (Nvar, Nnew), dtype is
+        float. Required if `old_var` is set.
+
+    Returns
+    -------
+    new_cal : ndarray of float or complex
+        Interpolated solutions, shape (Nants, Nfreqs, Nnew, Njones), matching the
+        dtype of `old_cal` (nominally floating or complexfloating dtypes).
+    new_flags : ndarray of bool
+        Flags for `new_cal`, shape (Nants, Nfreqs, Nnew, Njones).
+
+    Raises
+    ------
+    ValueError
+        If `interp_mode` or any of the interpolation kinds is unrecognised, if
+        `interp_mode` requires complex input but `old_cal` is real-valued, if only
+        one of `old_var`/`new_var` is supplied, or if their shapes are inconsistent
+        with each other or with the time arrays.
+
+    """
+    valid_modes = {"real", "imag", "amp", "phase", "ampphase", "complex"}
+    if interp_mode not in valid_modes:
+        raise ValueError(
+            f"Unrecognised interp_mode '{interp_mode}'. Choose from {valid_modes}."
+        )
+
+    if not (np.issubdtype(old_cal.dtype, np.complexfloating) or interp_mode == "real"):
+        raise ValueError(
+            f"interp_mode '{interp_mode}' is not compatible with real-valued old_cal."
+        )
+
+    valid_kinds = {"nearest", "linear", "cubic", "poly"}
+    if kind not in valid_kinds:
+        raise ValueError(
+            f"Unrecognised interpolation kind '{kind}'. Choose from {valid_kinds}."
+        )
+
+    if amp_kind is not None and amp_kind not in valid_kinds:
+        raise ValueError(
+            f"Unrecognised amplitude interpolation kind '{amp_kind}'. Choose from "
+            f"{valid_kinds}."
+        )
+
+    if pha_kind is not None and pha_kind not in valid_kinds:
+        raise ValueError(
+            f"Unrecognised phase interpolation kind '{pha_kind}'. Choose from "
+            f"{valid_kinds}."
+        )
+
+    # Get the time arrays properly set up
+    old_times = np.asarray(old_times, dtype=float)
+    new_times = np.asarray(new_times, dtype=float)
+
+    # Numba has no support for arrays that are not in the native byte order, which
+    # data read out of a FITS file frequently are not, so byte-swap those up front.
+    if not old_cal.dtype.isnative:
+        old_cal = old_cal.astype(old_cal.dtype.newbyteorder("="))
+    if not old_flags.dtype.isnative:
+        old_flags = old_flags.astype(old_flags.dtype.newbyteorder("="))
+
+    # Note that amp_kind and pha_kind can each select a polynomial fit on their own,
+    # so the fit variables have to be built whenever any of the three asks for one.
+    if "poly" in (kind, amp_kind, pha_kind):
+        if (old_var is None) != (new_var is None):
+            raise ValueError(
+                "old_var and new_var must either both be set or both be left as None."
+            )
+        elif old_var is None:
+            # Fit against time alone, shaped as a single row so that it matches the
+            # (Nvar, Ntimes) layout that the fitting routines expect.
+            old_var = old_times.reshape(1, -1)
+            new_var = new_times.reshape(1, -1)
+        else:
+            if old_var.shape[0] != new_var.shape[0]:
+                raise ValueError(
+                    "old_var and new_var must contain the same number of variables."
+                )
+            if old_var.shape[-1] != len(old_times):
+                raise ValueError(
+                    "old_var must have the same number of entries as old_times."
+                )
+            if new_var.shape[1] != len(new_times):
+                raise ValueError(
+                    "new_var must have the same number of entries as new_times."
+                )
+
+            old_var = np.vstack((old_times, old_var))
+            new_var = np.vstack((new_times, new_var))
+
+        # Note that this has to come after the above, since the variable count only
+        # includes time once the arrays have been assembled.
+        n_var = old_var.shape[0]
+
+        try:
+            poly_order = np.full(n_var, poly_order, dtype=int)
+            if amp_poly_order is not None:
+                amp_poly_order = np.full(n_var, amp_poly_order, dtype=int)
+            if pha_poly_order is not None:
+                pha_poly_order = np.full(n_var, pha_poly_order, dtype=int)
+        except ValueError as err:
+            if "broadcast" in str(err):
+                raise ValueError(
+                    "poly_order must either have 1 value or must have length equal "
+                    "to the total number of variables being fit against (1 for "
+                    "time plus that contained in old_var/new_var)."
+                ) from err
+            raise err
+
+    interp_kwargs = {
+        "old_times": old_times,
+        "old_cal": old_cal,
+        "old_flags": old_flags,
+        "new_times": new_times,
+        "kind": kind,
+        "amp_kind": amp_kind,
+        "pha_kind": pha_kind,
+        "poly_order": poly_order,
+        "amp_poly_order": amp_poly_order,
+        "pha_poly_order": pha_poly_order,
+        "old_var": old_var,
+        "new_var": new_var,
+        "flag_delta": flag_delta,
+        "amp_flag_delta": amp_flag_delta,
+        "pha_flag_delta": pha_flag_delta,
+        "flag_nearest": flag_nearest,
+        "allow_extrapolation": allow_extrapolation,
+        "max_time_delta": max_time_delta,
+        "amp_max_time_delta": amp_max_time_delta,
+        "pha_max_time_delta": pha_max_time_delta,
+    }
+
+    if interp_mode == "complex":
+        new_cal, new_flags = _interp_dispatcher(mode="real", **interp_kwargs)
+        new_cal, new_flags = _interp_dispatcher(
+            mode="imag", new_cal=new_cal, new_flags=new_flags, **interp_kwargs
+        )
+    elif interp_mode == "ampphase":
+        new_cal, new_flags = _interp_dispatcher(mode="amp", **interp_kwargs)
+        new_cal, new_flags = _interp_dispatcher(
+            mode="phase", new_cal=new_cal, new_flags=new_flags, **interp_kwargs
+        )
+    else:
+        new_cal, new_flags = _interp_dispatcher(mode=interp_mode, **interp_kwargs)
+
+    return new_cal, new_flags

--- a/src/pyuvdata/utils/gain_interpolate.py
+++ b/src/pyuvdata/utils/gain_interpolate.py
@@ -1286,4 +1286,11 @@ def time_interp_cal(
     else:
         new_cal, new_flags = _interp_dispatcher(mode=interp_mode, **interp_kwargs)
 
+    # Some schemes, e.g., "cubic" and "poly", will return NaN if no interpolation can
+    # be generated b/c of a lack of enough data points to interpolate/fit to -- make
+    # sure those are flagged now in the returned solns.
+    bad_vals = ~np.isfinite(new_cal)
+    if np.any(bad_vals):
+        new_flags |= bad_vals
+
     return new_cal, new_flags

--- a/src/pyuvdata/utils/gain_interpolate.py
+++ b/src/pyuvdata/utils/gain_interpolate.py
@@ -7,6 +7,7 @@ from typing import Literal
 import numba as nb
 import numpy as np
 
+from .tools import mask_slicify
 from .types import BoolArray, ComplexArray, FloatArray, IntArray
 
 _MIN_CUBIC_SAMPLES = 4
@@ -161,12 +162,14 @@ def build_interp_flags(
     # Capture any NaN values in cal_array and flag them.
     flag_array = flag_array | np.isnan(cal_array)
 
-    # If this is a gain amplitude array, also flag any zero values (which are invalid).
     if is_gain_amp or is_gain_pha:
         if not np.issubdtype(cal_array.dtype, np.complexfloating):
             raise ValueError(
                 "cal_array must be complex if is_gain_amp or is_gain_pha is True."
             )
+        # Treat complex gain entries that are zero as being implicitly flagged, since
+        # either multiplying or dividing by them will produce visibilities that are
+        # either zero or inf.
         flag_array |= cal_array == 0.0
 
     if len(old_times) < 2:
@@ -644,6 +647,15 @@ def _interp_cubic_cal(
         Interpolated solutions, shape (Nants, Nfreqs, Nnew, Njones), dtype is float.
         Entries where too few unflagged samples were available are set to NaN.
     """
+    good_time_slice = mask_slicify(
+        np.all(np.all(np.all(old_flags, axis=3), axis=1), axis=0), invert=True
+    )
+    # If all entries in a given time index are bad, drop those now, since it will
+    # potentially lead to a lot of wasted effort downstream
+    old_times = old_times[good_time_slice]
+    old_cal = old_cal[:, :, good_time_slice, :]
+    old_flags = old_flags[:, :, good_time_slice, :]
+
     n_old_times = len(old_times)
 
     if n_old_times < _MIN_CUBIC_SAMPLES:
@@ -659,7 +671,7 @@ def _interp_cubic_cal(
 
     # Every unflagged solution shares the same time grid, so the whole array can be
     # fit in one pass, which is typically 1-2 orders of magnitude faster than going
-    # slice by slice. Worst case, this adds a ~10% overhead of all solutions are flagged
+    # slice by slice. Worst case, this adds a ~10% overhead if all solutions are flagged
     # (though the logic check below traps this worst case scenario).
     if np.any(n_good_times == n_old_times):
         new_cal = np.asarray(
@@ -674,12 +686,18 @@ def _interp_cubic_cal(
             dtype=old_cal.dtype,
         )
 
-    if np.any(n_good_times != n_old_times):
+    if np.any((n_good_times != n_old_times) & (n_good_times >= _MIN_CUBIC_SAMPLES)):
         # If anything is flagged, we need to step through the solutions individually to
         # refit them.
         _interp_cubic_slices(
             old_times, old_cal, old_flags, new_times, new_cal, n_good_times
         )
+    elif np.any(n_good_times < _MIN_CUBIC_SAMPLES):
+        # If any solution has too few unflagged samples (but went through batch
+        # processing), blank it out.
+        mask = n_good_times < _MIN_CUBIC_SAMPLES
+        for idx in range(len(new_times)):
+            new_cal[:, :, idx, :] = np.where(mask, np.nan, new_cal[:, :, idx, :])
 
     return new_cal
 
@@ -912,9 +930,9 @@ def _interp_dispatcher(
     new_times: FloatArray,
     new_cal: FloatArray | ComplexArray | None = None,
     new_flags: BoolArray | None = None,
-    kind: Literal["nearest", "linear", "cubic", "poly"],
-    amp_kind: Literal["nearest", "linear", "cubic", "poly"] | None = None,
-    pha_kind: Literal["nearest", "linear", "cubic", "poly"] | None = None,
+    kind: Literal["nearest", "linear", "cubic", "chebyshev"],
+    amp_kind: Literal["nearest", "linear", "cubic", "chebyshev"] | None = None,
+    pha_kind: Literal["nearest", "linear", "cubic", "chebyshev"] | None = None,
     poly_order: int | None = None,
     amp_poly_order: int | None = None,
     pha_poly_order: int | None = None,
@@ -990,7 +1008,7 @@ def _interp_dispatcher(
         interp_cal = _interp_linear_cal(old_times, old_cal, old_flags, new_times)
     elif kind == "cubic":
         interp_cal = _interp_cubic_cal(old_times, old_cal, old_flags, new_times)
-    elif kind == "poly":
+    elif kind == "chebyshev":
         interp_cal = _interp_poly_cal(old_cal, old_flags, old_var, new_var, poly_order)
     else:
         raise ValueError(f"Unrecognised interpolation kind '{kind}'.")
@@ -1030,9 +1048,9 @@ def time_interp_cal(
     interp_mode: Literal[
         "real", "imag", "amp", "phase", "ampphase", "complex"
     ] = "ampphase",
-    kind: Literal["nearest", "linear", "cubic", "poly"] = "linear",
-    amp_kind: Literal["nearest", "linear", "cubic", "poly"] | None = None,
-    pha_kind: Literal["nearest", "linear", "cubic", "poly"] | None = None,
+    kind: Literal["nearest", "linear", "cubic", "chebyshev"] = "linear",
+    amp_kind: Literal["nearest", "linear", "cubic", "chebyshev"] | None = None,
+    pha_kind: Literal["nearest", "linear", "cubic", "chebyshev"] | None = None,
     poly_order: int = 3,
     amp_poly_order: int | None = None,
     pha_poly_order: int | None = None,
@@ -1079,8 +1097,8 @@ def time_interp_cal(
         separately), "real" (real-values only), "imag" (imaginary values only), "amp"
         (amplitude only), and "phase" (phase only). Default is "ampphase".
     kind : str
-        The type of interpolation to use. Options are "nearest", "linear", "cubic",
-        and "poly" (polynomial fit using Chebyshev polynomials). Default is "linear".
+        The type of interpolation to use. Options are "nearest", "linear", "cubic", and
+        "chebyshev" (polynomial fit using Chebyshev polynomials). Default is "linear".
     amp_kind : str or None
         If set, allows the interpolation kind to be set for amplitude separately.
         Default is None, which uses the value set for `kind` for interpolating
@@ -1089,11 +1107,11 @@ def time_interp_cal(
         If set, allows the interpolation kind to be set for phase separately. Default is
         None, which uses the value set for `kind` for interpolating phase.
     poly_order : int or sequence of int
-        Polynomial order to use when `kind` is "poly". May be provided as a single int,
-        or sequence of length Nvar + 1, which allows a different order polynomial to be
-        fit against variables provided via `old_var` and `new_var` (with the first entry
-        corresponding to the polynomial used for time). Note that basis set used for
-        fitting are Chebyshev polynomials. Default is 3 for all variables (including
+        Polynomial order to use when `kind` is "chebyshev". May be provided as a single
+        int, or sequence of length Nvar + 1, which allows a different order polynomial
+        to be fit against variables provided via `old_var` and `new_var` (with the first
+        entry corresponding to the polynomial used for time). Note that basis set used
+        for fitting are Chebyshev polynomials. Default is 3 for all variables (including
         time).
     amp_poly_order : int or None
         If set, allows the polynomial order to be set for amplitude separately. Default
@@ -1140,13 +1158,13 @@ def time_interp_cal(
         Only used when `interp_mode` is either "phase" or "ampphase". Default is None,
         which uses the value set for `max_time_delta`.
     old_var : ndarray of float or None
-        Additional variables to fit against when `kind="poly"`, shape (Nvar, Ntimes),
-        dtype is float. Note that time is always included as a fit variable, and do not
-        need to also be supplied here (and will in fact result in a degenerate fit).
-        Default is None, which causes to fit to be against time alone.
+        Additional variables to fit against when `kind="chebyshev"`, shape
+        (Nvar, Ntimes), dtype is float. Note that time is always included as a fit
+        variable, and do not need to also be supplied here (and will in fact result in a
+        degenerate fit). Default is None, which causes to fit to be against time alone.
     new_var : ndarray of float
-        Values of those variables at `new_times`, shape (Nvar, Nnew), dtype is
-        float. Required if `old_var` is set.
+        Values of those variables at `new_times`, shape (Nvar, Nnew), dtype is float.
+        Required if `old_var` is set.
 
     Returns
     -------
@@ -1171,12 +1189,16 @@ def time_interp_cal(
             f"Unrecognised interp_mode '{interp_mode}'. Choose from {valid_modes}."
         )
 
+    # If the calibration are solutions, then any interp_mode can be used. If they are
+    # real-valued, then only the "real" mode is compatible. Check that either the
+    # calibration solutions are complex or that "real" mode is being used, otherwise
+    # raise an error.
     if not (np.issubdtype(old_cal.dtype, np.complexfloating) or interp_mode == "real"):
         raise ValueError(
             f"interp_mode '{interp_mode}' is not compatible with real-valued old_cal."
         )
 
-    valid_kinds = {"nearest", "linear", "cubic", "poly"}
+    valid_kinds = {"nearest", "linear", "cubic", "chebyshev"}
     if kind not in valid_kinds:
         raise ValueError(
             f"Unrecognised interpolation kind '{kind}'. Choose from {valid_kinds}."
@@ -1204,7 +1226,7 @@ def time_interp_cal(
 
     # Note that amp_kind and pha_kind can each select a polynomial fit on their own,
     # so the fit variables have to be built whenever any of the three asks for one.
-    if "poly" in (kind, amp_kind, pha_kind):
+    if "chebyshev" in (kind, amp_kind, pha_kind):
         if (old_var is None) != (new_var is None):
             raise ValueError(
                 "old_var and new_var must either both be set or both be left as None."
@@ -1286,8 +1308,8 @@ def time_interp_cal(
     else:
         new_cal, new_flags = _interp_dispatcher(mode=interp_mode, **interp_kwargs)
 
-    # Some schemes, e.g., "cubic" and "poly", will return NaN if no interpolation can
-    # be generated b/c of a lack of enough data points to interpolate/fit to -- make
+    # Some schemes, e.g., "cubic" and "chebyshev", will return NaN if no interpolation
+    # can be generated b/c of a lack of enough data points to interpolate/fit to -- make
     # sure those are flagged now in the returned solns.
     bad_vals = ~np.isfinite(new_cal)
     if np.any(bad_vals):

--- a/src/pyuvdata/utils/gain_interpolate.py
+++ b/src/pyuvdata/utils/gain_interpolate.py
@@ -1198,12 +1198,9 @@ def time_interp_cal(
     old_times = np.asarray(old_times, dtype=float)
     new_times = np.asarray(new_times, dtype=float)
 
-    # Numba has no support for arrays that are not in the native byte order, which
-    # data read out of a FITS file frequently are not, so byte-swap those up front.
+    # Numba has no support for arrays that are not in the native byte order
     if not old_cal.dtype.isnative:
         old_cal = old_cal.astype(old_cal.dtype.newbyteorder("="))
-    if not old_flags.dtype.isnative:
-        old_flags = old_flags.astype(old_flags.dtype.newbyteorder("="))
 
     # Note that amp_kind and pha_kind can each select a polynomial fit on their own,
     # so the fit variables have to be built whenever any of the three asks for one.

--- a/src/pyuvdata/utils/tools.py
+++ b/src/pyuvdata/utils/tools.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Iterable as IterableType
 
 import numpy as np
 
-from .types import FloatArray, IntArray, StrArray
+from .types import BoolArray, FloatArray, IntArray, StrArray
 
 
 def _get_iterable(x):
@@ -202,6 +202,30 @@ def slicify(
     else:
         # can't slicify
         return ind
+
+
+def mask_slicify(mask: BoolArray, invert: bool = False):
+    """
+    Convert a boolean mask to a slice or array of index positions.
+
+    Parameters
+    ----------
+    mask : ndarray of bool
+        Boolean mask marking the array positions to index.
+    invert : bool
+        If False, then positions in `mask` marked as True are used to build the
+        slice or index array. If True, then positions where `mask` is marked as
+        True are discarded instead (e.g., `mask` is treated as "flagged" positions
+        rather than those to be preserved). Default is False.
+
+    Returns
+    -------
+    index_obj : slice or ndarray of np.int64
+        If the list of indices can be represented by a slice, a slice is returned,
+        otherwise the list of indices is returned.
+    """
+    ind_arr = np.nonzero(~mask if invert else mask)[0]
+    return slicify(ind_arr, allow_empty=True)
 
 
 def _multidim_ind2sub(dims_dict, dims):

--- a/src/pyuvdata/utils/types.py
+++ b/src/pyuvdata/utils/types.py
@@ -7,6 +7,7 @@ from numpy.typing import NDArray
 
 IntArray = NDArray[np.integer]
 FloatArray = NDArray[np.floating]
+ComplexArray = NDArray[np.complexfloating]
 StrArray = NDArray[np.str_]
 BoolArray = NDArray[np.bool_]
 

--- a/src/pyuvdata/utils/uvcalibrate.py
+++ b/src/pyuvdata/utils/uvcalibrate.py
@@ -142,6 +142,100 @@ def _apply_pol_convention_corrections(
     uvdata.pol_convention = None if undo else uvd_pol_convention
 
 
+def _select_uvd_records(uvdata, uvd_select_kwargs):
+    """
+    Work out which records a calibration should be applied to.
+
+    Note that this is an internal helper function, not meant to be called by users.
+    This function grabs the indicies that match a given set of `select` keywords, for
+    use during `uvcalibrate`. Under the hood, it uses `UVData._select_preprocess`, to
+    identify these index positions, allowing for a subset of visibilities to be modified
+    in place (rather than selecting out a subset, applying calibration, and then
+    merging the modified visibilities back in).
+
+    Note this chooses what to calibrate; nothing is removed from `uvdata` either way.
+
+    Parameters
+    ----------
+    uvdata : UVData object
+        Object being calibrated, used to resolve the selection and size the masks.
+    uvd_select_kwargs : dict or None
+        Keywords describing the selection, as accepted by `UVData.select`.
+
+    Returns
+    -------
+    blt_mask : ndarray of bool or None
+        Mask of shape (Nblts,), or None when every record is being calibrated.
+    freq_inds : ndarray of int or None
+        Indices of the channels being calibrated, or None for all of them. Returned
+        as indices rather than a mask because they are used to index the data.
+    pol_mask : ndarray of bool or None
+        Mask of shape (Npols,), or None when every polarization is being calibrated.
+
+    Raises
+    ------
+    ValueError
+        If a keyword is not one `UVData.select` accepts, or if the selection leaves
+        nothing to calibrate.
+    """
+    if not uvd_select_kwargs:
+        return None, None, None
+
+    # `_select_preprocess` takes every selection keyword positionally-by-name with no
+    # defaults, so fill in the ones the caller did not ask about.
+    allowed = {
+        "antenna_nums": None,
+        "antenna_names": None,
+        "ant_str": None,
+        "bls": None,
+        "frequencies": None,
+        "freq_chans": None,
+        "spws": None,
+        "times": None,
+        "time_range": None,
+        "lsts": None,
+        "lst_range": None,
+        "polarizations": None,
+        "blt_inds": None,
+        "phase_center_ids": None,
+        "catalog_names": None,
+    }
+    passthrough = {"invert", "strict", "warn_spacing"}
+    unknown = set(uvd_select_kwargs) - set(allowed) - passthrough
+    if unknown:
+        raise ValueError(
+            f"Unrecognized keyword(s) in uvd_select_kwargs: {sorted(unknown)}. "
+            f"Allowed: {sorted(set(allowed) | passthrough)}."
+        )
+    kwargs = dict(allowed)
+    kwargs.update(uvd_select_kwargs)
+
+    blt_inds, freq_inds, _, pol_inds, _ = uvdata._select_preprocess(**kwargs)
+
+    blt_mask = None
+    if blt_inds is not None:
+        blt_mask = np.zeros(uvdata.Nblts, dtype=bool)
+        blt_mask[blt_inds] = True
+        if not blt_mask.any():
+            raise ValueError(
+                "The selection leaves no baseline-time records to calibrate."
+            )
+
+    if freq_inds is not None:
+        freq_inds = np.asarray(freq_inds)
+        if not freq_inds.size:
+            raise ValueError("The selection leaves no frequencies to calibrate.")
+
+    pol_mask = None
+    if pol_inds is not None:
+        pol_mask = np.zeros(uvdata.Npols, dtype=bool)
+        pol_mask[pol_inds] = True
+        if not pol_mask.any():
+            raise ValueError("The selection leaves no polarizations to calibrate.")
+
+    return blt_mask, freq_inds, pol_mask
+
+
 def uvcalibrate(
     uvdata,
     uvcal,
@@ -158,6 +252,10 @@ def uvcalibrate(
     uvc_pol_convention: Literal["sum", "avg"] | None = None,
     uvd_pol_convention: Literal["sum", "avg"] | None = None,
     apply_to_weights: bool = False,
+    uvd_select_kwargs=None,
+    uvc_select_kwargs=None,
+    interpolate: bool = False,
+    interp_kwargs=None,
 ):
     """
     Calibrate a UVData object with a UVCal object.
@@ -220,6 +318,27 @@ def uvcalibrate(
         array will be multiplied by the inverse-square of the absolute value of the
         gains correction applied to the data (similar to the behavior of CASA's
         applycal function with `calwt=True`). Default is False.
+    uvd_select_kwargs : dict, optional
+        Keywords describing which data to calibrate, using the same vocabulary
+        `UVData.select` accepts -- e.g. `{"catalog_names": ["3c279"]}` to calibrate
+        one source, or `{"antenna_nums": [1, 2]}`, `{"time_range": [...]}`,
+        `{"blt_inds": [...]}`. Default is None, which calibrates everything. See the
+        `UVData.select` docstring for further details.
+    uvc_select_kwargs : dict, optional
+        Keywords passed to `UVCal.select` to choose which solutions to calibrate
+        with, e.g. `{"catalog_names": ["3c279"]}` to use the solutions derived from
+        one source. Default is None, which uses all of the solutions. See the
+        `UVCal.select` docstring for further details.
+    interpolate : bool
+        If True, interpolate the calibration onto the times of the data being
+        calibrated (via `UVCal.interpolate_in_time`) before applying it, rather than
+        requiring the two to already agree. Default is False.
+    interp_kwargs : dict, optional
+        Keywords passed through to `UVCal.interpolate_in_time` when
+        `interpolate=True`, e.g. `{"kind": "linear"}`. The times to interpolate onto
+        are supplied by this method, and `inplace` may not be set. Default is None,
+        which uses the defaults of `interpolate_in_time` (see that methods docstring
+        for further details).
 
     Returns
     -------
@@ -330,6 +449,41 @@ def uvcalibrate(
                         "are missing on UVCal. To continue calibration and "
                         "flag the data from missing antennas, set ant_check=False."
                     )
+
+    # Work out which baseline-time records are being calibrated, and find those entries
+    blt_mask, freq_inds, pol_mask = _select_uvd_records(uvdata, uvd_select_kwargs)
+    # A plain slice when nothing was selected, so the untouched path stays a view.
+    freq_sel = slice(None) if freq_inds is None else freq_inds
+
+    if uvc_select_kwargs is not None:
+        # Narrow the solutions before anything else looks at them, so that the time
+        # checks and any interpolation below see only the ones being applied.
+        if "inplace" in uvc_select_kwargs:
+            raise ValueError(
+                "Cannot set inplace via uvc_select_kwargs, since uvcalibrate needs "
+                "to leave the UVCal object it was handed alone."
+            )
+        uvcal = uvcal.select(**uvc_select_kwargs, inplace=False)
+
+    if interpolate:
+        interp_kwargs = {} if interp_kwargs is None else dict(interp_kwargs)
+        if "inplace" in interp_kwargs:
+            raise ValueError(
+                "Cannot set inplace via interp_kwargs, since uvcalibrate needs to "
+                "leave the UVCal object it was handed alone."
+            )
+        if uvcal.time_range is not None:
+            raise ValueError(
+                "Cannot interpolate a UVCal object that uses time_range rather than "
+                "time_array, since there is no single time to interpolate from."
+            )
+        # Interpolate onto every time in the data. Note that we do this also for the
+        # times left out of the selection to keep the time-axis "locking", since that
+        # is used by the checks below. The extra solutions simply go unused, and the
+        # overhead here is low to justify the extra arithmetic.
+        uvcal = uvcal.interpolate_in_time(
+            np.unique(uvdata.time_array), inplace=False, **interp_kwargs
+        )
 
     uvdata_times, uvd_time_ri = np.unique(uvdata.time_array, return_inverse=True)
     uvcal_times_to_keep = None
@@ -551,9 +705,28 @@ def uvcalibrate(
         for key in uvdata.get_antpairpols():
             # get indices for this key
             blt_inds = uvdata.antpair2ind(key)
+            keep_pos = None
+            if (blt_mask is not None or freq_inds is not None) and isinstance(
+                blt_inds, slice
+            ):
+                # `antpair2ind` hands back a slice when the records happen to be
+                # contiguous, but a slice won't work with the select operations,
+                # so make the indices.
+                blt_inds = np.arange(uvdata.Nblts)[blt_inds]
+            if blt_mask is not None:
+                # If we need are just performing the apply on a subset of baseline pairs
+                # then we want to grab those now.
+                keep_pos = blt_mask[blt_inds]
+                blt_inds = blt_inds[keep_pos]
+                if not blt_inds.size:
+                    # Nothing selected on this baseline, skip!
+                    continue
             pol_ind = np.argmin(
                 np.abs(uvdata.polarization_array - polstr2num(key[2], uvd_x))
             )
+            if pol_mask is not None and not pol_mask[pol_ind]:
+                # This polarization was not selected, so skip it
+                continue
 
             # try to get gains for each antenna
             ant1_num = key[0]
@@ -593,6 +766,11 @@ def uvcalibrate(
             if uvcal.time_range is not None and uvcal.Ntimes > 1:
                 gain = gain[trange_ind_arr[blt_inds], :]
                 flag = flag[trange_ind_arr[blt_inds], :]
+            elif keep_pos is not None and gain.shape[0] == keep_pos.size:
+                # If we only need a subset of the interpolated gains, grab them now
+                # for the apply step.
+                gain = gain[keep_pos]
+                flag = flag[keep_pos]
 
             # Use a slice operator to expand out the flags and gains with a wide_band
             # calibration solution, otherwise use the Ellipsis to select the whole
@@ -600,31 +778,37 @@ def uvcalibrate(
             gain_slice = ...
             if uvcal_use.wide_band:
                 gain_slice = np.s_[
-                    :, [uvc_spw_map[spw] for spw in uvdata.flex_spw_id_array]
+                    :, [uvc_spw_map[spw] for spw in uvdata.flex_spw_id_array[freq_sel]]
+                ]
+            elif freq_inds is not None:
+                gain_slice = np.s_[:, freq_inds]
+
+            # Do the same on the data side
+            if freq_inds is None:
+                data_slice = np.s_[blt_inds, :, pol_ind]
+            else:
+                data_slice = np.s_[
+                    blt_inds[:, np.newaxis], freq_inds[np.newaxis, :], pol_ind
                 ]
 
             # propagate flags
             if prop_flags:
                 mask = np.isclose(gain, 0.0) | flag
                 gain[mask] = 1.0
-                uvdata.flag_array[blt_inds, :, pol_ind] |= mask[gain_slice]
+                uvdata.flag_array[data_slice] |= mask[gain_slice]
 
             # apply to data
             mult_gains = uvcal_use.gain_convention == "multiply"
             if undo:
                 mult_gains = not mult_gains
             if mult_gains:
-                uvdata.data_array[blt_inds, :, pol_ind] *= gain[gain_slice]
+                uvdata.data_array[data_slice] *= gain[gain_slice]
                 if apply_to_weights:
-                    uvdata.nsample_array[blt_inds, :, pol_ind] /= (
-                        abs(gain[gain_slice]) ** 2
-                    )
+                    uvdata.nsample_array[data_slice] /= abs(gain[gain_slice]) ** 2
             else:
-                uvdata.data_array[blt_inds, :, pol_ind] /= gain[gain_slice]
+                uvdata.data_array[data_slice] /= gain[gain_slice]
                 if apply_to_weights:
-                    uvdata.nsample_array[blt_inds, :, pol_ind] *= (
-                        abs(gain[gain_slice]) ** 2
-                    )
+                    uvdata.nsample_array[data_slice] *= abs(gain[gain_slice]) ** 2
 
     # update attributes
     uvdata.history += "\nCalibrated with pyuvdata.utils.uvcalibrate."

--- a/src/pyuvdata/utils/uvcalibrate.py
+++ b/src/pyuvdata/utils/uvcalibrate.py
@@ -157,6 +157,7 @@ def uvcalibrate(
     freq_range_check: bool = True,
     uvc_pol_convention: Literal["sum", "avg"] | None = None,
     uvd_pol_convention: Literal["sum", "avg"] | None = None,
+    apply_to_weights: bool = False,
 ):
     """
     Calibrate a UVData object with a UVCal object.
@@ -213,6 +214,12 @@ def uvcalibrate(
         represents either the convention that *has* been adopted in ``uvdata`` (in the
         case that ``undo=True``), or the convention that is *desired* for the resulting
         ``UVData`` object (if ``undo=False``).
+    apply_to_weights : bool
+        Option to apply gains corrections to `UVData.nsample_array`, effectively
+        reweighting the data. Only applicable for gains calibration, `nsample_array`
+        array will be multiplied by the inverse-square of the absolute value of the
+        gains correction applied to the data (similar to the behavior of CASA's
+        applycal function with `calwt=True`). Default is False.
 
     Returns
     -------
@@ -507,6 +514,8 @@ def uvcalibrate(
             freq_array=freq_array_use,
             channel_width=channel_width,
         )
+        # Force this to false if we've got a delay soln, since it has no amplitude terms
+        apply_to_weights = False
 
     # D-term calibration
     if d_term_cal:
@@ -606,8 +615,16 @@ def uvcalibrate(
                 mult_gains = not mult_gains
             if mult_gains:
                 uvdata.data_array[blt_inds, :, pol_ind] *= gain[gain_slice]
+                if apply_to_weights:
+                    uvdata.nsample_array[blt_inds, :, pol_ind] /= (
+                        abs(gain[gain_slice]) ** 2
+                    )
             else:
                 uvdata.data_array[blt_inds, :, pol_ind] /= gain[gain_slice]
+                if apply_to_weights:
+                    uvdata.nsample_array[blt_inds, :, pol_ind] *= (
+                        abs(gain[gain_slice]) ** 2
+                    )
 
     # update attributes
     uvdata.history += "\nCalibrated with pyuvdata.utils.uvcalibrate."

--- a/src/pyuvdata/utils/uvcalibrate.py
+++ b/src/pyuvdata/utils/uvcalibrate.py
@@ -164,13 +164,12 @@ def _select_uvd_records(uvdata, uvd_select_kwargs):
 
     Returns
     -------
-    blt_mask : ndarray of bool or None
-        Mask of shape (Nblts,), or None when every record is being calibrated.
-    freq_inds : ndarray of int or None
-        Indices of the channels being calibrated, or None for all of them. Returned
-        as indices rather than a mask because they are used to index the data.
-    pol_mask : ndarray of bool or None
-        Mask of shape (Npols,), or None when every polarization is being calibrated.
+    blt_ind : ndarray of int or None
+        Indices of the baseline-time records being calibrated, or None for all of them.
+    freq_ind : ndarray of int or None
+        Indices of the channels being calibrated, or None for all of them.
+    pol_ind : ndarray of int or None
+        Indices of the polarizations being calibrated, or None for all of them.
 
     Raises
     ------
@@ -210,30 +209,14 @@ def _select_uvd_records(uvdata, uvd_select_kwargs):
     kwargs = dict(allowed)
     kwargs.update(uvd_select_kwargs)
 
-    blt_inds, freq_inds, _, pol_inds, _ = uvdata._select_preprocess(**kwargs)
+    blt_ind, freq_ind, _, pol_ind, _ = uvdata._select_preprocess(**kwargs)
 
-    blt_mask = None
-    if blt_inds is not None:
-        blt_mask = np.zeros(uvdata.Nblts, dtype=bool)
-        blt_mask[blt_inds] = True
-        if not blt_mask.any():
-            raise ValueError(
-                "The selection leaves no baseline-time records to calibrate."
-            )
+    # Make sure the returned indices are arrays of integers (if not None)
+    blt_ind = blt_ind if blt_ind is None else np.asarray(blt_ind, dtype=np.int64)
+    freq_ind = freq_ind if freq_ind is None else np.asarray(freq_ind, dtype=np.int64)
+    pol_ind = pol_ind if pol_ind is None else np.asarray(pol_ind, dtype=np.int64)
 
-    if freq_inds is not None:
-        freq_inds = np.asarray(freq_inds)
-        if not freq_inds.size:
-            raise ValueError("The selection leaves no frequencies to calibrate.")
-
-    pol_mask = None
-    if pol_inds is not None:
-        pol_mask = np.zeros(uvdata.Npols, dtype=bool)
-        pol_mask[pol_inds] = True
-        if not pol_mask.any():
-            raise ValueError("The selection leaves no polarizations to calibrate.")
-
-    return blt_mask, freq_inds, pol_mask
+    return blt_ind, freq_ind, pol_ind
 
 
 def uvcalibrate(
@@ -254,6 +237,7 @@ def uvcalibrate(
     apply_to_weights: bool = False,
     uvd_select_kwargs=None,
     uvc_select_kwargs=None,
+    flag_unselected: bool | None = None,
     interpolate: bool = False,
     interp_kwargs=None,
 ):
@@ -320,15 +304,27 @@ def uvcalibrate(
         applycal function with `calwt=True`). Default is False.
     uvd_select_kwargs : dict, optional
         Keywords describing which data to calibrate, using the same vocabulary
-        `UVData.select` accepts -- e.g. `{"catalog_names": ["3c279"]}` to calibrate
-        one source, or `{"antenna_nums": [1, 2]}`, `{"time_range": [...]}`,
+        `UVData.select` accepts -- e.g. `{"catalog_names": ["3c279"]}` to calibrate one
+        source, or `{"antenna_nums": [1, 2]}`, `{"time_range": [...]}`,
         `{"blt_inds": [...]}`. Default is None, which calibrates everything. See the
-        `UVData.select` docstring for further details.
+        `UVData.select` docstring for further details. Note that if supplied, the
+        calibration is applied to **only** the selected records, so the returned object
+        may hold a mix of calibrated and uncalibrated data, with nothing marking which
+        is which. The uncalibrated records are left unflagged unless `flag_unselected`
+        is set to True.
     uvc_select_kwargs : dict, optional
         Keywords passed to `UVCal.select` to choose which solutions to calibrate
         with, e.g. `{"catalog_names": ["3c279"]}` to use the solutions derived from
         one source. Default is None, which uses all of the solutions. See the
-        `UVCal.select` docstring for further details.
+        `UVCal.select` docstring for further details. Note that unlike
+        `uvd_select_kwargs`, this narrows the solutions themselves.
+    flag_unselected : bool or None
+        If True, flag every record that `uvd_select_kwargs` left out, so that the
+        uncalibrated data cannot be mistaken for calibrated data. Note that a record is
+        flagged if it falls outside the selection on any axis, so only the records that
+        were actually calibrated are left unflagged. If False, those records are left
+        alone. Default is None, which behaves as False but throws a warning if only
+        a subset of the data is being calibrated.
     interpolate : bool
         If True, interpolate the calibration onto the times of the data being
         calibrated (via `UVCal.interpolate_in_time`) before applying it, rather than
@@ -386,6 +382,16 @@ def uvcalibrate(
     # check both objects
     uvdata.check()
     uvcal.check()
+
+    # Narrow the solutions before anything else looks at them, so that the time
+    # checks and any interpolation below see only the ones being applied.
+    if uvc_select_kwargs is not None:
+        if "inplace" in uvc_select_kwargs:
+            raise ValueError(
+                "Cannot set inplace via uvc_select_kwargs, since uvcalibrate needs "
+                "to leave the UVCal object it was handed alone."
+            )
+        uvcal = uvcal.select(**uvc_select_kwargs, inplace=False)
 
     # Check whether the UVData antennas *that have data associated with them*
     # have associated data in the UVCal object
@@ -451,19 +457,32 @@ def uvcalibrate(
                     )
 
     # Work out which baseline-time records are being calibrated, and find those entries
-    blt_mask, freq_inds, pol_mask = _select_uvd_records(uvdata, uvd_select_kwargs)
-    # A plain slice when nothing was selected, so the untouched path stays a view.
-    freq_sel = slice(None) if freq_inds is None else freq_inds
+    blt_ind_arr, freq_ind_arr, pol_ind_arr = _select_uvd_records(
+        uvdata, uvd_select_kwargs
+    )
 
-    if uvc_select_kwargs is not None:
-        # Narrow the solutions before anything else looks at them, so that the time
-        # checks and any interpolation below see only the ones being applied.
-        if "inplace" in uvc_select_kwargs:
-            raise ValueError(
-                "Cannot set inplace via uvc_select_kwargs, since uvcalibrate needs "
-                "to leave the UVCal object it was handed alone."
-            )
-        uvcal = uvcal.select(**uvc_select_kwargs, inplace=False)
+    # A plain Ellipsis when nothing was selected, so the untouched path stays a view.
+    blt_mask = freq_mask = pol_mask = ...
+    if blt_ind_arr is not None:
+        blt_mask = np.zeros(uvdata.Nblts, dtype=bool)
+        blt_mask[blt_ind_arr] = True
+
+    if freq_ind_arr is not None:
+        freq_mask = np.zeros(uvdata.Nfreqs, dtype=bool)
+        freq_mask[freq_ind_arr] = True
+
+    if pol_ind_arr is not None:
+        pol_mask = np.zeros(uvdata.Npols, dtype=bool)
+        pol_mask[pol_ind_arr] = True
+
+    if uvd_select_kwargs is not None and flag_unselected is None:
+        warnings.warn(
+            "Calibrating a subset of the data leaves the object holding a mix of "
+            "calibrated and uncalibrated records, which nothing on the object marks "
+            "apart -- only the history records that it happened. Set "
+            "flag_unselected=True to flag the records that are left uncalibrated, "
+            "or flag_unselected=False to leave them alone and silence this warning."
+        )
 
     if interpolate:
         interp_kwargs = {} if interp_kwargs is None else dict(interp_kwargs)
@@ -472,18 +491,16 @@ def uvcalibrate(
                 "Cannot set inplace via interp_kwargs, since uvcalibrate needs to "
                 "leave the UVCal object it was handed alone."
             )
-        if uvcal.time_range is not None:
-            raise ValueError(
-                "Cannot interpolate a UVCal object that uses time_range rather than "
-                "time_array, since there is no single time to interpolate from."
-            )
         # Interpolate onto every time in the data. Note that we do this also for the
         # times left out of the selection to keep the time-axis "locking", since that
         # is used by the checks below. The extra solutions simply go unused, and the
-        # overhead here is low to justify the extra arithmetic.
+        # overhead here is low enough to justify the extra arithmetic.
+        preinterp_history_len = len(uvcal.history)
         uvcal = uvcal.interpolate_in_time(
             np.unique(uvdata.time_array), inplace=False, **interp_kwargs
         )
+        # Grab just what the interpolation recorded about itself.
+        interp_history = uvcal.history[preinterp_history_len:]
 
     uvdata_times, uvd_time_ri = np.unique(uvdata.time_array, return_inverse=True)
     uvcal_times_to_keep = None
@@ -623,7 +640,10 @@ def uvcalibrate(
             "Matching based on `x` and `y` only "
         )
 
-    uvdata_pol_strs = polnum2str(uvdata.polarization_array, x_orientation=uvd_x)
+    # Only the polarizations actually being calibrated need solutions to match against.
+    uvdata_pol_strs = polnum2str(
+        uvdata.polarization_array[pol_mask], x_orientation=uvd_x
+    )
     uvcal_pol_strs = jnum2str(
         uvcal.jones_array, x_orientation=uvcal.telescope.get_x_orientation_from_feeds()
     )
@@ -704,27 +724,27 @@ def uvcalibrate(
         # iterate over keys
         for key in uvdata.get_antpairpols():
             # get indices for this key
-            blt_inds = uvdata.antpair2ind(key)
+            blt_subinds = uvdata.antpair2ind(key)
             keep_pos = None
-            if (blt_mask is not None or freq_inds is not None) and isinstance(
-                blt_inds, slice
+            if (blt_ind_arr is not None or freq_ind_arr is not None) and isinstance(
+                blt_subinds, slice
             ):
                 # `antpair2ind` hands back a slice when the records happen to be
                 # contiguous, but a slice won't work with the select operations,
                 # so make the indices.
-                blt_inds = np.arange(uvdata.Nblts)[blt_inds]
-            if blt_mask is not None:
+                blt_subinds = np.arange(uvdata.Nblts)[blt_subinds]
+            if blt_ind_arr is not None:
                 # If we need are just performing the apply on a subset of baseline pairs
                 # then we want to grab those now.
-                keep_pos = blt_mask[blt_inds]
-                blt_inds = blt_inds[keep_pos]
-                if not blt_inds.size:
+                keep_pos = blt_mask[blt_subinds]
+                blt_subinds = blt_subinds[keep_pos]
+                if not blt_subinds.size:
                     # Nothing selected on this baseline, skip!
                     continue
             pol_ind = np.argmin(
                 np.abs(uvdata.polarization_array - polstr2num(key[2], uvd_x))
             )
-            if pol_mask is not None and not pol_mask[pol_ind]:
+            if pol_ind_arr is not None and not pol_mask[pol_ind]:
                 # This polarization was not selected, so skip it
                 continue
 
@@ -746,7 +766,7 @@ def uvcalibrate(
                 uvcal_use._key_exists(antnum=uvcal_ant1_num, jpol=feed1)
                 and uvcal_use._key_exists(antnum=uvcal_ant2_num, jpol=feed2)
             ):
-                uvdata.flag_array[blt_inds, :, pol_ind] = True
+                uvdata.flag_array[blt_subinds, :, pol_ind] = True
                 continue
 
             uvcal_key1 = (uvcal_ant1_num, feed1)
@@ -764,8 +784,8 @@ def uvcalibrate(
             flag = (uvcal_use.get_flags(uvcal_key1) | uvcal_use.get_flags(uvcal_key2)).T
 
             if uvcal.time_range is not None and uvcal.Ntimes > 1:
-                gain = gain[trange_ind_arr[blt_inds], :]
-                flag = flag[trange_ind_arr[blt_inds], :]
+                gain = gain[trange_ind_arr[blt_subinds], :]
+                flag = flag[trange_ind_arr[blt_subinds], :]
             elif keep_pos is not None and gain.shape[0] == keep_pos.size:
                 # If we only need a subset of the interpolated gains, grab them now
                 # for the apply step.
@@ -778,17 +798,17 @@ def uvcalibrate(
             gain_slice = ...
             if uvcal_use.wide_band:
                 gain_slice = np.s_[
-                    :, [uvc_spw_map[spw] for spw in uvdata.flex_spw_id_array[freq_sel]]
+                    :, [uvc_spw_map[spw] for spw in uvdata.flex_spw_id_array[freq_mask]]
                 ]
-            elif freq_inds is not None:
-                gain_slice = np.s_[:, freq_inds]
+            elif freq_ind_arr is not None:
+                gain_slice = np.s_[:, freq_ind_arr]
 
             # Do the same on the data side
-            if freq_inds is None:
-                data_slice = np.s_[blt_inds, :, pol_ind]
+            if freq_ind_arr is None:
+                data_slice = np.s_[blt_subinds, :, pol_ind]
             else:
                 data_slice = np.s_[
-                    blt_inds[:, np.newaxis], freq_inds[np.newaxis, :], pol_ind
+                    blt_subinds[:, np.newaxis], freq_ind_arr[np.newaxis, :], pol_ind
                 ]
 
             # propagate flags
@@ -812,6 +832,37 @@ def uvcalibrate(
 
     # update attributes
     uvdata.history += "\nCalibrated with pyuvdata.utils.uvcalibrate."
+
+    # Record which records were touched, so that it's clear from the history where the
+    # calibration was applied and where it was not.
+    if uvd_select_kwargs is not None:
+        counts = [
+            f"{len(ind_arr)} of {total} {name}"
+            for name, ind_arr, total in [
+                ("baseline-times", blt_ind_arr, uvdata.Nblts),
+                ("frequencies", freq_ind_arr, uvdata.Nfreqs),
+                ("polarizations", pol_ind_arr, uvdata.Npols),
+            ]
+            if ind_arr is not None
+        ]
+        uvdata.history += (
+            " Applied to a subset of the data, selected on "
+            f"{', '.join(sorted(uvd_select_kwargs))}"
+            + (f" ({'; '.join(counts)})" if counts else "")
+            + ". Records outside that selection were left uncalibrated, and have "
+            + ("been flagged." if flag_unselected else "NOT been flagged.")
+        )
+
+    if uvc_select_kwargs is not None:
+        uvdata.history += (
+            " Calibration solutions were selected on "
+            f"{', '.join(sorted(uvc_select_kwargs))} before being applied."
+        )
+
+    # Carry over how the solutions were interpolated (if they were)
+    if interpolate:
+        uvdata.history += " Solutions were interpolated before use:" + interp_history
+
     if undo:
         uvdata.vis_units = "uncalib"
     else:
@@ -823,6 +874,14 @@ def uvcalibrate(
         _apply_pol_convention_corrections(
             uvdata, undo, uvc_pol_convention, uvd_pol_convention
         )
+
+    if flag_unselected:
+        if blt_ind_arr is not None:
+            uvdata.flag_array[~blt_mask, :, :] = True
+        if freq_ind_arr is not None:
+            uvdata.flag_array[:, ~freq_mask, :] = True
+        if pol_ind_arr is not None:
+            uvdata.flag_array[:, :, ~pol_mask] = True
 
     if not inplace:
         return uvdata

--- a/src/pyuvdata/uvcal/uvcal.py
+++ b/src/pyuvdata/uvcal/uvcal.py
@@ -4436,12 +4436,18 @@ class UVCal(UVBase):
         (the default) or real and imaginary, since amplitude and phase can vary on
         different timescales. Several keywords therefore have "amp" and "pha"
         counterparts, which override the shared value when interpolating amplitude and
-        phase respectively.
+        phase respectively. Note this is only applicable for objects where `cal_type`
+        is "gain" -- for "delay" objects, these arguments are ignored.
 
         Note that quantities which cannot be meaningfully interpolated are either
         carried over from the nearest old time (`integration_time`,
         `ref_antenna_array`) or dropped entirely (`quality_array`,
         `total_quality_array`, `phase_center_id_array`, `scan_number_array`).
+
+        UVCal objects with `time_range` set rather than `time_array` are
+        interpolated from the midpoint of each range. Since the result is evaluated at
+        discrete times, the returned object carries `time_array` (and `lst_array`) in
+        place of `time_range` and `lst_range`.
 
         Parameters
         ----------
@@ -4449,7 +4455,7 @@ class UVCal(UVBase):
             The new times to interpolate to, shape (Ntimes,), units are Julian days.
         kind : str
             The type of interpolation to use. Options are "nearest", "linear", "cubic",
-            and "poly" (polynomial fit using Chebyshev polynomials). Default is
+            and "chebyshev" (polynomial fit using Chebyshev polynomials). Default is
             "linear".
         amp_kind : str or None
             If set, the interpolation kind used for amplitude. Default is None, which
@@ -4458,7 +4464,8 @@ class UVCal(UVBase):
             If set, the interpolation kind used for phase. Default is None, which uses
             the value set for `kind`.
         poly_order : int or sequence of int
-            Polynomial order to use when the interpolation kind is "poly". Default is 3.
+            Polynomial order to use when the interpolation kind is "chebyshev". Default
+            is 3.
         amp_poly_order : int or None
             If set, the polynomial order used for amplitude. Default is None, which
             uses the value set for `poly_order`.
@@ -4495,7 +4502,7 @@ class UVCal(UVBase):
             If set, the gap limit used for phase. Default is None, which uses the value
             set for `max_time_delta`.
         old_var : ndarray of float or None
-            Additional variables to fit against when the kind is "poly", shape
+            Additional variables to fit against when the kind is "chebyshev", shape
             (Nvar, Ntimes). Note that time is always included as a fit variable, and
             does not need to be supplied here. Default is None.
         new_var : ndarray of float or None
@@ -4522,14 +4529,14 @@ class UVCal(UVBase):
         Raises
         ------
         ValueError
-            If the object records time_range rather than time_array, since
-            interpolation needs discrete times to work from.
+            If the object has neither time_array nor time_range set, since there are
+            then no times to interpolate from.
 
         """
-        if self.time_array is None or self.time_range is not None:
+        if self.time_array is None and self.time_range is None:
             raise ValueError(
-                "Cannot interpolate an object that records time_range rather than "
-                "time_array, since there are no discrete times to interpolate from."
+                "Cannot interpolate an object with neither time_array nor time_range "
+                "set, since there are no times to interpolate from."
             )
 
         # Check if the refant changes in time, and if so, throw a warning (since it may
@@ -4548,7 +4555,12 @@ class UVCal(UVBase):
         is_gain = cal_object.cal_type == "gain"
 
         new_times = np.asarray(new_times, dtype=float)
-        old_times = cal_object.time_array
+
+        if cal_object.time_array is None:
+            # Take the midpoint if using time_range
+            old_times = np.mean(cal_object.time_range, axis=1)
+        else:
+            old_times = cal_object.time_array
 
         if is_gain:
             interp_mode = "complex" if use_complex_interp else "ampphase"
@@ -4585,6 +4597,9 @@ class UVCal(UVBase):
         cal_object.time_array = new_times
         cal_object.Ntimes = len(new_times)
         cal_object.flag_array = new_flags
+        # The interpolated solutions sit at discrete times, so discard any time ranges.
+        cal_object.time_range = None
+        cal_object.lst_range = None
         if is_gain:
             cal_object.gain_array = new_cal
         else:
@@ -4611,6 +4626,33 @@ class UVCal(UVBase):
 
         # Set LSTs directly rather than interpolating
         cal_object.set_lsts_from_time_array()
+
+        # Record what was done, since the interpolation is not otherwise recoverable
+        # from the object once the original solutions have been replaced.
+        kind_str = kind + (f" (poly_order={poly_order})" if kind == "chebyshev" else "")
+        if is_gain:
+            if use_complex_interp:
+                kind_desc = f"real={kind_str}, imaginary={kind_str}"
+            else:
+                amp_str = amp_kind if amp_kind is not None else kind
+                pha_str = pha_kind if pha_kind is not None else kind
+                if amp_str == "chebyshev":
+                    amp_order = poly_order if amp_poly_order is None else amp_poly_order
+                    amp_str += f" (poly_order={amp_order})"
+                if pha_str == "chebyshev":
+                    pha_order = poly_order if pha_poly_order is None else pha_poly_order
+                    pha_str += f" (poly_order={pha_order})"
+                kind_desc = f"amplitude={amp_str}, phase={pha_str}"
+        else:
+            # Delays are real-valued, so there is only the one component to describe.
+            kind_desc = f"delay={kind_str}"
+
+        history_update_string = (
+            f"  Interpolated from {len(old_times)} to {len(new_times)} times using "
+            f"pyuvdata, with kind ({kind_desc}). Extrapolation beyond the original "
+            f"time range was {'allowed' if allow_extrapolation else 'not allowed'}."
+        )
+        cal_object.history += history_update_string
 
         if run_check:
             cal_object.check(

--- a/src/pyuvdata/uvcal/uvcal.py
+++ b/src/pyuvdata/uvcal/uvcal.py
@@ -4037,8 +4037,9 @@ class UVCal(UVBase):
             list of spw indices to keep. Can be None (to keep everything).
         freq_inds : list of int
             list of frequency indices to keep. Can be None (to keep everything).
-        pol_inds : list of int
-            list of polarization indices to keep. Can be None (to keep everything).
+        jones_inds : list of int
+            list of Jones polarization indices to keep. Can be None (to keep
+            everything).
         history_update_string : str
             string to append to the end of the history.
 

--- a/src/pyuvdata/uvcal/uvcal.py
+++ b/src/pyuvdata/uvcal/uvcal.py
@@ -4400,6 +4400,224 @@ class UVCal(UVBase):
             setattr(other_obj, p, param)
         return other_obj
 
+    def interpolate_in_time(
+        self,
+        new_times,
+        *,
+        kind="linear",
+        amp_kind=None,
+        pha_kind=None,
+        poly_order=3,
+        amp_poly_order=None,
+        pha_poly_order=None,
+        use_complex_interp=False,
+        flag_nearest=True,
+        allow_extrapolation=False,
+        flag_delta=0.0,
+        amp_flag_delta=None,
+        pha_flag_delta=None,
+        max_time_delta=1.0,
+        amp_max_time_delta=None,
+        pha_max_time_delta=None,
+        old_var=None,
+        new_var=None,
+        inplace=False,
+        run_check=True,
+        check_extra=True,
+        run_check_acceptability=True,
+    ):
+        """
+        Interpolate the gains or delays in time.
+
+        Interpolates the calibration solutions onto a new set of times, carrying the
+        flags along with them. Note that complex gains are split into a pair of
+        real-valued quantities before being interpolated, either amplitude and phase
+        (the default) or real and imaginary, since amplitude and phase can vary on
+        different timescales. Several keywords therefore have "amp" and "pha"
+        counterparts, which override the shared value when interpolating amplitude and
+        phase respectively.
+
+        Note that quantities which cannot be meaningfully interpolated are either
+        carried over from the nearest old time (`integration_time`,
+        `ref_antenna_array`) or dropped entirely (`quality_array`,
+        `total_quality_array`, `phase_center_id_array`, `scan_number_array`).
+
+        Parameters
+        ----------
+        new_times : array_like of float
+            The new times to interpolate to, shape (Ntimes,), units are Julian days.
+        kind : str
+            The type of interpolation to use. Options are "nearest", "linear", "cubic",
+            and "poly" (polynomial fit using Chebyshev polynomials). Default is
+            "linear".
+        amp_kind : str or None
+            If set, the interpolation kind used for amplitude. Default is None, which
+            uses the value set for `kind`.
+        pha_kind : str or None
+            If set, the interpolation kind used for phase. Default is None, which uses
+            the value set for `kind`.
+        poly_order : int or sequence of int
+            Polynomial order to use when the interpolation kind is "poly". Default is 3.
+        amp_poly_order : int or None
+            If set, the polynomial order used for amplitude. Default is None, which
+            uses the value set for `poly_order`.
+        pha_poly_order : int or None
+            If set, the polynomial order used for phase. Default is None, which uses
+            the value set for `poly_order`.
+        use_complex_interp : bool
+            If True, split complex gains into real and imaginary parts rather than
+            amplitude and phase. Ignored when `cal_type` is "delay". Default is False.
+        flag_nearest : bool
+            If True, interpolated solutions adjacent to a flagged solution are also
+            flagged. If False, flagged solutions are simply excluded from the
+            interpolation. Default is True.
+        allow_extrapolation : bool
+            If True, allow new times outside the range of the existing times. Default
+            is False, which flags those solutions.
+        flag_delta : float
+            Largest change between adjacent solutions that is considered acceptable,
+            used to flag apparent discontinuities. Default is 0.0, which disables the
+            check.
+        amp_flag_delta : float or None
+            If set, the flagging threshold used for amplitude, in fractional amplitude.
+            Default is None, which uses the value set for `flag_delta`.
+        pha_flag_delta : float or None
+            If set, the flagging threshold used for phase, in radians. Default is None,
+            which uses the value set for `flag_delta`.
+        max_time_delta : float
+            Largest gap allowed between a new time and the existing times that bracket
+            it, units are days. Default is 1.0.
+        amp_max_time_delta : float or None
+            If set, the gap limit used for amplitude. Default is None, which uses the
+            value set for `max_time_delta`.
+        pha_max_time_delta : float or None
+            If set, the gap limit used for phase. Default is None, which uses the value
+            set for `max_time_delta`.
+        old_var : ndarray of float or None
+            Additional variables to fit against when the kind is "poly", shape
+            (Nvar, Ntimes). Note that time is always included as a fit variable, and
+            does not need to be supplied here. Default is None.
+        new_var : ndarray of float or None
+            Values of those variables at `new_times`, shape (Nvar, Nnew). Required if
+            `old_var` is set.
+        inplace : bool
+            If True, modify this object, otherwise return a modified copy. Default is
+            False.
+        run_check : bool
+            Option to check for the existence and proper shapes of parameters after
+            interpolating. Default is True.
+        check_extra : bool
+            Option to check optional parameters as well as required ones. Default is
+            True.
+        run_check_acceptability : bool
+            Option to check acceptable range of the values of parameters after
+            interpolating. Default is True.
+
+        Returns
+        -------
+        UVCal object or None
+            The interpolated object, or None if `inplace` is True.
+
+        Raises
+        ------
+        ValueError
+            If the object records time_range rather than time_array, since
+            interpolation needs discrete times to work from.
+
+        """
+        if self.time_array is None or self.time_range is not None:
+            raise ValueError(
+                "Cannot interpolate an object that records time_range rather than "
+                "time_array, since there are no discrete times to interpolate from."
+            )
+
+        # Check if the refant changes in time, and if so, throw a warning (since it may
+        # introduce discontinuities in phase).
+        if (
+            self.ref_antenna_array is not None
+            and len(np.unique(self.ref_antenna_array)) > 1
+        ):
+            warnings.warn(
+                "Different reference antennas are used at different times, so the "
+                "solutions are not all on a common phase reference, and therefore may "
+                "introduce errors in the interpolated values."
+            )
+
+        cal_object = self if inplace else self.copy()
+        is_gain = cal_object.cal_type == "gain"
+
+        new_times = np.asarray(new_times, dtype=float)
+        old_times = cal_object.time_array
+
+        if is_gain:
+            interp_mode = "complex" if use_complex_interp else "ampphase"
+            old_cal = cal_object.gain_array
+        else:
+            # Delays are real-valued, so there is nothing to split apart.
+            interp_mode = "real"
+            old_cal = cal_object.delay_array
+
+        new_cal, new_flags = utils.gain_interpolate.time_interp_cal(
+            old_times,
+            old_cal,
+            cal_object.flag_array,
+            new_times,
+            interp_mode=interp_mode,
+            kind=kind,
+            amp_kind=amp_kind,
+            pha_kind=pha_kind,
+            poly_order=poly_order,
+            amp_poly_order=amp_poly_order,
+            pha_poly_order=pha_poly_order,
+            flag_nearest=flag_nearest,
+            allow_extrapolation=allow_extrapolation,
+            flag_delta=flag_delta,
+            amp_flag_delta=amp_flag_delta,
+            pha_flag_delta=pha_flag_delta,
+            max_time_delta=max_time_delta,
+            amp_max_time_delta=amp_max_time_delta,
+            pha_max_time_delta=pha_max_time_delta,
+            old_var=old_var,
+            new_var=new_var,
+        )
+
+        cal_object.time_array = new_times
+        cal_object.Ntimes = len(new_times)
+        cal_object.flag_array = new_flags
+        if is_gain:
+            cal_object.gain_array = new_cal
+        else:
+            cal_object.delay_array = new_cal
+
+        # Integration time and refant can't be interpolated, so carry it over from
+        # whichever old time each new time sits closest to.
+        near_idx = np.argmin(
+            np.abs(new_times[:, np.newaxis] - old_times[np.newaxis, :]), axis=1
+        )
+
+        for name in ["integration_time", "ref_antenna_array"]:
+            if getattr(cal_object, name) is not None:
+                setattr(cal_object, name, getattr(cal_object, name)[near_idx])
+
+        # Quality arrays are no longer sensical, given that they describe the quality
+        # of the original solns -- dump them now. The same goes for scan numbers and
+        # phase centers IDs per time interval (though the phase catalog is left
+        # untouched).
+        cal_object.quality_array = None
+        cal_object.total_quality_array = None
+        cal_object.phase_center_id_array = None
+        cal_object.scan_number_array = None
+
+        # Set LSTs directly rather than interpolating
+        cal_object.set_lsts_from_time_array()
+
+        if run_check:
+            cal_object.check(
+                check_extra=check_extra, run_check_acceptability=run_check_acceptability
+            )
+
+        return None if inplace else cal_object
+
     @classmethod
     @combine_docstrings(initializers.new_uvcal_from_uvdata)
     def initialize_from_uvdata(

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -6569,6 +6569,9 @@ class UVData(UVBase):
             list of baseline-time indices to keep. Can be None (to keep everything).
         freq_inds : list of int
             list of frequency indices to keep. Can be None (to keep everything).
+        spw_inds : list of int
+            list of spectral window indices to keep. Can be None (to keep
+            everything).
         pol_inds : list of int
             list of polarization indices to keep. Can be None (to keep everything).
         history_update_string : str

--- a/src/pyuvdata/uvflag/uvflag.py
+++ b/src/pyuvdata/uvflag/uvflag.py
@@ -2489,11 +2489,17 @@ class UVFlag(UVBase):
         -------
         blt_inds : list of int
             list of baseline-time indices to keep. Can be None (to keep everything).
+        time_inds : list of int
+            list of time indices to keep. Can be None (to keep everything; only
+            valid for "waterfall" and "antenna" modes).
         ant_inds : list of int
             list of antenna number indices to keep. Can be None
             (keep all; only valid for "antenna" mode).
         freq_inds : list of int
             list of frequency indices to keep. Can be None (to keep everything).
+        spw_inds : list of int
+            list of spectral window indices to keep. Can be None (to keep
+            everything).
         pol_inds : list of int
             list of polarization indices to keep. Can be None (to keep everything).
         history_update_string : str

--- a/tests/utils/test_gain_interpolate.py
+++ b/tests/utils/test_gain_interpolate.py
@@ -1,0 +1,906 @@
+# Copyright (c) 2026 Radio Astronomy Software Group
+# Licensed under the 2-clause BSD License
+
+"""Tests for gain interpolation utility functions.
+
+Performs a series of tests on the routines used to interpolate calibration solutions
+onto a new set of times, covering the individual interpolation kernels, the flagging
+that accompanies them, and the user-facing entry point that ties the two together.
+"""
+
+import numpy as np
+import pytest
+from scipy.interpolate import PchipInterpolator
+
+import pyuvdata.utils.gain_interpolate as gi_utils
+
+# Array dimensions used throughout, kept small so that the jit-disabled CI job, which
+# runs everything through the python interpreter, stays quick.
+NANTS = 3
+NFREQS = 2
+NTIMES = 12
+NJONES = 2
+NNEW = 7
+
+
+@pytest.fixture(scope="module")
+def old_times():
+    return np.linspace(0.0, 1.0, NTIMES)
+
+
+@pytest.fixture(scope="module")
+def new_times():
+    # Interior only, so that the extrapolation flags stay clear unless a test asks
+    # for them.
+    return np.linspace(0.05, 0.95, NNEW)
+
+
+@pytest.fixture(scope="module")
+def gain_array(old_times):
+    """Smooth complex gains, varying in both amplitude and phase."""
+    amp = 1.0 + 0.3 * np.sin(2 * np.pi * old_times)
+    pha = 0.5 * np.cos(2 * np.pi * old_times)
+    gains = amp * np.exp(1j * pha)
+    return np.broadcast_to(
+        gains[None, None, :, None], (NANTS, NFREQS, NTIMES, NJONES)
+    ).copy()
+
+
+@pytest.fixture(scope="module")
+def delay_array(old_times):
+    """Smooth real-valued solutions, standing in for delays."""
+    vals = 2.0 - (3.0 * old_times) + (5.0 * old_times**2)
+    return np.broadcast_to(
+        vals[None, None, :, None], (NANTS, NFREQS, NTIMES, NJONES)
+    ).copy()
+
+
+@pytest.fixture(scope="module")
+def blank_flags():
+    return np.zeros((NANTS, NFREQS, NTIMES, NJONES), dtype=bool)
+
+
+def make_flags(partial=(), dead=()):
+    """Build a flag array, partly flagging some solutions and fully flagging others."""
+    flags = np.zeros((NANTS, NFREQS, NTIMES, NJONES), dtype=bool)
+    for ant, freq, jones in partial:
+        flags[ant, freq, 2:5, jones] = True
+    for ant, freq, jones in dead:
+        flags[ant, freq, :, jones] = True
+    return flags
+
+
+def test_flag_outlier_cal_spike(delay_array):
+    """An isolated outlier is caught, and nothing else is."""
+    cal_array = delay_array.copy()
+    cal_array[0, 0, 5, 0] += 10.0
+
+    new_flags = gi_utils._flag_outlier_cal(cal_array, 2.0)
+
+    assert new_flags[0, 0, 5, 0]
+    new_flags[0, 0, 5, 0] = False
+    assert not new_flags.any()
+
+
+def test_flag_outlier_cal_smooth(delay_array):
+    assert not gi_utils._flag_outlier_cal(delay_array, 2.0).any()
+
+
+def test_flag_outlier_cal_nan(delay_array):
+    cal_array = delay_array.copy()
+    cal_array[1, 1, 7, 1] = np.nan
+
+    assert gi_utils._flag_outlier_cal(cal_array, 2.0)[1, 1, 7, 1]
+
+
+def test_flag_outlier_cal_edges(delay_array):
+    """Outliers at the first and last sample are caught too."""
+    cal_array = delay_array.copy()
+    cal_array[0, 0, 0, 0] += 10.0
+    cal_array[0, 0, -1, 0] += 10.0
+
+    new_flags = gi_utils._flag_outlier_cal(cal_array, 2.0)
+
+    assert new_flags[0, 0, 0, 0]
+    assert new_flags[0, 0, -1, 0]
+
+
+@pytest.mark.parametrize("is_gain_amp,is_gain_pha", [[True, False], [False, True]])
+def test_flag_outlier_cal_gain(gain_array, is_gain_amp, is_gain_pha):
+    """Both gain modes see a large excursion in amp and phase."""
+    cal_array = gain_array.copy()
+    cal_array[0, 1, 6, 0] *= 5.0 * np.exp(1j * 2.0)
+
+    new_flags = gi_utils._flag_outlier_cal(
+        cal_array, 0.5, is_gain_amp=is_gain_amp, is_gain_pha=is_gain_pha
+    )
+
+    assert new_flags[0, 1, 6, 0]
+
+
+@pytest.mark.parametrize("gain_kwarg", ["is_gain_amp", "is_gain_pha"])
+def test_flag_outlier_cal_zeros(gain_array, gain_kwarg):
+    """Zeros are flagged, and the caller's array left alone."""
+    cal_array = gain_array.copy()
+    cal_array[2, 0, 4, 1] = 0.0
+    exp_array = cal_array.copy()
+
+    new_flags = gi_utils._flag_outlier_cal(cal_array, 0.5, **{gain_kwarg: True})
+
+    assert new_flags[2, 0, 4, 1]
+    # The zero is swapped for a NaN internally, which must not reach the caller.
+    np.testing.assert_array_equal(exp_array, cal_array)
+
+
+@pytest.mark.parametrize("gain_kwarg", ["is_gain_amp", "is_gain_pha"])
+def test_flag_outlier_cal_errs(delay_array, gain_kwarg):
+    with pytest.raises(ValueError, match="cal_array must be complex"):
+        gi_utils._flag_outlier_cal(delay_array, 0.5, **{gain_kwarg: True})
+
+
+def test_build_interp_flags_clean(delay_array, blank_flags, old_times, new_times):
+    new_flags = gi_utils.build_interp_flags(
+        delay_array, blank_flags, old_times, new_times
+    )
+
+    assert new_flags.shape == (NANTS, NFREQS, NNEW, NJONES)
+    assert not new_flags.any()
+
+
+def test_build_interp_flags_adjacent(delay_array, old_times, new_times):
+    """flag_adjacent widens the flags around a flagged sample."""
+    flags = make_flags(partial=[[0, 0, 0]])
+
+    with_adjacent = gi_utils.build_interp_flags(
+        delay_array, flags, old_times, new_times, flag_adjacent=True
+    )
+    without = gi_utils.build_interp_flags(
+        delay_array, flags, old_times, new_times, flag_adjacent=False
+    )
+
+    assert with_adjacent[0, 0, :, 0].sum() > without[0, 0, :, 0].sum()
+    assert not with_adjacent[1, 1, :, 1].any()
+
+
+def test_build_interp_flags_single_time(delay_array):
+    flags = np.zeros((NANTS, NFREQS, 1, NJONES), dtype=bool)
+    flags[0, 0, 0, 0] = True
+
+    new_flags = gi_utils.build_interp_flags(
+        delay_array[:, :, :1, :], flags, np.array([0.5]), np.linspace(0, 1, NNEW)
+    )
+
+    assert new_flags.shape == (NANTS, NFREQS, NNEW, NJONES)
+    assert new_flags[0, 0, :, 0].all()
+    assert not new_flags[1, 1, :, 1].any()
+
+
+def test_build_interp_flags_no_times(delay_array):
+    flags = np.zeros((NANTS, NFREQS, 0, NJONES), dtype=bool)
+
+    new_flags = gi_utils.build_interp_flags(
+        delay_array[:, :, :0, :], flags, np.array([]), np.linspace(0, 1, NNEW)
+    )
+
+    assert new_flags.shape == (NANTS, NFREQS, NNEW, NJONES)
+    assert new_flags.all()
+
+
+def test_build_interp_flags_unsorted(delay_array, blank_flags, old_times, new_times):
+    """Time-reversed input gets sorted internally, and agrees."""
+    sort_idx = np.argsort(old_times)[::-1]
+
+    exp_flags = gi_utils.build_interp_flags(
+        delay_array, blank_flags, old_times, new_times
+    )
+    new_flags = gi_utils.build_interp_flags(
+        delay_array[:, :, sort_idx, :],
+        blank_flags[:, :, sort_idx, :],
+        old_times[sort_idx],
+        new_times,
+    )
+
+    np.testing.assert_array_equal(exp_flags, new_flags)
+
+
+def test_build_interp_flags_tol_lim(delay_array, blank_flags, old_times, new_times):
+    cal_array = delay_array.copy()
+    cal_array[0, 0, 6:, 0] += 50.0
+
+    new_flags = gi_utils.build_interp_flags(
+        cal_array, blank_flags, old_times, new_times, tol_lim=1.0
+    )
+
+    assert new_flags[0, 0, :, 0].any()
+    assert not new_flags[1, 1, :, 1].any()
+
+
+@pytest.mark.parametrize("is_gain_amp,is_gain_pha", [[True, False], [False, True]])
+def test_build_interp_flags_gain(
+    gain_array, blank_flags, old_times, new_times, is_gain_amp, is_gain_pha
+):
+    """Test the amplitude and phase forms of the tol_lim check."""
+    cal_array = gain_array.copy()
+    cal_array[0, 0, 6:, 0] *= 5.0 * np.exp(1j * 2.0)
+
+    new_flags = gi_utils.build_interp_flags(
+        cal_array,
+        blank_flags,
+        old_times,
+        new_times,
+        tol_lim=0.5,
+        is_gain_amp=is_gain_amp,
+        is_gain_pha=is_gain_pha,
+    )
+
+    assert new_flags[0, 0, :, 0].any()
+    assert not new_flags[1, 1, :, 1].any()
+
+
+def test_build_interp_flags_max_time_delta(
+    delay_array, blank_flags, old_times, new_times
+):
+    loose = gi_utils.build_interp_flags(
+        delay_array, blank_flags, old_times, new_times, max_time_delta=1.0
+    )
+    tight = gi_utils.build_interp_flags(
+        delay_array, blank_flags, old_times, new_times, max_time_delta=1e-6
+    )
+
+    assert not loose.any()
+    assert tight.all()
+
+
+@pytest.mark.parametrize("allow_extrapolation", [True, False])
+def test_build_interp_flags_extrapolation(
+    delay_array, blank_flags, old_times, allow_extrapolation
+):
+    """A new time landing on an old one is not extrapolated."""
+    probe_times = np.array([old_times[0] - 0.5, old_times[0], old_times[-1], 1.5])
+
+    new_flags = gi_utils.build_interp_flags(
+        delay_array,
+        blank_flags,
+        old_times,
+        probe_times,
+        allow_extrapolation=allow_extrapolation,
+    )
+
+    exp_flags = [not allow_extrapolation, False, False, not allow_extrapolation]
+    np.testing.assert_array_equal(new_flags[0, 0, :, 0], exp_flags)
+
+
+@pytest.mark.parametrize("gain_kwarg", ["is_gain_amp", "is_gain_pha"])
+def test_build_interp_flags_errs(
+    delay_array, blank_flags, old_times, new_times, gain_kwarg
+):
+    with pytest.raises(ValueError, match="cal_array must be complex"):
+        gi_utils.build_interp_flags(
+            delay_array, blank_flags, old_times, new_times, **{gain_kwarg: True}
+        )
+
+
+@pytest.mark.parametrize(
+    "interp_func", [gi_utils._interp_linear_cal, gi_utils._interp_nearest_cal]
+)
+def test_interp_simple_roundtrip(interp_func, delay_array, blank_flags, old_times):
+    new_cal = interp_func(old_times, delay_array, blank_flags, old_times)
+
+    np.testing.assert_allclose(new_cal, delay_array)
+
+
+@pytest.mark.parametrize(
+    "interp_func", [gi_utils._interp_linear_cal, gi_utils._interp_nearest_cal]
+)
+@pytest.mark.parametrize("ignore_flags", [True, False])
+def test_interp_simple_flags(
+    interp_func, delay_array, old_times, new_times, ignore_flags
+):
+    """Flagged samples are dropped unless ignore_flags is set."""
+    flags = make_flags(partial=[[0, 0, 0]], dead=[[1, 1, 1]])
+
+    new_cal = interp_func(old_times, delay_array, flags, new_times, ignore_flags)
+
+    assert new_cal.shape == (NANTS, NFREQS, NNEW, NJONES)
+    if ignore_flags:
+        assert np.isfinite(new_cal).all()
+    else:
+        # Nothing left to work from on the fully flagged solution.
+        assert np.isnan(new_cal[1, 1, :, 1]).all()
+        assert np.isfinite(new_cal[2, 0, :, 0]).all()
+
+
+def test_interp_linear_cal(delay_array, blank_flags, old_times, new_times):
+    """Test the linear interpolation against np.interp."""
+    new_cal = gi_utils._interp_linear_cal(
+        old_times, delay_array, blank_flags, new_times
+    )
+
+    exp_cal = np.interp(new_times, old_times, delay_array[0, 0, :, 0])
+    np.testing.assert_allclose(new_cal[0, 0, :, 0], exp_cal)
+
+
+def test_interp_nearest_cal(delay_array, blank_flags, old_times):
+    """The nearest sample is picked, nudging just off each old time."""
+    probe_times = old_times[:-1] + (0.01 * np.diff(old_times))
+
+    new_cal = gi_utils._interp_nearest_cal(
+        old_times, delay_array, blank_flags, probe_times
+    )
+
+    np.testing.assert_allclose(new_cal[0, 0, :, 0], delay_array[0, 0, :-1, 0])
+
+
+def test_pchip_slopes_two_points():
+    slopes = gi_utils._pchip_slopes(np.array([2.0]), np.array([3.0]))
+
+    np.testing.assert_allclose(slopes, [3.0, 3.0])
+
+
+@pytest.mark.parametrize(
+    "delta,exp_slope",
+    [
+        [[1.0, -1.0], 0.0],  # secants change sign, so the knot is an extremum
+        [[0.0, 1.0], 0.0],  # a zero secant marks an extremum as well
+        [[1.0, 1.0], 1.0],  # matched secants give the harmonic mean back
+    ],
+)
+def test_pchip_slopes_extrema(delta, exp_slope):
+    """Test how an interior knot responds to the adjacent secants."""
+    slopes = gi_utils._pchip_slopes(np.ones(2), np.array(delta))
+
+    assert slopes[1] == exp_slope
+
+
+def test_pchip_slopes_signed_zeros():
+    """Verify that -0.0 and 0.0 secants both count as flat.
+
+    The sign product is used rather than a direct comparison precisely because
+    np.sign(-0.0) == np.sign(0.0), which would otherwise divide by zero here.
+    """
+    slopes = gi_utils._pchip_slopes(np.ones(3), np.array([-0.0, 0.0, -0.0]))
+
+    assert np.isfinite(slopes).all()
+
+
+def test_pchip_slopes_endpoint_limit():
+    """An overshooting endpoint estimate is capped at three secants."""
+    # The raw estimate here is 6.5 against a 3.0 cap.
+    delta = np.array([1.0, -10.0])
+
+    slopes = gi_utils._pchip_slopes(np.ones(2), delta)
+
+    assert slopes[0] == 3 * delta[0]
+
+
+@pytest.mark.parametrize("style", ["noise", "increasing", "flat", "plateau"])
+def test_interp_pchip(style):
+    """Test the cubic kernel against scipy, over a range of data shapes."""
+    rng = np.random.default_rng(42)
+    x = np.sort(rng.uniform(0, 10, NTIMES))
+    if style == "noise":
+        y = rng.normal(size=NTIMES)
+    elif style == "increasing":
+        y = np.sort(rng.uniform(size=NTIMES))
+    elif style == "flat":
+        y = np.zeros(NTIMES)
+    else:
+        y = np.repeat(rng.normal(size=(NTIMES + 1) // 2), 2)[:NTIMES]
+
+    # Knots, interior points, and a point off each end.
+    xq = np.concatenate([x, x[:-1] + (np.diff(x) / 3), [x[0] - 1.0, x[-1] + 1.0]])
+
+    np.testing.assert_allclose(
+        gi_utils._interp_pchip(x, y, xq),
+        PchipInterpolator(x, y, extrapolate=True)(xq),
+        atol=1e-10,
+    )
+
+
+def test_interp_pchip_4d(gain_array, old_times, new_times):
+    """The batched cubic agrees with going solution by solution."""
+    cal_array = np.abs(gain_array)
+
+    new_cal = gi_utils._interp_pchip_4d(old_times, cal_array, new_times)
+
+    for ant in range(NANTS):
+        for freq in range(NFREQS):
+            for jones in range(NJONES):
+                np.testing.assert_allclose(
+                    new_cal[ant, freq, :, jones],
+                    gi_utils._interp_pchip(
+                        old_times,
+                        np.ascontiguousarray(cal_array[ant, freq, :, jones]),
+                        new_times,
+                    ),
+                )
+
+
+def test_interp_cubic_cal_roundtrip(delay_array, blank_flags, old_times):
+    new_cal = gi_utils._interp_cubic_cal(old_times, delay_array, blank_flags, old_times)
+
+    np.testing.assert_allclose(new_cal, delay_array)
+
+
+def test_interp_cubic_cal_short_track(delay_array, old_times):
+    n_keep = gi_utils._MIN_CUBIC_SAMPLES - 1
+    flags = np.zeros((NANTS, NFREQS, n_keep, NJONES), dtype=bool)
+
+    new_cal = gi_utils._interp_cubic_cal(
+        old_times[:n_keep],
+        delay_array[:, :, :n_keep, :],
+        flags,
+        np.linspace(0, 1, NNEW),
+    )
+
+    assert np.isnan(new_cal).all()
+
+
+def test_interp_cubic_cal_flags(delay_array, old_times, new_times):
+    """Partly flagged solutions get refit, dead ones get blanked."""
+    flags = make_flags(partial=[[0, 0, 0]], dead=[[1, 1, 1]])
+
+    new_cal = gi_utils._interp_cubic_cal(old_times, delay_array, flags, new_times)
+
+    assert np.isnan(new_cal[1, 1, :, 1]).all()
+    assert np.isfinite(new_cal[0, 0, :, 0]).all()
+    assert np.isfinite(new_cal[2, 0, :, 0]).all()
+
+
+def test_interp_cubic_cal_no_clean_solns(delay_array, old_times, new_times):
+    """With no clean solution, the batched pass is skipped entirely."""
+    flags = np.zeros((NANTS, NFREQS, NTIMES, NJONES), dtype=bool)
+    flags[:, :, 0, :] = True
+
+    new_cal = gi_utils._interp_cubic_cal(old_times, delay_array, flags, new_times)
+
+    assert np.isfinite(new_cal).all()
+
+
+def test_interp_cubic_cal_starved(delay_array, old_times, new_times):
+    flags = np.zeros((NANTS, NFREQS, NTIMES, NJONES), dtype=bool)
+    flags[0, 0, gi_utils._MIN_CUBIC_SAMPLES - 1 :, 0] = True
+
+    new_cal = gi_utils._interp_cubic_cal(old_times, delay_array, flags, new_times)
+
+    assert np.isnan(new_cal[0, 0, :, 0]).all()
+    assert np.isfinite(new_cal[1, 1, :, 1]).all()
+
+
+def test_prep_matrix_poly_lsqfit_cal(old_times, new_times):
+    """The fit matrix holds Chebyshev polynomials of the first kind."""
+    order = 5
+    xval_matrix, eval_matrix = gi_utils._prep_matrix_poly_lsqfit_cal(
+        old_times.reshape(1, -1), new_times.reshape(1, -1), np.array([order])
+    )
+
+    lo_val, hi_val = old_times.min(), old_times.max()
+    old_norm = (2 * (old_times - lo_val) / (hi_val - lo_val)) - 1
+    exp_matrix = np.column_stack(
+        [np.polynomial.chebyshev.Chebyshev.basis(k)(old_norm) for k in range(order + 1)]
+    )
+
+    np.testing.assert_allclose(xval_matrix, exp_matrix, atol=1e-12)
+    assert eval_matrix.shape == (NNEW, order + 1)
+
+
+def test_prep_matrix_poly_lsqfit_cal_zero_order(old_times, new_times):
+    xval_matrix, _ = gi_utils._prep_matrix_poly_lsqfit_cal(
+        np.vstack([old_times, np.ones(NTIMES)]),
+        np.vstack([new_times, np.ones(NNEW)]),
+        np.array([2, 0]),
+    )
+
+    # Just the constant plus the two time terms.
+    assert xval_matrix.shape == (NTIMES, 3)
+
+
+def test_interp_lsqfit_cal_partial_flags(delay_array, old_times):
+    """Test the masked branch, where the fit matrix is cut down."""
+    flags = make_flags(partial=[[0, 0, 0]])
+    xval_matrix = np.column_stack([np.ones(NTIMES), old_times, old_times**2])
+    new_norm = np.linspace(0, 1, NNEW)
+    eval_matrix = np.column_stack([np.ones(NNEW), new_norm, new_norm**2])
+
+    new_cal = gi_utils._interp_lsqfit_cal(delay_array, flags, xval_matrix, eval_matrix)
+
+    assert np.isfinite(new_cal).all()
+
+
+def test_interp_lsqfit_cal_singular(delay_array, blank_flags, old_times):
+    xval_matrix = np.ones((NTIMES, 3))
+    xval_matrix[:, 1] = old_times
+    # Duplicate a column, so that the normal-equation matrix is singular.
+    xval_matrix[:, 2] = xval_matrix[:, 1]
+
+    new_cal = gi_utils._interp_lsqfit_cal(
+        delay_array, blank_flags, xval_matrix, np.ones((NNEW, 3))
+    )
+
+    assert np.isnan(new_cal).all()
+
+
+@pytest.mark.parametrize("order", [1, 2, 3, 5])
+def test_interp_poly_cal(old_times, new_times, order):
+    """A known polynomial is recovered, flags and all."""
+    lo_val, hi_val = old_times.min(), old_times.max()
+    old_norm = (2 * (old_times - lo_val) / (hi_val - lo_val)) - 1
+    new_norm = (2 * (new_times - lo_val) / (hi_val - lo_val)) - 1
+
+    rng = np.random.default_rng(7)
+    coeffs = rng.normal(size=order + 1)
+    old_vals = sum(coeffs[p] * old_norm**p for p in range(order + 1))
+    exp_vals = sum(coeffs[p] * new_norm**p for p in range(order + 1))
+
+    cal_array = np.broadcast_to(
+        old_vals[None, None, :, None], (NANTS, NFREQS, NTIMES, NJONES)
+    ).copy()
+
+    new_cal = gi_utils._interp_poly_cal(
+        cal_array,
+        make_flags(partial=[[0, 0, 0]]),
+        old_times.reshape(1, -1),
+        new_times.reshape(1, -1),
+        np.array([order]),
+    )
+
+    np.testing.assert_allclose(new_cal[0, 0, :, 0], exp_vals, atol=1e-10)
+    np.testing.assert_allclose(new_cal[1, 1, :, 1], exp_vals, atol=1e-10)
+
+
+def test_interp_poly_cal_multivar(delay_array, blank_flags, old_times, new_times):
+    new_cal = gi_utils._interp_poly_cal(
+        delay_array,
+        blank_flags,
+        np.vstack([old_times, np.sin(3 * old_times)]),
+        np.vstack([new_times, np.sin(3 * new_times)]),
+        np.array([2, 1]),
+    )
+
+    assert new_cal.shape == (NANTS, NFREQS, NNEW, NJONES)
+    assert np.isfinite(new_cal).all()
+
+
+def test_interp_poly_cal_starved(delay_array, old_times, new_times):
+    flags = np.zeros((NANTS, NFREQS, NTIMES, NJONES), dtype=bool)
+    flags[0, 0, 2:, 0] = True
+
+    new_cal = gi_utils._interp_poly_cal(
+        delay_array,
+        flags,
+        old_times.reshape(1, -1),
+        new_times.reshape(1, -1),
+        np.array([3]),
+    )
+
+    assert np.isnan(new_cal[0, 0, :, 0]).all()
+    assert np.isfinite(new_cal[1, 1, :, 1]).all()
+
+
+def test_interp_poly_cal_errs(delay_array, blank_flags, old_times, new_times):
+    with pytest.raises(ValueError, match="order cannot be negative."):
+        gi_utils._interp_poly_cal(
+            delay_array,
+            blank_flags,
+            old_times.reshape(1, -1),
+            new_times.reshape(1, -1),
+            np.array([-1]),
+        )
+
+    with pytest.raises(
+        ValueError, match="Length of order must match the first dimension"
+    ):
+        gi_utils._interp_poly_cal(
+            delay_array,
+            blank_flags,
+            old_times.reshape(1, -1),
+            new_times.reshape(1, -1),
+            np.array([2, 2]),
+        )
+
+    with pytest.raises(
+        ValueError, match="old_var and new_var must contain the same number"
+    ):
+        gi_utils._interp_poly_cal(
+            delay_array,
+            blank_flags,
+            np.vstack([old_times, old_times]),
+            new_times.reshape(1, -1),
+            np.array([2, 2]),
+        )
+
+    with pytest.raises(ValueError, match="Variable 1 is constant"):
+        gi_utils._interp_poly_cal(
+            delay_array,
+            blank_flags,
+            np.vstack([old_times, np.ones(NTIMES)]),
+            np.vstack([new_times, np.ones(NNEW)]),
+            np.array([2, 1]),
+        )
+
+
+@pytest.mark.parametrize("mode", ["real", "amp"])
+def test_interp_dispatcher_update(gain_array, blank_flags, old_times, new_times, mode):
+    """Verify the second-pass branches, which fold into an existing array.
+
+    time_interp_cal always runs real before imag and amp before phase, so these two
+    branches are only reachable by driving the dispatcher directly.
+    """
+    new_cal = np.ones((NANTS, NFREQS, NNEW, NJONES), dtype=complex)
+
+    out_cal, out_flags = gi_utils._interp_dispatcher(
+        mode=mode,
+        old_times=old_times,
+        old_cal=gain_array,
+        old_flags=blank_flags,
+        new_times=new_times,
+        new_cal=new_cal,
+        new_flags=np.zeros((NANTS, NFREQS, NNEW, NJONES), dtype=bool),
+        kind="linear",
+    )
+
+    assert out_flags.shape == (NANTS, NFREQS, NNEW, NJONES)
+    # The array handed in is updated in place rather than replaced.
+    assert out_cal is new_cal
+
+
+def test_interp_dispatcher_errs(gain_array, blank_flags, old_times, new_times):
+    disp_kwargs = {
+        "old_times": old_times,
+        "old_cal": gain_array,
+        "old_flags": blank_flags,
+        "new_times": new_times,
+    }
+
+    with pytest.raises(ValueError, match="Unrecognised mode 'foo'"):
+        gi_utils._interp_dispatcher(mode="foo", kind="linear", **disp_kwargs)
+
+    with pytest.raises(ValueError, match="Unrecognised interpolation kind 'foo'"):
+        gi_utils._interp_dispatcher(mode="amp", kind="foo", **disp_kwargs)
+
+
+@pytest.mark.parametrize("kind", ["nearest", "linear", "cubic", "poly"])
+@pytest.mark.parametrize("interp_mode", ["ampphase", "complex", "amp", "phase"])
+def test_time_interp_cal(
+    gain_array, blank_flags, old_times, new_times, kind, interp_mode
+):
+    """Test every kind and mode combination for the expected arrays."""
+    new_cal, new_flags = gi_utils.time_interp_cal(
+        old_times,
+        gain_array,
+        blank_flags,
+        new_times,
+        kind=kind,
+        interp_mode=interp_mode,
+    )
+
+    assert new_cal.shape == (NANTS, NFREQS, NNEW, NJONES)
+    assert new_flags.shape == (NANTS, NFREQS, NNEW, NJONES)
+    assert new_flags.dtype == np.bool_
+    assert np.iscomplexobj(new_cal)
+
+
+@pytest.mark.parametrize("kind", ["nearest", "linear", "cubic"])
+def test_time_interp_cal_roundtrip(gain_array, blank_flags, old_times, kind):
+    new_cal, new_flags = gi_utils.time_interp_cal(
+        old_times, gain_array, blank_flags, old_times, kind=kind
+    )
+
+    np.testing.assert_allclose(new_cal, gain_array, atol=1e-12)
+    assert not new_flags.any()
+
+
+def test_time_interp_cal_real(delay_array, blank_flags, old_times, new_times):
+    new_cal, _ = gi_utils.time_interp_cal(
+        old_times, delay_array, blank_flags, new_times, interp_mode="real"
+    )
+
+    assert new_cal.shape == (NANTS, NFREQS, NNEW, NJONES)
+    assert np.isfinite(new_cal).all()
+
+
+def test_time_interp_cal_imag(gain_array, blank_flags, old_times, new_times):
+    """The imaginary-only mode scales the result by 1j."""
+    new_cal, _ = gi_utils.time_interp_cal(
+        old_times, gain_array, blank_flags, new_times, interp_mode="imag"
+    )
+
+    assert np.iscomplexobj(new_cal)
+    np.testing.assert_allclose(new_cal.real, 0.0, atol=1e-12)
+
+
+@pytest.mark.parametrize("interp_mode", ["complex", "ampphase"])
+def test_time_interp_cal_two_pass(gain_array, blank_flags, old_times, interp_mode):
+    """Both two-pass modes fill the array in on the second call."""
+    new_cal, _ = gi_utils.time_interp_cal(
+        old_times, gain_array, blank_flags, old_times, interp_mode=interp_mode
+    )
+
+    np.testing.assert_allclose(new_cal, gain_array, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "amp_kind,pha_kind", [["cubic", "linear"], ["poly", "nearest"], [None, "poly"]]
+)
+def test_time_interp_cal_split_kind(
+    gain_array, blank_flags, old_times, new_times, amp_kind, pha_kind
+):
+    """Amplitude and phase can be interpolated in different ways."""
+    new_cal, _ = gi_utils.time_interp_cal(
+        old_times,
+        gain_array,
+        blank_flags,
+        new_times,
+        amp_kind=amp_kind,
+        pha_kind=pha_kind,
+    )
+
+    assert np.isfinite(new_cal).all()
+
+
+@pytest.mark.parametrize(
+    "split_kwargs",
+    [
+        {"amp_poly_order": 2, "pha_poly_order": 4},
+        {"pha_flag_delta": 0.25, "pha_max_time_delta": 0.5},
+        {"amp_flag_delta": 0.25, "amp_max_time_delta": 0.5},
+    ],
+)
+def test_time_interp_cal_split_kwargs(
+    gain_array, blank_flags, old_times, new_times, split_kwargs
+):
+    """Test the amp and phase overrides of the shared keywords."""
+    new_cal, new_flags = gi_utils.time_interp_cal(
+        old_times, gain_array, blank_flags, new_times, kind="poly", **split_kwargs
+    )
+
+    assert new_cal.shape == (NANTS, NFREQS, NNEW, NJONES)
+    assert new_flags.shape == (NANTS, NFREQS, NNEW, NJONES)
+
+
+def test_time_interp_cal_var(gain_array, blank_flags, old_times, new_times):
+    """A polynomial fit can take extra variables alongside time."""
+    new_cal, _ = gi_utils.time_interp_cal(
+        old_times,
+        gain_array,
+        blank_flags,
+        new_times,
+        kind="poly",
+        old_var=np.vstack([np.sin(3 * old_times)]),
+        new_var=np.vstack([np.sin(3 * new_times)]),
+        poly_order=[3, 1],
+    )
+
+    assert np.isfinite(new_cal).all()
+
+
+def test_time_interp_cal_fully_flagged(gain_array, old_times, new_times):
+    flags = np.ones((NANTS, NFREQS, NTIMES, NJONES), dtype=bool)
+
+    new_cal, new_flags = gi_utils.time_interp_cal(
+        old_times, gain_array, flags, new_times, kind="cubic"
+    )
+
+    assert new_flags.all()
+    assert np.isnan(new_cal).all()
+
+
+@pytest.mark.parametrize("allow_extrapolation", [True, False])
+def test_time_interp_cal_extrapolation(
+    gain_array, blank_flags, old_times, allow_extrapolation
+):
+    """Only genuinely out-of-range times count as extrapolated."""
+    probe_times = np.array([old_times[0] - 0.5, old_times[0], 0.5, old_times[-1], 1.5])
+
+    _, new_flags = gi_utils.time_interp_cal(
+        old_times,
+        gain_array,
+        blank_flags,
+        probe_times,
+        allow_extrapolation=allow_extrapolation,
+    )
+
+    exp_flags = [not allow_extrapolation, False, False, False, not allow_extrapolation]
+    np.testing.assert_array_equal(new_flags[0, 0, :, 0], exp_flags)
+
+
+def test_time_interp_cal_flag_isolation(gain_array, old_times):
+    """Flagging one solution leaves the others alone."""
+    flags = make_flags(partial=[[0, 0, 0]])
+
+    _, new_flags = gi_utils.time_interp_cal(
+        old_times, gain_array, flags, old_times, kind="linear"
+    )
+
+    assert new_flags[0, 0, :, 0].any()
+    assert not new_flags[1, 1, :, 1].any()
+
+
+@pytest.mark.parametrize(
+    "err_kwargs,err_msg",
+    [
+        [{"interp_mode": "foo"}, "Unrecognised interp_mode 'foo'"],
+        [{"kind": "foo"}, "Unrecognised interpolation kind 'foo'"],
+        [{"amp_kind": "foo"}, "Unrecognised amplitude interpolation kind 'foo'"],
+        [{"pha_kind": "foo"}, "Unrecognised phase interpolation kind 'foo'"],
+    ],
+)
+def test_time_interp_cal_errs(
+    gain_array, blank_flags, old_times, new_times, err_kwargs, err_msg
+):
+    with pytest.raises(ValueError, match=err_msg):
+        gi_utils.time_interp_cal(
+            old_times, gain_array, blank_flags, new_times, **err_kwargs
+        )
+
+
+def test_time_interp_cal_real_input_errs(
+    delay_array, blank_flags, old_times, new_times
+):
+    with pytest.raises(ValueError, match="is not compatible with real-valued old_cal"):
+        gi_utils.time_interp_cal(
+            old_times, delay_array, blank_flags, new_times, interp_mode="ampphase"
+        )
+
+
+@pytest.mark.parametrize("drop_var", ["old_var", "new_var"])
+def test_time_interp_cal_lone_var_errs(
+    gain_array, blank_flags, old_times, new_times, drop_var
+):
+    var_kwargs = {
+        "old_var": np.vstack([np.sin(3 * old_times)]),
+        "new_var": np.vstack([np.sin(3 * new_times)]),
+    }
+    var_kwargs[drop_var] = None
+
+    with pytest.raises(ValueError, match="must either both be set or both be left"):
+        gi_utils.time_interp_cal(
+            old_times, gain_array, blank_flags, new_times, kind="poly", **var_kwargs
+        )
+
+
+@pytest.mark.parametrize(
+    "var_kwargs,err_msg",
+    [
+        [
+            {"old_var": "double_time", "new_var": "time"},
+            "old_var and new_var must contain the same number",
+        ],
+        [
+            {"old_var": "short_time", "new_var": "time"},
+            "old_var must have the same number of entries as old_times",
+        ],
+        [
+            {"old_var": "time", "new_var": "short_time"},
+            "new_var must have the same number of entries as new_times",
+        ],
+        [
+            {"old_var": "sine", "new_var": "sine", "poly_order": [1, 2, 3]},
+            "poly_order must either have 1 value",
+        ],
+        [
+            {"old_var": "sine", "new_var": "sine", "poly_order": "not-a-number"},
+            "invalid literal|could not convert",
+        ],
+    ],
+)
+def test_time_interp_cal_var_errs(
+    gain_array, blank_flags, old_times, new_times, var_kwargs, err_msg
+):
+    var_lookup = {
+        "time": [np.vstack([old_times]), np.vstack([new_times])],
+        "double_time": [np.vstack([old_times] * 2), np.vstack([new_times] * 2)],
+        "short_time": [np.vstack([old_times[:-1]]), np.vstack([new_times[:-1]])],
+        "sine": [
+            np.vstack([np.sin(3 * old_times)]),
+            np.vstack([np.sin(3 * new_times)]),
+        ],
+    }
+    var_kwargs = dict(var_kwargs)
+    var_kwargs["old_var"] = var_lookup[var_kwargs["old_var"]][0]
+    var_kwargs["new_var"] = var_lookup[var_kwargs["new_var"]][1]
+
+    with pytest.raises(ValueError, match=err_msg):
+        gi_utils.time_interp_cal(
+            old_times, gain_array, blank_flags, new_times, kind="poly", **var_kwargs
+        )

--- a/tests/utils/test_gain_interpolate.py
+++ b/tests/utils/test_gain_interpolate.py
@@ -904,3 +904,22 @@ def test_time_interp_cal_var_errs(
         gi_utils.time_interp_cal(
             old_times, gain_array, blank_flags, new_times, kind="poly", **var_kwargs
         )
+
+
+@pytest.mark.parametrize("kind,kwargs", [["cubic", {}], ["poly", {"poly_order": 3}]])
+def test_time_interp_cal_undersupplied_flags_nans(
+    gain_array, blank_flags, old_times, new_times, kind, kwargs
+):
+    # Verify that cubin/poly interpolation with too few solns get flagged
+    few = slice(0, 3)
+    new_cal, new_flags = gi_utils.time_interp_cal(
+        old_times[few],
+        gain_array[:, :, few],
+        blank_flags[:, :, few],
+        new_times,
+        kind=kind,
+        **kwargs,
+    )
+
+    assert not np.all(np.isfinite(new_cal)), "expected this case to produce NaN"
+    assert np.all(new_flags[~np.isfinite(new_cal)])

--- a/tests/utils/test_gain_interpolate.py
+++ b/tests/utils/test_gain_interpolate.py
@@ -449,12 +449,44 @@ def test_interp_cubic_cal_flags(delay_array, old_times, new_times):
 
 def test_interp_cubic_cal_no_clean_solns(delay_array, old_times, new_times):
     """With no clean solution, the batched pass is skipped entirely."""
+    # Flag a different time for every solution, so that no solution is left clean while
+    # no single time is dead across the whole array (which would just get dropped).
+    flags = np.zeros((NANTS, NFREQS, NTIMES, NJONES), dtype=bool)
+    for idx, (ant, freq, jones) in enumerate(np.ndindex(NANTS, NFREQS, NJONES)):
+        flags[ant, freq, idx % NTIMES, jones] = True
+
+    assert not np.any(np.all(flags, axis=(0, 1, 3)))  # No time dead array-wide
+    assert not np.any(np.sum(~flags, axis=2) == NTIMES)  # No solution left clean
+
+    new_cal = gi_utils._interp_cubic_cal(old_times, delay_array, flags, new_times)
+
+    # Every solution has to be refit off the blank (NaN-filled) array.
+    assert np.isfinite(new_cal).all()
+
+    # Dropping one of twelve knots leaves the fit close to, but not exactly on, the
+    # smooth function the solutions were built from.
+    truth = np.broadcast_to(
+        (2.0 - (3.0 * new_times) + (5.0 * new_times**2))[None, None, :, None],
+        new_cal.shape,
+    )
+    np.testing.assert_allclose(new_cal, truth, rtol=0.05)
+
+
+def test_interp_cubic_cal_drops_dead_times(delay_array, old_times, new_times):
+    """Times that are flagged array-wide drop out without changing the result."""
     flags = np.zeros((NANTS, NFREQS, NTIMES, NJONES), dtype=bool)
     flags[:, :, 0, :] = True
 
     new_cal = gi_utils._interp_cubic_cal(old_times, delay_array, flags, new_times)
 
+    # Dropping the dead time is an optimization, so the answer has to match what comes
+    # back when that time was never handed over in the first place.
+    ref_cal = gi_utils._interp_cubic_cal(
+        old_times[1:], delay_array[:, :, 1:, :], flags[:, :, 1:, :], new_times
+    )
+
     assert np.isfinite(new_cal).all()
+    np.testing.assert_allclose(new_cal, ref_cal)
 
 
 def test_interp_cubic_cal_starved(delay_array, old_times, new_times):
@@ -659,7 +691,7 @@ def test_interp_dispatcher_errs(gain_array, blank_flags, old_times, new_times):
         gi_utils._interp_dispatcher(mode="amp", kind="foo", **disp_kwargs)
 
 
-@pytest.mark.parametrize("kind", ["nearest", "linear", "cubic", "poly"])
+@pytest.mark.parametrize("kind", ["nearest", "linear", "cubic", "chebyshev"])
 @pytest.mark.parametrize("interp_mode", ["ampphase", "complex", "amp", "phase"])
 def test_time_interp_cal(
     gain_array, blank_flags, old_times, new_times, kind, interp_mode
@@ -720,7 +752,8 @@ def test_time_interp_cal_two_pass(gain_array, blank_flags, old_times, interp_mod
 
 
 @pytest.mark.parametrize(
-    "amp_kind,pha_kind", [["cubic", "linear"], ["poly", "nearest"], [None, "poly"]]
+    "amp_kind,pha_kind",
+    [["cubic", "linear"], ["chebyshev", "nearest"], [None, "chebyshev"]],
 )
 def test_time_interp_cal_split_kind(
     gain_array, blank_flags, old_times, new_times, amp_kind, pha_kind
@@ -751,7 +784,7 @@ def test_time_interp_cal_split_kwargs(
 ):
     """Test the amp and phase overrides of the shared keywords."""
     new_cal, new_flags = gi_utils.time_interp_cal(
-        old_times, gain_array, blank_flags, new_times, kind="poly", **split_kwargs
+        old_times, gain_array, blank_flags, new_times, kind="chebyshev", **split_kwargs
     )
 
     assert new_cal.shape == (NANTS, NFREQS, NNEW, NJONES)
@@ -765,7 +798,7 @@ def test_time_interp_cal_var(gain_array, blank_flags, old_times, new_times):
         gain_array,
         blank_flags,
         new_times,
-        kind="poly",
+        kind="chebyshev",
         old_var=np.vstack([np.sin(3 * old_times)]),
         new_var=np.vstack([np.sin(3 * new_times)]),
         poly_order=[3, 1],
@@ -855,7 +888,12 @@ def test_time_interp_cal_lone_var_errs(
 
     with pytest.raises(ValueError, match="must either both be set or both be left"):
         gi_utils.time_interp_cal(
-            old_times, gain_array, blank_flags, new_times, kind="poly", **var_kwargs
+            old_times,
+            gain_array,
+            blank_flags,
+            new_times,
+            kind="chebyshev",
+            **var_kwargs,
         )
 
 
@@ -902,11 +940,18 @@ def test_time_interp_cal_var_errs(
 
     with pytest.raises(ValueError, match=err_msg):
         gi_utils.time_interp_cal(
-            old_times, gain_array, blank_flags, new_times, kind="poly", **var_kwargs
+            old_times,
+            gain_array,
+            blank_flags,
+            new_times,
+            kind="chebyshev",
+            **var_kwargs,
         )
 
 
-@pytest.mark.parametrize("kind,kwargs", [["cubic", {}], ["poly", {"poly_order": 3}]])
+@pytest.mark.parametrize(
+    "kind,kwargs", [["cubic", {}], ["chebyshev", {"poly_order": 3}]]
+)
 def test_time_interp_cal_undersupplied_flags_nans(
     gain_array, blank_flags, old_times, new_times, kind, kwargs
 ):

--- a/tests/utils/test_tools.py
+++ b/tests/utils/test_tools.py
@@ -41,6 +41,28 @@ def test_slicify():
     assert utils.tools.slicify([0, 1, 2, 7]) == [0, 1, 2, 7]
 
 
+@pytest.mark.parametrize("invert", [True, False])
+@pytest.mark.parametrize(
+    "mask,keep_result,drop_result",
+    [
+        [[False, True, True, True], slice(1, 4, 1), slice(0, 1, 1)],  # Contiguous
+        [[True, False, True, False, True], slice(0, 6, 2), slice(1, 5, 2)],  # Strided
+        [[False, True, False], slice(1, 2, 1), slice(0, 4, 2)],  # Single entry
+        [[True] * 3 + [False] * 4 + [True], [0, 1, 2, 7], slice(3, 7, 1)],  # No slice
+        [[True, True, True], slice(0, 3, 1), slice(0, 0, 1)],  # All marked
+        [[False, False, False], slice(0, 0, 1), slice(0, 3, 1)],  # None marked
+        [[], slice(0, 0, 1), slice(0, 0, 1)],  # Empty
+    ],
+)
+def test_mask_slicify(mask, keep_result, drop_result, invert):
+    result = utils.tools.mask_slicify(np.array(mask, dtype=bool), invert=invert)
+    answer = drop_result if invert else keep_result
+    if isinstance(answer, slice):
+        assert result == answer
+    else:
+        assert np.array_equal(result, answer)
+
+
 @pytest.mark.parametrize(
     "obj1,obj2,union_result,interset_result,diff_result",
     [

--- a/tests/utils/test_uvcalibrate.py
+++ b/tests/utils/test_uvcalibrate.py
@@ -976,7 +976,7 @@ def test_uvcalibrate_interpolated_gains(uvcalibrate_data):
     # Down-select the solns to test the interpolation
     uvc2 = uvc.select(times=uvc.time_array[::3], inplace=False)
     uvc3 = uvc2.interpolate_in_time(
-        uvc.time_array, amp_kind="poly", amp_poly_order=3, pha_kind="linear"
+        uvc.time_array, amp_kind="chebyshev", amp_poly_order=3, pha_kind="linear"
     )
 
     assert uvc3.Ntimes == uvc.Ntimes
@@ -1069,6 +1069,7 @@ def test_uvcalibrate_apply_to_weights_delay(uvcalibrate_data):
     np.testing.assert_array_equal(uvd_weight.nsample_array, 1.0)
 
 
+@pytest.mark.filterwarnings("ignore:Calibrating a subset of the data")
 def test_uvcalibrate_select_blt_inds(uvcalibrate_data):
     uvd, uvc = uvcalibrate_data
 
@@ -1093,6 +1094,7 @@ def test_uvcalibrate_select_blt_inds(uvcalibrate_data):
     np.testing.assert_array_equal(part.nsample_array[~mask], uvd.nsample_array[~mask])
 
 
+@pytest.mark.filterwarnings("ignore:Calibrating a subset of the data")
 def test_uvcalibrate_catalog_names(uvcalibrate_data):
     uvd, uvc = uvcalibrate_data
 
@@ -1127,6 +1129,7 @@ def test_uvcalibrate_catalog_names(uvcalibrate_data):
     np.testing.assert_array_equal(both.data_array, full.data_array)
 
 
+@pytest.mark.filterwarnings("ignore:Calibrating a subset of the data")
 def test_uvcalibrate_select_polarizations(uvcalibrate_data):
     """Selecting a polarization should leave the others exactly as they were."""
     uvd, uvc = uvcalibrate_data
@@ -1142,6 +1145,7 @@ def test_uvcalibrate_select_polarizations(uvcalibrate_data):
     np.testing.assert_array_equal(part.flag_array[:, :, 1:], uvd.flag_array[:, :, 1:])
 
 
+@pytest.mark.filterwarnings("ignore:Calibrating a subset of the data")
 @pytest.mark.parametrize("by_chans", [True, False])
 def test_uvcalibrate_select_frequencies(uvcalibrate_data, by_chans):
     """Selecting channels should leave the rest of the band exactly as it was."""
@@ -1160,6 +1164,7 @@ def test_uvcalibrate_select_frequencies(uvcalibrate_data, by_chans):
     np.testing.assert_array_equal(part.flag_array[:, rest], uvd.flag_array[:, rest])
 
 
+@pytest.mark.filterwarnings("ignore:Calibrating a subset of the data")
 def test_uvcalibrate_select_frequencies_with_blts(uvcalibrate_data):
     uvd, uvc = uvcalibrate_data
 
@@ -1184,6 +1189,196 @@ def test_uvcalibrate_select_frequencies_with_blts(uvcalibrate_data):
         part.data_array[np.ix_(~mask, keep_f)], uvd.data_array[np.ix_(~mask, keep_f)]
     )
     np.testing.assert_array_equal(part.data_array[:, rest_f], uvd.data_array[:, rest_f])
+
+
+@pytest.mark.filterwarnings("ignore:Calibrating a subset of the data")
+@pytest.mark.parametrize("axis", ["blt", "freq", "pol"])
+def test_uvcalibrate_flag_unselected(uvcalibrate_data, axis):
+    """Records left out of the selection get flagged rather than left alone."""
+    uvd, uvc = uvcalibrate_data
+
+    if axis == "blt":
+        keep = np.zeros(uvd.Nblts, dtype=bool)
+        keep[: uvd.Nblts // 3] = True
+        sel = {"blt_inds": np.nonzero(keep)[0]}
+        inside, outside = np.s_[keep], np.s_[~keep]
+    elif axis == "freq":
+        keep = np.zeros(uvd.Nfreqs, dtype=bool)
+        keep[: uvd.Nfreqs // 3] = True
+        sel = {"freq_chans": np.nonzero(keep)[0]}
+        inside, outside = np.s_[:, keep], np.s_[:, ~keep]
+    else:
+        keep = np.zeros(uvd.Npols, dtype=bool)
+        keep[0] = True
+        sel = {"polarizations": uvd.polarization_array[keep]}
+        inside, outside = np.s_[:, :, keep], np.s_[:, :, ~keep]
+
+    part = utils.uvcalibrate(uvd, uvc, inplace=False, uvd_select_kwargs=sel)
+    flagged = utils.uvcalibrate(
+        uvd, uvc, inplace=False, uvd_select_kwargs=sel, flag_unselected=True
+    )
+
+    # Everything outside the selection is flagged, where by default it is not.
+    assert flagged.flag_array[outside].all()
+    assert not part.flag_array[outside].all()
+    # The selection itself is unaffected by the option, as are the data.
+    np.testing.assert_array_equal(flagged.flag_array[inside], part.flag_array[inside])
+    np.testing.assert_array_equal(flagged.data_array, part.data_array)
+
+
+@pytest.mark.parametrize("flag_unselected", [None, True, False])
+def test_uvcalibrate_flag_unselected_warning(uvcalibrate_data, flag_unselected):
+    """Only the default warns -- setting it either way is an explicit choice."""
+    uvd, uvc = uvcalibrate_data
+
+    keep = np.zeros(uvd.Nblts, dtype=bool)
+    keep[: uvd.Nblts // 3] = True
+
+    with check_warnings(
+        UserWarning if flag_unselected is None else None,
+        match="Calibrating a subset of the data",
+    ):
+        part = utils.uvcalibrate(
+            uvd,
+            uvc,
+            inplace=False,
+            uvd_select_kwargs={"blt_inds": np.nonzero(keep)[0]},
+            flag_unselected=flag_unselected,
+        )
+
+    # None behaves as False, i.e. the unselected records are left alone.
+    assert part.flag_array[~keep].all() == bool(flag_unselected)
+
+
+def test_uvcalibrate_flag_unselected_no_selection(uvcalibrate_data):
+    """With nothing selected out, the option has nothing to flag."""
+    uvd, uvc = uvcalibrate_data
+
+    full = utils.uvcalibrate(uvd, uvc, inplace=False)
+    flagged = utils.uvcalibrate(uvd, uvc, inplace=False, flag_unselected=True)
+
+    assert full == flagged
+
+
+def test_uvcalibrate_flag_unselected_multi_axis(uvcalibrate_data):
+    """Anything outside the selection on any axis gets flagged, not just the corner."""
+    uvd, uvc = uvcalibrate_data
+
+    blt_good = np.zeros(uvd.Nblts, dtype=bool)
+    blt_good[::2] = True
+    freq_good = np.zeros(uvd.Nfreqs, dtype=bool)
+    freq_good[: uvd.Nfreqs // 3] = True
+
+    flagged = utils.uvcalibrate(
+        uvd,
+        uvc,
+        inplace=False,
+        uvd_select_kwargs={
+            "blt_inds": np.nonzero(blt_good)[0],
+            "freq_chans": np.nonzero(freq_good)[0],
+        },
+        flag_unselected=True,
+    )
+
+    assert flagged.flag_array[~blt_good].all()
+    assert flagged.flag_array[:, ~freq_good].all()
+    # Only the intersection of the two selections escapes being flagged outright.
+    assert not flagged.flag_array[np.ix_(blt_good, freq_good)].all()
+
+
+@pytest.mark.parametrize("flag_unselected", [None, True, False])
+def test_uvcalibrate_history_selection(uvcalibrate_data, flag_unselected):
+    uvd, uvc = uvcalibrate_data
+
+    f_keep = np.arange(uvd.Nfreqs // 3)
+
+    # Only the default (None) raises a warning
+    with check_warnings(
+        UserWarning if flag_unselected is None else None,
+        match="Calibrating a subset of the data",
+    ):
+        part = utils.uvcalibrate(
+            uvd,
+            uvc,
+            inplace=False,
+            uvd_select_kwargs={"freq_chans": f_keep},
+            uvc_select_kwargs={"times": uvc.time_array},
+            flag_unselected=flag_unselected,
+        )
+
+    added = part.history[len(uvd.history) :]
+    assert "Applied to a subset of the data, selected on freq_chans" in added
+    assert f"({f_keep.size} of {uvd.Nfreqs} frequencies)" in added
+    assert ("have been flagged" in added) != ("have NOT been flagged" in added)
+    assert ("have been flagged" in added) == bool(flag_unselected)
+    assert "Calibration solutions were selected on times" in added
+
+
+@pytest.mark.filterwarnings("ignore:Calibrating a subset of the data")
+def test_uvcalibrate_history_no_selection(uvcalibrate_data):
+    uvd, uvc = uvcalibrate_data
+
+    full = utils.uvcalibrate(uvd, uvc, inplace=False)
+
+    added = full.history[len(uvd.history) :]
+    assert "Calibrated with pyuvdata.utils.uvcalibrate." in added
+    assert "subset of the data" not in added
+    assert "flagged" not in added
+
+
+def test_uvcalibrate_history_interpolation(uvcalibrate_data):
+    """Interpolation done inside uvcalibrate is recorded on the calibrated data."""
+    uvd, uvc = uvcalibrate_data
+
+    out = utils.uvcalibrate(
+        uvd, uvc, inplace=False, interpolate=True, interp_kwargs={"kind": "nearest"}
+    )
+
+    assert "Interpolated from" in out.history
+    assert "kind (amplitude=nearest, phase=nearest)" in out.history
+
+
+@pytest.mark.filterwarnings("ignore:Calibrating a subset of the data")
+def test_uvcalibrate_uvc_select_jones_paired(uvcalibrate_data):
+    """Dropping a Jones term is allowed if the matching polarization is dropped too."""
+    uvd, uvc = uvcalibrate_data
+
+    full = utils.uvcalibrate(uvd, uvc, inplace=False)
+    part = utils.uvcalibrate(
+        uvd,
+        uvc,
+        inplace=False,
+        uvd_select_kwargs={"polarizations": uvd.polarization_array[:1]},
+        uvc_select_kwargs={"jones": uvc.jones_array[:1]},
+        flag_unselected=True,
+    )
+
+    # The calibrated polarization has to match what the full run produced, and the
+    # one left out has to come back flagged.
+    np.testing.assert_allclose(part.data_array[:, :, 0], full.data_array[:, :, 0])
+    assert part.flag_array[:, :, 1:].all()
+
+
+@pytest.mark.filterwarnings("ignore:Calibrating a subset of the data")
+@pytest.mark.parametrize("pol_slice", [slice(None), slice(1, None)])
+def test_uvcalibrate_uvc_select_jones_unpaired_err(uvcalibrate_data, pol_slice):
+    """Dropping a Jones term without dropping its polarization is an error."""
+    uvd, uvc = uvcalibrate_data
+
+    uvd_select_kwargs = None
+    if pol_slice != slice(None):
+        uvd_select_kwargs = {"polarizations": uvd.polarization_array[pol_slice]}
+
+    with pytest.raises(
+        ValueError, match="Feed polarization . exists on UVData but not on UVCal"
+    ):
+        utils.uvcalibrate(
+            uvd,
+            uvc,
+            inplace=False,
+            uvd_select_kwargs=uvd_select_kwargs,
+            uvc_select_kwargs={"jones": uvc.jones_array[:1]},
+        )
 
 
 def test_uvcalibrate_select_errs(uvcalibrate_data):
@@ -1226,6 +1421,26 @@ def test_uvcalibrate_interpolate(uvcalibrate_data, kind):
     assert uvc_copy.Ntimes == uvc.Ntimes // 2 + uvc.Ntimes % 2
 
 
+def test_uvcalibrate_interpolate_time_range(uvcalibrate_data):
+    """Solutions on time ranges interpolate from the midpoints of those ranges."""
+    from ..uvcal import time_array_to_time_range
+
+    uvd, uvc = uvcalibrate_data
+    uvc_range = time_array_to_time_range(uvc, keep_time_array=False)
+
+    expected = utils.uvcalibrate(uvd, uvc, inplace=False, interpolate=True)
+    got = utils.uvcalibrate(uvd, uvc_range, inplace=False, interpolate=True)
+
+    # The helper centers each range on the original time, so the midpoints are those
+    # times and the two paths have to agree.
+    np.testing.assert_allclose(got.data_array, expected.data_array)
+    np.testing.assert_array_equal(got.flag_array, expected.flag_array)
+    # The object handed in must not be modified.
+    assert uvc_range.time_array is None
+    assert uvc_range.time_range is not None
+
+
+@pytest.mark.filterwarnings("ignore:Calibrating a subset of the data")
 def test_uvcalibrate_interpolate_with_select(uvcalibrate_data):
     """Interpolation and record selection should compose."""
     uvd, uvc = uvcalibrate_data
@@ -1255,23 +1470,26 @@ def test_uvcalibrate_interpolate_with_select(uvcalibrate_data):
 def test_uvcalibrate_uvc_select_kwargs(uvcalibrate_data):
     uvd, uvc = uvcalibrate_data
 
-    # Drop an antenna from the solutions -- a selection that leaves the time axis
-    # alone, so it does not need interpolating back to match the data.
+    # Drop the last antenna from the solutions, verify that we can still interpolate
+    # the others.
     keep = uvc.ant_array[:-1]
-    manual = uvc.select(antenna_nums=keep, inplace=False)
-    expected = utils.uvcalibrate(uvd, manual, inplace=False, ant_check=False)
-    got = utils.uvcalibrate(
+    drop_ant = uvc.ant_array[-1]
+    uvc_copy = uvc.select(antenna_nums=keep, inplace=False)
+    uvd_copy = utils.uvcalibrate(uvd, uvc_copy, inplace=False, ant_check=False)
+    _ = utils.uvcalibrate(
         uvd,
         uvc,
-        inplace=False,
+        inplace=True,
         ant_check=False,
         uvc_select_kwargs={"antenna_nums": keep},
     )
 
-    np.testing.assert_array_equal(got.data_array, expected.data_array)
-    np.testing.assert_array_equal(got.flag_array, expected.flag_array)
-    # Dropping the antenna has to actually change the result, or this proves nothing.
-    full = utils.uvcalibrate(uvd, uvc, inplace=False, ant_check=False)
-    assert not np.array_equal(got.flag_array, full.flag_array)
+    np.testing.assert_array_equal(uvd.data_array, uvd_copy.data_array)
+    np.testing.assert_array_equal(uvd.flag_array, uvd_copy.flag_array)
+
+    # Verify that the dropped antenna is flagged in the output.
+    mask = (uvd.ant_1_array == drop_ant) | (uvd.ant_2_array == drop_ant)
+    assert np.all(uvd.flag_array[mask])
+
     # The UVCal handed in must be untouched.
     assert len(uvc.ant_array) == len(keep) + 1

--- a/tests/utils/test_uvcalibrate.py
+++ b/tests/utils/test_uvcalibrate.py
@@ -1067,3 +1067,211 @@ def test_uvcalibrate_apply_to_weights_delay(uvcalibrate_data):
     uvd_weight = utils.uvcalibrate(uvd, uvc, apply_to_weights=True, inplace=False)
 
     np.testing.assert_array_equal(uvd_weight.nsample_array, 1.0)
+
+
+def test_uvcalibrate_select_blt_inds(uvcalibrate_data):
+    uvd, uvc = uvcalibrate_data
+
+    # Both calls need apply_to_weights, since the weights are compared below.
+    full = utils.uvcalibrate(uvd, uvc, inplace=False, apply_to_weights=True)
+    mask = np.zeros(uvd.Nblts, dtype=bool)
+    mask[: uvd.Nblts // 3] = True
+    part = utils.uvcalibrate(
+        uvd,
+        uvc,
+        inplace=False,
+        uvd_select_kwargs={"blt_inds": np.nonzero(mask)[0]},
+        apply_to_weights=True,
+    )
+
+    np.testing.assert_array_equal(part.data_array[mask], full.data_array[mask])
+    np.testing.assert_array_equal(part.flag_array[mask], full.flag_array[mask])
+    np.testing.assert_array_equal(part.nsample_array[mask], full.nsample_array[mask])
+    # Everything outside the selection has to come back untouched.
+    np.testing.assert_array_equal(part.data_array[~mask], uvd.data_array[~mask])
+    np.testing.assert_array_equal(part.flag_array[~mask], uvd.flag_array[~mask])
+    np.testing.assert_array_equal(part.nsample_array[~mask], uvd.nsample_array[~mask])
+
+
+def test_uvcalibrate_catalog_names(uvcalibrate_data):
+    uvd, uvc = uvcalibrate_data
+
+    # Split the data across two phase centers so there is something to choose between.
+    cat_id = uvd._add_phase_center(cat_name="second_source", cat_type="unprojected")
+    half = np.zeros(uvd.Nblts, dtype=bool)
+    half[uvd.Nblts // 2 :] = True
+    uvd.phase_center_id_array[half] = cat_id
+    first_name = uvd.phase_center_catalog[uvd.phase_center_id_array[0]]["cat_name"]
+
+    full = utils.uvcalibrate(uvd, uvc, inplace=False)
+    part = utils.uvcalibrate(
+        uvd, uvc, inplace=False, uvd_select_kwargs={"catalog_names": ["second_source"]}
+    )
+
+    np.testing.assert_array_equal(part.data_array[half], full.data_array[half])
+    np.testing.assert_array_equal(part.data_array[~half], uvd.data_array[~half])
+
+    # A bare string should behave the same as a length-one list.
+    single = utils.uvcalibrate(
+        uvd, uvc, inplace=False, uvd_select_kwargs={"catalog_names": "second_source"}
+    )
+    np.testing.assert_array_equal(single.data_array, part.data_array)
+
+    # Naming every phase center is the same as not selecting at all.
+    both = utils.uvcalibrate(
+        uvd,
+        uvc,
+        inplace=False,
+        uvd_select_kwargs={"catalog_names": [first_name, "second_source"]},
+    )
+    np.testing.assert_array_equal(both.data_array, full.data_array)
+
+
+def test_uvcalibrate_select_polarizations(uvcalibrate_data):
+    """Selecting a polarization should leave the others exactly as they were."""
+    uvd, uvc = uvcalibrate_data
+
+    keep = uvd.polarization_array[0]
+    full = utils.uvcalibrate(uvd, uvc, inplace=False)
+    part = utils.uvcalibrate(
+        uvd, uvc, inplace=False, uvd_select_kwargs={"polarizations": [keep]}
+    )
+
+    np.testing.assert_array_equal(part.data_array[:, :, 0], full.data_array[:, :, 0])
+    np.testing.assert_array_equal(part.data_array[:, :, 1:], uvd.data_array[:, :, 1:])
+    np.testing.assert_array_equal(part.flag_array[:, :, 1:], uvd.flag_array[:, :, 1:])
+
+
+@pytest.mark.parametrize("by_chans", [True, False])
+def test_uvcalibrate_select_frequencies(uvcalibrate_data, by_chans):
+    """Selecting channels should leave the rest of the band exactly as it was."""
+    uvd, uvc = uvcalibrate_data
+
+    keep = np.arange(uvd.Nfreqs // 3)
+    sel = {"freq_chans": keep} if by_chans else {"frequencies": uvd.freq_array[keep]}
+    rest = np.setdiff1d(np.arange(uvd.Nfreqs), keep)
+
+    full = utils.uvcalibrate(uvd, uvc, inplace=False)
+    part = utils.uvcalibrate(uvd, uvc, inplace=False, uvd_select_kwargs=sel)
+
+    np.testing.assert_array_equal(part.data_array[:, keep], full.data_array[:, keep])
+    np.testing.assert_array_equal(part.flag_array[:, keep], full.flag_array[:, keep])
+    np.testing.assert_array_equal(part.data_array[:, rest], uvd.data_array[:, rest])
+    np.testing.assert_array_equal(part.flag_array[:, rest], uvd.flag_array[:, rest])
+
+
+def test_uvcalibrate_select_frequencies_with_blts(uvcalibrate_data):
+    uvd, uvc = uvcalibrate_data
+
+    keep_f = np.arange(uvd.Nfreqs // 3)
+    rest_f = np.setdiff1d(np.arange(uvd.Nfreqs), keep_f)
+    mask = np.zeros(uvd.Nblts, dtype=bool)
+    mask[::2] = True
+
+    full = utils.uvcalibrate(uvd, uvc, inplace=False)
+    part = utils.uvcalibrate(
+        uvd,
+        uvc,
+        inplace=False,
+        uvd_select_kwargs={"freq_chans": keep_f, "blt_inds": np.nonzero(mask)[0]},
+    )
+
+    # Only the intersection is calibrated.
+    np.testing.assert_array_equal(
+        part.data_array[np.ix_(mask, keep_f)], full.data_array[np.ix_(mask, keep_f)]
+    )
+    np.testing.assert_array_equal(
+        part.data_array[np.ix_(~mask, keep_f)], uvd.data_array[np.ix_(~mask, keep_f)]
+    )
+    np.testing.assert_array_equal(part.data_array[:, rest_f], uvd.data_array[:, rest_f])
+
+
+def test_uvcalibrate_select_errs(uvcalibrate_data):
+    uvd, uvc = uvcalibrate_data
+    with pytest.raises(
+        ValueError, match=re.escape("Unrecognized keyword(s) in uvd_select_kwargs")
+    ):
+        utils.uvcalibrate(uvd, uvc, inplace=False, uvd_select_kwargs={"nonsense": 1})
+
+    with pytest.raises(ValueError, match="Cannot set inplace via interp_kwargs"):
+        utils.uvcalibrate(
+            uvd, uvc, inplace=False, interpolate=True, interp_kwargs={"inplace": True}
+        )
+
+    with pytest.raises(ValueError, match="Cannot set inplace via uvc_select_kwargs"):
+        utils.uvcalibrate(uvd, uvc, inplace=False, uvc_select_kwargs={"inplace": True})
+
+
+@pytest.mark.parametrize("kind", ["nearest", "linear"])
+def test_uvcalibrate_interpolate(uvcalibrate_data, kind):
+    uvd, uvc = uvcalibrate_data
+
+    uvc_copy = uvc.select(times=uvc.time_array[::2], inplace=False)
+
+    manual = uvc_copy.interpolate_in_time(
+        np.unique(uvd.time_array), kind=kind, allow_extrapolation=True, inplace=False
+    )
+    expected = utils.uvcalibrate(uvd, manual, inplace=False)
+    got = utils.uvcalibrate(
+        uvd,
+        uvc_copy,
+        inplace=False,
+        interpolate=True,
+        interp_kwargs={"kind": kind, "allow_extrapolation": True},
+    )
+
+    np.testing.assert_allclose(got.data_array, expected.data_array)
+    np.testing.assert_array_equal(got.flag_array, expected.flag_array)
+    # The object handed in must not be modified.
+    assert uvc_copy.Ntimes == uvc.Ntimes // 2 + uvc.Ntimes % 2
+
+
+def test_uvcalibrate_interpolate_with_select(uvcalibrate_data):
+    """Interpolation and record selection should compose."""
+    uvd, uvc = uvcalibrate_data
+    uvc_thin = uvc.select(times=uvc.time_array[::2], inplace=False)
+    interp_kwargs = {"kind": "linear", "allow_extrapolation": True}
+
+    full = utils.uvcalibrate(
+        uvd, uvc_thin, inplace=False, interpolate=True, interp_kwargs=interp_kwargs
+    )
+    mask = np.zeros(uvd.Nblts, dtype=bool)
+    mask[::2] = True
+    part = utils.uvcalibrate(
+        uvd,
+        uvc_thin,
+        inplace=False,
+        interpolate=True,
+        interp_kwargs=interp_kwargs,
+        uvd_select_kwargs={"blt_inds": np.nonzero(mask)[0]},
+    )
+
+    np.testing.assert_array_equal(part.data_array[mask], full.data_array[mask])
+    np.testing.assert_array_equal(part.data_array[~mask], uvd.data_array[~mask])
+
+
+@pytest.mark.filterwarnings("ignore:Antennas .* have data on UVData but are missing")
+@pytest.mark.filterwarnings("ignore:Changing number of antennas, but preserving")
+def test_uvcalibrate_uvc_select_kwargs(uvcalibrate_data):
+    uvd, uvc = uvcalibrate_data
+
+    # Drop an antenna from the solutions -- a selection that leaves the time axis
+    # alone, so it does not need interpolating back to match the data.
+    keep = uvc.ant_array[:-1]
+    manual = uvc.select(antenna_nums=keep, inplace=False)
+    expected = utils.uvcalibrate(uvd, manual, inplace=False, ant_check=False)
+    got = utils.uvcalibrate(
+        uvd,
+        uvc,
+        inplace=False,
+        ant_check=False,
+        uvc_select_kwargs={"antenna_nums": keep},
+    )
+
+    np.testing.assert_array_equal(got.data_array, expected.data_array)
+    np.testing.assert_array_equal(got.flag_array, expected.flag_array)
+    # Dropping the antenna has to actually change the result, or this proves nothing.
+    full = utils.uvcalibrate(uvd, uvc, inplace=False, ant_check=False)
+    assert not np.array_equal(got.flag_array, full.flag_array)
+    # The UVCal handed in must be untouched.
+    assert len(uvc.ant_array) == len(keep) + 1

--- a/tests/utils/test_uvcalibrate.py
+++ b/tests/utils/test_uvcalibrate.py
@@ -1001,3 +1001,69 @@ def test_uvcalibrate_interpolated_gains(uvcalibrate_data):
         )
 
     assert amp_errs[0] < amp_errs[1]
+
+
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
+@pytest.mark.filterwarnings("ignore:pol_convention is not specified on the UVData")
+@pytest.mark.parametrize("gain_convention", ["divide", "multiply"])
+@pytest.mark.parametrize("undo", [False, True])
+def test_uvcalibrate_apply_to_weights(uvcalibrate_data, gain_convention, undo):
+    uvd, uvc = uvcalibrate_data
+    uvc.gain_convention = gain_convention
+    if undo:
+        # uvcalibrate refuses to undo unless the data are already in the gain units.
+        uvd.vis_units = uvc.gain_scale
+
+    # The weights should be left well enough alone if the option is not selected.
+    uvd_noweight = utils.uvcalibrate(uvd, uvc, undo=undo, inplace=False)
+    np.testing.assert_array_equal(uvd_noweight.nsample_array, uvd.nsample_array)
+
+    uvd_weight = utils.uvcalibrate(
+        uvd, uvc, undo=undo, apply_to_weights=True, inplace=False
+    )
+    assert uvd_weight.nsample_array.dtype == uvd.nsample_array.dtype
+
+    # Nothing but the weights themselves should be touched by the reweighting.
+    uvd_weight_check = uvd_weight.copy()
+    uvd_weight_check.nsample_array = uvd_noweight.nsample_array
+    assert uvd_weight_check == uvd_noweight
+
+    # The correction applied to the weights should be the inverse-square of the one
+    # applied to the visibilities, which we can pull straight back out of the data.
+    good_mask = (uvd.data_array != 0.0) & (uvd_weight.data_array != 0.0)
+    amp_corr = np.abs(uvd_weight.data_array[good_mask]) / np.abs(
+        uvd.data_array[good_mask]
+    )
+
+    np.testing.assert_allclose(
+        uvd_weight.nsample_array[good_mask] / uvd.nsample_array[good_mask],
+        amp_corr**-2.0,
+        rtol=1e-4,
+    )
+
+
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only,")
+def test_uvcalibrate_apply_to_weights_delay(uvcalibrate_data):
+    # Verify that delay solutions leave the weights alone
+    uvd, _ = uvcalibrate_data
+    uvd.nsample_array[:] = 1.0
+
+    uvc = UVCal.initialize_from_uvdata(
+        uvd,
+        gain_convention="divide",
+        cal_style="redundant",
+        cal_type="delay",
+        wide_band=True,
+        metadata_only=False,
+        jones_array="linear",
+        pol_convention="avg",
+        gain_scale="Jy",
+    )
+    uvc.delay_array[:] = np.linspace(
+        -1.0, 1.0, uvc.delay_array.size, dtype=float
+    ).reshape(uvc.delay_array.shape)
+    uvc.flag_array[:] = False
+
+    uvd_weight = utils.uvcalibrate(uvd, uvc, apply_to_weights=True, inplace=False)
+
+    np.testing.assert_array_equal(uvd_weight.nsample_array, 1.0)

--- a/tests/utils/test_uvcalibrate.py
+++ b/tests/utils/test_uvcalibrate.py
@@ -939,3 +939,65 @@ def test_uvcalibrate_wideband_gains():
 
     # Check that either things agree with expectations or that data are flagged
     assert np.all((exp_data == new_uvd.data_array) | new_uvd.flag_array)
+
+
+def test_uvcalibrate_interpolated_gains(uvcalibrate_data):
+    """End-to-end check that interpolated solutions calibrate correctly."""
+    uvd, uvc = uvcalibrate_data
+
+    # Start from unity visibilities, so that stamping the gains in and then taking
+    # them back out again should land on exactly what it started with.
+    uvd.data_array[:] = 1.0
+    uvd.flag_array[:] = False
+
+    # Antenna-based gains along the lines of what SMA data actually looks like, with
+    # phase drifting linearly in time and amplitude following a slower third-order
+    # curve, each scaled per antenna so that every baseline encodes a different pattern.
+    time_ramp = ((uvc.time_array - uvc.time_array[0]) / np.ptp(uvc.time_array))[
+        None, None, :, None
+    ]
+    ant_ramp = ((np.arange(uvc.Nants_data) + 1.0) / uvc.Nants_data)[
+        :, None, None, None
+    ] * time_ramp
+    gain_amp = 1 + (0.1 * ant_ramp) - (0.5 * ant_ramp**2) + (0.6 * ant_ramp**3)
+    gain_pha = 0.6 * ant_ramp
+    uvc.gain_array = np.broadcast_to(
+        gain_amp * np.exp(1j * gain_pha), uvc.gain_array.shape
+    ).astype(uvc.gain_array.dtype)
+    uvc.flag_array[:] = False
+
+    # Stamp the gains onto the data.
+    uvc.gain_convention = "multiply"
+    uvd2 = utils.uvcalibrate(uvd, uvc, inplace=False)
+
+    # Verify that the visibilities have changed.
+    assert not np.allclose(uvd2.data_array, uvd.data_array)
+
+    # Down-select the solns to test the interpolation
+    uvc2 = uvc.select(times=uvc.time_array[::3], inplace=False)
+    uvc3 = uvc2.interpolate_in_time(
+        uvc.time_array, amp_kind="poly", amp_poly_order=3, pha_kind="linear"
+    )
+
+    assert uvc3.Ntimes == uvc.Ntimes
+    assert not uvc3.flag_array.any()
+    np.testing.assert_allclose(uvc3.gain_array, uvc.gain_array, rtol=1e-10)
+
+    # Flip the gain convention to see that the interpolated gains (correctly) undo
+    # the previous uvcalibrate with the full time series gains tables.
+    uvc3.gain_convention = "divide"
+    uvd3 = utils.uvcalibrate(uvd2, uvc3, inplace=False)
+
+    np.testing.assert_allclose(uvd3.data_array, uvd.data_array, rtol=1e-5)
+
+    # Verify the cubic interp does a better job fitting the non-linear ramp
+    amp_errs = []
+    for amp_kind in ["cubic", "linear"]:
+        uvc4 = uvc2.interpolate_in_time(
+            uvc.time_array, amp_kind=amp_kind, pha_kind="linear"
+        )
+        amp_errs.append(
+            np.max(np.abs(np.abs(uvc4.gain_array) - np.abs(uvc.gain_array)))
+        )
+
+    assert amp_errs[0] < amp_errs[1]

--- a/tests/uvcal/test_uvcal.py
+++ b/tests/uvcal/test_uvcal.py
@@ -4732,7 +4732,7 @@ def test_interpolate_in_time(caltype, kind, gain_data, delay_data):
 
 
 @pytest.mark.parametrize("caltype", ["gain", "delay"])
-@pytest.mark.parametrize("kind", ["nearest", "linear", "cubic", "poly"])
+@pytest.mark.parametrize("kind", ["nearest", "linear", "cubic", "chebyshev"])
 def test_interpolate_in_time_upsample(caltype, kind, gain_data, delay_data):
     # Check that upsampling the solns actually returns something
     if caltype == "gain":
@@ -4785,6 +4785,58 @@ def test_interpolate_in_time_metadata(caltype, gain_data, delay_data):
     assert len(calobj2.lst_array) == len(new_times)
 
 
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        [{}, "kind (amplitude=linear, phase=linear)"],
+        [{"amp_kind": "cubic"}, "kind (amplitude=cubic, phase=linear)"],
+        [{"use_complex_interp": True}, "kind (real=linear, imaginary=linear)"],
+        [
+            {"kind": "chebyshev"},
+            "kind (amplitude=chebyshev (poly_order=3), phase=chebyshev (poly_order=3))",
+        ],
+        [
+            # The per-component orders have to follow the kind they belong to.
+            {"kind": "chebyshev", "amp_poly_order": 4},
+            "kind (amplitude=chebyshev (poly_order=4), phase=chebyshev (poly_order=3))",
+        ],
+        [{"allow_extrapolation": True}, "Extrapolation beyond the original time"],
+    ],
+)
+def test_interpolate_in_time_history(gain_data, kwargs, expected):
+    """The interpolation is recorded, since the object no longer shows what was done."""
+    calobj = gain_data
+    new_times = calobj.time_array[:3]
+
+    calobj2 = calobj.interpolate_in_time(new_times, max_time_delta=0.0, **kwargs)
+
+    added = calobj2.history[len(calobj.history) :]
+    assert f"Interpolated from {calobj.Ntimes} to 3 times using pyuvdata" in added
+    assert expected in added
+    allowed = kwargs.get("allow_extrapolation", False)
+    assert ("was allowed" in added) == allowed
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        [{}, "kind (delay=linear)"],
+        [
+            {"kind": "chebyshev", "poly_order": 2},
+            "kind (delay=chebyshev (poly_order=2))",
+        ],
+    ],
+)
+def test_interpolate_in_time_history_delay(delay_data, kwargs, expected):
+    """Delays are real-valued, so there is only the one component to describe."""
+    calobj = delay_data
+    new_times = calobj.time_array[:3]
+
+    calobj2 = calobj.interpolate_in_time(new_times, max_time_delta=0.0, **kwargs)
+
+    assert expected in calobj2.history[len(calobj.history) :]
+
+
 def test_interpolate_in_time_refant_warning(gain_data):
     calobj = gain_data
     calobj.ref_antenna_array = np.arange(calobj.Ntimes)
@@ -4828,7 +4880,7 @@ def test_interpolate_in_time_complex(use_complex_interp, gain_data):
     "interp_kwargs",
     [
         {"amp_kind": "cubic", "pha_kind": "linear"},
-        {"kind": "poly", "amp_poly_order": 2, "pha_poly_order": 1},
+        {"kind": "chebyshev", "amp_poly_order": 2, "pha_poly_order": 1},
         {"amp_flag_delta": 0.5, "pha_flag_delta": 0.5},
         {"amp_max_time_delta": 100.0, "pha_max_time_delta": 100.0},
     ],
@@ -4864,7 +4916,7 @@ def test_interpolate_in_time_var(gain_data):
 
     calobj2 = calobj.interpolate_in_time(
         new_times,
-        kind="poly",
+        kind="chebyshev",
         poly_order=[2, 1],
         old_var=np.vstack([np.sin(old_times)]),
         new_var=np.vstack([np.sin(new_times)]),
@@ -4876,9 +4928,29 @@ def test_interpolate_in_time_var(gain_data):
 
 
 @pytest.mark.parametrize("keep_time_array", [True, False])
-def test_interpolate_in_time_errs(gain_data, keep_time_array):
+def test_interpolate_in_time_time_range(gain_data, keep_time_array):
+    """Solutions recorded against time ranges interpolate from the range midpoints."""
     new_times = gain_data.time_array[:3]
     calobj = time_array_to_time_range(gain_data, keep_time_array=keep_time_array)
 
-    with pytest.raises(ValueError, match="Cannot interpolate an object that records"):
-        calobj.interpolate_in_time(new_times)
+    calobj2 = calobj.interpolate_in_time(new_times, max_time_delta=0.0)
+
+    # Whichever way the input recorded its times, the result sits at discrete ones.
+    np.testing.assert_allclose(calobj2.time_array, new_times)
+    assert calobj2.time_range is None
+    assert calobj2.lst_range is None
+    assert calobj2.lst_array is not None
+    calobj2.check()
+
+    ref = gain_data.interpolate_in_time(new_times, max_time_delta=0.0)
+    np.testing.assert_allclose(calobj2.gain_array, ref.gain_array)
+    np.testing.assert_array_equal(calobj2.flag_array, ref.flag_array)
+
+
+def test_interpolate_in_time_no_times_err(gain_data):
+    calobj = gain_data
+    calobj.time_array = None
+    calobj.lst_array = None
+
+    with pytest.raises(ValueError, match="Cannot interpolate an object with neither"):
+        calobj.interpolate_in_time(np.array([2457698.4]))

--- a/tests/uvcal/test_uvcal.py
+++ b/tests/uvcal/test_uvcal.py
@@ -4701,3 +4701,184 @@ def test_fast_concat_phase_center_missing_err(uvcal_phase_center):
 
     with pytest.raises(ValueError, match="To combine these data, phase_center_id_"):
         uvcal_phase_center.fast_concat(uvcopy, axis="time")
+
+
+@pytest.mark.parametrize("caltype", ["gain", "delay"])
+@pytest.mark.parametrize("kind", ["nearest", "linear", "cubic"])
+def test_interpolate_in_time(caltype, kind, gain_data, delay_data):
+    # Check that interpolating back to the original times returns the orig solns
+    if caltype == "gain":
+        calobj = gain_data
+    else:
+        calobj = delay_data
+
+    old_times = calobj.time_array.copy()
+    if caltype == "gain":
+        exp_cal = calobj.gain_array.copy()
+    else:
+        exp_cal = calobj.delay_array.copy()
+
+    # max_time_delta is disabled here, since the times in these files are spaced
+    # much further apart than any sensible limit.
+    calobj2 = calobj.interpolate_in_time(old_times, kind=kind, max_time_delta=0.0)
+
+    assert calobj2.Ntimes == len(old_times)
+    np.testing.assert_allclose(calobj2.time_array, old_times)
+    if caltype == "gain":
+        np.testing.assert_allclose(calobj2.gain_array, exp_cal, rtol=1e-5)
+    else:
+        np.testing.assert_allclose(calobj2.delay_array, exp_cal, rtol=1e-5)
+    assert not calobj2.flag_array.any()
+
+
+@pytest.mark.parametrize("caltype", ["gain", "delay"])
+@pytest.mark.parametrize("kind", ["nearest", "linear", "cubic", "poly"])
+def test_interpolate_in_time_upsample(caltype, kind, gain_data, delay_data):
+    # Check that upsampling the solns actually returns something
+    if caltype == "gain":
+        calobj = gain_data
+    else:
+        calobj = delay_data
+
+    old_times = calobj.time_array
+    new_times = np.sort(
+        np.concatenate([old_times, 0.5 * (old_times[1:] + old_times[:-1])])
+    )
+
+    calobj2 = calobj.interpolate_in_time(new_times, kind=kind, max_time_delta=0.0)
+
+    assert calobj2.Ntimes == len(new_times)
+    if caltype == "gain":
+        new_cal = calobj2.gain_array
+    else:
+        new_cal = calobj2.delay_array
+    assert new_cal.shape[2] == len(new_times)
+    assert np.isfinite(new_cal).all()
+    assert calobj2.check()
+
+
+@pytest.mark.parametrize("caltype", ["gain", "delay"])
+def test_interpolate_in_time_metadata(caltype, gain_data, delay_data):
+    if caltype == "gain":
+        calobj = gain_data
+    else:
+        calobj = delay_data
+
+    # None of the test files carry these, so set them here.
+    calobj.integration_time = np.arange(calobj.Ntimes) + 1.0
+    calobj.ref_antenna_array = np.full(calobj.Ntimes, 7)
+    calobj.scan_number_array = np.arange(calobj.Ntimes)
+    calobj.phase_center_id_array = np.zeros(calobj.Ntimes, dtype=int)
+    old_times = calobj.time_array
+    new_times = old_times[[0, 0, -1]]
+
+    calobj2 = calobj.interpolate_in_time(new_times, max_time_delta=0.0)
+
+    # Check that the non-interpolated parameters are dropped
+    assert calobj2.quality_array is None
+    assert calobj2.total_quality_array is None
+    assert calobj2.scan_number_array is None
+    assert calobj2.phase_center_id_array is None
+
+    np.testing.assert_array_equal(calobj2.ref_antenna_array, [7, 7, 7])
+    np.testing.assert_allclose(calobj2.integration_time, [1.0, 1.0, calobj.Ntimes])
+    assert len(calobj2.lst_array) == len(new_times)
+
+
+def test_interpolate_in_time_refant_warning(gain_data):
+    calobj = gain_data
+    calobj.ref_antenna_array = np.arange(calobj.Ntimes)
+    new_times = calobj.time_array[[0, -1]]
+
+    with check_warnings(
+        UserWarning, match="Different reference antennas are used at different times"
+    ):
+        calobj2 = calobj.interpolate_in_time(new_times, max_time_delta=0.0)
+
+    np.testing.assert_array_equal(calobj2.ref_antenna_array, [0, calobj.Ntimes - 1])
+
+
+def test_interpolate_in_time_inplace(gain_data):
+    calobj = gain_data
+    calobj2 = calobj.copy()
+    new_times = calobj.time_array[:3]
+
+    ret_val = calobj2.interpolate_in_time(new_times, max_time_delta=0.0, inplace=True)
+
+    assert ret_val is None
+    assert calobj2.Ntimes == 3
+    assert calobj.Ntimes != 3
+
+
+@pytest.mark.parametrize("use_complex_interp", [True, False])
+def test_interpolate_in_time_complex(use_complex_interp, gain_data):
+    """Check complex (real/imaginary) interpolation."""
+    calobj = gain_data
+    old_times = calobj.time_array.copy()
+    exp_gains = calobj.gain_array.copy()
+
+    calobj2 = calobj.interpolate_in_time(
+        old_times, use_complex_interp=use_complex_interp, max_time_delta=0.0
+    )
+
+    np.testing.assert_allclose(calobj2.gain_array, exp_gains, rtol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "interp_kwargs",
+    [
+        {"amp_kind": "cubic", "pha_kind": "linear"},
+        {"kind": "poly", "amp_poly_order": 2, "pha_poly_order": 1},
+        {"amp_flag_delta": 0.5, "pha_flag_delta": 0.5},
+        {"amp_max_time_delta": 100.0, "pha_max_time_delta": 100.0},
+    ],
+)
+def test_interpolate_in_time_split_kwargs(interp_kwargs, gain_data):
+    calobj = gain_data
+    new_times = calobj.time_array[:3]
+
+    calobj2 = calobj.interpolate_in_time(new_times, **interp_kwargs)
+
+    assert calobj2.Ntimes == 3
+    assert np.isfinite(calobj2.gain_array).all()
+
+
+@pytest.mark.parametrize("allow_extrapolation", [True, False])
+def test_interpolate_in_time_extrapolation(allow_extrapolation, gain_data):
+    calobj = gain_data
+    old_times = calobj.time_array
+    new_times = np.array([old_times[0] - 1.0, old_times[0], old_times[-1] + 1.0])
+
+    calobj2 = calobj.interpolate_in_time(
+        new_times, allow_extrapolation=allow_extrapolation, max_time_delta=0.0
+    )
+
+    exp_flags = [not allow_extrapolation, False, not allow_extrapolation]
+    np.testing.assert_array_equal(calobj2.flag_array[0, 0, :, 0], exp_flags)
+
+
+def test_interpolate_in_time_var(gain_data):
+    calobj = gain_data
+    old_times = calobj.time_array
+    new_times = old_times[:3]
+
+    calobj2 = calobj.interpolate_in_time(
+        new_times,
+        kind="poly",
+        poly_order=[2, 1],
+        old_var=np.vstack([np.sin(old_times)]),
+        new_var=np.vstack([np.sin(new_times)]),
+        max_time_delta=0.0,
+    )
+
+    assert calobj2.Ntimes == 3
+    assert np.isfinite(calobj2.gain_array).all()
+
+
+@pytest.mark.parametrize("keep_time_array", [True, False])
+def test_interpolate_in_time_errs(gain_data, keep_time_array):
+    new_times = gain_data.time_array[:3]
+    calobj = time_array_to_time_range(gain_data, keep_time_array=keep_time_array)
+
+    with pytest.raises(ValueError, match="Cannot interpolate an object that records"):
+        calobj.interpolate_in_time(new_times)

--- a/tests/uvdata/test_uvdata.py
+++ b/tests/uvdata/test_uvdata.py
@@ -295,12 +295,17 @@ def mwa_integration_time():
     new_times = np.min(uv_init.time_array) + (
         np.arange(11, dtype=float) * new_int_time_jd
     )
+    # Selecting a subset of the antennas here, since it catches the critical integ
+    # time issue but significantly reduces the file size (and reduces the testing time
+    # by about 10% across the full run).
+    ant_nums = sorted({58, 61}.union(uv_init.telescope.antenna_numbers[:12].tolist()))
     uvd = UVData.new(
         freq_array=uv_init.freq_array,
         channel_width=uv_init.channel_width,
         polarization_array=uv_init.polarization_array,
         times=new_times,
         telescope=uv_init.telescope,
+        antpairs=list(itertools.combinations_with_replacement(ant_nums, 2)),
         do_blt_outer=True,
         empty=True,
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

A new method has been added to UVCal (`interpolate_in_time`) that allows for calibration tables to be "upsampled", effectively allowing gains/delay measurements taken at one set of times to be interpolated/extrapolated to another set of times. Code associated with performing the interpolations has also been added to a new module, `utils.gain_interpolation`, which supports several different interpolation schemes, including nearest, linear, and cubic (PCHIP) interpolation strategies. An additional strategy -- "poly" -- allows for fitting the calibration solution with a variable-order Chebyshev polynomial and then performing interpolation/extrapolation using the fitted polynomial.

A separate small change has been made to `uvcalibrate`, which also allows users to reweight `nsamples_array` based on the amplitude calibration being applied to `data_array`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

Higher frequency interferometers like the SMA frequently interleave observations of science targets with observations of bright quasars (or other point sources) that can act as gain calibrators for the data. Because those observations are disjoint in time with the observations of the "source", interpolation between the derived gain solutions is typically used to derive effective gains corrections during science target observations. This PR effectively provides that functionality, allowing `uvcalibrate` to be used for SMA observations (among other facilities) .

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added/updated tests to cover my new feature.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
