### PR TITLE
Near field select mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- A bug in `UVData.phase` where near-field phasing ignored `select_mask` and applied the
+near-field correction to every record, overwriting the w-coordinate and rotating the
+visibilities of records belonging to other phase centers.
+
 ## [3.2.7] - 2025-08-20
 
 ### Added

--- a/src/pyuvdata/utils/phasing.py
+++ b/src/pyuvdata/utils/phasing.py
@@ -2521,7 +2521,7 @@ def uvw_track_generator(
     }
 
 
-def _get_focus_xyz(uvd, focus, ra, dec):
+def _get_focus_xyz(uvd, focus, ra, dec, select_mask=None):
     """
     Return the x,y,z coordinates of the focal point.
 
@@ -2535,19 +2535,25 @@ def _get_focus_xyz(uvd, focus, ra, dec):
     uvd : UVData object
         UVData object
     focus : float
-        Focal distance of the array (km)
+        Focal distance of the array (km). Either a single value, or one value per
+        unique time of the selected records (shape (Ntimes,)).
     ra : float
         Right ascension of the focal point ie phase center (deg; shape (Ntimes,))
     dec : float
         Declination of the focal point ie phase center (deg; shape (Ntimes,))
+    select_mask : ndarray of bool
+        Array of shape (Nblts,), which identifies which records to focus. Times are
+        taken from the selected records only, so that `Ntimes` counts the unique times
+        of the selection. Default is to use all records.
 
     Returns
     -------
     x, y, z: ndarray, ndarray, ndarray
         ENU-frame coordinates of the focal point (meters) (shape (Ntimes,))
     """
-    # Obtain timesteps
-    timesteps = Time(np.unique(uvd.time_array), format="jd")
+    # Obtain timesteps, which are those of the selected records only
+    time_array = uvd.time_array if select_mask is None else uvd.time_array[select_mask]
+    timesteps = Time(np.unique(time_array), format="jd")
 
     # Initialize sky-based coordinates using right ascension and declination
     obj = SkyCoord(ra * units.deg, dec * units.deg)
@@ -2573,7 +2579,7 @@ def _get_focus_xyz(uvd, focus, ra, dec):
     return x, y, z
 
 
-def _get_nearfield_delay(uvd, focus_x, focus_y, focus_z):
+def _get_nearfield_delay(uvd, focus_x, focus_y, focus_z, select_mask=None):
     """
     Calculate near-field phase/delay along the Nblts axis.
 
@@ -2582,7 +2588,11 @@ def _get_nearfield_delay(uvd, focus_x, focus_y, focus_z):
     uvd : UVData object
         UVData object
     focus_x, focus_y, focus_z : ndarray, ndarray, ndarray
-        ENU-frame coordinates of focal point (Each of shape (Ntimes,))
+        ENU-frame coordinates of focal point (Each of shape (Ntimes,), counting the
+        unique times of the selected records)
+    select_mask : ndarray of bool
+        Array of shape (Nblts,), which identifies which records to focus. Unselected
+        records keep their existing w-coordinate. Default is to focus all records.
 
     Returns
     -------
@@ -2598,16 +2608,18 @@ def _get_nearfield_delay(uvd, focus_x, focus_y, focus_z):
         uvd.telescope.get_enu_antpos(), axis=0
     )
 
-    # Get tile positions for each baseline
-    tile1 = antpos[ind1]  # Shape (Nblts, 3)
-    tile2 = antpos[ind2]  # Shape (Nblts, 3)
+    sel = slice(None) if select_mask is None else select_mask
 
-    # Focus points have shape (Ntimes,); convert to shape (Nblts,)
-    t_inds = _ntimes_to_nblts(uvd)
+    # Get tile positions for each selected baseline
+    tile1 = antpos[ind1[sel]]  # Shape (Nselect, 3)
+    tile2 = antpos[ind2[sel]]  # Shape (Nselect, 3)
+
+    # Focus points have shape (Ntimes,); convert to shape (Nselect,)
+    t_inds = _ntimes_to_nblts(uvd, select_mask=select_mask)
     (focus_x, focus_y, focus_z) = (focus_x[t_inds], focus_y[t_inds], focus_z[t_inds])
 
     # Calculate distance from antennas to focal point
-    # for each visibility along the Nblts axis
+    # for each selected visibility
     r1 = np.sqrt(
         (tile1[:, 0] - focus_x) ** 2
         + (tile1[:, 1] - focus_y) ** 2
@@ -2619,14 +2631,11 @@ def _get_nearfield_delay(uvd, focus_x, focus_y, focus_z):
         + (tile2[:, 2] - focus_z) ** 2
     )
 
-    # Get the uvw array along the Nblts axis; select only the w's
-    old_w = uvd.uvw_array[:, -1]
+    # Start from the existing w's, so that unselected records are left untouched
+    new_w = uvd.uvw_array[:, -1].copy()
 
-    # Calculate near-field delay
-    new_w = r1 - r2
-
-    # Mask autocorrelations
-    mask = np.not_equal(uvd.ant_1_array, uvd.ant_2_array)
-    new_w = np.where(mask, new_w, old_w)
+    # Calculate near-field delay, masking autocorrelations
+    mask = np.not_equal(uvd.ant_1_array[sel], uvd.ant_2_array[sel])
+    new_w[sel] = np.where(mask, r1 - r2, new_w[sel])
 
     return new_w  # Shape (Nblts,)

--- a/src/pyuvdata/utils/tools.py
+++ b/src/pyuvdata/utils/tools.py
@@ -690,7 +690,7 @@ def _nants_to_nblts(uvd):
     return np.asarray(ind1), np.asarray(ind2)
 
 
-def _ntimes_to_nblts(uvd):
+def _ntimes_to_nblts(uvd, select_mask=None):
     """
     Obtain indices to convert (Ntimes,) to (Nblts,).
 
@@ -698,6 +698,11 @@ def _ntimes_to_nblts(uvd):
     ----------
     uvd : UVData object
         UVData object
+    select_mask : ndarray of bool
+        Array of shape (Nblts,), which identifies which records to consider. If set,
+        the returned indices run over the unique times of the selected records only,
+        and are of length equal to the number of selected records. Default is to use
+        all records.
 
     Returns
     -------
@@ -705,14 +710,9 @@ def _ntimes_to_nblts(uvd):
         Indices that, when applied to an array of shape (Ntimes,),
         correctly convert it to shape (Nblts,)
     """
-    unique_t = np.unique(uvd.time_array)
-    t = uvd.time_array
+    time_array = uvd.time_array if select_mask is None else uvd.time_array[select_mask]
 
-    inds = []
-    for i in t:
-        inds.append(np.where(unique_t == i)[0][0])
-
-    return np.asarray(inds)
+    return np.unique(time_array, return_inverse=True)[1]
 
 
 def float_int_to_str_array(

--- a/src/pyuvdata/uvdata/uvdata.py
+++ b/src/pyuvdata/uvdata/uvdata.py
@@ -4635,18 +4635,29 @@ class UVData(UVBase):
                 phase_dict[key] = float(phase_dict[key])
         return phase_dict
 
-    def _apply_near_field_corrections(self, focus, ra, dec):
+    def _apply_near_field_corrections(
+        self, focus, ra, dec, *, update_vis=True, select_mask=None
+    ):
         """
         Apply near-field corrections by focusing the array to the specified focal point.
 
         Parameters
         ----------
         focus : astropy.units.Quantity object
-            Focal point of the array
+            Focal point of the array. Either a single distance, or one distance per
+            unique time of the selected records (shape (Ntimes,)).
         ra : ndarray
             Right ascension of the focal point ie phase center (rad; shape (Ntimes,))
         dec : ndarray
             Declination of the focal point ie phase center (rad; shape (Ntimes,))
+        update_vis : bool
+            Option to update the visibilities to account for the change in the
+            w-coordinate. Setting this to False assigns the near-field w-coordinate
+            without modifying the data, which is only appropriate if the data have not
+            already been phased to the focal point. Default is True.
+        select_mask : ndarray of bool
+            Array of shape (Nblts,), which identifies which records to focus.
+            Unselected records are left unchanged. Default is to focus all records.
 
         Returns
         -------
@@ -4659,15 +4670,25 @@ class UVData(UVBase):
         ra, dec = np.degrees(ra), np.degrees(dec)
 
         # Calculate the x, y, z coordinates of the focal point
-        # in ENU frame for each vis along Nblts axis
-        focus_x, focus_y, focus_z = _get_focus_xyz(self, focus, ra, dec)
+        # in ENU frame for each selected vis
+        focus_x, focus_y, focus_z = _get_focus_xyz(
+            self, focus, ra, dec, select_mask=select_mask
+        )
 
         # Calculate near-field correction at the specified timestep
-        # for each vis along Nblts axis
-        new_w = _get_nearfield_delay(self, focus_x, focus_y, focus_z)
+        # for each vis along Nblts axis. Unselected records come back unchanged,
+        # so the w assignment below leaves them alone.
+        new_w = _get_nearfield_delay(
+            self, focus_x, focus_y, focus_z, select_mask=select_mask
+        )
 
         # Update phase and w
-        self._apply_w_proj(new_w_vals=new_w, old_w_vals=self.uvw_array[:, -1])
+        if update_vis:
+            self._apply_w_proj(
+                new_w_vals=new_w,
+                old_w_vals=self.uvw_array[:, -1],
+                select_mask=select_mask,
+            )
         self.uvw_array[:, -1] = new_w
 
     def phase(
@@ -4967,7 +4988,10 @@ class UVData(UVBase):
         # Lastly, apply near-field corrections if specified
         if cat_type == "near_field":
             self._apply_near_field_corrections(
-                focus=dist_qt, ra=phase_dict["cat_lon"], dec=phase_dict["cat_lat"]
+                focus=dist_qt,
+                ra=phase_dict["cat_lon"],
+                dec=phase_dict["cat_lat"],
+                select_mask=select_mask,
             )
 
     def phase_to_time(

--- a/tests/uvdata/test_uvdata.py
+++ b/tests/uvdata/test_uvdata.py
@@ -12620,6 +12620,85 @@ def test_near_field_err():
 
 
 @pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+def test_near_field_select_mask():
+    uvfits_sample = fetch_data("mwa_2013_uvfits")
+
+    uvd = UVData()
+    uvd.read(uvfits_sample)
+
+    phase_kwargs = {
+        "ra": np.radians(30),
+        "dec": np.radians(-20),
+        "cat_name": "foo",
+        "dist": 10000,
+        "cat_type": "near_field",
+    }
+
+    # Focus the second integration only, leaving the first on its original sidereal
+    # phase center. The selection has fewer unique times than the object does, which
+    # is the time axis the focal point has to be calculated on.
+    times = np.unique(uvd.time_array)
+    select_mask = uvd.time_array == times[1]
+
+    uvd_masked = uvd.copy()
+    uvd_masked.phase(**phase_kwargs, select_mask=select_mask)
+
+    # Records outside the selection belong to a different phase center, so they must
+    # keep their uvws, their visibilities and their phase center assignment.
+    assert np.array_equal(
+        uvd_masked.uvw_array[~select_mask], uvd.uvw_array[~select_mask]
+    )
+    assert np.array_equal(
+        uvd_masked.data_array[~select_mask], uvd.data_array[~select_mask]
+    )
+    assert np.array_equal(
+        uvd_masked.phase_center_id_array[~select_mask],
+        uvd.phase_center_id_array[~select_mask],
+    )
+
+    # The focused records should match phasing the same records on their own.
+    uvd_sub = uvd.select(times=[times[1]], inplace=False)
+    uvd_sub.phase(**phase_kwargs)
+
+    assert np.allclose(uvd_sub.uvw_array, uvd_masked.uvw_array[select_mask])
+    assert np.allclose(uvd_sub.data_array, uvd_masked.data_array[select_mask])
+
+
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
+@pytest.mark.parametrize("update_vis", [True, False])
+def test_near_field_update_vis(update_vis):
+    uvfits_sample = fetch_data("mwa_2013_uvfits")
+
+    uvd = UVData()
+    uvd.read(uvfits_sample)
+    uvd.phase(
+        ra=np.radians(30),
+        dec=np.radians(-20),
+        cat_name="foo",
+        dist=10000,
+        cat_type="near_field",
+    )
+
+    # Move the focal point closer. The w's follow it either way, but the visibilities
+    # should only be rotated to match when update_vis is set.
+    uvd_refocused = uvd.copy()
+    uvd_refocused._apply_near_field_corrections(
+        focus=1000 * units.m,
+        ra=np.radians(30),
+        dec=np.radians(-20),
+        update_vis=update_vis,
+    )
+
+    cross = uvd.ant_1_array != uvd.ant_2_array
+    assert not np.allclose(uvd_refocused.uvw_array[cross, -1], uvd.uvw_array[cross, -1])
+
+    if update_vis:
+        assert not np.allclose(uvd_refocused.data_array, uvd.data_array)
+    else:
+        assert np.array_equal(uvd_refocused.data_array, uvd.data_array)
+
+
+@pytest.mark.filterwarnings("ignore:The uvw_array does not match the expected values")
 @pytest.mark.parametrize(
     "file_format, import_check, error_message",
     [


### PR DESCRIPTION
## Description

Adds keyword-only `update_vis` and `select_mask` arguments to the private `UVData._apply_near_field_corrections()`, and threads `select_mask` through `_get_focus_xyz`, `_get_nearfield_delay` and `_ntimes_to_nblts`.

`select_mask` fixes a bug: `phase()` honors `select_mask` everywhere except the near-field correction, which took no mask and rewrote `uvw_array[:, -1]` for every record before applying the w-projection to the whole data array. Phasing a subset of records to a near-field target therefore also overwrote the w-coordinate and rotated the visibilities of records belonging to *other* phase centers, silently — in the added test the w of unselected records moves from 0.28 m to 26.41 m while their u and v stay identical.

`update_vis` gates only the w-projection, so the exact near-field w can be assigned without modifying data that has not been phased to the focal point. It has no caller in this PR — it is groundwork for time-dependent near-field phase centers (#1710), where `set_uvws_from_antenna_positions()` applies the correction to objects whose visibilities may not be phased. Happy to split it out if you'd rather not carry an unused argument.

Behavior with no selection is unchanged and bit-identical in both `uvw_array` and `data_array`. This also replaces the index loop in `_ntimes_to_nblts` with `np.unique(..., return_inverse=True)`, which computes the same mapping without a Python loop over `Nblts`; happy to revert that if you'd prefer the diff stay narrower.

## Motivation and Context

Groundwork for moving (time-dependent) near-field phase centers, proposed in #1710. A moving focus applies to its own records and its `cat_times` need not span the whole file, so the near-field correction has to be selection-aware. Fixing the ignored `select_mask` is the same code change, so it comes along here.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have read the contribution guide.
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] I have updated the CHANGELOG.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the numpy docstring format.
- [ ] I have updated the tutorial to highlight my new feature (if appropriate). — not applicable, all changes are to private methods
- [x] I have added/updated tests to cover my new feature.
- [x] I have updated the CHANGELOG.
