### PR TITLE
Adding support for MIRIAD calibration tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Moved the miriad telescope, antenna and frequency axis handling on to the
+`aipy_extracts.UV` object so that it is shared between the `UVData` and `UVCal` readers,
+adding `UV.get_telescope`, `UV.get_freq_axis` and `UV.get_data_antennas` methods.
 - Changed how `UVCal.read_ms_cal` groups together calibration solutions based on time.
 Previously solution timestamps needed to be within the default tolerance for
 `UVCal.time_array` (1 millisecond), but testing suggests that CASA-based processes
@@ -20,6 +23,8 @@ solutions were interpolated if `interpolate` was set.
 - Require lunarsky>1.0 to drop spiceypy requirement
 
 ### Added
+- Support for reading Miriad bandpass, gains, delays, and leakage calibration tables
+into `UVCal` via `UVCal.read_miriad_cal`.
 - A new utility function `utils.averaging.mapped_average`, which performs a weighted
 average of an array along a single axis using an arbitrary map of input to output
 positions.

--- a/src/pyuvdata/uvcal/miriad_cal.py
+++ b/src/pyuvdata/uvcal/miriad_cal.py
@@ -1,0 +1,433 @@
+# Copyright (c) 2025 Radio Astronomy Software Group
+# Licensed under the 2-clause BSD License
+
+"""Class for reading Miriad calibration tables."""
+
+import os
+import warnings
+
+import numpy as np
+from docstring_parser import DocstringStyle
+
+from ..docstrings import copy_replace_short_description
+from . import UVCal
+
+__all__ = ["MiriadCal"]
+
+
+class MiriadCal(UVCal):
+    """
+    Defines a Miriad-specific subclass of UVCal for reading Miriad calibration tables.
+
+    This class should not be interacted with directly, instead use the
+    read_miriad_cal method on the UVCal class.
+
+    """
+
+    @copy_replace_short_description(
+        UVCal.read_miriad_cal, style=DocstringStyle.NUMPYDOC
+    )
+    def read_miriad_cal(
+        self,
+        filepath,
+        *,
+        soln_type=None,
+        default_mount_type="other",
+        default_x_orientation=None,
+        run_check=True,
+        check_extra=True,
+        run_check_acceptability=True,
+        astrometry_library=None,
+    ):
+        """Read in calibration solutions from a Miriad data set."""
+        from ..uvdata import aipy_extracts
+
+        if not os.path.exists(filepath):
+            raise OSError(filepath + " not found")
+
+        uv = aipy_extracts.UV(filepath)
+        soln_type, read_soln = self._select_soln(uv, soln_type)
+
+        self.history = uv["history"]
+        self.filename = [os.path.basename(filepath.rstrip("/"))]
+        self._filename.form = (1,)
+
+        self._set_sky()
+        self.cal_style = "sky"
+        self.sky_catalog = "unknown"
+        # Karto: manually confirmed in testing the ATCA test file
+        self.gain_convention = "multiply"
+
+        pol_check = uv["pol"]
+        nfeeds = uv["nfeeds"]
+        if nfeeds == 1:
+            # Assume that the Jones type matches the pol listed.
+            self.jones_array = np.atleast_1d(pol_check)
+        elif nfeeds == 2:
+            if pol_check in [-1, -2, -3, -4]:
+                # If circular, use circular codes (cross-hand if leakages)
+                self.jones_array = np.array(
+                    [-3, -4] if soln_type == "leakage" else [-1, -2]
+                )
+            elif pol_check in [-5, -6, -7, -8]:
+                # If linear, use linear codes (cross-hand if leakages)
+                self.jones_array = np.array(
+                    [-7, -8] if soln_type == "leakage" else [-5, -6]
+                )
+            else:
+                raise ValueError(
+                    f"Miriad data set has an unrecognized pol code ({pol_check}), "
+                    "cannot determine feed basis of the calibration table."
+                )
+        else:
+            raise ValueError(
+                f"MIRIAD data set shows {nfeeds} feeds, expected only 1 or 2."
+            )
+
+        self.Njones = self.jones_array.size
+
+        self.history += (
+            f"  Read the {soln_type} table from a Miriad data set using pyuvdata."
+        )
+
+        # Njones has to be known before the table is read, and the antennas that the
+        # table covers have to be known before the telescope is built.
+        read_soln(uv)
+
+        # Grab the telescope information from the file.
+        uv.get_telescope(telescope=self.telescope, sorted_unique_ants=self.ant_array)
+
+        if self.cal_type == "delay":
+            # The reference antenna is the one left with no delay at all.
+            ref_check = np.abs(self.delay_array)
+        else:
+            ref_check = np.abs(np.angle(self.gain_array))
+
+        good_mask = ~self.flag_array
+
+        # Reference antenna is nominally pinned to exactly zero phase, but the solver
+        # can leave residuals of a few eps. Use a threshold of 1e-6 times the largest
+        # value to determine which antennas might be the refant.
+        ref_ant = np.nonzero(
+            np.any((ref_check < 1e-6 * np.max(ref_check)) & good_mask, axis=(1, 2, 3))
+        )[0]
+
+        if ref_ant.size != 1:
+            self.ref_antenna_name = "unknown"
+        else:
+            ant_idx = np.nonzero(
+                self.telescope.antenna_numbers == self.ant_array[ref_ant[0]]
+            )[0][0]
+            self.ref_antenna_name = self.telescope.antenna_names[ant_idx]
+
+        # Miriad only records the feed orientation if the data set was written by
+        # pyuvdata, so default to "east" if nothing is recorded or specified.
+        if "xorient" in uv.vartable:
+            x_orientation = uv["xorient"].replace("\x00", "")
+        elif default_x_orientation is not None:
+            x_orientation = default_x_orientation
+        else:
+            x_orientation = "east"
+            warnings.warn('Unknown x_orientation basis for solutions, assuming "east".')
+
+        self.set_lsts_from_time_array(astrometry_library=astrometry_library)
+        # Skip the check here since it is run (or deliberately skipped) below.
+        self.set_telescope_params(
+            x_orientation=x_orientation, mount_type=default_mount_type, run_check=False
+        )
+
+        if run_check:
+            self.check(
+                check_extra=check_extra, run_check_acceptability=run_check_acceptability
+            )
+
+    def _select_soln(self, uv, soln_type):
+        """
+        Validate the requested calibration table against what the data set holds.
+
+        Parameters
+        ----------
+        uv : aipy_extracts.UV
+            An open handle to the Miriad data set.
+        soln_type : str or None
+            The requested table, or None to select one automatically.
+
+        Returns
+        -------
+        soln_type : str
+            The table to read.
+        read_soln : callable
+            The method that reads that table.
+        """
+        # Header item that has to be present, plus the reader, for each table.
+        _SOLN_TYPES = {
+            "gains": ("nsols", self._read_gains_table),
+            "delays": ("ntau", self._read_delays_table),
+            "bandpass": ("nchan0", self._read_bandpass_table),
+            "leakage": ("leakage", self._read_leakage_table),
+        }
+
+        found = []
+        for item, (probe, _) in _SOLN_TYPES.items():
+            try:
+                # ntau is recorded as zero when no delays were solved for.
+                if item == "delays" and uv[probe] < 1:
+                    continue
+                uv[probe]
+            except (KeyError, OSError):
+                # Miriad raises OSError rather than KeyError for a missing header item.
+                continue
+
+            found.append(item)
+
+        listing = found if found else "no calibration tables"
+
+        if soln_type is None:
+            if len(found) != 1:
+                raise ValueError(
+                    "Cannot determine which calibration table to read: this data set "
+                    f"contains {listing}. Set soln_type to select one."
+                )
+            soln_type = found[0]
+
+        if soln_type not in _SOLN_TYPES:
+            raise ValueError(
+                f"soln_type must be one of {list(_SOLN_TYPES)}, got {soln_type}."
+            )
+        if soln_type not in found:
+            raise ValueError(
+                f"This Miriad data set has no {soln_type} table, it contains {listing}."
+            )
+
+        return soln_type, _SOLN_TYPES[soln_type][1]
+
+    def _set_freq_range_from_vis(self, uv):
+        """
+        Build a wide-band frequency axis from the spectral layout of the visibilities.
+
+        Parameters
+        ----------
+        uv : aipy_extracts.UV
+            An open handle to the Miriad data set.
+
+        """
+        freq_array, channel_width, flex_spw_id_array, spw_array = uv.get_freq_axis()
+
+        self._set_wide_band()
+        self.spw_array = spw_array
+        self.Nspws = spw_array.size
+        self.Nfreqs = 1
+        self.freq_range = np.empty((self.Nspws, 2), dtype=float)
+        for idx, spw in enumerate(self.spw_array):
+            spw_mask = flex_spw_id_array == spw
+            spw_freqs = freq_array[spw_mask]
+            half_width = 0.5 * channel_width[spw_mask]
+            self.freq_range[idx] = [
+                np.min(spw_freqs - half_width),
+                np.max(spw_freqs + half_width),
+            ]
+
+    def _set_times_from_table(self, uv, time_array):
+        """
+        Record the solution times, and the interval that Miriad declares for them.
+
+        Parameters
+        ----------
+        uv : aipy_extracts.UV
+            An open handle to the Miriad data set.
+        time_array : ndarray of float
+            Solution timestamps in JD.
+
+        """
+        self.time_array = time_array
+        self.Ntimes = time_array.size
+
+        interval = uv["interval"] * 86400.0
+        # Note that mfcal hardwires interval to half a day rather than recording what
+        # was actually used (as evidenced by the ATCA file and evaluating the code), but
+        # it always produces a single entry.
+        if self.Ntimes > 1:
+            spacing = np.median(np.diff(np.sort(time_array))) * 86400.0
+            if interval > 2 * spacing:
+                # Usually the interval is only long like this b/c it's been mucked with
+                # via gpedit -- let the user know since it'll make the int times
+                # somewhat meaningless.
+                warnings.warn(
+                    f"Miriad records a solution interval of {interval:.0f} s, which is "
+                    f"much longer than the {spacing:.0f} s spacing between solutions."
+                )
+        self.integration_time = np.full(self.Ntimes, interval)
+
+    def _read_bandpass_table(self, uv):
+        """
+        Read the Miriad bandpass table into a frequency resolved gain object.
+
+        Parameters
+        ----------
+        uv : aipy_extracts.UV
+            An open handle to the Miriad data set.
+
+        """
+        self._set_gain()
+
+        # Grab the frequency information
+        freq_info = np.asarray(uv["freqs"][1:], dtype=float).reshape(-1, 3)
+        if freq_info.shape[0] != uv["nspect0"]:  # pragma: no cover
+            raise ValueError(
+                f"Miriad freqs item describes {freq_info.shape[0]} windows, but "
+                f"nspect0 records {uv['nspect0']}."
+            )
+
+        nschan = freq_info[:, 0].astype(int)
+        if nschan.sum() != uv["nchan0"]:  # pragma: no cover
+            raise ValueError(
+                f"Miriad freqs item describes {nschan.sum()} channels, but nchan0 "
+                f" records {uv['nchan0']}."
+            )
+
+        # sfreq and sdf are recorded in GHz, and sdf may be negative.
+        sfreq, sdf = freq_info[:, 1], freq_info[:, 2]
+        windows = zip(nschan, sfreq, sdf, strict=True)
+        self.freq_array = np.concatenate(
+            [1e9 * (start + np.arange(nch) * width) for nch, start, width in windows]
+        )
+        self.channel_width = np.concatenate(
+            [
+                np.full(nchan, 1e9 * np.abs(width))
+                for nchan, width in zip(nschan, sdf, strict=True)
+            ]
+        )
+        self.flex_spw_id_array = np.concatenate(
+            [np.full(nchan, idx) for idx, nchan in enumerate(nschan)]
+        )
+
+        self.Nfreqs = self.freq_array.size
+        self.spw_array = np.unique(self.flex_spw_id_array)
+        self.Nspws = self.spw_array.size
+
+        time_array, bandpass = uv["bandpass"]
+        soln_mask = np.any(bandpass, axis=(0, 2, 3))
+        self._set_times_from_table(uv, time_array)
+
+        # Shape is (Ntimes, Nants, Njones, Nfreqs), and needs to end up as
+        # (Nants_data, Nfreqs, Ntimes, Njones).
+        self.gain_array = np.transpose(bandpass[:, soln_mask], (1, 3, 0, 2))
+        self.flag_array = self.gain_array == 0
+        self.ant_array = np.nonzero(soln_mask)[0]
+        self.Nants_data = self.ant_array.size
+
+    def _read_gains_table(self, uv, do_delays=False):
+        """
+        Read the Miriad gains table into a wide-band gain object.
+
+        Parameters
+        ----------
+        uv : aipy_extracts.UV
+            An open handle to the Miriad data set.
+
+        """
+        time_array, gain_arr, delay_arr = uv["gains"]
+
+        self._set_times_from_table(uv, time_array)
+        # Set the freqs from the vis for gains/delays tables
+        self._set_freq_range_from_vis(uv)
+        soln_mask = np.any(gain_arr, axis=(0, 2))
+
+        if do_delays:
+            self._set_delay()
+            # mfcal appears to be the only one that writes the tau term, with tau
+            # written in nanoseconds (as seems to be conventional in MIRIAD). Note that
+            # delays are applied relative to some given reference frequency (freq0)
+            # rather than as an absolute value (w/ a corresponding phase offset).
+            delay_arr = -1e-9 * delay_arr / (2 * np.pi)
+
+            # MIRIAD records one delay per antenna regardless of the number of feeds, so
+            # so the value applies to every Jones component. Similar to the bandpass, it
+            # also appears to only allow for one delay soln to be derived for a given
+            # data set (via mfcal, which seems to be the only one to derive these).
+            # Shape is (Ntimes, Nants_data, Njones), and needs to end up as
+            # (Nants_data, Nspws, Ntimes, Njones).
+            delay_arr = np.transpose(delay_arr[:, soln_mask, :], (1, 0, 2))[:, None]
+            self.delay_array = np.repeat(
+                np.repeat(delay_arr, self.Nspws, axis=1), self.Njones, axis=3
+            )
+
+            # Record the reference frequency here as an extra keyword
+            self.extra_keywords["FREQ0"] = uv["freq0"]
+            self.history += f"  MIRIAD delay freq0 = {uv['freq0']:.6g} GHz."
+        else:
+            self._set_gain()
+
+            # Shape is (Ntimes, Nants_data, Njones), and needs to end up as
+            # (Nants_data, Nspws, Ntimes, Njones).
+            self.gain_array = np.repeat(
+                np.transpose(gain_arr[:, soln_mask, :], (1, 0, 2))[:, None],
+                self.Nspws,
+                axis=1,
+            )
+
+        # Miriad marks a gain solution bad by storing an exact zero.
+        flag_arr = gain_arr[:, soln_mask, :] == 0.0
+        self.flag_array = np.repeat(
+            np.transpose(flag_arr, (1, 0, 2))[:, None], self.Nspws, axis=1
+        )
+        if self.cal_type == "delay":
+            # Miriad records one delay per antenna, so the flags apply to every Jones.
+            self.flag_array = np.repeat(self.flag_array[..., :1], self.Njones, axis=3)
+        self.ant_array = np.nonzero(soln_mask)[0]
+        self.Nants_data = self.ant_array.size
+
+    def _read_delays_table(self, uv):
+        """
+        Read the delay terms of the Miriad gains table into a delay object.
+
+        Parameters
+        ----------
+        uv : aipy_extracts.UV
+            An open handle to the Miriad data set.
+
+        """
+        self._read_gains_table(uv, do_delays=True)
+
+    def _read_leakage_table(self, uv):
+        """
+        Read the Miriad leakage table into a cross-handed gain object.
+
+        Parameters
+        ----------
+        uv : aipy_extracts.UV
+            An open handle to the Miriad data set.
+
+        """
+        if uv["nfeeds"] != 2:  # pragma: no cover
+            raise ValueError("Data set must have `nfeeds=2` for leakage tables")
+
+        self._set_gain()
+        self._set_freq_range_from_vis(uv)
+        leakage = uv["leakage"]
+
+        # Miriad records a single set of d-terms for the whole data set, somewhat
+        # similar to how they're stored in MeasuremenSet format.
+        times = None
+        for name in ("gains", "bandpass"):
+            try:
+                times = uv[name][0]
+                break
+            except (KeyError, OSError):
+                continue
+        if times is None:
+            # Nothing else to go on, use the first record of the data.
+            times = np.array([uv["time"]])
+
+        self.Ntimes = 1
+        self.time_range = np.array([[times.min(), times.max()]])
+        self.integration_time = np.array([(times.max() - times.min()) * 86400.0])
+
+        soln_mask = ~np.all(leakage == 0.0, axis=1)
+
+        # Shape is (Nants_data, Njones), and needs to end up as
+        # (Nants_data, Nspws, Ntimes, Njones).
+        self.gain_array = np.repeat(leakage[soln_mask, None, None], self.Nspws, axis=1)
+        self.flag_array = self.gain_array == 0.0
+        self.ant_array = np.nonzero(soln_mask)[0]
+        self.Nants_data = self.ant_array.size

--- a/src/pyuvdata/uvcal/miriad_cal.py
+++ b/src/pyuvdata/uvcal/miriad_cal.py
@@ -167,6 +167,11 @@ class MiriadCal(UVCal):
             "leakage": ("leakage", self._read_leakage_table),
         }
 
+        if (soln_type is not None) and (soln_type not in _SOLN_TYPES):
+            raise ValueError(
+                f"soln_type must be one of {list(_SOLN_TYPES)}, got {soln_type}."
+            )
+
         found = []
         for item, (probe, _) in _SOLN_TYPES.items():
             try:
@@ -190,10 +195,6 @@ class MiriadCal(UVCal):
                 )
             soln_type = found[0]
 
-        if soln_type not in _SOLN_TYPES:
-            raise ValueError(
-                f"soln_type must be one of {list(_SOLN_TYPES)}, got {soln_type}."
-            )
         if soln_type not in found:
             raise ValueError(
                 f"This Miriad data set has no {soln_type} table, it contains {listing}."

--- a/src/pyuvdata/uvcal/uvcal.py
+++ b/src/pyuvdata/uvcal/uvcal.py
@@ -4974,6 +4974,62 @@ class UVCal(UVBase):
         self._convert_from_filetype(ms_cal_obj)
         del ms_cal_obj
 
+    def read_miriad_cal(self, filepath, **kwargs):
+        """
+        Read in calibration solutions from a Miriad data set.
+
+        Miriad stores calibration solutions alongside the visibilities rather than in
+        a standalone table, so this reads the calibration items out of a Miriad data
+        set and uses the visibility header for the antenna and frequency metadata.
+
+        Parameters
+        ----------
+        filepath : str
+            The Miriad data set to read from.
+        soln_type : str
+            Which calibration table to read, one of "gains", "delays", "bandpass" or
+            "leakage". Each is returned as an independent UVCal object: "gains" and
+            "delays" are wide band (the latter being the tau terms stored alongside
+            the gains), "bandpass" is frequency resolved, and "leakage" is carried as
+            the cross-handed Jones terms. If left unset, the table is selected
+            automatically, which requires that the data set contain exactly one.
+        default_mount_type : str
+            If not recorded in the data set or telescope is unknown to pyuvdata, the
+            `Telescope.mount_type` parameter is automatically set to "other". However,
+            users can specify a different default by passing an argument here.
+        default_x_orientation : str
+            By default, if not found on read, the x_orientation parameter will be
+            set to "east" and a warning will be raised. However, if a value for
+            default_x_orientation is provided, it will be used instead and the
+            warning will be suppressed.
+        run_check : bool
+            Option to check for the existence and proper shapes of
+            parameters after reading in the file.
+        check_extra : bool
+            Option to check optional parameters as well as required ones.
+        run_check_acceptability : bool
+            Option to check acceptable range of the values of
+            parameters after reading in the file.
+        astrometry_library : str
+            Library used for calculating LSTs. Allowed options are 'erfa' (which
+            uses the pyERFA), 'novas' (which uses the python-novas library), and
+            'astropy' (which uses the astropy utilities). Default is erfa unless
+            the telescope_location frame is MCMF (on the moon), in which case the
+            default is astropy.
+
+        """
+        from . import miriad_cal
+
+        if isinstance(filepath, list | tuple):
+            raise ValueError(
+                "Use the generic `UVCal.read` method to read multiple files."
+            )
+
+        miriad_obj = miriad_cal.MiriadCal()
+        miriad_obj.read_miriad_cal(filepath, **kwargs)
+        self._convert_from_filetype(miriad_obj)
+        del miriad_obj
+
     def read(
         self,
         filename,

--- a/src/pyuvdata/uvcal/uvcal.py
+++ b/src/pyuvdata/uvcal/uvcal.py
@@ -5064,10 +5064,13 @@ class UVCal(UVBase):
         settings_file=None,
         raw=True,
         extra_history=None,
-        # MSCal
+        # MSCal 
+        time_atol=0.25,
+        # MSCal and MiriadCal
         default_x_orientation=None,
         default_jones_array=None,
-        time_atol=0.25,
+        # MiriadCal
+        soln_type=None,
     ):
         """
         Read a generic file into a UVCal object.
@@ -5083,10 +5086,11 @@ class UVCal(UVBase):
         filename : str or array_like of str
             The file(s) or list(s) (or array(s)) of files to read from.
         file_type : str
-            One of ['calfits', 'fhd'] or None. If None, the code attempts to guess what
-            the file type is based on file extensions (FHD: .sav, .txt;
-            uvfits: .calfits). Note that if a list of datasets is passed, the file type
-            is determined from the first dataset.
+            One of ['calfits', 'fhd', 'ms', 'miriad'] or None. If None, the code
+            attempts to guess what the file type is based on file extensions
+            (FHD: .sav, .txt; uvfits: .calfits) or contents (MIRIAD: presence of
+            vartable, MS: presence of the OBSERVATION table). Note that if a list of
+            datasets is passed, the file type is determined from the first dataset.
         axis : str
             Axis to concatenate files along. This enables fast concatenation
             along the specified axis without the normal checking that all other
@@ -5195,6 +5199,15 @@ class UVCal(UVBase):
 
         MSCal
         -----
+        time_atol : float
+            Absolute tolerance for time comparisons, in units of seconds. Can be used
+            to adjust the strictness of time matching during read in of calibration
+            solutions (since some operations can introduce small time offsets larger
+            than the `UVCal` default tolerance of 1 millisecond). Default is 0.25,
+            based on emperical measurements form CASA-derived calibration tables.
+
+        MSCal and MiriadCal
+        -----
         default_x_orientation : str
             By default, if not found on read, the x_orientation parameter will be
             set to "east" and a warning will be raised. However, if a value for
@@ -5205,12 +5218,13 @@ class UVCal(UVBase):
             set to [-5, -6] (linear pols) and a warning will be raised. However,
             if a value for default_jones_array is provided, it will be used instead
             and the warning will be suppressed.
-        time_atol : float
-            Absolute tolerance for time comparisons, in units of seconds. Can be used
-            to adjust the strictness of time matching during read in of calibration
-            solutions (since some operations can introduce small time offsets larger
-            than the `UVCal` default tolerance of 1 millisecond). Default is 0.25,
-            based on emperical measurements form CASA-derived calibration tables.
+
+        MiriadCal
+        ---------
+        soln_type : str or None
+            The type of solution used in the MiriadCal file. Must be one of "bandpass",
+            "gain", "delay", or "leakage". Default is None, which will look at the file
+            and attempt to infer the solution type from the file contents.
 
         """
         if isinstance(filename, list | tuple | np.ndarray):
@@ -5251,6 +5265,9 @@ class UVCal(UVBase):
             ):
                 # It's a measurement set.
                 file_type = "ms"
+            elif os.path.exists(os.path.join(file_test, "vartable")):
+                # It's miriad.
+                file_type = "miriad"
 
         if file_type is None:
             raise ValueError(
@@ -5258,9 +5275,10 @@ class UVCal(UVBase):
                 "file_type keyword to specify the type."
             )
 
-        if file_type not in ["calfits", "fhd", "calh5", "ms"]:
+        if file_type not in ["calfits", "fhd", "calh5", "ms", "miriad"]:
             raise ValueError(
-                "The only supported file_types are 'calfits', 'calh5', 'fhd', and 'ms'."
+                "The only supported file_types are 'calfits', 'calh5', 'fhd', "
+                "'ms', and 'miriad'."
             )
 
         obs_file_use = None
@@ -5418,7 +5436,7 @@ class UVCal(UVBase):
                 # Because self was at the beginning of the list,
                 # everything is merged into it at the end of this loop
         else:
-            if file_type in ["fhd", "calfits", "ms"]:
+            if file_type in ["fhd", "calfits", "ms", "miriad"]:
                 if (
                     antenna_nums is not None
                     or antenna_names is not None
@@ -5521,6 +5539,17 @@ class UVCal(UVBase):
                     run_check_acceptability=run_check_acceptability,
                     astrometry_library=astrometry_library,
                     time_atol=time_atol,
+                )
+            elif file_type == "miriad":
+                self.read_miriad_cal(
+                    filename,
+                    soln_type=soln_type,
+                    default_x_orientation=default_x_orientation,
+                    default_mount_type=default_mount_type,
+                    run_check=run_check,
+                    check_extra=check_extra,
+                    run_check_acceptability=run_check_acceptability,
+                    astrometry_library=astrometry_library,
                 )
 
             if select:

--- a/src/pyuvdata/uvcal/uvcal.py
+++ b/src/pyuvdata/uvcal/uvcal.py
@@ -5064,7 +5064,7 @@ class UVCal(UVBase):
         settings_file=None,
         raw=True,
         extra_history=None,
-        # MSCal 
+        # MSCal
         time_atol=0.25,
         # MSCal and MiriadCal
         default_x_orientation=None,

--- a/src/pyuvdata/uvdata/aipy_extracts.py
+++ b/src/pyuvdata/uvdata/aipy_extracts.py
@@ -568,8 +568,6 @@ class UV(_miriad.UV):
 
     def _hinit_special(self, name):
         """Initialize a special header table."""
-        if name not in ["gains", "bandpass", "leakage"]:
-            pass
         # Initialize an 8-byte entry so that uvio can "latch"
         np.int64(0).tofile(os.path.join(self.filename, name))
         handle = self.haccess(name, "append")
@@ -624,7 +622,9 @@ class UV(_miriad.UV):
                 ntau = delay_arr.shape[2]
                 val_arr = delay_arr
             if gain_arr is not None and delay_arr is not None:
-                val_arr = np.concatenate((gain_arr, delay_arr))
+                # Miriad stores the tau term alongside the gains for each antenna, so
+                # the two have to be interleaved along the feed axis.
+                val_arr = np.concatenate((gain_arr, delay_arr), axis=2)
 
             nsolns = len(timestamps)
             for idx in range(nsolns):

--- a/src/pyuvdata/uvdata/aipy_extracts.py
+++ b/src/pyuvdata/uvdata/aipy_extracts.py
@@ -13,6 +13,7 @@ used by pyuvdata are ``uv_selector`` and ``UV``.
 __all__ = ["uv_selector", "UV"]
 
 import contextlib
+import os
 import re
 
 import numpy as np
@@ -256,10 +257,12 @@ itemtable = {
     "ntau": "i",
     "nsols": "i",
     "interval": "d",
-    "leakage": "c",
+    "leakage": "?",
+    "gains": "?",
     "freq0": "d",
     "freqs": "?",
-    "bandpass": "c",
+    "bandpass": "?",
+    "nbpsols": "i",
     "nspect0": "i",
     "nchan0": "i",
     "stopt": "d",
@@ -306,7 +309,7 @@ class UV(_miriad.UV):
             )
         # when reading mutliple files we may get a numpy array of file names
         # numpy casts arrays as np.str_ and cython does not like this
-        _miriad.UV.__init__(self, str(filename), status, corrmode)
+        _miriad.UV.__init__(self, self.filename, status, corrmode)
 
         self.status = status
         self.nchan = _miriad.MAXCHAN
@@ -504,8 +507,70 @@ class UV(_miriad.UV):
 
             _miriad.hdaccess(h)
             return rv
+        elif name == "gains":
+            h = self.haccess(name, "read")
+            offset = 8
+            nsolns = self["nsols"]
+            ngains = self["ngains"]
+            nants = self["nants"]
+            ntau = self["ntau"]
+            nfeeds = self["nfeeds"]
+            timestamps = np.empty(nsolns, dtype=float)
+            soln_arr = np.empty((nsolns, ngains), dtype=np.complex64)
+
+            for idx in range(nsolns):
+                timestamps[idx], o = _miriad.hread(h, offset, "d")
+                offset += o
+                for jdx in range(ngains):
+                    soln_arr[idx, jdx], o = _miriad.hread(h, offset, "c")
+                    offset += o
+            _miriad.hdaccess(h)
+            soln_arr = np.reshape(soln_arr, (nsolns, nants, nfeeds + ntau))
+            gain_arr = None if (nfeeds == 0) else soln_arr[:, :, :nfeeds]
+            delay_arr = None if (ntau == 0) else soln_arr[:, :, nfeeds:].imag
+
+            return timestamps, gain_arr, delay_arr
+        elif name == "bandpass":
+            h = self.haccess(name, "read")
+            offset = 8
+            nvals = self["nchan0"] * self["nfeeds"] * self["nants"]
+            nsolns = self["nbpsols"]
+            timestamps = np.empty(nsolns, dtype=np.float64)
+            soln_arr = np.empty((nsolns, nvals), dtype=np.complex64)
+            for idx in range(nsolns):
+                for jdx in range(nvals):
+                    soln_arr[idx, jdx], o = _miriad.hread(h, offset, "c")
+                    offset += o
+                timestamps[idx], o = _miriad.hread(h, offset, "d")
+                offset += o
+            _miriad.hdaccess(h)
+            soln_arr = np.reshape(
+                soln_arr, (nsolns, self["nants"], self["nfeeds"], self["nchan0"])
+            )
+            return timestamps, soln_arr
+        elif name == "leakage":
+            h = self.haccess(name, "read")
+            offset = 8
+            nvals = self["nants"] * self["nfeeds"]
+            soln_arr = np.empty(nvals, dtype=np.complex64)
+            for idx in range(nvals):
+                soln_arr[idx], o = _miriad.hread(h, offset, "c")
+                offset += o
+            _miriad.hdaccess(h)
+            soln_arr = np.reshape(soln_arr, (self["nants"], self["nfeeds"]))
+            return soln_arr
         else:
             raise ValueError("Unknown special header: " + name)
+
+    def _hinit_special(self, name):
+        """Initialize a special header table."""
+        if name not in ["gains", "bandpass", "leakage"]:
+            pass
+        # Initialize an 8-byte entry so that uvio can "latch"
+        np.int64(0).tofile(os.path.join(self.filename, name))
+        handle = self.haccess(name, "append")
+        offset = 8
+        return handle, offset
 
     def _wrhd_special(self, name, val):
         """Provide write access to special header items of type '?' to _wrhd."""
@@ -522,6 +587,54 @@ class UV(_miriad.UV):
                 offset += 8
 
             _miriad.hdaccess(h)
+        elif name == "leakage":
+            # Initialize the leakage table
+            handle, offset = self._hinit_special(name)
+            for item in val.flat:
+                _miriad.hwrite(handle, offset, item, "c")
+                offset += 8
+            _miriad.hdaccess(handle)
+        elif name == "bandpass":
+            handle, offset = self._hinit_special(name)
+            timestamps, soln_arr = val
+            nsolns = soln_arr.shape[0]
+            for idx in range(nsolns):
+                for item in soln_arr[idx].flat:
+                    _miriad.hwrite(handle, offset, item, "c")
+                    offset += 8
+                _miriad.hwrite(handle, offset, timestamps[idx], "d")
+                offset += 8
+            self["nbpsols"] = nsolns
+            _miriad.hdaccess(handle)
+        elif name == "gains":
+            handle, offset = self._hinit_special(name)
+            timestamps, gain_arr, delay_arr = val
+            nfeeds = ntau = val_arr = 0
+            if gain_arr is not None:
+                nfeeds = gain_arr.shape[2]
+                val_arr = gain_arr
+            if delay_arr is not None:
+                temp_arr = np.zeros_like(delay_arr, dtype=np.complex64)
+                temp_arr.imag[:] = delay_arr
+                delay_arr = temp_arr
+                ntau = delay_arr.shape[2]
+                val_arr = delay_arr
+            if gain_arr is not None and delay_arr is not None:
+                val_arr = np.concatenate((gain_arr, delay_arr))
+
+            nsolns = len(timestamps)
+            for idx in range(nsolns):
+                _miriad.hwrite(handle, offset, timestamps[idx], "d")
+                offset += 8
+                for item in val_arr[idx].flat:
+                    _miriad.hwrite(handle, offset, item, "c")
+                    offset += 8
+
+            self["ngains"] = val_arr.size // nsolns
+            self["nfeeds"] = nfeeds
+            self["ntau"] = ntau
+            self["nsols"] = nsolns
+            _miriad.hdaccess(handle)
         else:
             raise ValueError("Unknown special header: " + name)
 

--- a/src/pyuvdata/uvdata/aipy_extracts.py
+++ b/src/pyuvdata/uvdata/aipy_extracts.py
@@ -15,8 +15,11 @@ __all__ = ["uv_selector", "UV"]
 import contextlib
 import os
 import re
+import warnings
 
 import numpy as np
+from astropy import constants as const, units
+from astropy.coordinates import EarthLocation
 
 try:
     from . import _miriad
@@ -309,6 +312,7 @@ class UV(_miriad.UV):
             )
         # when reading mutliple files we may get a numpy array of file names
         # numpy casts arrays as np.str_ and cython does not like this
+        self.filename = str(filename)
         _miriad.UV.__init__(self, self.filename, status, corrmode)
 
         self.status = status
@@ -866,3 +870,534 @@ class UV(_miriad.UV):
             string indicating the variable type (e.g. 'a', 'i', 'd')
         """
         self.vartable[name] = var_type
+
+    def get_freq_axis(self):
+        """
+        Construct the frequency axis of the underlying visibility data.
+
+        Returns
+        -------
+        freq_array : ndarray of float
+            Channel frequencies in Hz, shape (nchan,).
+        channel_width : ndarray of float
+            Channel widths in Hz, shape (nchan,).
+        flex_spw_id_array : ndarray of int
+            Spectral window number for each channel, shape (nchan,).
+        spw_array : ndarray of int
+            The spectral window numbers, shape (nspect,).
+        """
+        nspws = self["nspect"]
+        if nspws > 1:
+            # Channel widths are described per spw, just need to expand it out to be
+            # for each frequency channel.
+            channel_width = np.concatenate(
+                tuple(
+                    np.full(nchan, 1e9 * np.abs(chan_width), dtype=np.float64)
+                    for chan_width, nchan in zip(
+                        self["sdf"], self["nschan"], strict=True
+                    )
+                )
+            )
+            freq_array = np.concatenate(
+                tuple(
+                    (chan_width * np.arange(nchan, dtype=np.float64) + sfreq) * 1e9
+                    for chan_width, nchan, sfreq in zip(
+                        self["sdf"], self["nschan"], self["sfreq"], strict=True
+                    )
+                )
+            )
+            # TODO: Fix this to capture unsorted spectra
+            flex_spw_id_array = np.concatenate(
+                tuple(
+                    np.full(nchan, idx, dtype=int)
+                    for idx, nchan in zip(range(nspws), self["nschan"], strict=True)
+                )
+            )
+        else:
+            # sdf (delta freq) and sfreq (chan0 freq) are both in GHz
+            nchan = self["nchan"]
+            flex_spw_id_array = np.zeros(nchan, dtype=int)
+            freq_array = 1e9 * (np.arange(nchan) * self["sdf"] + self["sfreq"])
+            # Do the units and potential sign conversion for channel_width
+            channel_width = np.full(nchan, np.abs(self["sdf"] * 1e9))
+
+        return freq_array, channel_width, flex_spw_id_array, np.arange(nspws)
+
+    def get_data_antennas(self):
+        """
+        Determine which antennas actually appear in the visibilities.
+
+        Returns
+        -------
+        list of int
+            Sorted antenna numbers that appear in the data.
+
+        """
+        ants = set()
+        while True:
+            try:
+                bl_ants = self.read(raw=True)[0][2]
+            except OSError:
+                # Raised once the records have been exhausted.
+                break
+            ants.update(bl_ants)
+        self.rewind()
+
+        return sorted(int(ant) for ant in ants)
+
+    def get_telescope(
+        self, *, telescope=None, sorted_unique_ants=None, correct_lat_lon=True
+    ):
+        """
+        Build a Telescope object from the metadata recorded in a Miriad data set.
+
+        Parameters
+        ----------
+        telescope : Telescope
+            An existing object to populate, which will preserve attributes not directly
+            set by this method (e.g., `Telescope.instrument`). Default is None, which
+            creates a new Telescope object from scratch.
+        sorted_unique_ants : list of int
+            The antennas that actually appear in the visibilities, used to work out
+            which antennas to keep track of. Note this is needed because MIRIAD uses
+            antenna number to index antenna-based information (such that if only
+            antennas 0 and 100 are present, values for antennas 1-99 are populated with
+            zeros). Default is None, in which case `get_data_antennas` is used to
+            determine the antennas.
+        correct_lat_lon : bool
+            Option to update the latitude and longitude from the known_telescopes
+            list if the altitude is missing.
+
+        Returns
+        -------
+        telescope : Telescope
+            The telescope described by the data set.
+
+        """
+        from ..telescopes import Telescope
+
+        if sorted_unique_ants is None:
+            sorted_unique_ants = self.get_data_antennas()
+        if telescope is None:
+            telescope = Telescope()
+        telescope.name = self["telescop"].replace("\x00", "")
+        if "instrume" in self.vartable:
+            telescope.instrument = self["instrume"].replace("\x00", "")
+        else:
+            # set instrument to the telescope name if not set
+            telescope.instrument = telescope.name
+
+        self._load_telescope_coords(telescope, correct_lat_lon=correct_lat_lon)
+        self._load_antpos(telescope, sorted_unique_ants=sorted_unique_ants)
+        self._load_feeds(telescope)
+
+        return telescope
+
+    def _load_feeds(self, telescope):
+        """
+        Load the mount and feed description onto a Telescope object, if recorded.
+
+        Miriad records `mount` for every one of the `nants` antennas, while pyuvdata
+        writes these out per antenna that it is tracking, so anything sized by `nants`
+        has to be cut down to the antennas that were kept.
+
+        Parameters
+        ----------
+        telescope : Telescope
+            The object to load the mount and feed information onto. The antennas must
+            already have been loaded onto it by `_load_antpos`.
+
+        """
+        from .. import utils
+
+        nants = self["nants"]
+        ant_nums = telescope.antenna_numbers
+
+        def _select_ants(arr):
+            """Cut an array indexed by Miriad antenna number down to the ants used."""
+            return arr[ant_nums] if len(arr) == nants else arr
+
+        if "mount" in self.vartable:
+            mount = self["mount"]
+            if not isinstance(mount, np.ndarray):
+                mount = np.full(nants, mount)
+            telescope.mount_type = [
+                utils.antenna.MOUNT_NUM2STR_DICT[item] for item in _select_ants(mount)
+            ]
+        if all(item in self.vartable for item in ["nfeeds", "feedarr", "feedang"]):
+            telescope.Nfeeds = self["nfeeds"]
+            telescope.feed_array = _select_ants(
+                np.array(
+                    [
+                        item.strip()
+                        for item in self["feedarr"].replace("\x00", "")[1:-1].split(",")
+                    ],
+                    dtype=np.object_,
+                ).reshape(-1, telescope.Nfeeds)
+            )
+            telescope.feed_angle = _select_ants(
+                self["feedang"].reshape(-1, telescope.Nfeeds)
+            )
+
+    def _load_telescope_coords(self, telescope, *, correct_lat_lon=True):
+        """
+        Load telescope lat, lon, alt coordinates onto a Telescope object.
+
+        Parameters
+        ----------
+        telescope : Telescope
+            The object to load the coordinates onto.
+        correct_lat_lon : bool
+            Option to update the latitude and longitude from the known_telescopes
+            list if the altitude is missing.
+
+        """
+        from ..telescopes import known_telescope_location
+
+        latitude = self["latitud"]  # in units of radians
+        longitude = self["longitu"]
+
+        # Catch a weird case where where sometimes long is wrapped like RA (0 -> 2pi
+        # instead of -pi -> pi)
+        if longitude > np.pi:
+            longitude -= 2 * np.pi
+        try:
+            altitude = self["altitude"]
+            telescope.location = EarthLocation.from_geodetic(
+                lat=latitude * units.rad,
+                lon=longitude * units.rad,
+                height=altitude * units.m,
+            )
+        except KeyError:
+            # get info from known telescopes.
+            # Check to make sure the lat/lon values match reasonably well
+            try:
+                telescope_loc = known_telescope_location(telescope.name)
+            except ValueError:
+                telescope_loc = None
+            if telescope_loc is not None:
+                tol = 2 * np.pi * 1e-3 / (60.0 * 60.0 * 24.0)  # 1mas in radians
+                lat_close = np.isclose(
+                    telescope_loc.lat.rad, latitude, rtol=0, atol=tol
+                )
+                lon_close = np.isclose(
+                    telescope_loc.lon.rad, longitude, rtol=0, atol=tol
+                )
+                if correct_lat_lon:
+                    telescope.location = telescope_loc
+                else:
+                    telescope.location = EarthLocation.from_geodetic(
+                        lat=latitude * units.rad,
+                        lon=longitude * units.rad,
+                        height=telescope_loc.height,
+                    )
+                if lat_close and lon_close:
+                    if correct_lat_lon:
+                        warnings.warn(
+                            "Altitude is not present in Miriad file, "
+                            f"using known location values for {telescope.name}."
+                        )
+                    else:
+                        warnings.warn(
+                            "Altitude is not present in Miriad file, "
+                            "using known location altitude value "
+                            f"for {telescope.name} and lat/lon from file."
+                        )
+                else:
+                    warn_string = "Altitude is not present in file "
+                    if not lat_close and not lon_close:
+                        warn_string = (
+                            warn_string
+                            + "and latitude and longitude values do not match values "
+                        )
+                    else:
+                        if not lat_close:
+                            warn_string = (
+                                warn_string + "and latitude value does not match value "
+                            )
+                        else:
+                            warn_string = (
+                                warn_string
+                                + "and longitude value does not match value "
+                            )
+                    if correct_lat_lon:
+                        warn_string = (
+                            warn_string + f"for {telescope.name} in known "
+                            "telescopes. Using values from known telescopes."
+                        )
+                        warnings.warn(warn_string)
+                    else:
+                        warn_string = (
+                            warn_string + f"for {telescope.name} in known "
+                            "telescopes. Using altitude value from known "
+                            "telescopes and lat/lon from file."
+                        )
+                        warnings.warn(warn_string)
+            else:
+                warnings.warn(
+                    "Altitude is not present in Miriad file, and "
+                    f"telescope {telescope.name} is not in "
+                    "known_telescopes. Telescope location will be "
+                    "set using antenna positions."
+                )
+
+    def _load_antpos(self, telescope, *, sorted_unique_ants=None):
+        """
+        Load antennas and their positions onto a Telescope object.
+
+        Parameters
+        ----------
+        telescope : Telescope
+            The object to load the antennas and positions onto.
+        sorted_unique_ants : list of int
+            The antennas that actually appear in the visibilities.
+
+        """
+        from .. import utils
+
+        latitude = self["latitud"]  # in units of radians
+        longitude = self["longitu"]
+
+        # Miriad has no way to keep track of antenna numbers, so the antenna
+        # numbers are simply the index for each antenna in any array that
+        # describes antenna attributes (e.g. antpos for the antenna_positions).
+        # Therefore on write, nants (which gives the size of the antpos array)
+        # needs to be increased to be the max value of antenna_numbers+1 and the
+        # antpos array needs to be inflated with zeros at locations where we
+        # don't have antenna information. These inflations need to be undone at
+        # read. If the file was written by pyuvdata, then the variable antnums
+        # will be present and we can use it, otherwise we need to test for zeros
+        # in the antpos array and/or antennas with no visibilities.
+        try:
+            # The antnums variable will only exist if the file was written with
+            # pyuvdata.
+            # For some reason Miriad doesn't handle an array of integers properly,
+            # so we convert to floats on write and back here
+            telescope.antenna_numbers = self["antnums"].astype(int)
+            telescope.Nants = len(telescope.antenna_numbers)
+        except KeyError:
+            telescope.antenna_numbers = None
+            telescope.Nants = None
+
+        nants = self["nants"]
+        try:
+            # Miriad stores antpos values in units of ns, pyuvdata uses meters.
+            antpos = self["antpos"].reshape(3, nants).T * const.c.to_value("m/ns")
+
+            # first figure out what are good antenna positions so we can only
+            # use the non-zero ones to evaluate position information
+            antpos_length = np.sqrt(np.sum(np.abs(antpos) ** 2, axis=1))
+            good_antpos = np.where(antpos_length > 0)[0]
+            absolute_positions = False
+            if any(good_antpos):
+                mean_antpos_length = np.mean(antpos_length[good_antpos])
+                if mean_antpos_length > 6.35e6 and mean_antpos_length < 6.39e6:
+                    absolute_positions = True
+
+            # Miriad stores antpos values in a rotated ECEF coordinate system
+            # where the x-axis goes through the local meridan. Need to convert
+            # these positions back to standard ECEF and if they are absolute
+            # positions, subtract off the telescope position to make them
+            # relative to the array center.
+            ecef_antpos = utils.ECEF_from_rotECEF(antpos, longitude)
+
+            if telescope.location is not None:
+                if absolute_positions:
+                    rel_ecef_antpos = ecef_antpos - telescope._location.xyz()
+                    # maintain zeros because they mark missing data
+                    rel_ecef_antpos[np.where(antpos_length == 0)[0]] = ecef_antpos[
+                        np.where(antpos_length == 0)[0]
+                    ]
+                else:
+                    rel_ecef_antpos = ecef_antpos
+            else:
+                telescope.location = EarthLocation.from_geocentric(
+                    *np.mean(ecef_antpos[good_antpos, :], axis=0) * units.m
+                )
+                valid_location = utils.coordinates.check_surface_based_positions(
+                    telescope_loc=telescope.location,
+                    raise_error=False,
+                    raise_warning=False,
+                )
+
+                # check to see if this could be a valid telescope location
+                if valid_location:
+                    mean_lon, mean_lat, mean_alt = telescope.location.geodetic
+                    mean_lat = mean_lat.rad
+                    mean_lon = mean_lon.rad
+                    mean_alt = mean_alt.to_value("m")
+                    tol = 2 * np.pi / (60.0 * 60.0 * 24.0)  # 1 arcsecond in radians
+                    mean_lat_close = np.isclose(mean_lat, latitude, rtol=0, atol=tol)
+                    mean_lon_close = np.isclose(mean_lon, longitude, rtol=0, atol=tol)
+
+                    if mean_lat_close and mean_lon_close:
+                        # this looks like a valid telescope location, and the
+                        # mean antenna lat & lon values are close. Set the
+                        # telescope location using the file lat/lons and the mean alt.
+                        # Then subtract it off of the antenna positions
+                        warnings.warn(
+                            "Telescope location is not set, but antenna "
+                            "positions are present. Mean antenna latitude and "
+                            "longitude values match file values, so "
+                            "telescope_position will be set using the "
+                            "mean of the antenna altitudes"
+                        )
+                        telescope.location = EarthLocation.from_geodetic(
+                            lat=latitude * units.rad,
+                            lon=longitude * units.rad,
+                            height=mean_alt * units.m,
+                        )
+                        rel_ecef_antpos = ecef_antpos - telescope._location.xyz()
+
+                    else:
+                        # this looks like a valid telescope location, but the
+                        # mean antenna lat & lon values are not close. Set the
+                        # telescope location using the file lat/lons at sea level.
+                        # Then subtract it off of the antenna positions
+                        telescope.location = EarthLocation.from_geodetic(
+                            lat=latitude * units.rad, lon=longitude * units.rad
+                        )
+                        warn_string = (
+                            "Telescope location is set at sealevel at "
+                            "the file lat/lon coordinates. Antenna "
+                            "positions are present, but the mean "
+                            "antenna "
+                        )
+                        rel_ecef_antpos = ecef_antpos - telescope._location.xyz()
+
+                        if not mean_lat_close and not mean_lon_close:
+                            warn_string += (
+                                "latitude and longitude values do not "
+                                "match file values so they are not used "
+                                "for altitude."
+                            )
+                        elif not mean_lat_close:
+                            warn_string += (
+                                "latitude value does not "
+                                "match file values so they are not used "
+                                "for altitude."
+                            )
+                        else:
+                            warn_string += (
+                                "longitude value does not "
+                                "match file values so they are not used "
+                                "for altitude."
+                            )
+                        warnings.warn(warn_string)
+
+                else:
+                    # This does not give a valid telescope location. Instead
+                    # calculate it from the file lat/lon and sea level for altitude
+                    telescope.location = EarthLocation.from_geodetic(
+                        lat=latitude * units.rad, lon=longitude * units.rad
+                    )
+                    warn_string = (
+                        "Telescope location is set at sealevel at the file lat/lon "
+                        "coordinates. Antenna positions are present, but the mean "
+                        "antenna position does not give a telescope location on the "
+                        "surface of the earth."
+                    )
+                    if absolute_positions:
+                        rel_ecef_antpos = ecef_antpos - telescope._location.xyz()
+                    else:
+                        warn_string += (
+                            " Antenna positions do not appear to be "
+                            "on the surface of the earth and will be treated "
+                            "as relative."
+                        )
+                        rel_ecef_antpos = ecef_antpos
+
+                    warnings.warn(warn_string)
+
+            if telescope.Nants is not None:
+                # in this case there is an antnums variable
+                # (meaning that the file was written with pyuvdata), so we'll use it
+                if nants == telescope.Nants:
+                    # no inflation, so just use the positions
+                    telescope.antenna_positions = rel_ecef_antpos
+                else:
+                    # there is some inflation, just use the ones that appear in antnums
+                    telescope.antenna_positions = np.zeros(
+                        (telescope.Nants, 3), dtype=antpos.dtype
+                    )
+                    for ai, num in enumerate(telescope.antenna_numbers):
+                        telescope.antenna_positions[ai, :] = rel_ecef_antpos[num, :]
+            else:
+                # there is no antnums variable (meaning that this file was not
+                # written by pyuvdata), so we test for antennas with non-zero
+                # positions and/or that appear in the visibility data
+                # (meaning that they have entries in ant_1_array or ant_2_array)
+                antpos_length = np.sqrt(np.sum(np.abs(antpos) ** 2, axis=1))
+                good_antpos = np.where(antpos_length > 0)[0]
+                # take the union of the antennas with good positions (good_antpos)
+                # and the antennas that have visisbilities (sorted_unique_ants)
+                # if there are antennas with visibilities but zeroed positions
+                # we issue a warning below
+                if sorted_unique_ants is not None:
+                    ants_use = set(good_antpos).union(sorted_unique_ants)
+                else:
+                    ants_use = set(good_antpos)
+                # ants_use are the antennas we'll keep track of in the UVData
+                # object, so they dictate Nants_telescope
+                telescope.Nants = len(ants_use)
+                telescope.antenna_numbers = np.array(list(ants_use))
+                telescope.antenna_positions = np.zeros(
+                    (telescope.Nants, 3), dtype=rel_ecef_antpos.dtype
+                )
+                for ai, num in enumerate(telescope.antenna_numbers):
+                    if antpos_length[num] == 0:
+                        warnings.warn(
+                            f"antenna number {num} has visibilities "
+                            "associated with it, but it has a position"
+                            " of (0,0,0)"
+                        )
+                    else:
+                        # leave bad locations as zeros to make them obvious
+                        telescope.antenna_positions[ai, :] = rel_ecef_antpos[num, :]
+
+        except KeyError:
+            # there is no antpos variable
+            warnings.warn("Antenna positions are not present in the file.")
+            telescope.antenna_positions = None
+
+            if telescope.location is None:
+                telescope.location = EarthLocation.from_geodetic(
+                    lat=latitude * units.rad, lon=longitude * units.rad
+                )
+                warnings.warn(
+                    "Telescope location is set at sealevel at the file lat/lon "
+                    "coordinates because neither altitude nor antenna positions "
+                    "are present in the file."
+                )
+
+        if telescope.antenna_numbers is None and sorted_unique_ants is not None:
+            # there are no antenna_numbers or antenna_positions, so just use
+            # the antennas present in the visibilities
+            # (Nants_data will therefore match Nants_telescope)
+            telescope.antenna_numbers = np.array(sorted_unique_ants)
+            telescope.Nants = len(telescope.antenna_numbers)
+
+        # antenna names is a foreign concept in miriad but required in other formats.
+        try:
+            # Here we deal with the way pyuvdata tacks it on to keep the
+            # name information if we have it:
+            # make it into one long comma-separated string
+            ant_name_var = self["antnames"]
+            ant_name_str = ant_name_var.replace("\x00", "")
+            ant_name_list = ant_name_str[1:-1].split(", ")
+            telescope.antenna_names = ant_name_list
+        except KeyError:
+            if telescope.antenna_numbers is not None:
+                telescope.antenna_names = telescope.antenna_numbers.astype(str).tolist()
+
+        # check for antenna diameters
+        try:
+            telescope.antenna_diameters = self["antdiam"]
+        except KeyError:
+            # backwards compatibility for when keyword was 'diameter'
+            with contextlib.suppress(KeyError):
+                telescope.antenna_diameters = self["diameter"]
+        if telescope.antenna_diameters is not None:
+            telescope.antenna_diameters = telescope.antenna_diameters * np.ones(
+                telescope.Nants, dtype=np.float64
+            )

--- a/src/pyuvdata/uvdata/miriad.py
+++ b/src/pyuvdata/uvdata/miriad.py
@@ -122,6 +122,7 @@ class Miriad(UVData):
             "freq",
             "freqs",
             "leakage",
+            "gains",
             "bandpass",
             "tscale",
             "coord",

--- a/src/pyuvdata/uvdata/miriad.py
+++ b/src/pyuvdata/uvdata/miriad.py
@@ -213,7 +213,7 @@ class Miriad(UVData):
                 self._blt_order.form = (1,)
         return default_miriad_variables, other_miriad_variables, extra_miriad_variables
 
-    def _read_miriad_metadata(self, uv, *, correct_lat_lon=True):
+    def _read_miriad_metadata(self, uv, *, correct_lat_lon=True, read_data=True):
         """
         Read in metadata (parameter info) but not data from a miriad file.
 
@@ -224,6 +224,10 @@ class Miriad(UVData):
         correct_lat_lon : bool
             Option to update the latitude and longitude from the known_telescopes
             list if the altitude is missing.
+        read_data : bool
+            Whether the caller goes on to read the visibilities. If it does, the
+            antennas carrying data are identified during that pass and loaded then,
+            so the scan for them is skipped here.
 
         Returns
         -------
@@ -281,7 +285,13 @@ class Miriad(UVData):
                     self.extra_keywords[key] = uv[key]
 
         # load the telescope object
-        uv.get_telescope(telescope=self.telescope, correct_lat_lon=correct_lat_lon)
+        # A full read works the antennas out from the data it is about to load and
+        # hands them to _load_antpos below, so skip scanning for them here.
+        uv.get_telescope(
+            telescope=self.telescope,
+            correct_lat_lon=correct_lat_lon,
+            sorted_unique_ants=[] if read_data else None,
+        )
 
         if "antdiam" not in uv.vartable and "diameter" in uv.vartable:
             # the diameters came from the legacy 'diameter' keyword, so drop it from

--- a/src/pyuvdata/uvdata/miriad.py
+++ b/src/pyuvdata/uvdata/miriad.py
@@ -10,14 +10,13 @@ import warnings
 
 import numpy as np
 import scipy
-from astropy import constants as const, units
+from astropy import constants as const
 from astropy.coordinates import Angle, EarthLocation, SkyCoord
 from astropy.time import Time
 from docstring_parser import DocstringStyle
 
 from .. import utils
 from ..docstrings import copy_replace_short_description
-from ..telescopes import known_telescope_location
 from . import UVData
 from .uvdata import reporting_request
 
@@ -176,42 +175,13 @@ class Miriad(UVData):
             header_value = uv[miriad_header_data[item]]
             setattr(self, item, header_value)
 
-        self.telescope.name = uv["telescop"].replace("\x00", "")
-
         # Deal with the spectral axis now
-        if self.Nspws > 1:
-            # Channel widths are described per spw, just need to expand it out to be
-            # for each frequency channel.
-            self.channel_width = np.concatenate(
-                tuple(
-                    np.full(nchan, 1e9 * np.abs(chan_width), dtype=np.float64)
-                    for chan_width, nchan in zip(uv["sdf"], uv["nschan"], strict=True)
-                )
-            )
-            # Now setup frequency array
-            self.freq_array = np.concatenate(
-                tuple(
-                    (chan_width * np.arange(nchan, dtype=np.float64) + sfreq) * 1e9
-                    for chan_width, nchan, sfreq in zip(
-                        uv["sdf"], uv["nschan"], uv["sfreq"], strict=True
-                    )
-                )
-            )
-            # TODO: Fix this to capture unsorted spectra
-            self.flex_spw_id_array = np.concatenate(
-                tuple(
-                    np.full(nchan, idx, dtype=int)
-                    for idx, nchan in zip(range(self.Nspws), uv["nschan"], strict=True)
-                )
-            )
-        else:
-            # sdf (delta freq) and sfreq (chan0 freq) are both in GHz
-            self.flex_spw_id_array = np.zeros(self.Nfreqs, dtype=int)
-            self.freq_array = 1e9 * (np.arange(self.Nfreqs) * uv["sdf"] + uv["sfreq"])
-            # Do the units and potential sign conversion for channel_width
-            self.channel_width = np.full(self.Nfreqs, np.abs(uv["sdf"] * 1e9))
-
-        self.spw_array = np.arange(self.Nspws)
+        (
+            self.freq_array,
+            self.channel_width,
+            self.flex_spw_id_array,
+            self.spw_array,
+        ) = uv.get_freq_axis()
 
         self.history = uv["history"]
         if not utils.history._check_history_version(
@@ -224,12 +194,6 @@ class Miriad(UVData):
             self.vis_units = uv["visunits"].replace("\x00", "")
         else:
             self.vis_units = "uncalib"  # assume no calibration
-        if "instrume" in uv.vartable:
-            self.telescope.instrument = uv["instrume"].replace("\x00", "")
-        else:
-            # set instrument = telescope name
-            self.telescope.instrument = self.telescope.name
-
         if "dut1" in uv.vartable:
             self.dut1 = uv["dut1"]
         if "degpdy" in uv.vartable:
@@ -247,409 +211,7 @@ class Miriad(UVData):
             self.blt_order = tuple(blt_order_str.split(", "))
             if self.blt_order == ("bda",):
                 self._blt_order.form = (1,)
-        if "mount" in uv.vartable:
-            mount = uv["mount"]
-            if not isinstance(mount, np.ndarray):
-                mount = np.full(uv["nants"], mount)
-            self.telescope.mount_type = [
-                utils.antenna.MOUNT_NUM2STR_DICT[item] for item in mount
-            ]
-        if all(item in uv.vartable for item in ["nfeeds", "feedarr", "feedang"]):
-            self.telescope.Nfeeds = uv["nfeeds"]
-            self.telescope.feed_array = np.array(
-                [
-                    item.strip()
-                    for item in uv["feedarr"].replace("\x00", "")[1:-1].split(",")
-                ],
-                dtype=np.object_,
-            ).reshape(-1, self.telescope.Nfeeds)
-            self.telescope.feed_angle = uv["feedang"].reshape(-1, self.telescope.Nfeeds)
-
         return default_miriad_variables, other_miriad_variables, extra_miriad_variables
-
-    def _load_telescope_coords(self, uv, *, correct_lat_lon=True):
-        """
-        Load telescope lat, lon, alt coordinates from aipy.miriad UV descriptor.
-
-        Parameters
-        ----------
-        uv : aipy.miriad.UV
-            aipy object to load lat, lon, alt coordinates from.
-        correct_lat_lon : bool
-            Option to update the latitude and longitude from the known_telescopes
-            list if the altitude is missing.
-
-        """
-        # check if telescope name is present
-        if self.telescope.name is None:
-            self._load_miriad_variables(uv)
-
-        latitude = uv["latitud"]  # in units of radians
-        longitude = uv["longitu"]
-
-        # Catch a weird case where where sometimes long is wrapped like RA (0 -> 2pi
-        # instead of -pi -> pi)
-        if longitude > np.pi:
-            longitude -= 2 * np.pi
-        try:
-            altitude = uv["altitude"]
-            self.telescope.location = EarthLocation.from_geodetic(
-                lat=latitude * units.rad,
-                lon=longitude * units.rad,
-                height=altitude * units.m,
-            )
-        except KeyError:
-            # get info from known telescopes.
-            # Check to make sure the lat/lon values match reasonably well
-            try:
-                telescope_loc = known_telescope_location(self.telescope.name)
-            except ValueError:
-                telescope_loc = None
-            if telescope_loc is not None:
-                tol = 2 * np.pi * 1e-3 / (60.0 * 60.0 * 24.0)  # 1mas in radians
-                lat_close = np.isclose(
-                    telescope_loc.lat.rad, latitude, rtol=0, atol=tol
-                )
-                lon_close = np.isclose(
-                    telescope_loc.lon.rad, longitude, rtol=0, atol=tol
-                )
-                if correct_lat_lon:
-                    self.telescope.location = telescope_loc
-                else:
-                    self.telescope.location = EarthLocation.from_geodetic(
-                        lat=latitude * units.rad,
-                        lon=longitude * units.rad,
-                        height=telescope_loc.height,
-                    )
-                if lat_close and lon_close:
-                    if correct_lat_lon:
-                        warnings.warn(
-                            "Altitude is not present in Miriad file, "
-                            "using known location values for "
-                            f"{self.telescope.name}."
-                        )
-                    else:
-                        warnings.warn(
-                            "Altitude is not present in Miriad file, "
-                            "using known location altitude value "
-                            f"for {self.telescope.name} and lat/lon from "
-                            "file."
-                        )
-                else:
-                    warn_string = "Altitude is not present in file "
-                    if not lat_close and not lon_close:
-                        warn_string = (
-                            warn_string
-                            + "and latitude and longitude values do not match values "
-                        )
-                    else:
-                        if not lat_close:
-                            warn_string = (
-                                warn_string + "and latitude value does not match value "
-                            )
-                        else:
-                            warn_string = (
-                                warn_string
-                                + "and longitude value does not match value "
-                            )
-                    if correct_lat_lon:
-                        warn_string = (
-                            warn_string + f"for {self.telescope.name} in known "
-                            "telescopes. Using values from known telescopes."
-                        )
-                        warnings.warn(warn_string)
-                    else:
-                        warn_string = (
-                            warn_string + f"for {self.telescope.name} in known "
-                            "telescopes. Using altitude value from known "
-                            "telescopes and lat/lon from file."
-                        )
-                        warnings.warn(warn_string)
-            else:
-                warnings.warn(
-                    "Altitude is not present in Miriad file, and "
-                    f"telescope {self.telescope.name} is not in "
-                    "known_telescopes. Telescope location will be "
-                    "set using antenna positions."
-                )
-
-    def _load_antpos(self, uv, *, sorted_unique_ants=None, correct_lat_lon=True):
-        """
-        Load antennas and their positions from a Miriad UV descriptor.
-
-        Parameters
-        ----------
-        uv : aipy.miriad.UV
-            aipy object to antennas and positions from.
-        sorted_unique_ants : list of ints, optional
-            List of unique antennas.
-        correct_lat_lon : bool
-            Option to update the latitude and longitude from the known_telescopes
-            list if the altitude is missing.
-
-        """
-        # check if telescope coords exist
-        if self.telescope.location is None:
-            self._load_telescope_coords(uv, correct_lat_lon=correct_lat_lon)
-
-        latitude = uv["latitud"]  # in units of radians
-        longitude = uv["longitu"]
-
-        # Miriad has no way to keep track of antenna numbers, so the antenna
-        # numbers are simply the index for each antenna in any array that
-        # describes antenna attributes (e.g. antpos for the antenna_positions).
-        # Therefore on write, nants (which gives the size of the antpos array)
-        # needs to be increased to be the max value of antenna_numbers+1 and the
-        # antpos array needs to be inflated with zeros at locations where we
-        # don't have antenna information. These inflations need to be undone at
-        # read. If the file was written by pyuvdata, then the variable antnums
-        # will be present and we can use it, otherwise we need to test for zeros
-        # in the antpos array and/or antennas with no visibilities.
-        try:
-            # The antnums variable will only exist if the file was written with
-            # pyuvdata.
-            # For some reason Miriad doesn't handle an array of integers properly,
-            # so we convert to floats on write and back here
-            self.telescope.antenna_numbers = uv["antnums"].astype(int)
-            self.telescope.Nants = len(self.telescope.antenna_numbers)
-        except KeyError:
-            self.telescope.antenna_numbers = None
-            self.telescope.Nants = None
-
-        nants = uv["nants"]
-        try:
-            # Miriad stores antpos values in units of ns, pyuvdata uses meters.
-            antpos = uv["antpos"].reshape(3, nants).T * const.c.to_value("m/ns")
-
-            # first figure out what are good antenna positions so we can only
-            # use the non-zero ones to evaluate position information
-            antpos_length = np.sqrt(np.sum(np.abs(antpos) ** 2, axis=1))
-            good_antpos = np.where(antpos_length > 0)[0]
-            absolute_positions = False
-            if any(good_antpos):
-                mean_antpos_length = np.mean(antpos_length[good_antpos])
-                if mean_antpos_length > 6.35e6 and mean_antpos_length < 6.39e6:
-                    absolute_positions = True
-
-            # Miriad stores antpos values in a rotated ECEF coordinate system
-            # where the x-axis goes through the local meridan. Need to convert
-            # these positions back to standard ECEF and if they are absolute
-            # positions, subtract off the telescope position to make them
-            # relative to the array center.
-            ecef_antpos = utils.ECEF_from_rotECEF(antpos, longitude)
-
-            if self.telescope.location is not None:
-                if absolute_positions:
-                    rel_ecef_antpos = ecef_antpos - self.telescope._location.xyz()
-                    # maintain zeros because they mark missing data
-                    rel_ecef_antpos[np.where(antpos_length == 0)[0]] = ecef_antpos[
-                        np.where(antpos_length == 0)[0]
-                    ]
-                else:
-                    rel_ecef_antpos = ecef_antpos
-            else:
-                self.telescope.location = EarthLocation.from_geocentric(
-                    *np.mean(ecef_antpos[good_antpos, :], axis=0) * units.m
-                )
-                valid_location = utils.coordinates.check_surface_based_positions(
-                    telescope_loc=self.telescope.location,
-                    raise_error=False,
-                    raise_warning=False,
-                )
-
-                # check to see if this could be a valid telescope location
-                if valid_location:
-                    mean_lon, mean_lat, mean_alt = self.telescope.location.geodetic
-                    mean_lat = mean_lat.rad
-                    mean_lon = mean_lon.rad
-                    mean_alt = mean_alt.to_value("m")
-                    tol = 2 * np.pi / (60.0 * 60.0 * 24.0)  # 1 arcsecond in radians
-                    mean_lat_close = np.isclose(mean_lat, latitude, rtol=0, atol=tol)
-                    mean_lon_close = np.isclose(mean_lon, longitude, rtol=0, atol=tol)
-
-                    if mean_lat_close and mean_lon_close:
-                        # this looks like a valid telescope location, and the
-                        # mean antenna lat & lon values are close. Set the
-                        # telescope location using the file lat/lons and the mean alt.
-                        # Then subtract it off of the antenna positions
-                        warnings.warn(
-                            "Telescope location is not set, but antenna "
-                            "positions are present. Mean antenna latitude and "
-                            "longitude values match file values, so "
-                            "telescope_position will be set using the "
-                            "mean of the antenna altitudes"
-                        )
-                        self.telescope.location = EarthLocation.from_geodetic(
-                            lat=latitude * units.rad,
-                            lon=longitude * units.rad,
-                            height=mean_alt * units.m,
-                        )
-                        rel_ecef_antpos = ecef_antpos - self.telescope._location.xyz()
-
-                    else:
-                        # this looks like a valid telescope location, but the
-                        # mean antenna lat & lon values are not close. Set the
-                        # telescope location using the file lat/lons at sea level.
-                        # Then subtract it off of the antenna positions
-                        self.telescope.location = EarthLocation.from_geodetic(
-                            lat=latitude * units.rad, lon=longitude * units.rad
-                        )
-                        warn_string = (
-                            "Telescope location is set at sealevel at "
-                            "the file lat/lon coordinates. Antenna "
-                            "positions are present, but the mean "
-                            "antenna "
-                        )
-                        rel_ecef_antpos = ecef_antpos - self.telescope._location.xyz()
-
-                        if not mean_lat_close and not mean_lon_close:
-                            warn_string += (
-                                "latitude and longitude values do not "
-                                "match file values so they are not used "
-                                "for altitude."
-                            )
-                        elif not mean_lat_close:
-                            warn_string += (
-                                "latitude value does not "
-                                "match file values so they are not used "
-                                "for altitude."
-                            )
-                        else:
-                            warn_string += (
-                                "longitude value does not "
-                                "match file values so they are not used "
-                                "for altitude."
-                            )
-                        warnings.warn(warn_string)
-
-                else:
-                    # This does not give a valid telescope location. Instead
-                    # calculate it from the file lat/lon and sea level for altitude
-                    self.telescope.location = EarthLocation.from_geodetic(
-                        lat=latitude * units.rad, lon=longitude * units.rad
-                    )
-                    warn_string = (
-                        "Telescope location is set at sealevel at the file lat/lon "
-                        "coordinates. Antenna positions are present, but the mean "
-                        "antenna position does not give a telescope location on the "
-                        "surface of the earth."
-                    )
-                    if absolute_positions:
-                        rel_ecef_antpos = ecef_antpos - self.telescope._location.xyz()
-                    else:
-                        warn_string += (
-                            " Antenna positions do not appear to be "
-                            "on the surface of the earth and will be treated "
-                            "as relative."
-                        )
-                        rel_ecef_antpos = ecef_antpos
-
-                    warnings.warn(warn_string)
-
-            if self.telescope.Nants is not None:
-                # in this case there is an antnums variable
-                # (meaning that the file was written with pyuvdata), so we'll use it
-                if nants == self.telescope.Nants:
-                    # no inflation, so just use the positions
-                    self.telescope.antenna_positions = rel_ecef_antpos
-                else:
-                    # there is some inflation, just use the ones that appear in antnums
-                    self.telescope.antenna_positions = np.zeros(
-                        (self.telescope.Nants, 3), dtype=antpos.dtype
-                    )
-                    for ai, num in enumerate(self.telescope.antenna_numbers):
-                        self.telescope.antenna_positions[ai, :] = rel_ecef_antpos[
-                            num, :
-                        ]
-            else:
-                # there is no antnums variable (meaning that this file was not
-                # written by pyuvdata), so we test for antennas with non-zero
-                # positions and/or that appear in the visibility data
-                # (meaning that they have entries in ant_1_array or ant_2_array)
-                antpos_length = np.sqrt(np.sum(np.abs(antpos) ** 2, axis=1))
-                good_antpos = np.where(antpos_length > 0)[0]
-                # take the union of the antennas with good positions (good_antpos)
-                # and the antennas that have visisbilities (sorted_unique_ants)
-                # if there are antennas with visibilities but zeroed positions
-                # we issue a warning below
-                if sorted_unique_ants is not None:
-                    ants_use = set(good_antpos).union(sorted_unique_ants)
-                else:
-                    ants_use = set(good_antpos)
-                # ants_use are the antennas we'll keep track of in the UVData
-                # object, so they dictate Nants_telescope
-                self.telescope.Nants = len(ants_use)
-                self.telescope.antenna_numbers = np.array(list(ants_use))
-                self.telescope.antenna_positions = np.zeros(
-                    (self.telescope.Nants, 3), dtype=rel_ecef_antpos.dtype
-                )
-                for ai, num in enumerate(self.telescope.antenna_numbers):
-                    if antpos_length[num] == 0:
-                        warnings.warn(
-                            f"antenna number {num} has visibilities "
-                            "associated with it, but it has a position"
-                            " of (0,0,0)"
-                        )
-                    else:
-                        # leave bad locations as zeros to make them obvious
-                        self.telescope.antenna_positions[ai, :] = rel_ecef_antpos[
-                            num, :
-                        ]
-
-        except KeyError:
-            # there is no antpos variable
-            warnings.warn("Antenna positions are not present in the file.")
-            self.telescope.antenna_positions = None
-
-            if self.telescope.location is None:
-                self.telescope.location = EarthLocation.from_geodetic(
-                    lat=latitude * units.rad, lon=longitude * units.rad
-                )
-                warnings.warn(
-                    "Telescope location is set at sealevel at the file lat/lon "
-                    "coordinates because neither altitude nor antenna positions "
-                    "are present in the file."
-                )
-
-        if self.telescope.antenna_numbers is None and sorted_unique_ants is not None:
-            # there are no antenna_numbers or antenna_positions, so just use
-            # the antennas present in the visibilities
-            # (Nants_data will therefore match Nants_telescope)
-            self.telescope.antenna_numbers = np.array(sorted_unique_ants)
-            self.telescope.Nants = len(self.telescope.antenna_numbers)
-
-        # antenna names is a foreign concept in miriad but required in other formats.
-        try:
-            # Here we deal with the way pyuvdata tacks it on to keep the
-            # name information if we have it:
-            # make it into one long comma-separated string
-            ant_name_var = uv["antnames"]
-            ant_name_str = ant_name_var.replace("\x00", "")
-            ant_name_list = ant_name_str[1:-1].split(", ")
-            self.telescope.antenna_names = ant_name_list
-        except KeyError:
-            if self.telescope.antenna_numbers is not None:
-                self.telescope.antenna_names = self.telescope.antenna_numbers.astype(
-                    str
-                ).tolist()
-
-        # check for antenna diameters
-        try:
-            self.telescope.antenna_diameters = uv["antdiam"]
-        except KeyError:
-            # backwards compatibility for when keyword was 'diameter'
-            try:
-                self.telescope.antenna_diameters = uv["diameter"]
-                # if we find it, we need to remove it from extra_keywords to
-                # keep from writing it out
-                self.extra_keywords.pop("diameter")
-            except KeyError:
-                pass
-        if self.telescope.antenna_diameters is not None:
-            self.telescope.antenna_diameters = (
-                self.telescope.antenna_diameters
-                * np.ones(self.telescope.Nants, dtype=np.float64)
-            )
 
     def _read_miriad_metadata(self, uv, *, correct_lat_lon=True):
         """
@@ -718,11 +280,13 @@ class Miriad(UVData):
                 else:
                     self.extra_keywords[key] = uv[key]
 
-        # load telescope coords
-        self._load_telescope_coords(uv, correct_lat_lon=correct_lat_lon)
+        # load the telescope object
+        uv.get_telescope(telescope=self.telescope, correct_lat_lon=correct_lat_lon)
 
-        # load antenna positions
-        self._load_antpos(uv)
+        if "antdiam" not in uv.vartable and "diameter" in uv.vartable:
+            # the diameters came from the legacy 'diameter' keyword, so drop it from
+            # extra_keywords to keep from writing it out
+            self.extra_keywords.pop("diameter", None)
 
         return (
             default_miriad_variables,
@@ -770,7 +334,9 @@ class Miriad(UVData):
             other_miriad_variables,
             extra_miriad_variables,
             check_variables,
-        ) = self._read_miriad_metadata(uv, correct_lat_lon=correct_lat_lon)
+        ) = self._read_miriad_metadata(
+            uv, correct_lat_lon=correct_lat_lon, read_data=read_data
+        )
 
         # update filename attribute
         basename = filepath.rstrip("/")
@@ -1135,8 +701,11 @@ class Miriad(UVData):
         reverse_inds = dict(zip(unique_blts, range(len(unique_blts)), strict=True))
         self.Nants_data = len(sorted_unique_ants)
 
-        # load antennas and antenna positions using sorted unique ants list
-        self._load_antpos(uv, sorted_unique_ants=sorted_unique_ants)
+        # load antennas and antenna positions using sorted unique ants list. The
+        # metadata pass only had the antennas with non-zero positions to go on, so the
+        # feeds have to be reloaded alongside them to stay aligned.
+        uv._load_antpos(self.telescope, sorted_unique_ants=sorted_unique_ants)
+        uv._load_feeds(self.telescope)
 
         # form up a grid which indexes time and baselines along the 'long'
         # axis of the visdata array

--- a/src/pyuvdata/uvdata/miriad.py
+++ b/src/pyuvdata/uvdata/miriad.py
@@ -558,7 +558,11 @@ class Miriad(UVData):
             if len(d.shape) == 1:
                 d = np.reshape(d, (1, *d.shape))
 
-            if np.size(d) != self.Nfreqs:
+            if np.size(d) != self.Nfreqs:  # pragma: no cover
+                # N.b. (Karto): UV.read always asks for the nchan recorded when the
+                # file was opened, which is the same value Nfreqs is taken from, so the
+                # two cannot disagree no matter what the individual records hold, at
+                # least not with a valid reader.
                 raise ValueError("Number of channels in spectrum has changed!")
             try:
                 cnt = uv["cnt"]
@@ -1065,7 +1069,7 @@ class Miriad(UVData):
                                 lat_use[inverse == t_ind], tols=radian_tols
                             ):
                                 raise ValueError(
-                                    f"Source {name} has different RA values for "
+                                    f"Source {name} has different Dec values for "
                                     "different baselines at the same time."
                                     + reporting_request
                                 )

--- a/tests/uvcal/test_miriad_cal.py
+++ b/tests/uvcal/test_miriad_cal.py
@@ -94,7 +94,7 @@ def delay_path(tmp_path, atca_path):
 def test_read_atca(atca_path, soln_type, cal_type, wide_band, jones):
     """Check each table this data set carries comes back with the right shape."""
     uvc = UVCal()
-    uvc.read_miriad_cal(atca_path, soln_type=soln_type)
+    uvc.read(atca_path, soln_type=soln_type)
 
     assert uvc.cal_type == cal_type
     assert uvc.wide_band == wide_band
@@ -118,7 +118,7 @@ def test_values_match_low_level(atca_path):
     uv.close()
 
     uvc = UVCal()
-    uvc.read_miriad_cal(atca_path, soln_type="gains")
+    uvc.read(atca_path, soln_type="gains")
     # (Ntimes, Nants, Njones) -> (Nants, Nspws, Ntimes, Njones), replicated over spws
     assert np.array_equal(uvc.gain_array[:, 0], np.transpose(gains, (1, 0, 2)))
 
@@ -126,7 +126,7 @@ def test_values_match_low_level(atca_path):
 def test_freq_range_covers_data(atca_path):
     """Each wide band window must span the channels it is meant to apply to."""
     uvc = UVCal()
-    uvc.read_miriad_cal(atca_path, soln_type="gains")
+    uvc.read(atca_path, soln_type="gains")
 
     uv = aipy_extracts.UV(atca_path)
     freq_array, _, flex_spw_id_array, spw_array = uv.get_freq_axis()
@@ -145,7 +145,7 @@ def test_bandpass_uses_own_freq_axis(atca_path):
     uv.close()
 
     uvc = UVCal()
-    uvc.read_miriad_cal(atca_path, soln_type="bandpass")
+    uvc.read(atca_path, soln_type="bandpass")
     assert uvc.Nfreqs == nchan0
     assert uvc.freq_array.size == nchan0
 
@@ -153,7 +153,7 @@ def test_bandpass_uses_own_freq_axis(atca_path):
 def test_reference_antenna(atca_path):
     """Miriad pins the reference antenna to zero phase, which is recoverable."""
     uvc = UVCal()
-    uvc.read_miriad_cal(atca_path, soln_type="gains")
+    uvc.read(atca_path, soln_type="gains")
     ant_num = uvc.telescope.antenna_numbers[
         list(uvc.telescope.antenna_names).index(uvc.ref_antenna_name)
     ]
@@ -178,7 +178,7 @@ def test_antennas_from_solutions(tmp_path, atca_path):
 
     testfile = _copy_with(tmp_path, atca_path, "refpad.uv", override={"antpos": antpos})
     uvc = UVCal()
-    uvc.read_miriad_cal(testfile, soln_type="gains")
+    uvc.read(testfile, soln_type="gains")
     assert uvc.Nants_data == nants
     assert 0 in uvc.ant_array
 
@@ -194,7 +194,7 @@ def test_unpopulated_antenna_dropped(tmp_path, atca_path):
 
     testfile = _copy_with(tmp_path, atca_path, "deadant.uv", gains=(times, gains, None))
     uvc = UVCal()
-    uvc.read_miriad_cal(testfile, soln_type="gains")
+    uvc.read(testfile, soln_type="gains")
     assert uvc.Nants_data == nants - 1
     assert 3 not in uvc.ant_array
 
@@ -247,9 +247,9 @@ def test_read_delays(delay_path):
 def test_delays_and_gains_agree(delay_path):
     """The gains and delays tables describe the same antennas and times."""
     gain_obj = UVCal()
-    gain_obj.read_miriad_cal(delay_path, soln_type="gains")
+    gain_obj.read(delay_path, soln_type="gains")
     delay_obj = UVCal()
-    delay_obj.read_miriad_cal(delay_path, soln_type="delays")
+    delay_obj.read(delay_path, soln_type="delays")
 
     assert np.array_equal(gain_obj.ant_array, delay_obj.ant_array)
     assert np.array_equal(gain_obj.time_array, delay_obj.time_array)
@@ -282,7 +282,7 @@ def test_two_feed_circular(tmp_path, atca_path, leakage):
     """Circular data gets circular Jones codes, cross-handed for leakages."""
     testfile = _copy_with(tmp_path, atca_path, "atca_circ.uv", override={"pol": -2})
     uvc = UVCal()
-    uvc.read_miriad_cal(testfile, soln_type="leakage" if leakage else "gains")
+    uvc.read(testfile, soln_type="leakage" if leakage else "gains")
     assert np.array_equal(uvc.jones_array, [-3, -4] if leakage else [-1, -2])
 
 
@@ -320,7 +320,7 @@ def test_soln_type_autodetect(tmp_path, atca_path):
         tmp_path, atca_path, "gains_only.uv", exclude=_DROP_BANDPASS + _DROP_LEAKAGE
     )
     uvc = UVCal()
-    uvc.read_miriad_cal(testfile)
+    uvc.read(testfile)
     assert uvc.cal_type == "gain"
     assert uvc.wide_band
 
@@ -330,7 +330,7 @@ def test_leakage_time_fallback(tmp_path, atca_path):
         tmp_path, atca_path, "leakage_only.uv", exclude=_DROP_GAINS + _DROP_BANDPASS
     )
     uvc = UVCal()
-    uvc.read_miriad_cal(testfile, soln_type="leakage")
+    uvc.read(testfile, soln_type="leakage")
 
     uv = aipy_extracts.UV(testfile)
     uv.read(raw=True)

--- a/tests/uvcal/test_miriad_cal.py
+++ b/tests/uvcal/test_miriad_cal.py
@@ -10,6 +10,7 @@ import pytest
 
 from pyuvdata import UVCal
 from pyuvdata.datasets import fetch_data
+from pyuvdata.testing import check_warnings
 
 aipy_extracts = pytest.importorskip(
     "pyuvdata.uvdata.aipy_extracts", exc_type=ImportError
@@ -26,19 +27,60 @@ def atca_path():
     return str(fetch_data("atca_miriad"))
 
 
-def _copy_with(tmp_path, source, name, *, override=None, gains=None):
+def _copy_with(
+    tmp_path, source, name, *, override=None, gains=None, items=None, exclude=None
+):
     """Write a copy of a Miriad data set, optionally altering it on the way out."""
     outfile = os.path.join(tmp_path, name)
     uv_in = aipy_extracts.UV(source)
     uv_out = aipy_extracts.UV(outfile, status="new")
-    uv_out.init_from_uv(uv_in, override={} if override is None else override)
+    uv_out.init_from_uv(
+        uv_in,
+        override={} if override is None else override,
+        exclude=[] if exclude is None else exclude,
+    )
+    # Variables have to be registered after init_from_uv, which rebuilds the vartable,
+    # and written before the records so that they get flushed along with them.
+    for key, value in (items or {}).items():
+        if key not in aipy_extracts.itemtable:
+            uv_out.add_var(key, "a")
+            uv_out[key] = value
     uv_out.pipe(uv_in)
     if gains is not None:
         uv_out["gains"] = gains
+    for key, value in (items or {}).items():
+        if key in aipy_extracts.itemtable:
+            uv_out[key] = value
     uv_in.close()
     uv_out.close()
 
     return outfile
+
+
+# Items that have to be dropped to leave a data set carrying a single table.
+_DROP_GAINS = ["gains", "nsols", "ngains", "ntau"]
+_DROP_BANDPASS = ["bandpass", "nchan0", "nspect0", "nbpsols", "freqs"]
+_DROP_LEAKAGE = ["leakage"]
+
+
+@pytest.fixture(scope="function")
+def delay_path(tmp_path, atca_path):
+    """A copy of the ATCA set with tau terms added to the gains table."""
+    uv = aipy_extracts.UV(atca_path)
+    times, gains, _ = uv["gains"]
+    uv.close()
+    nsols, nants, _ = gains.shape
+    # tau is stored in nanoseconds, as -2 * pi * tau
+    delays = np.linspace(-0.5, 0.5, nsols * nants, dtype=np.float32)
+    delays = (-2 * np.pi * delays).reshape(nsols, nants, 1)
+
+    return _copy_with(
+        tmp_path,
+        atca_path,
+        "atca_delays.uv",
+        gains=(times, gains, delays),
+        items={"freq0": 2.1},
+    )
 
 
 @pytest.mark.parametrize(
@@ -179,3 +221,160 @@ def test_read_missing_file():
 def test_read_list_error(atca_path):
     with pytest.raises(ValueError, match="Use the generic `UVCal.read` method"):
         UVCal().read_miriad_cal([atca_path, atca_path])
+
+
+def test_read_delays(delay_path):
+    """The tau terms come back as a delay object, in seconds."""
+    uv = aipy_extracts.UV(delay_path)
+    _, _, theta = uv["gains"]
+    freq0 = uv["freq0"]
+    uv.close()
+
+    uvc = UVCal()
+    uvc.read_miriad_cal(delay_path, soln_type="delays")
+
+    assert uvc.cal_type == "delay"
+    assert uvc.wide_band
+    assert uvc.delay_array.shape == (uvc.Nants_data, uvc.Nspws, uvc.Ntimes, uvc.Njones)
+    # Miriad writes -2 * pi * tau with tau in nanoseconds
+    want = -1e-9 * np.transpose(theta, (1, 0, 2)) / (2 * np.pi)
+    assert np.allclose(uvc.delay_array[:, 0, :, :1], want)
+    # one delay per antenna, replicated over the Jones axis
+    assert np.allclose(uvc.delay_array[..., 0], uvc.delay_array[..., -1])
+    assert uvc.extra_keywords["FREQ0"] == freq0
+    assert "freq0" in uvc.history
+
+
+def test_delays_and_gains_agree(delay_path):
+    """The gains and delays tables describe the same antennas and times."""
+    gain_obj = UVCal()
+    gain_obj.read_miriad_cal(delay_path, soln_type="gains")
+    delay_obj = UVCal()
+    delay_obj.read_miriad_cal(delay_path, soln_type="delays")
+
+    assert np.array_equal(gain_obj.ant_array, delay_obj.ant_array)
+    assert np.array_equal(gain_obj.time_array, delay_obj.time_array)
+    assert np.array_equal(gain_obj.jones_array, delay_obj.jones_array)
+    assert gain_obj.cal_type == "gain"
+    assert delay_obj.cal_type == "delay"
+
+
+def test_single_feed_circular(tmp_path, atca_path):
+    """A single circular feed takes its Jones component from the data pol."""
+    uv = aipy_extracts.UV(atca_path)
+    times, gains, _ = uv["gains"]
+    uv.close()
+    # keep one feed, and relabel the data as circular
+    testfile = _copy_with(
+        tmp_path,
+        atca_path,
+        "atca_1feed.uv",
+        override={"pol": -1},
+        gains=(times, gains[:, :, :1], None),
+    )
+    uvc = UVCal()
+    uvc.read_miriad_cal(testfile, soln_type="gains")
+    assert np.array_equal(uvc.jones_array, [-1])
+    assert uvc.Njones == 1
+
+
+@pytest.mark.parametrize("leakage", [False, True])
+def test_two_feed_circular(tmp_path, atca_path, leakage):
+    """Circular data gets circular Jones codes, cross-handed for leakages."""
+    testfile = _copy_with(tmp_path, atca_path, "atca_circ.uv", override={"pol": -2})
+    uvc = UVCal()
+    uvc.read_miriad_cal(testfile, soln_type="leakage" if leakage else "gains")
+    assert np.array_equal(uvc.jones_array, [-3, -4] if leakage else [-1, -2])
+
+
+def test_x_orientation_from_default(atca_path):
+    """A supplied default is used in place of the warning."""
+    uvc = UVCal()
+    # only the altitude warning -- the x_orientation one must not be raised
+    with check_warnings(UserWarning, match="Altitude is not present in file"):
+        uvc.read_miriad_cal(atca_path, soln_type="gains", default_x_orientation="north")
+    assert uvc.telescope.get_x_orientation_from_feeds() == "north"
+
+
+@pytest.mark.parametrize(
+    "override,msg",
+    [({"pol": 1}, "unrecognized pol code"), ({"npol": 3}, "expected only 1 or 2")],
+)
+def test_feed_errors(tmp_path, atca_path, override, msg):
+    """Pol codes and feed counts that cannot describe a Jones vector."""
+    uv = aipy_extracts.UV(atca_path)
+    times, gains, _ = uv["gains"]
+    uv.close()
+    gains_arg = None
+    if "npol" in override:
+        # nfeeds is written from the gains table, not from npol
+        gains_arg = (times, np.repeat(gains, 2, axis=2)[:, :, :3], None)
+        override = {}
+    testfile = _copy_with(
+        tmp_path, atca_path, "atca_badpol.uv", override=override, gains=gains_arg
+    )
+    with pytest.raises(ValueError, match=msg):
+        UVCal().read_miriad_cal(testfile, soln_type="gains")
+
+
+def test_soln_type_autodetect(tmp_path, atca_path):
+    """With only one table present, soln_type does not have to be given."""
+    testfile = _copy_with(
+        tmp_path, atca_path, "gains_only.uv", exclude=_DROP_BANDPASS + _DROP_LEAKAGE
+    )
+    uvc = UVCal()
+    uvc.read_miriad_cal(testfile)
+    assert uvc.cal_type == "gain"
+    assert uvc.wide_band
+
+
+def test_leakage_time_fallback(tmp_path, atca_path):
+    """With no gains or bandpass to date it against, leakage uses the data time."""
+    testfile = _copy_with(
+        tmp_path, atca_path, "leakage_only.uv", exclude=_DROP_GAINS + _DROP_BANDPASS
+    )
+    uvc = UVCal()
+    uvc.read_miriad_cal(testfile, soln_type="leakage")
+
+    uv = aipy_extracts.UV(testfile)
+    uv.read(raw=True)
+    first_time = uv["time"]
+    uv.close()
+    assert uvc.Ntimes == 1
+    assert np.allclose(uvc.time_range, first_time)
+
+
+def test_x_orientation_from_file(tmp_path, atca_path):
+    """A recorded xorient is used in preference to the default."""
+    testfile = _copy_with(tmp_path, atca_path, "xorient.uv", items={"xorient": "north"})
+    uvc = UVCal()
+    with check_warnings(UserWarning, match="Altitude is not present in file"):
+        uvc.read_miriad_cal(testfile, soln_type="gains")
+    assert uvc.telescope.get_x_orientation_from_feeds() == "north"
+
+
+def test_suspect_interval_warning(tmp_path, atca_path):
+    """mfcal hardcodes the interval, so flag it when it dwarfs the cadence."""
+    uv = aipy_extracts.UV(atca_path)
+    _, gains, _ = uv["gains"]
+    uv.close()
+    # four solutions a minute apart, against a declared interval of half a day
+    times = 2457080.5 + np.arange(4) / 1440.0
+    gains = np.repeat(gains, 4, axis=0)
+
+    testfile = _copy_with(
+        tmp_path,
+        atca_path,
+        "long_interval.uv",
+        gains=(times, gains, None),
+        items={"interval": 0.5},
+    )
+    with check_warnings(
+        UserWarning,
+        match=[
+            "solution interval",
+            "Altitude is not present in file",
+            "Unknown x_orientation basis",
+        ],
+    ):
+        UVCal().read_miriad_cal(testfile, soln_type="gains")

--- a/tests/uvcal/test_miriad_cal.py
+++ b/tests/uvcal/test_miriad_cal.py
@@ -88,7 +88,6 @@ def delay_path(tmp_path, atca_path):
     [
         ("gains", "gain", True, [-5, -6]),
         ("bandpass", "gain", False, [-5, -6]),
-        # leakages are carried as the cross-handed Jones terms
         ("leakage", "gain", True, [-7, -8]),
     ],
 )
@@ -301,7 +300,6 @@ def test_x_orientation_from_default(atca_path):
     [({"pol": 1}, "unrecognized pol code"), ({"npol": 3}, "expected only 1 or 2")],
 )
 def test_feed_errors(tmp_path, atca_path, override, msg):
-    """Pol codes and feed counts that cannot describe a Jones vector."""
     uv = aipy_extracts.UV(atca_path)
     times, gains, _ = uv["gains"]
     uv.close()
@@ -318,7 +316,6 @@ def test_feed_errors(tmp_path, atca_path, override, msg):
 
 
 def test_soln_type_autodetect(tmp_path, atca_path):
-    """With only one table present, soln_type does not have to be given."""
     testfile = _copy_with(
         tmp_path, atca_path, "gains_only.uv", exclude=_DROP_BANDPASS + _DROP_LEAKAGE
     )
@@ -329,7 +326,6 @@ def test_soln_type_autodetect(tmp_path, atca_path):
 
 
 def test_leakage_time_fallback(tmp_path, atca_path):
-    """With no gains or bandpass to date it against, leakage uses the data time."""
     testfile = _copy_with(
         tmp_path, atca_path, "leakage_only.uv", exclude=_DROP_GAINS + _DROP_BANDPASS
     )
@@ -345,7 +341,6 @@ def test_leakage_time_fallback(tmp_path, atca_path):
 
 
 def test_x_orientation_from_file(tmp_path, atca_path):
-    """A recorded xorient is used in preference to the default."""
     testfile = _copy_with(tmp_path, atca_path, "xorient.uv", items={"xorient": "north"})
     uvc = UVCal()
     with check_warnings(UserWarning, match="Altitude is not present in file"):
@@ -354,7 +349,6 @@ def test_x_orientation_from_file(tmp_path, atca_path):
 
 
 def test_suspect_interval_warning(tmp_path, atca_path):
-    """mfcal hardcodes the interval, so flag it when it dwarfs the cadence."""
     uv = aipy_extracts.UV(atca_path)
     _, gains, _ = uv["gains"]
     uv.close()

--- a/tests/uvcal/test_miriad_cal.py
+++ b/tests/uvcal/test_miriad_cal.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2025 Radio Astronomy Software Group
+# Licensed under the 2-clause BSD License
+
+"""Tests for reading Miriad calibration tables."""
+
+import os
+
+import numpy as np
+import pytest
+
+from pyuvdata import UVCal
+from pyuvdata.datasets import fetch_data
+
+aipy_extracts = pytest.importorskip(
+    "pyuvdata.uvdata.aipy_extracts", exc_type=ImportError
+)
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Altitude is not present in file",
+    "ignore:Unknown x_orientation basis for solutions",
+)
+
+
+@pytest.fixture(scope="function")
+def atca_path():
+    return str(fetch_data("atca_miriad"))
+
+
+def _copy_with(tmp_path, source, name, *, override=None, gains=None):
+    """Write a copy of a Miriad data set, optionally altering it on the way out."""
+    outfile = os.path.join(tmp_path, name)
+    uv_in = aipy_extracts.UV(source)
+    uv_out = aipy_extracts.UV(outfile, status="new")
+    uv_out.init_from_uv(uv_in, override={} if override is None else override)
+    uv_out.pipe(uv_in)
+    if gains is not None:
+        uv_out["gains"] = gains
+    uv_in.close()
+    uv_out.close()
+
+    return outfile
+
+
+@pytest.mark.parametrize(
+    "soln_type,cal_type,wide_band,jones",
+    [
+        ("gains", "gain", True, [-5, -6]),
+        ("bandpass", "gain", False, [-5, -6]),
+        # leakages are carried as the cross-handed Jones terms
+        ("leakage", "gain", True, [-7, -8]),
+    ],
+)
+def test_read_atca(atca_path, soln_type, cal_type, wide_band, jones):
+    """Check each table this data set carries comes back with the right shape."""
+    uvc = UVCal()
+    uvc.read_miriad_cal(atca_path, soln_type=soln_type)
+
+    assert uvc.cal_type == cal_type
+    assert uvc.wide_band == wide_band
+    assert np.array_equal(uvc.jones_array, jones)
+    # Miriad multiplies the solutions into the data rather than dividing
+    assert uvc.gain_convention == "multiply"
+    assert uvc.gain_array.shape == (
+        uvc.Nants_data,
+        uvc.Nspws if wide_band else uvc.Nfreqs,
+        uvc.Ntimes,
+        uvc.Njones,
+    )
+    # a flagged solution is stored as an exact zero
+    assert np.array_equal(uvc.flag_array, uvc.gain_array == 0)
+
+
+def test_values_match_low_level(atca_path):
+    """The gains must survive the trip onto the UVCal object untouched."""
+    uv = aipy_extracts.UV(atca_path)
+    _, gains, _ = uv["gains"]
+    uv.close()
+
+    uvc = UVCal()
+    uvc.read_miriad_cal(atca_path, soln_type="gains")
+    # (Ntimes, Nants, Njones) -> (Nants, Nspws, Ntimes, Njones), replicated over spws
+    assert np.array_equal(uvc.gain_array[:, 0], np.transpose(gains, (1, 0, 2)))
+
+
+def test_freq_range_covers_data(atca_path):
+    """Each wide band window must span the channels it is meant to apply to."""
+    uvc = UVCal()
+    uvc.read_miriad_cal(atca_path, soln_type="gains")
+
+    uv = aipy_extracts.UV(atca_path)
+    freq_array, _, flex_spw_id_array, spw_array = uv.get_freq_axis()
+    uv.close()
+
+    for idx, spw in enumerate(spw_array):
+        spw_freqs = freq_array[flex_spw_id_array == spw]
+        assert uvc.freq_range[idx, 0] <= spw_freqs.min()
+        assert uvc.freq_range[idx, 1] >= spw_freqs.max()
+
+
+def test_bandpass_uses_own_freq_axis(atca_path):
+    """The bandpass axis comes from the freqs item, not the visibilities."""
+    uv = aipy_extracts.UV(atca_path)
+    nchan0 = uv["nchan0"]
+    uv.close()
+
+    uvc = UVCal()
+    uvc.read_miriad_cal(atca_path, soln_type="bandpass")
+    assert uvc.Nfreqs == nchan0
+    assert uvc.freq_array.size == nchan0
+
+
+def test_reference_antenna(atca_path):
+    """Miriad pins the reference antenna to zero phase, which is recoverable."""
+    uvc = UVCal()
+    uvc.read_miriad_cal(atca_path, soln_type="gains")
+    ant_num = uvc.telescope.antenna_numbers[
+        list(uvc.telescope.antenna_names).index(uvc.ref_antenna_name)
+    ]
+    ant_idx = np.nonzero(uvc.ant_array == ant_num)[0]
+    assert ant_idx.size == 1
+    assert np.allclose(np.angle(uvc.gain_array[ant_idx]), 0)
+
+
+@pytest.mark.filterwarnings("ignore:antenna number 0 has visibilities")
+def test_antennas_from_solutions(tmp_path, atca_path):
+    """Antennas are screened on the solutions, not on their positions.
+
+    An antenna sitting on the array reference point has a position of exactly
+    (0,0,0), which is also how Miriad marks an antenna that is not present, so the
+    positions cannot be used to tell the two apart.
+    """
+    uv = aipy_extracts.UV(atca_path)
+    nants = uv["nants"]
+    antpos = uv["antpos"].copy()
+    antpos.reshape(3, nants)[:, 0] = 0.0
+    uv.close()
+
+    testfile = _copy_with(tmp_path, atca_path, "refpad.uv", override={"antpos": antpos})
+    uvc = UVCal()
+    uvc.read_miriad_cal(testfile, soln_type="gains")
+    assert uvc.Nants_data == nants
+    assert 0 in uvc.ant_array
+
+
+def test_unpopulated_antenna_dropped(tmp_path, atca_path):
+    """An antenna with no solutions at all is left out."""
+    uv = aipy_extracts.UV(atca_path)
+    nants = uv["nants"]
+    times, gains, _ = uv["gains"]
+    gains = gains.copy()
+    gains[:, 3, :] = 0
+    uv.close()
+
+    testfile = _copy_with(tmp_path, atca_path, "deadant.uv", gains=(times, gains, None))
+    uvc = UVCal()
+    uvc.read_miriad_cal(testfile, soln_type="gains")
+    assert uvc.Nants_data == nants - 1
+    assert 3 not in uvc.ant_array
+
+
+@pytest.mark.parametrize(
+    "kwargs,err,msg",
+    [
+        ({}, ValueError, "Cannot determine which calibration table to read"),
+        ({"soln_type": "delays"}, ValueError, "has no delays table"),
+        ({"soln_type": "nonsense"}, ValueError, "soln_type must be one of"),
+    ],
+)
+def test_read_errors(atca_path, kwargs, err, msg):
+    with pytest.raises(err, match=msg):
+        UVCal().read_miriad_cal(atca_path, **kwargs)
+
+
+def test_read_missing_file():
+    with pytest.raises(OSError, match="not found"):
+        UVCal().read_miriad_cal("/no/such/miriad/set")
+
+
+def test_read_list_error(atca_path):
+    with pytest.raises(ValueError, match="Use the generic `UVCal.read` method"):
+        UVCal().read_miriad_cal([atca_path, atca_path])

--- a/tests/uvcal/test_uvcal.py
+++ b/tests/uvcal/test_uvcal.py
@@ -3416,7 +3416,8 @@ def test_read_errors():
 
     with pytest.raises(
         ValueError,
-        match="The only supported file_types are 'calfits', 'calh5', 'fhd', and 'ms'.",
+        match="The only supported file_types are 'calfits', 'calh5', 'fhd', "
+        "'ms', and 'miriad'.",
     ):
         UVCal.from_file(gainfile, file_type="foo")
 

--- a/tests/uvdata/test_aipy_extracts.py
+++ b/tests/uvdata/test_aipy_extracts.py
@@ -371,3 +371,62 @@ def test_uv_selector(polstr, antstr, ants_exp, nrec_exp):
 
     assert nrec == nrec_exp
     aipy_uv.close()
+
+
+def test_get_freq_axis():
+    """Check the frequency axis against the values recorded in the file."""
+    aipy_uv = aipy_extracts.UV(fetch_data("paper_2014_miriad"))
+    freq_array, channel_width, flex_spw_id_array, spw_array = aipy_uv.get_freq_axis()
+
+    nchan = aipy_uv["nchan"]
+    # sdf and sfreq are both recorded in GHz
+    assert np.allclose(
+        freq_array, 1e9 * (aipy_uv["sfreq"] + np.arange(nchan) * aipy_uv["sdf"])
+    )
+    assert np.allclose(channel_width, 1e9 * np.abs(aipy_uv["sdf"]))
+    assert np.array_equal(flex_spw_id_array, np.zeros(nchan, dtype=int))
+    assert np.array_equal(spw_array, np.arange(aipy_uv["nspect"]))
+    aipy_uv.close()
+
+
+@pytest.mark.filterwarnings("ignore:Altitude is not present in Miriad file")
+@pytest.mark.filterwarnings("ignore:antenna number")
+def test_get_telescope():
+    """Check that the telescope is built out of the file metadata."""
+    aipy_uv = aipy_extracts.UV(fetch_data("paper_2014_miriad"))
+    telescope = aipy_uv.get_telescope()
+
+    assert telescope.name == aipy_uv["telescop"].replace("\x00", "")
+    # instrument falls back to the telescope name when it is not recorded
+    assert telescope.instrument == telescope.name
+    assert telescope.location is not None
+    assert telescope.Nants == telescope.antenna_numbers.size
+    assert telescope.antenna_positions.shape == (telescope.Nants, 3)
+    assert len(telescope.antenna_names) == telescope.Nants
+
+    # antennas with a zeroed position are only kept if they turn up in the data,
+    # so handing one of the dropped antennas back adds it to the list
+    dropped = sorted(set(range(aipy_uv["nants"])) - set(telescope.antenna_numbers))
+    assert len(dropped) > 0
+    more_ants = aipy_uv.get_telescope(sorted_unique_ants=dropped[:1])
+    assert more_ants.Nants == telescope.Nants + 1
+    aipy_uv.close()
+
+
+def test_get_data_antennas():
+    """Check that the antennas carrying data are found, and the position restored."""
+    aipy_uv = aipy_extracts.UV(fetch_data("paper_2014_miriad"))
+    ants = aipy_uv.get_data_antennas()
+
+    # cross-check against a plain scan of the records
+    expected = set()
+    while True:
+        try:
+            expected.update(aipy_uv.read(raw=True)[0][2])
+        except OSError:
+            break
+    aipy_uv.rewind()
+    assert ants == sorted(expected)
+    # the scan must leave the data set readable from the top
+    assert aipy_uv.read(raw=True)[0][2] is not None
+    aipy_uv.close()

--- a/tests/uvdata/test_miriad.py
+++ b/tests/uvdata/test_miriad.py
@@ -2084,3 +2084,57 @@ def test_miriad_read_xorient(tmp_path):
     assert uv.telescope.Nfeeds == 1
     assert np.array_equal(uv.telescope.feed_array, [["x"]] * nants)
     assert np.array_equal(uv.telescope.feed_angle, [[np.pi / 2]] * nants)
+
+
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.filterwarnings("ignore:writing default values for restfreq")
+@pytest.mark.parametrize(
+    "varying,per_pol,err_type,err_msg",
+    [
+        ("uvw", True, ValueError, "uvw values are different"),
+        ("phsframe", True, ValueError, "phsframe values are different"),
+        ("ra", True, ValueError, "ra values are different"),
+        ("dec", True, ValueError, "dec values are different"),
+        ("ra", False, ValueError, "different RA values"),
+        ("dec", False, ValueError, "different Dec values"),
+        ("epoch", False, UserWarning, "Epoch values are varying within a single"),
+    ],
+)
+def test_inconsistent_record_values(
+    casa_uvfits: UVData, tmp_path, varying, per_pol, err_type, err_msg
+):
+    """Values that pyuvdata cannot describe as varying by pol or by baseline."""
+    uv_in = casa_uvfits
+    orig_file = os.path.join(tmp_path, "record_orig.uv")
+    test_file = os.path.join(tmp_path, "record_vary.uv")
+
+    uv_in.select(times=np.unique(uv_in.time_array)[:2])
+    npols = uv_in.Npols
+    uv_in.write_miriad(orig_file)
+
+    uv_read = aipy_extracts.UV(orig_file)
+    uv_out = aipy_extracts.UV(test_file, status="new")
+    uv_out.init_from_uv(uv_read)
+    for idx, (preamble, data, flags) in enumerate(uv_read.all_data(raw=True)):
+        # copyvr first, so anything set below is not overwritten by it
+        uv_out.copyvr(uv_read)
+        # per_pol varies the value inside a baseline-time, so the difference falls
+        # across polarizations. Otherwise it is held fixed across the pols of a
+        # baseline and varied between them, which the pol check has to not catch.
+        offset = (idx % npols) if per_pol else ((idx // npols) % 2)
+        if varying == "uvw":
+            preamble = (preamble[0] + offset, preamble[1], preamble[2])
+        elif varying == "phsframe":
+            uv_out[varying] = "icrs" if offset else "fk5 "
+        else:
+            uv_out[varying] = uv_read[varying] + 0.1 * offset
+        uv_out.write(preamble, data, flags)
+    uv_read.close()
+    uv_out.close()
+
+    if issubclass(err_type, UserWarning):
+        with check_warnings(UserWarning, [err_msg, warn_dict["uvw_mismatch"]]):
+            UVData.from_file(test_file)
+    else:
+        with pytest.raises(err_type, match=err_msg):
+            UVData.from_file(test_file)

--- a/tests/uvdata/test_miriad.py
+++ b/tests/uvdata/test_miriad.py
@@ -31,9 +31,8 @@ from astropy.time import Time, TimeDelta
 
 from pyuvdata import UVData, utils
 from pyuvdata.datasets import fetch_data
-from pyuvdata.telescopes import known_telescope_location
+from pyuvdata.telescopes import Telescope, known_telescope_location
 from pyuvdata.testing import check_warnings
-from pyuvdata.uvdata.miriad import Miriad
 
 aipy_extracts = pytest.importorskip(
     "pyuvdata.uvdata.aipy_extracts", exc_type=ImportError
@@ -468,11 +467,7 @@ def test_wronglatlon(tmp_path, override_dict, correct_lat_lon):
 
     if "telescop" in override_dict:
         warn_list.extend(
-            [
-                warn_dict["altitude_missing_foo"],
-                warn_dict["altitude_missing_foo"],
-                warn_dict["telescope_at_sealevel"],
-            ]
+            [warn_dict["altitude_missing_foo"], warn_dict["telescope_at_sealevel"]]
         )
     elif "latitud" in override_dict and "longitu" in override_dict:
         warn_list.append(warn_dict["altitude_missing_lat_long"])
@@ -531,7 +526,6 @@ def test_miriad_location_handling(paper_miriad_main, tmp_path):
         UserWarning,
         [
             warn_dict["altitude_missing_foo"],
-            warn_dict["altitude_missing_foo"],  # raised twice
             warn_dict["no_telescope_loc"],
             warn_dict["uvw_mismatch"],
         ],
@@ -554,7 +548,6 @@ def test_miriad_location_handling(paper_miriad_main, tmp_path):
         UserWarning,
         match=[
             warn_dict["altitude_missing_foo"],
-            warn_dict["altitude_missing_foo"],  # raised twice
             "Antenna positions are not present in the file.",
             "Antenna positions are not present in the file.",  # raised twice
             "Telescope location is set at sealevel at the file lat/lon "
@@ -586,7 +579,6 @@ def test_miriad_location_handling(paper_miriad_main, tmp_path):
         UserWarning,
         [
             warn_dict["altitude_missing_foo"],
-            warn_dict["altitude_missing_foo"],
             warn_dict["telescope_at_sealevel_foo"],
             warn_dict["projection_false_offset"],
             warn_dict["uvw_mismatch"],
@@ -616,7 +608,6 @@ def test_miriad_location_handling(paper_miriad_main, tmp_path):
     with check_warnings(
         UserWarning,
         [
-            warn_dict["altitude_missing_foo"],
             warn_dict["altitude_missing_foo"],
             (
                 "Telescope location is set at sealevel at the "
@@ -656,7 +647,6 @@ def test_miriad_location_handling(paper_miriad_main, tmp_path):
     with check_warnings(
         UserWarning,
         [
-            warn_dict["altitude_missing_foo"],
             warn_dict["altitude_missing_foo"],
             warn_dict["telescope_at_sealevel_lat_long"],
             warn_dict["projection_false_offset"],
@@ -700,7 +690,6 @@ def test_miriad_location_handling(paper_miriad_main, tmp_path):
     with check_warnings(
         UserWarning,
         [
-            warn_dict["altitude_missing_foo"],
             warn_dict["altitude_missing_foo"],
             (
                 "Telescope location is set at sealevel at the "
@@ -1335,17 +1324,44 @@ def test_miriad_and_aipy_reads(uv_in_paper):
 
 
 def test_miriad_telescope_locations():
-    # test load_telescope_coords w/ blank Miriad
-    uv_in = Miriad()
+    # test load_telescope_coords w/ blank Telescope
     uv = aipy_extracts.UV(fetch_data("paper_2014_miriad"))
-    uv_in._load_telescope_coords(uv)
-    assert uv_in.telescope.location is not None
+    telescope = Telescope()
+    telescope.name = uv["telescop"].replace("\x00", "")
+    uv._load_telescope_coords(telescope)
+    assert telescope.location is not None
     uv.close()
-    # test load_antpos w/ blank Miriad
-    uv_in = Miriad()
+    # test load_antpos w/ blank Telescope
     uv = aipy_extracts.UV(fetch_data("paper_2014_miriad"))
-    uv_in._load_antpos(uv)
-    assert uv_in.telescope.antenna_positions is not None
+    telescope = Telescope()
+    telescope.name = uv["telescop"].replace("\x00", "")
+    uv._load_telescope_coords(telescope)
+    uv._load_antpos(telescope)
+    assert telescope.antenna_positions is not None
+
+
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.parametrize(
+    "written,expected",
+    [("a test string", "a test string"), ("True", True), ("False", False)],
+)
+def test_miriad_string_header_item(tmp_path, monkeypatch, written, expected):
+    """Check that string header items land in extra_keywords, booleans decoded."""
+    # Every string-valued entry in the default itemtable is one that is read
+    # elsewhere, so a new one has to be registered to exercise this at all.
+    monkeypatch.setitem(aipy_extracts.itemtable, "tstitem", "a")
+
+    test_file = os.path.join(tmp_path, "miriad_string_item.uv")
+    aipy_uv = aipy_extracts.UV(fetch_data("paper_2014_miriad"))
+    aipy_uv2 = aipy_extracts.UV(test_file, status="new")
+    aipy_uv2["tstitem"] = written
+    aipy_uv2.init_from_uv(aipy_uv)
+    aipy_uv2.pipe(aipy_uv)
+    aipy_uv.close()
+    aipy_uv2.close()
+
+    uv_in = UVData.from_file(test_file)
+    assert uv_in.extra_keywords["tstitem"] == expected
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a new class, `MiriadCal`, which supports reading of MIRIAD-based calibration solutions. As part of this, several functions from the UVData-based `Miriad` class have been moved over to `aipy_extracts.py` (added to the `UV` class) to allow for both UVCal and UVData objects from MIRIAD to use the same underlying functions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
SMA has a large stack of historic calibration tables in MIRIAD, and after pyuvdata added support for writing MeasurementSet-formated gains tables, there was some discussion about getting the read operation to work (both to cross-verify our own internal pipeline as well as to be able to carry forward work that had been previously done in MIRIAD). The existing AIPY interface -- and it's bindings to the `uvio` interface -- actually provided much of what was needed for reading this in, most of what was left was some relatively simple plumbing. Note that the ATCA test file actually has calibration solutions for three of the four types supported here, and was used fairly heavily in the testing phase of the code to verify that things were working.

(Also, this was this lowest-numbered issue I could close without knowing what an orthoslant is).

Closes #107.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added/updated tests to cover my new feature.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).