### PR TITLE
Fix to allow for graceful handling of timeout errors in CI

### DIFF
--- a/.github/workflows/macosx_windows_ci.yaml
+++ b/.github/workflows/macosx_windows_ci.yaml
@@ -19,6 +19,9 @@ jobs:
     name: Run Tests
     env:
       PYTHON: ${{ matrix.python-version }}
+      # Keep the test data in the workspace rather than the per-OS default cache
+      # location, so it can be cached with a single path on every runner.
+      PYUVDATA_DATA_DIR: ${{ github.workspace }}/pooch_cache
     runs-on: ${{ matrix.os }}
     defaults:
      run:
@@ -58,6 +61,22 @@ jobs:
           if [[ $PYVER != $PYTHON ]]; then
             exit 1;
           fi
+
+      - name: Get the test data version
+        id: data-version
+        run: |
+          version=$(python -c "import re, pathlib; print(re.search(r'^data_version = \"(.+)\"', pathlib.Path('src/pyuvdata/datasets.py').read_text(), re.M).group(1))")
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached test data
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: pooch_cache
+          key: pooch-${{ runner.os }}-${{ steps.data-version.outputs.version }}
+
+      - name: Download any test data not already cached
+        run: |
+          python ci/prefetch_test_data.py "$PYUVDATA_DATA_DIR"
 
       - name: Install
         run: |

--- a/.github/workflows/macosx_windows_ci.yaml
+++ b/.github/workflows/macosx_windows_ci.yaml
@@ -62,17 +62,11 @@ jobs:
             exit 1;
           fi
 
-      - name: Get the test data version
-        id: data-version
-        run: |
-          version=$(python -c "import re, pathlib; print(re.search(r'^data_version = \"(.+)\"', pathlib.Path('src/pyuvdata/datasets.py').read_text(), re.M).group(1))")
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
       - name: Restore cached test data
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: pooch_cache
-          key: pooch-${{ runner.os }}-${{ steps.data-version.outputs.version }}
+          key: pooch-${{ runner.os }}-${{ hashFiles('src/pyuvdata/datasets.py') }}
 
       - name: Download any test data not already cached
         run: |

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -16,6 +16,8 @@ jobs:
   build_wheels:
     name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }} ${{ matrix.buildplat[2] }}
     runs-on: ${{ matrix.buildplat[0] }}
+    env:
+      PYUVDATA_DATA_DIR: ${{ github.workspace }}/pooch_cache
     strategy:
       fail-fast: false
       matrix:
@@ -35,6 +37,29 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Only for the prefetch step below
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version-file: pyproject.toml
+
+      # Suppress the cache-poisoning audit for this step, since the only way to fix it
+      # is to allow for lookup-only , which would stop the cache from being restored.
+      # Known issue: https://github.com/zizmorcore/zizmor/issues/2071 -- the ignore can
+      # get removed once the issue is implemented in zizmor.
+      - name: Restore cached test data
+        if: github.event_name != 'release'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
+        with:
+          path: pooch_cache
+          key: pooch-${{ runner.os }}-${{ hashFiles('src/pyuvdata/datasets.py') }}
+
+      - name: Download any test data not already cached
+        shell: bash
+        run: |
+          python -m pip install pooch pyyaml
+          python ci/prefetch_test_data.py "$PYUVDATA_DATA_DIR"
+
       - name: Build wheels
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
@@ -42,6 +67,8 @@ jobs:
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_TEST_REQUIRES: "-r ci/test_requirements.txt"
           CIBW_TEST_COMMAND: "pytest {project}/tests -n auto"
+          CIBW_ENVIRONMENT: PYUVDATA_DATA_DIR='${{ env.PYUVDATA_DATA_DIR }}'
+          CIBW_ENVIRONMENT_LINUX: PYUVDATA_DATA_DIR=/project/pooch_cache
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ src/pyuvdata/uvdata/corr_fits.c
 src/pyuvdata/uvdata/src/miriad_wrap.cpp
 
 .vscode/
+
+# test data cache populated by ci/prefetch_test_data.py
+pooch_cache/

--- a/ci/prefetch_test_data.py
+++ b/ci/prefetch_test_data.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""
+Download the pyuvdata test data into a shared pooch cache.
+
+The wheel-building jobs run the test suite once per wheel, in an environment with a
+cold cache, so each one re-downloads the whole test dataset from github. Running this
+once on the runner and pointing the test environments at the result via the
+PYUVDATA_DATA_DIR environment variable turns those N downloads into one.
+
+Usage: python ci/prefetch_test_data.py <cache_dir>
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = REPO_ROOT / "src" / "pyuvdata"
+
+
+def load_datasets_module():
+    """
+    Load pyuvdata.datasets without importing pyuvdata itself.
+
+    Importing the real package pulls in the compiled extensions, which have not been
+    built yet when this runs. datasets.py only needs DATA_PATH from the parent, so
+    stub out just enough of the package for it to import.
+    """
+    pkg = types.ModuleType("pyuvdata")
+    pkg.__path__ = [str(SRC)]
+    data_pkg = types.ModuleType("pyuvdata.data")
+    data_pkg.DATA_PATH = str(SRC / "data")
+    sys.modules["pyuvdata"] = pkg
+    sys.modules["pyuvdata.data"] = data_pkg
+
+    spec = importlib.util.spec_from_file_location(
+        "pyuvdata.datasets", SRC / "datasets.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["pyuvdata.datasets"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main():
+    """Fetch every dataset in the registry into the requested cache directory."""
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} <cache_dir>")
+
+    # pooch reads this when the Pooch object is created, so it has to be set before
+    # datasets.py is executed.
+    cache_dir = Path(sys.argv[1]).resolve()
+    os.environ["PYUVDATA_DATA_DIR"] = str(cache_dir)
+
+    datasets = load_datasets_module()
+    print(f"Caching {len(datasets.fetch_dict)} datasets into {datasets.pup.abspath}")
+
+    for name in datasets.fetch_dict:
+        datasets.fetch_data(name)
+
+    print(f"Done. Cache is at {datasets.pup.abspath}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyuvdata/datasets.py
+++ b/src/pyuvdata/datasets.py
@@ -22,6 +22,8 @@ pup = pooch.create(
     version=data_version,
     # If this is a development version, get the data from the "main" branch
     version_dev="main",
+    env="PYUVDATA_DATA_DIR",
+    retry_if_failed=3,
     registry=None,
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def setup_and_teardown_package():
             iers.conf.auto_max_age = None
 
     # Also ensure that we're downloading the site data from astropy
-    with contextlib.suppress(FileNotFoundError):
+    with contextlib.suppress(OSError):
         # this sometimes errors on windows, unclear why, but most of the time the
         # registry hasn't changed, so just move on with our testing if it errors
         if Version(astropy.__version__) < Version("7.2.1"):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Minor change to `conftest.py` to allow for time-out errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

This PR covers two changes:

1. Timeout errors related to `astropy._get_site_registry` have been causing a large number of CI failures recently -- this broadens the try/except catch error to allow for these errors so as to allow testing to continue (nominally with whatever sites are in the cache already).
2. A prefetch script for downloading and caching test data has been added to reduce the number of downloads needed through pooch, with the call for pooch modified to allow for retries. 

Both of these have been causing a fair number of CI failures recently, and I'm hoping that the combination of them will help to reduce the thrashing we've seen a bit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme, pyproject.toml, environment.yaml and CI conda yaml files to reflect the changes.
