### PR TITLE
Removing setting of ndarray shape directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Updating code to no longer set shapes directly on ndarrays (deprecated in NumPy 2.5)
 - Require lunarsky>1.0 to drop spiceypy requirement
 
 ### Added

--- a/src/pyuvdata/utils/phasing.py
+++ b/src/pyuvdata/utils/phasing.py
@@ -817,8 +817,8 @@ def transform_sidereal_coords(
         raise ValueError("lon and lat must be the same shape.")
 
     if lon_coord.ndim == 0:
-        lon_coord.shape += (1,)
-        lat_coord.shape += (1,)
+        lon_coord = np.atleast_1d(lon_coord)
+        lat_coord = np.atleast_1d(lat_coord)
 
     # Check to make sure that we have a properly formatted epoch for our in-bound
     # coordinate frame
@@ -1082,16 +1082,16 @@ def transform_icrs_to_app(
     # throw errors if we try to treat it as an array. Reshape to a 1D array of len 1
     # so that all the calls can be uniform
     if ra_coord.ndim == 0:
-        ra_coord.shape += (1,)
-        dec_coord.shape += (1,)
+        ra_coord = np.atleast_1d(ra_coord)
+        dec_coord = np.atleast_1d(dec_coord)
         if pm_ra_coord is not None:
-            pm_ra_coord.shape += (1,)
+            pm_ra_coord = np.atleast_1d(pm_ra_coord)
         if pm_dec_coord is not None:
-            pm_dec_coord.shape += (1,)
+            pm_dec_coord = np.atleast_1d(pm_dec_coord)
         if d_coord is not None:
-            d_coord.shape += (1,)
+            d_coord = np.atleast_1d(d_coord)
         if v_coord is not None:
-            v_coord.shape += (1,)
+            v_coord = np.atleast_1d(v_coord)
 
     if astrometry_library == "astropy":
         # Astropy doesn't have (oddly enough) a way of getting at the apparent RA/Dec

--- a/src/pyuvdata/uvdata/miriad.py
+++ b/src/pyuvdata/uvdata/miriad.py
@@ -979,7 +979,7 @@ class Miriad(UVData):
             # some point, the below will need to be fixed -- I'm keeping this here so
             # that I can skip reading through the MIRIAD programmers guide yet again.
             if len(d.shape) == 1:
-                d.shape = (1,) + d.shape
+                d = np.reshape(d, (1, *d.shape))
 
             if np.size(d) != self.Nfreqs:
                 raise ValueError("Number of channels in spectrum has changed!")
@@ -1251,8 +1251,7 @@ class Miriad(UVData):
                 # because there are uvws/ra/dec for each pol, and one pol may not
                 # have that visibility, we collapse along the polarization
                 # axis but avoid any missing visbilities
-                uvw = d[0] * c_ns
-                uvw.shape = (1, 3)
+                uvw = np.reshape(d[0] * c_ns, (1, 3))
                 uvw_pol_list[blt_index, :, pol_ind] = uvw
                 ra_pol_list[blt_index, pol_ind] = d[7]
                 dec_pol_list[blt_index, pol_ind] = d[8]

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -4582,9 +4582,9 @@ class UVData(UVBase):
             cat_lon = np.array(cat_lon, dtype=float)
             cat_lat = np.array(cat_lat, dtype=float)
             cat_times = np.array(cat_times, dtype=float)
-            cat_lon.shape += (1,) if (cat_lon.ndim == 0) else ()
-            cat_lat.shape += (1,) if (cat_lat.ndim == 0) else ()
-            cat_times.shape += (1,) if (cat_times.ndim == 0) else ()
+            cat_lon = np.atleast_1d(cat_lon)
+            cat_lat = np.atleast_1d(cat_lat)
+            cat_times = np.atleast_1d(cat_times)
             check_ephem = np.min(time_array) < np.min(cat_times)
             check_ephem = check_ephem or (np.max(time_array) > np.max(cat_times))
             # If the ephem was supplied by JPL-Horizons, then we can easily expand


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes setting the shape directly on ndarrays.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Numpy v2.5 deprecates the ability to set the shape directly on ndarray objects, so this (very small) PR simply removes that from the code so as to prevent warnings from being raised, since it's breaking various CI jobs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Build or continuous integration change

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme, pyproject.toml, environment.yaml and CI conda yaml files to reflect the changes.
