### PR TITLE
Fix intermittent failure in test_known_telescopes

### DIFF
--- a/tests/test_telescopes.py
+++ b/tests/test_telescopes.py
@@ -58,14 +58,7 @@ other_attributes = [
     "telescope_location_lat_lon_alt_degrees",
     "pyuvdata_version_str",
 ]
-astropy_sites = EarthLocation.get_site_names()
-while "" in astropy_sites:
-    astropy_sites.remove("")
-
-# Using set here is a quick way to drop duplicate entries
-expected_known_telescopes = list(
-    set(astropy_sites + ["PAPER", "HERA", "SMA", "SZA", "OVRO-LWA", "ATA"])
-)
+pyuvdata_sites = ["PAPER", "HERA", "SMA", "SZA", "OVRO-LWA", "ATA"]
 
 
 @pytest.fixture(scope="function")
@@ -155,6 +148,14 @@ def test_properties():
 
 def test_known_telescopes():
     """Test known_telescopes function returns expected results."""
+    # Note the astropy site list is fetched here rather than at import, because what
+    # `EarthLocation.get_site_names` returns depends on whether the site registry has
+    # been downloaded yet, which appears to be setting up something of a minor race
+    # condition when setup at the import step.
+    astropy_sites = [site for site in EarthLocation.get_site_names() if site != ""]
+    # Using set here is a quick way to drop duplicate entries
+    expected_known_telescopes = set(astropy_sites) | set(pyuvdata_sites)
+
     assert sorted(pyuvdata.telescopes.known_telescopes()) == sorted(
         expected_known_telescopes
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes an issue w/ `test_known_telescopes`, where some downloading issues appear to have caused a race condition (causing some CIs to fail).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

Trying to avoid CI jobs failing b/c of flaky tests....

(also, apparently if you tell an AI agent to draft a PR, it'll just generate and push the whole thing without asking, oy!)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.


Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme, pyproject.toml, environment.yaml and CI conda yaml files to reflect the changes.

