### PR TITLE
Change to how calibration solutions are grouped together based on time for MeasurementSet-based tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Changed how `UVCal.read_ms_cal` groups together calibration solutions based on time.
+Previously solution timestamps needed to be within the default tolerance for
+`UVCal.time_array` (1 millisecond), but testing suggests that CASA-based processes
+have some "slop" in them on the order of tens of milliseconds, and therefore the
+time tolerance was increased to 250 ms. This can be controlled through the keyword
+`time_atol` (specified in seconds).
 - Refactored `UVData.frequency_average` and `UVData.downsample_in_time` to use the new
 numba-based `utils.averaging.mapped_average` routine, which is significantly faster and
 uses less memory (substantially so for `UVData.frequency_average`).

--- a/src/pyuvdata/utils/tools.py
+++ b/src/pyuvdata/utils/tools.py
@@ -822,7 +822,7 @@ def _quantized_group(arr, tols, force=False):
         # matters - the check is about 100x faster than running the code below (and
         # about 10x faster that the code above), so it's a relatively trivial check.
         group_arr = np.zeros(len(arr), dtype=int)
-        check_val = sort_arr[0]
+        check_val = (sort_arr[0] + atol) * (1 + rtol)
         count = 0
         # Note that the tolist call helps to speed up the line below by ~10-20%
         for val, idx in zip(sort_arr.tolist(), np.argsort(arr).tolist(), strict=True):

--- a/src/pyuvdata/utils/tools.py
+++ b/src/pyuvdata/utils/tools.py
@@ -765,3 +765,75 @@ def float_int_to_str_array(
     else:
         list_of_lists = [int_str_list, flt_str_list]
     return np.array(["_".join(zpval) for zpval in zip(*list_of_lists, strict=True)])
+
+
+def _quantized_group(arr, tols, force=False):
+    """
+    Group values based on tolerances.
+
+    This is a utility function for grouping floating point data in the presence of
+    tolerances. Note that the grouping that is performed here is maximally exclusive,
+    e.g. if an absolute tolerance of 1 is used on the array [1, 2, 3], two groups
+    will be formed (effectively [1, 2] and [3]) instead of one.
+
+    Parameters
+    ----------
+    arr : array-like of float
+        Array from which to produce groups based on the sorted values and tolerances.
+    tols : tuple of float
+        Tolerances to be used, must be length 2. First value is the relative tolerance,
+        second is the absolute tolerance.
+    force : bool
+        Set to False by default, which means that if arr has no values within tolerances
+        (that aren't identical), then the function will simply return back the original
+        array, since the existing values can already be used to group the data. However,
+        if set to True, then the function will return back an array of integer values
+        representing the groupings of arr.
+
+    Returns
+    -------
+    group_arr : ndarray
+        If no values are within tols (but not identical to other values) and force is
+        not set to True, then the original arr is returned. Otherwise, an array of ints
+        is returned, of the same length as arr, demarking which group each index
+        position belongs to (where group numbering is ordered by ascending order of
+        values in arr).
+    """
+    rtol, atol = tols
+    if (rtol == 0) and (atol == 0) and (not force):
+        # Cover the no-op case, just return the original array
+        return arr
+
+    sort_arr = np.sort(arr)
+    tol_check = atol
+
+    if rtol != 0:
+        tol_check = (rtol * sort_arr) if (atol == 0) else ((rtol * sort_arr) + atol)
+        tol_check = tol_check[:-1]
+
+    diff_arr = np.diff(sort_arr)
+
+    # We want to make sure we return something, so plug in the existing array for
+    # now as the thing we want to assign.
+    group_arr = arr
+
+    if np.any(np.logical_and(diff_arr < tol_check, diff_arr != 0)):
+        # This check basically looks to see if there's anything where the tolerance
+        # matters - the check is about 100x faster than running the code below (and
+        # about 10x faster that the code above), so it's a relatively trivial check.
+        group_arr = np.zeros(len(arr), dtype=int)
+        check_val = sort_arr[0]
+        count = 0
+        # Note that the tolist call helps to speed up the line below by ~10-20%
+        for val, idx in zip(sort_arr.tolist(), np.argsort(arr).tolist(), strict=True):
+            if check_val < val:
+                check_val = (val + atol) * (1 + rtol)
+                count = count + 1
+            group_arr[idx] = count
+    elif force:
+        # Otherwise if nothing is within tol but we're forcing things, then we just
+        # need to count where the entries are different.
+        group_arr = np.zeros(len(arr), dtype=int)
+        group_arr[np.argsort(arr)[1:]] = np.cumsum(diff_arr != 0)
+
+    return group_arr

--- a/src/pyuvdata/uvcal/ms_cal.py
+++ b/src/pyuvdata/uvcal/ms_cal.py
@@ -47,6 +47,60 @@ DEFAULT_CAT_DICT = {
 }
 
 
+def _map_times(time_vals, *, rtol, atol):
+    """
+    Map a list of time stamps to a set of unique, time-ordered entries.
+
+    Parameters
+    ----------
+    time_vals : ndarray of float
+        Time stamps to map, of shape (Nrows,). Units are arbitrary, although they must
+        match those used for `atol`.
+    rtol : float
+        Relative tolerance to use for determining whether two time stamps match.
+    atol : float
+        Absolute tolerance to use for determining whether two time stamps match, in the
+        same units as `time_vals`.
+
+    Returns
+    -------
+    unique_times : ndarray of float
+        Sorted array of unique time stamps, of shape (Ntimes,).
+    index_map : ndarray of int
+        Index of `unique_times` that each entry in `time_vals` maps to, of shape
+        (Nrows,).
+    """
+    time_dict = {}
+    time_list = []
+    index_map = np.zeros(len(time_vals), dtype=int)
+    for idx, time in enumerate(time_vals):
+        try:
+            index_map[idx] = time_dict[time]
+            continue
+        except KeyError:
+            pass
+        # Check to see if there are any nearby entries, since time stamps that agree
+        # to within the tolerances are considered to be the same solution interval.
+        close_check = np.isclose(time_list, time, rtol=rtol, atol=atol)
+        if any(close_check):
+            # Fill in the first closest entry matched
+            time_dict[time] = np.where(close_check)[0][0]
+        else:
+            # Otherwise, plug in a new entry
+            time_dict[time] = len(time_list)
+            time_list.append(time)
+        index_map[idx] = time_dict[time]
+
+    # Rows are usually recorded in time order, but that's not guaranteed, so sort the
+    # unique entries here and remap the indices accordingly.
+    unique_times = np.array(time_list, dtype=float)
+    sort_idx = np.argsort(unique_times)
+    inv_idx = np.empty_like(sort_idx)
+    inv_idx[sort_idx] = np.arange(len(sort_idx))
+
+    return unique_times[sort_idx], inv_idx[index_map]
+
+
 class MSCal(UVCal):
     """
     Defines an MS-specific subclass of UVCal for reading MS calibration tables.
@@ -263,37 +317,14 @@ class MSCal(UVCal):
             self.sky_catalog = "CASA (import)"
             self._set_sky()
 
-        time_dict = {}
-        row_timeidx_map = []
-        time_count = 0
-        for time in tb_main.getcol("TIME"):
-            try:
-                row_timeidx_map.append(time_dict[time])
-            except KeyError:
-                # Check to see if there are any nearby entries, accounting for the fact
-                # that MS stores times in seconds and time_array tolerances are
-                # specified in days.
-                close_check = np.isclose(
-                    list(time_dict),
-                    time,
-                    rtol=self._time_array.tols[0] * 86400,
-                    atol=self._time_array.tols[1] * 86400,
-                )
-                if any(close_check):
-                    # Fill in the first closest entry matched
-                    time_dict[time] = time_dict[
-                        list(time_dict)[np.where(close_check)[0][0]]
-                    ]
-                else:
-                    # Otherwise, plug in a new entry
-                    time_dict[time] = time_count
-                    time_count += 1
-                # Finally, update the row_map with the correct value
-                row_timeidx_map.append(time_dict[time])
-
-        self.time_array = np.zeros(time_count, dtype=float)
-        self.integration_time = np.zeros(time_count, dtype=float)
-        self.Ntimes = time_count
+        time_col = tb_main.getcol("TIME")
+        row_time_idx = utils.tools._quantized_group(
+            time_col / 86400.0, self._time_array.tols, force=True
+        )
+        self.time_array = np.zeros(1 + row_time_idx.max(), dtype=float)
+        self.time_array[row_time_idx] = time_col
+        self.Ntimes = len(self.time_array)
+        self.integration_time = np.zeros(self.Ntimes, dtype=float)
 
         # Make a map to things.
         ant_dict = {ant: idx for idx, ant in enumerate(self.telescope.antenna_numbers)}
@@ -312,11 +343,10 @@ class MSCal(UVCal):
         exp_time = 0.0  # Default value if no exposure stored
         int_arr = np.zeros_like(self.time_array, dtype=float)
 
-        for row_idx, time_idx in enumerate(row_timeidx_map):
+        for row_idx, time_idx in enumerate(row_time_idx):
             try:
                 ant_idx = ant_dict[tb_main.getcell("ANTENNA1", row_idx)]
                 ref_ant = tb_main.getcell("ANTENNA2", row_idx)
-                time_val = tb_main.getcell("TIME", row_idx)
                 cal_soln = tb_main.getcell(cal_column, row_idx)
                 cal_qual = tb_main.getcell("PARAMERR", row_idx)
                 cal_flag = tb_main.getcell("FLAG", row_idx)
@@ -336,7 +366,6 @@ class MSCal(UVCal):
                 # and thus no flip is necessary for gains solns.
                 # TODO: Verify this is the case for delay solns as well.
                 ms_cal_soln[ant_idx, spw_slice, time_idx, :] = cal_soln
-                self.time_array[time_idx] = time_val
                 self.integration_time[time_idx] = exp_time
                 int_arr[time_idx] = int_time
                 self.quality_array[ant_idx, spw_slice, time_idx, :] = cal_qual

--- a/src/pyuvdata/uvcal/ms_cal.py
+++ b/src/pyuvdata/uvcal/ms_cal.py
@@ -47,60 +47,6 @@ DEFAULT_CAT_DICT = {
 }
 
 
-def _map_times(time_vals, *, rtol, atol):
-    """
-    Map a list of time stamps to a set of unique, time-ordered entries.
-
-    Parameters
-    ----------
-    time_vals : ndarray of float
-        Time stamps to map, of shape (Nrows,). Units are arbitrary, although they must
-        match those used for `atol`.
-    rtol : float
-        Relative tolerance to use for determining whether two time stamps match.
-    atol : float
-        Absolute tolerance to use for determining whether two time stamps match, in the
-        same units as `time_vals`.
-
-    Returns
-    -------
-    unique_times : ndarray of float
-        Sorted array of unique time stamps, of shape (Ntimes,).
-    index_map : ndarray of int
-        Index of `unique_times` that each entry in `time_vals` maps to, of shape
-        (Nrows,).
-    """
-    time_dict = {}
-    time_list = []
-    index_map = np.zeros(len(time_vals), dtype=int)
-    for idx, time in enumerate(time_vals):
-        try:
-            index_map[idx] = time_dict[time]
-            continue
-        except KeyError:
-            pass
-        # Check to see if there are any nearby entries, since time stamps that agree
-        # to within the tolerances are considered to be the same solution interval.
-        close_check = np.isclose(time_list, time, rtol=rtol, atol=atol)
-        if any(close_check):
-            # Fill in the first closest entry matched
-            time_dict[time] = np.where(close_check)[0][0]
-        else:
-            # Otherwise, plug in a new entry
-            time_dict[time] = len(time_list)
-            time_list.append(time)
-        index_map[idx] = time_dict[time]
-
-    # Rows are usually recorded in time order, but that's not guaranteed, so sort the
-    # unique entries here and remap the indices accordingly.
-    unique_times = np.array(time_list, dtype=float)
-    sort_idx = np.argsort(unique_times)
-    inv_idx = np.empty_like(sort_idx)
-    inv_idx[sort_idx] = np.arange(len(sort_idx))
-
-    return unique_times[sort_idx], inv_idx[index_map]
-
-
 class MSCal(UVCal):
     """
     Defines an MS-specific subclass of UVCal for reading MS calibration tables.
@@ -117,6 +63,7 @@ class MSCal(UVCal):
         default_x_orientation=None,
         default_jones_array=None,
         default_mount_type="other",
+        time_atol=0.25,
         run_check=True,
         check_extra=True,
         run_check_acceptability=True,
@@ -319,7 +266,9 @@ class MSCal(UVCal):
 
         time_col = tb_main.getcol("TIME")
         row_time_idx = utils.tools._quantized_group(
-            time_col / 86400.0, self._time_array.tols, force=True
+            time_col / 86400.0,
+            self._time_array.tols if time_atol is None else (0.0, time_atol / 86400.0),
+            force=True,
         )
         self.time_array = np.zeros(1 + row_time_idx.max(), dtype=float)
         self.time_array[row_time_idx] = time_col

--- a/src/pyuvdata/uvcal/uvcal.py
+++ b/src/pyuvdata/uvcal/uvcal.py
@@ -4944,6 +4944,12 @@ class UVCal(UVBase):
             If not recorded in the data set or telescope is unknown to pyuvdata, the
             `Telescope.mount_type` parameter is automatically set to "other". However,
             users can specify a different default by passing an argument here.
+        time_atol : float or None
+            Absolute tolerance for time comparisons, in units of seconds. Can be used
+            to adjust the strictness of time matching during read in of calibration
+            solutions (since some operations can introduce small time offsets larger
+            than the `UVCal` default tolerance of 1 millisecond). Default is 0.25,
+            based on emperical measurements form CASA-derived calibration tables.
         check_extra : bool
             Option to check optional parameters as well as required ones.
         run_check_acceptability : bool
@@ -5005,6 +5011,7 @@ class UVCal(UVBase):
         # MSCal
         default_x_orientation=None,
         default_jones_array=None,
+        time_atol=0.25,
     ):
         """
         Read a generic file into a UVCal object.
@@ -5142,6 +5149,12 @@ class UVCal(UVBase):
             set to [-5, -6] (linear pols) and a warning will be raised. However,
             if a value for default_jones_array is provided, it will be used instead
             and the warning will be suppressed.
+        time_atol : float
+            Absolute tolerance for time comparisons, in units of seconds. Can be used
+            to adjust the strictness of time matching during read in of calibration
+            solutions (since some operations can introduce small time offsets larger
+            than the `UVCal` default tolerance of 1 millisecond). Default is 0.25,
+            based on emperical measurements form CASA-derived calibration tables.
 
         """
         if isinstance(filename, list | tuple | np.ndarray):
@@ -5269,6 +5282,7 @@ class UVCal(UVBase):
                 # MSCal
                 default_x_orientation=default_x_orientation,
                 default_jones_array=default_jones_array,
+                time_atol=time_atol,
             )
             uv_list = []
             for ind, file in enumerate(filename[1:]):
@@ -5315,6 +5329,7 @@ class UVCal(UVBase):
                     # MSCal
                     default_x_orientation=default_x_orientation,
                     default_jones_array=default_jones_array,
+                    time_atol=time_atol,
                 )
                 uv_list.append(uvcal2)
             # Concatenate once at end
@@ -5449,6 +5464,7 @@ class UVCal(UVBase):
                     check_extra=check_extra,
                     run_check_acceptability=run_check_acceptability,
                     astrometry_library=astrometry_library,
+                    time_atol=time_atol,
                 )
 
             if select:

--- a/tests/utils/test_tools.py
+++ b/tests/utils/test_tools.py
@@ -260,3 +260,29 @@ def test_convert_to_slices(kwargs, exp_output):
 
     assert isinstance(slice_list[0], slice) == check
     assert slice_list == exp_output
+
+
+@pytest.mark.parametrize(
+    "arr,tols,force,expected",
+    [
+        # no tolerances and not forced, so the values can already group themselves
+        ([3.0, 1.0, 2.0], (0.0, 0.0), False, [3.0, 1.0, 2.0]),
+        # nothing lands within the tolerance, so again the values are handed back
+        ([1.0, 10.0, 20.0], (0.0, 0.5), False, [1.0, 10.0, 20.0]),
+        # grouping is maximally exclusive, giving [1, 2] and [3] rather than one group
+        ([1.0, 2.0, 3.0], (0.0, 1.5), False, [0, 0, 1]),
+        # relative tolerance on its own
+        ([1.0, 1.05, 2.0], (0.1, 0.0), False, [0, 0, 1]),
+        # relative and absolute tolerances together
+        ([1.0, 1.05, 2.0], (0.05, 0.02), False, [0, 0, 1]),
+        # forced, so groups come back even though nothing is within tolerance
+        ([1.0, 2.0, 3.0], (0.0, 0.0), True, [0, 1, 2]),
+        # forced, with identical values sharing a group
+        ([2.0, 1.0, 1.0], (0.0, 0.0), True, [1, 0, 0]),
+        # groups are numbered by ascending value, indexed by position in arr
+        ([3.0, 1.0, 1.2], (0.0, 0.5), False, [1, 0, 0]),
+    ],
+)
+def test_quantized_group(arr, tols, force, expected):
+    result = utils.tools._quantized_group(np.array(arr), tols, force=force)
+    assert np.array_equal(result, expected)

--- a/tests/uvcal/test_ms_cal.py
+++ b/tests/uvcal/test_ms_cal.py
@@ -450,7 +450,7 @@ def test_ms_cal_uneven_spw_times(sma_pcal, tmp_path):
 
     with tables.table(testfile, ack=False, readonly=False) as tb:
         spw_ids = tb.getcol("SPECTRAL_WINDOW_ID")
-        tb.putcol("TIME", tb.getcol("TIME") + (10.0 * spw_ids))
+        tb.putcol("TIME", tb.getcol("TIME") + (1.0 * spw_ids))
 
     # Drop the first solution of the last window, so that the two windows no longer
     # agree on how many solutions they have.
@@ -465,6 +465,11 @@ def test_ms_cal_uneven_spw_times(sma_pcal, tmp_path):
     uvcal = UVCal()
     uvcal.read(testfile)
     assert uvcal.Ntimes == (sma_pcal.Nspws * sma_pcal.Ntimes) - 1
+
+    # Now make the time comparison less strict by using a large time_atol.
+    uvcal = UVCal()
+    uvcal.read(testfile, time_atol=30.0)
+    assert uvcal.Ntimes == sma_pcal.Ntimes
 
 
 def test_ms_close_spaced_times(tmp_path):

--- a/tests/uvcal/test_ms_cal.py
+++ b/tests/uvcal/test_ms_cal.py
@@ -400,6 +400,73 @@ def test_ms_dterm_warning(sma_pcal, tmp_path):
         sma_pcal.write_ms_cal(testfile, clobber=True)
 
 
+@pytest.mark.parametrize("offset", [1e-5, 10.0])
+def test_ms_cal_offset_spw_times(sma_bcal, tmp_path, offset):
+    """Check that per-spw time stamps get lined up on a common time axis."""
+    from casacore import tables
+
+    testfile = os.path.join(tmp_path, "offset_spw_times.ms")
+    sma_bcal.write_ms_cal(testfile, clobber=True)
+    with tables.table(testfile, ack=False, readonly=False) as tb:
+        nrows = tb.nrows()
+        spw_ids = tb.getcol("SPECTRAL_WINDOW_ID")
+        tb.putcol("TIME", tb.getcol("TIME") + (offset * spw_ids))
+
+    uvcal = UVCal()
+    uvcal.read(testfile)
+
+    if offset < 1e-3:
+        # If the offset is small, we should get back the orig number of timestamps
+        assert uvcal.Ntimes == sma_bcal.Ntimes
+        assert uvcal.__eq__(
+            sma_bcal, allowed_failures=allowed_failures + ["_time_array", "_lst_array"]
+        )
+
+        # And writing back out should reproduce the same number of records we read in.
+        outfile = os.path.join(tmp_path, "offset_spw_times_rewrite.ms")
+        uvcal.write_ms_cal(outfile, clobber=True)
+        with tables.table(outfile, ack=False) as tb:
+            assert tb.nrows() == nrows
+    else:
+        # Otherwise, we'll get one entry per spectral window
+        assert uvcal.Ntimes == sma_bcal.Ntimes * sma_bcal.Nspws
+
+        # Confirm that the data are stripped in the way that we expect
+        for spw in sma_bcal.spw_array:
+            chan_mask = sma_bcal.flex_spw_id_array == spw
+            for item in ["gain_array", "flag_array", "quality_array"]:
+                np.testing.assert_array_almost_equal(
+                    getattr(sma_bcal, item)[:, chan_mask, 0, :],
+                    getattr(uvcal, item)[:, chan_mask, spw, :],
+                )
+
+
+def test_ms_cal_uneven_spw_times(sma_pcal, tmp_path):
+    """Check handling when windows record differing numbers of solutions."""
+    from casacore import tables
+
+    testfile = os.path.join(tmp_path, "uneven_spw_times.ms")
+    sma_pcal.write_ms_cal(testfile, clobber=True)
+
+    with tables.table(testfile, ack=False, readonly=False) as tb:
+        spw_ids = tb.getcol("SPECTRAL_WINDOW_ID")
+        tb.putcol("TIME", tb.getcol("TIME") + (10.0 * spw_ids))
+
+    # Drop the first solution of the last window, so that the two windows no longer
+    # agree on how many solutions they have.
+    with tables.table(testfile, ack=False, readonly=False) as tb:
+        spw_ids = tb.getcol("SPECTRAL_WINDOW_ID")
+        times = tb.getcol("TIME")
+        last_spw = spw_ids == np.max(spw_ids)
+        drop = np.nonzero(last_spw & (times == np.min(times[last_spw])))[0]
+        tb.removerows(drop)
+
+    # With no way to line the windows up, each window keeps its own time stamps.
+    uvcal = UVCal()
+    uvcal.read(testfile)
+    assert uvcal.Ntimes == (sma_pcal.Nspws * sma_pcal.Ntimes) - 1
+
+
 def test_ms_close_spaced_times(tmp_path):
 
     uvobj = UVCal()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`MSCal.read_ms_cal` has a new keyword, `time_atol`, which allows the user to specify the time tolerance when calibration tables are read in from MS format. The default has been set to 0.25 (250 ms), based on some testing of CASA-derived calibration tables. Additionally, a new helper function `utils.tools._quantized_group` has been added, that allows for grouping of floating-point variables based on some specified set of numerical tolerances. 

Note that I've called this a "bug fix", although the issue exists outside of pyuvdata -- this is just making _our_ reader more tolerant of the scatter that appears to come from timestamps in MS format (whether this is b/c of numerical precision issues or something more mundane like data-weighting).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
It seems as though CASA-derived calibration tables, like those that come from `gaincal` have some scatter when being written out that is larger than the standard tolerance for `UVCal.time_array`, which is currently set to 1 ms. This was causing an issue with round-tripping of data, and given that this issue was actually present in the test files for `MSCal` (as well as a separate appearance that showed up in #1654), I felt that the best "do no harm" option for users was to change the default tolerance for the _read_ operation only (on `MSCal` alone) to something that wouldn't cause a single set of solutions to get split across multiple intervals (the cost of which was that this generated a lot of blank entries, which inside of CASA get flagged and cause the gains interpolation to flag a _lot_ of data).

Closes #1654.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).
